### PR TITLE
fix(onboarding): keep Scene Info bar always visible + prompt AI to read it first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Versions follow [Semantic Versioning](https://semver.org).
   added an explicit `--branch=main` to the deploy command, and dropped
   the unused `gitHubToken` input. Repo secrets shrink from three to two
   (`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`), matching `amio-love/amio`
+- **Onboarding** Scene Info bar is now always visible in-game instead of collapsing
+  behind an unlabelled chevron on mobile — first-time players no longer have to
+  discover and tap a toggle to find the serial number, battery count, and indicator
+  lights their AI partner needs. The standard assistant prompt has also been
+  rewritten to make reading the full Scene Info bar the explicit opening move
+  before any module is attempted
 - **Daily mode** `GamePage` now distinguishes "manual not yet published" (404)
   from generic load failures and renders a dedicated fallback that links to
   Practice mode instead of showing the opaque "Could not load manual" retry

--- a/packages/game/src/components/SceneInfoBar.module.css
+++ b/packages/game/src/components/SceneInfoBar.module.css
@@ -1,37 +1,3 @@
-.wrapper {
-  width: 100%;
-}
-
-/* Toggle button: hidden on desktop, shown on mobile */
-.toggle {
-  display: none;
-  width: 100%;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 4px;
-  padding: 8px 12px;
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  color: var(--color-text-primary);
-  cursor: pointer;
-  text-align: left;
-  gap: 8px;
-  align-items: center;
-  min-height: var(--touch-target);
-}
-
-.toggle:focus-visible {
-  outline: 2px solid var(--color-neon-cyan);
-  outline-offset: 2px;
-}
-
-.chevron {
-  margin-left: auto;
-  color: var(--color-text-muted);
-  font-size: 0.7rem;
-}
-
-/* Details panel */
 .bar {
   display: flex;
   flex-wrap: wrap;
@@ -76,20 +42,4 @@
 .unlit {
   background: var(--color-border);
   color: var(--color-text-muted);
-}
-
-/* Mobile: collapse details behind toggle */
-@media (max-width: 768px) {
-  .toggle {
-    display: flex;
-  }
-
-  .bar {
-    display: none;
-    margin-top: 4px;
-  }
-
-  .bar.open {
-    display: flex;
-  }
 }

--- a/packages/game/src/components/SceneInfoBar.tsx
+++ b/packages/game/src/components/SceneInfoBar.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import type { SceneInfo } from '@shared/manual-schema'
 import styles from './SceneInfoBar.module.css'
 
@@ -6,47 +5,32 @@ interface SceneInfoBarProps {
   sceneInfo: SceneInfo
 }
 
+/**
+ * Permanent HUD row showing the puzzle-global variables the player has to read
+ * to their AI (serial number, battery count, and indicators with lit/unlit
+ * state). Always visible — the earlier mobile collapse hid the single most
+ * important piece of onboarding information behind an unlabelled chevron.
+ */
 export default function SceneInfoBar({ sceneInfo }: SceneInfoBarProps) {
-  const [expanded, setExpanded] = useState(false)
-
   return (
-    <div className={styles.wrapper}>
-      {/* Toggle only visible on mobile via CSS */}
-      <button
-        className={styles.toggle}
-        onClick={() => setExpanded(e => !e)}
-        aria-expanded={expanded}
-        aria-controls="scene-info-details"
-      >
+    <div className={styles.bar} aria-label="Scene information panel">
+      <span className={styles.field}>
         <span className={styles.label}>SN:</span>
         <span className={styles.value}>{sceneInfo.serialNumber}</span>
-        <span className={styles.chevron}>{expanded ? '▲' : '▼'}</span>
-      </button>
-
-      {/* Details: always visible on desktop, toggle on mobile */}
-      <div
-        id="scene-info-details"
-        className={`${styles.bar} ${expanded ? styles.open : ''}`}
-        aria-label="Scene information panel"
-      >
-        <span className={styles.field}>
-          <span className={styles.label}>SN:</span>
-          <span className={styles.value}>{sceneInfo.serialNumber}</span>
+      </span>
+      <span className={styles.field}>
+        <span className={styles.label}>BATT:</span>
+        <span className={styles.value}>{sceneInfo.batteryCount}</span>
+      </span>
+      {sceneInfo.indicators.map((ind, i) => (
+        <span
+          key={`${ind.label}-${i}`}
+          className={`${styles.indicator} ${ind.lit ? styles.lit : styles.unlit}`}
+          title={ind.lit ? `${ind.label} (lit)` : `${ind.label} (unlit)`}
+        >
+          {ind.label}
         </span>
-        <span className={styles.field}>
-          <span className={styles.label}>BATT:</span>
-          <span className={styles.value}>{sceneInfo.batteryCount}</span>
-        </span>
-        {sceneInfo.indicators.map((ind, i) => (
-          <span
-            key={`${ind.label}-${i}`}
-            className={`${styles.indicator} ${ind.lit ? styles.lit : styles.unlit}`}
-            title={ind.lit ? `${ind.label} (lit)` : `${ind.label} (unlit)`}
-          >
-            {ind.label}
-          </span>
-        ))}
-      </div>
+      ))}
     </div>
   )
 }

--- a/packages/game/src/utils/assistant-prompt.ts
+++ b/packages/game/src/utils/assistant-prompt.ts
@@ -19,10 +19,12 @@ Please read the complete manual first, then tell your partner you are ready.
 
 ${modeBrief}
 
+Opening move (do this BEFORE the first module):
+Ask your partner to read the entire Scene Info bar at the bottom of the screen. It contains the serial number, the battery count, and zero or more indicator lights. For each indicator they must tell you the label AND whether it is lit or unlit — many rules depend on the unlit ones too. These values stay the same for the whole run, so note them once and reuse across modules.
+
 Rules:
 - They will describe what they see via voice
 - You find the matching rules and tell them what to do
 - Shorter time = higher global rank on daily runs
-- Ask about the Scene Info bar (serial number, battery count, indicator lights) — many rules depend on these
 - Give concise instructions; ask follow-up questions if unsure`
 }


### PR DESCRIPTION
## Summary

- Scene Info bar (SN / BATT / indicators) is no longer collapsed behind an unlabelled chevron at mobile widths. A first-time player had no way to discover the toggle, so the single most important run-global state was effectively hidden.
- Assistant prompt rewritten so reading the entire Scene Info bar — serial number, battery count, and every indicator's lit/unlit state — is the explicit opening move before the first module, instead of being one bullet among five generic rules.
- Removed the \`useState\` + toggle button + mobile \`@media\` branch entirely; the bar already wraps with flex-wrap.

## Test plan

- [x] \`pnpm test:run\` — 66/66 passing (assistant-prompt tests still match "practice mode" / "daily challenge" substrings)
- [x] \`pnpm lint\` — clean
- [x] \`pnpm build\` — bundles cleanly
- [x] Visual check via the Vite preview at mobile width — SN / BATT / BOB / CAR all render without any user interaction on entering WIRE ROUTING

🤖 Generated with [Claude Code](https://claude.com/claude-code)