### PR TITLE
fix(tsconfig): drop deprecated baseUrl for TypeScript 6 readiness

### DIFF
--- a/packages/game/tsconfig.json
+++ b/packages/game/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
+      "@/*": ["./src/*"],
       "@shared/*": ["../../shared/*"]
     },
     "types": ["vite/client", "node"]


### PR DESCRIPTION
## Summary

Drops \`baseUrl\` from \`packages/game/tsconfig.json\`. TypeScript 6 reports it as deprecated (TS5101) and fails compilation without an \`ignoreDeprecations\` opt-in; TS 5+ resolves tsconfig \`paths\` relative to the tsconfig file's own directory, so removing \`baseUrl\` is cleaner than silencing the deprecation. Unblocks [#30](https://github.com/amio-love/amiclaw/pull/30).

## Test plan

- [x] \`pnpm --filter game exec tsc --noEmit\` — clean
- [x] \`pnpm --filter api typecheck\` — clean
- [x] \`pnpm test:run\` — 66/66 passing
- [x] \`pnpm build\` — bundles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)