### PR TITLE
feat(i18n): translate UI and manual prose to Simplified Chinese

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ### Improvements
 
+- **Localization** Full Simplified-Chinese translation of every player-facing
+  string — home page, game HUD, Scene Info bar labels, result page, leaderboard,
+  404 "manual not published" fallback, assistant prompt, and the human-readable
+  banner on the manual page. Schema values (wire colors, symbol IDs, module
+  slugs) remain English because they are matched as enum IDs by generators and
+  solvers; the AI bridges Chinese player descriptions to the English data
 - **Cloudflare Pages deployment** GitHub Actions can now build the monorepo and
   publish the assembled Pages artifact with `wrangler pages deploy`, avoiding
   the broken dashboard deploy-command path.

--- a/packages/game/index.html
+++ b/packages/game/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BombSquad — AmiClaw</title>
+    <title>BombSquad 拆弹小队 — AmiClaw</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/game/src/components/ProgressBar.tsx
+++ b/packages/game/src/components/ProgressBar.tsx
@@ -1,9 +1,9 @@
 import styles from './ProgressBar.module.css'
 
 interface ProgressBarProps {
-  total: number      // always 4 for MVP
+  total: number // always 4 for MVP
   completed: number
-  current: number    // index of active module
+  current: number // index of active module
 }
 
 export default function ProgressBar({ total, completed, current }: ProgressBarProps) {
@@ -13,7 +13,7 @@ export default function ProgressBar({ total, completed, current }: ProgressBarPr
       role="progressbar"
       aria-valuenow={completed}
       aria-valuemax={total}
-      aria-label={`${completed} of ${total} modules complete`}
+      aria-label={`已完成 ${completed} / ${total} 个模块`}
     >
       {Array.from({ length: total }, (_, i) => {
         let segClass = styles.segment
@@ -23,7 +23,7 @@ export default function ProgressBar({ total, completed, current }: ProgressBarPr
           <span
             key={i}
             className={segClass}
-            aria-label={`Module ${i + 1}: ${i < completed ? 'complete' : i === current ? 'in progress' : 'pending'}`}
+            aria-label={`模块 ${i + 1}：${i < completed ? '已完成' : i === current ? '进行中' : '待拆'}`}
           />
         )
       })}

--- a/packages/game/src/components/SceneInfoBar.tsx
+++ b/packages/game/src/components/SceneInfoBar.tsx
@@ -13,20 +13,20 @@ interface SceneInfoBarProps {
  */
 export default function SceneInfoBar({ sceneInfo }: SceneInfoBarProps) {
   return (
-    <div className={styles.bar} aria-label="Scene information panel">
+    <div className={styles.bar} aria-label="场景信息栏">
       <span className={styles.field}>
-        <span className={styles.label}>SN:</span>
+        <span className={styles.label}>序号：</span>
         <span className={styles.value}>{sceneInfo.serialNumber}</span>
       </span>
       <span className={styles.field}>
-        <span className={styles.label}>BATT:</span>
+        <span className={styles.label}>电池：</span>
         <span className={styles.value}>{sceneInfo.batteryCount}</span>
       </span>
       {sceneInfo.indicators.map((ind, i) => (
         <span
           key={`${ind.label}-${i}`}
           className={`${styles.indicator} ${ind.lit ? styles.lit : styles.unlit}`}
-          title={ind.lit ? `${ind.label} (lit)` : `${ind.label} (unlit)`}
+          title={ind.lit ? `${ind.label}（亮）` : `${ind.label}（灭）`}
         >
           {ind.label}
         </span>

--- a/packages/game/src/components/Timer.tsx
+++ b/packages/game/src/components/Timer.tsx
@@ -1,7 +1,7 @@
 import styles from './Timer.module.css'
 
 interface TimerProps {
-  display: string     // MM:SS from useTimer
+  display: string // MM:SS from useTimer
   isRunning: boolean
 }
 
@@ -10,7 +10,7 @@ export default function Timer({ display, isRunning }: TimerProps) {
     <div
       className={`${styles.timer} ${isRunning ? styles.running : ''}`}
       role="timer"
-      aria-label={`Elapsed time: ${display}`}
+      aria-label={`已用时间：${display}`}
     >
       {display}
     </div>

--- a/packages/game/src/game-flow.test.tsx
+++ b/packages/game/src/game-flow.test.tsx
@@ -15,22 +15,30 @@ import App from './App'
 
 vi.mock('./modules/wire/WireModule', () => ({
   default: ({ onComplete }: { onComplete: () => void }) => (
-    <button data-testid="mock-wire-complete" onClick={onComplete}>complete-wire</button>
+    <button data-testid="mock-wire-complete" onClick={onComplete}>
+      complete-wire
+    </button>
   ),
 }))
 vi.mock('./modules/dial/DialModule', () => ({
   default: ({ onComplete }: { onComplete: () => void }) => (
-    <button data-testid="mock-dial-complete" onClick={onComplete}>complete-dial</button>
+    <button data-testid="mock-dial-complete" onClick={onComplete}>
+      complete-dial
+    </button>
   ),
 }))
 vi.mock('./modules/button/ButtonModule', () => ({
   default: ({ onComplete }: { onComplete: () => void }) => (
-    <button data-testid="mock-button-complete" onClick={onComplete}>complete-button</button>
+    <button data-testid="mock-button-complete" onClick={onComplete}>
+      complete-button
+    </button>
   ),
 }))
 vi.mock('./modules/keypad/KeypadModule', () => ({
   default: ({ onComplete }: { onComplete: () => void }) => (
-    <button data-testid="mock-keypad-complete" onClick={onComplete}>complete-keypad</button>
+    <button data-testid="mock-keypad-complete" onClick={onComplete}>
+      complete-keypad
+    </button>
   ),
 }))
 
@@ -47,44 +55,39 @@ const MODULE_TESTIDS = [
 ]
 
 describe('full game flow: home → practice → result', () => {
-  it(
-    'navigates through the full practice run and shows DEFUSED on result page',
-    async () => {
-      render(
-        <MemoryRouter initialEntries={['/']}>
-          <App />
-        </MemoryRouter>,
-      )
+  it('navigates through the full practice run and shows DEFUSED on result page', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App />
+      </MemoryRouter>
+    )
 
-      // Home page
-      expect(screen.getByText('BOMBSQUAD')).toBeInTheDocument()
+    // Home page
+    expect(screen.getByText('BOMBSQUAD')).toBeInTheDocument()
 
-      // Navigate to practice game
-      fireEvent.click(screen.getByRole('button', { name: /^PRACTICE$/i }))
+    // Navigate to practice game
+    fireEvent.click(screen.getByRole('button', { name: /^练习$/ }))
 
-      // Practice manual is inlined via ?raw — wait for the async load() microtask to complete
-      await waitFor(() => expect(screen.getByText('READY?')).toBeInTheDocument())
+    // Practice manual is inlined via ?raw — wait for the async load() microtask to complete
+    await waitFor(() => expect(screen.getByText('准备好了吗？')).toBeInTheDocument())
 
-      // Start the game
-      fireEvent.click(screen.getByRole('button', { name: /START/i }))
+    // Start the game
+    fireEvent.click(screen.getByRole('button', { name: /^开始$/ }))
 
-      // Complete all 4 modules.
-      // Each module has a unique testid so we wait for the correct one to mount
-      // before clicking — avoids re-clicking the same button during the 800 ms
-      // MODULE_COMPLETE overlay.
-      for (const testId of MODULE_TESTIDS) {
-        await waitFor(() => expect(screen.getByTestId(testId)).toBeInTheDocument(),
-          { timeout: 3000 })
-        fireEvent.click(screen.getByTestId(testId))
-      }
+    // Complete all 4 modules.
+    // Each module has a unique testid so we wait for the correct one to mount
+    // before clicking — avoids re-clicking the same button during the 800 ms
+    // MODULE_COMPLETE overlay.
+    for (const testId of MODULE_TESTIDS) {
+      await waitFor(() => expect(screen.getByTestId(testId)).toBeInTheDocument(), { timeout: 3000 })
+      fireEvent.click(screen.getByTestId(testId))
+    }
 
-      // After the 4th module: MODULE_COMPLETE → (800 ms) → NEXT_MODULE → ALL_COMPLETE
-      // → ALL_MODULES_COMPLETE → RESULT → navigate('/result') → ResultPage renders.
-      await waitFor(
-        () => expect(screen.getByRole('heading', { name: /DEFUSED/i })).toBeInTheDocument(),
-        { timeout: 5000 },
-      )
-    },
-    12000,
-  )
+    // After the 4th module: MODULE_COMPLETE → (800 ms) → NEXT_MODULE → ALL_COMPLETE
+    // → ALL_MODULES_COMPLETE → RESULT → navigate('/result') → ResultPage renders.
+    await waitFor(
+      () => expect(screen.getByRole('heading', { name: /拆弹成功/ })).toBeInTheDocument(),
+      { timeout: 5000 }
+    )
+  }, 12000)
 })

--- a/packages/game/src/pages/GamePage.tsx
+++ b/packages/game/src/pages/GamePage.tsx
@@ -21,7 +21,7 @@ import practiceYamlRaw from '../../../manual/data/practice.yaml?raw'
 import { getAttemptNumberForMode, getRunSeed } from '@/utils/session'
 import styles from './GamePage.module.css'
 
-const MODULE_NAMES = ['WIRE ROUTING', 'SYMBOL DIAL', 'BIG BUTTON', 'KEYPAD'] as const
+const MODULE_NAMES = ['线路', '密码盘', '按钮', '键盘'] as const
 
 const INDICATOR_LABELS = ['FRK', 'CAR', 'NSA', 'MSA', 'SND', 'CLR', 'BOB', 'TRN']
 const SERIAL_CHARS = 'ABCDEFGHJKLMNPRSTUVWXYZ0123456789'
@@ -73,7 +73,7 @@ async function loadWithCache(manualUrl: string): Promise<Manual> {
     if (err instanceof ManualNotFoundError) throw err
     const cached = sessionStorage.getItem(cacheKey)
     if (cached) return yaml.load(cached) as Manual
-    throw new Error('Could not load manual. Check your connection.')
+    throw new Error('手册加载失败，请检查网络。')
   }
 }
 
@@ -127,7 +127,7 @@ export default function GamePage() {
           console.error('Generator exhaustion:', genErr)
           dispatch({
             type: 'LOAD_ERROR',
-            message: 'Puzzle generation failed. Please restart.',
+            message: '谜题生成失败，请重新开始。',
           })
           return
         }
@@ -144,7 +144,7 @@ export default function GamePage() {
         const notPublished = err instanceof ManualNotFoundError
         dispatch({
           type: 'LOAD_ERROR',
-          message: err instanceof Error ? err.message : 'Failed to load manual',
+          message: err instanceof Error ? err.message : '手册加载失败',
           kind: notPublished ? 'not_published' : 'generic',
         })
       }
@@ -264,33 +264,33 @@ export default function GamePage() {
             state.errorKind === 'not_published' ? (
               <>
                 <p className={styles.errorText}>
-                  Today&apos;s manual is not published yet.
+                  今天的手册还没发布。
                   <br />
-                  Try Practice mode, or come back later.
+                  可以先玩练习模式，或稍后再来。
                 </p>
                 <button
                   className={styles.startBtn}
                   onClick={() => navigate('/game?mode=practice', { replace: true })}
                 >
-                  TRY PRACTICE
+                  去练习
                 </button>
                 <Link to="/" className={styles.homeLink}>
-                  ← Go Home
+                  ← 返回首页
                 </Link>
               </>
             ) : (
               <>
                 <p className={styles.errorText}>{state.errorMessage}</p>
                 <button className={styles.retryBtn} onClick={() => window.location.reload()}>
-                  RETRY
+                  重试
                 </button>
                 <Link to="/" className={styles.homeLink}>
-                  ← Go Home
+                  ← 返回首页
                 </Link>
               </>
             )
           ) : (
-            <p className={styles.loadingText}>LOADING MANUAL…</p>
+            <p className={styles.loadingText}>加载手册中…</p>
           )}
         </div>
       </main>
@@ -302,9 +302,9 @@ export default function GamePage() {
     return (
       <main className={styles.page}>
         <div className={styles.overlay}>
-          <p className={styles.readyText}>READY?</p>
+          <p className={styles.readyText}>准备好了吗？</p>
           <button className={styles.startBtn} onClick={() => dispatch({ type: 'START_GAME' })}>
-            START
+            开始
           </button>
         </div>
       </main>
@@ -317,8 +317,8 @@ export default function GamePage() {
       <div className={styles.topBar}>
         <Timer display={timerDisplay} isRunning={isRunning} />
         <div className={styles.modeMeta}>
-          <div>{mode === 'daily' ? 'DAILY' : 'PRACTICE'}</div>
-          <div>{mode === 'daily' ? `ATTEMPT #${state.attemptNumber}` : 'LOCAL PRACTICE'}</div>
+          <div>{mode === 'daily' ? '每日' : '练习'}</div>
+          <div>{mode === 'daily' ? `第 ${state.attemptNumber} 次` : '本地练习'}</div>
         </div>
       </div>
 
@@ -340,7 +340,7 @@ export default function GamePage() {
 
       {state.status === 'MODULE_COMPLETE' && (
         <div className={styles.overlay}>
-          <p className={styles.defusedText}>DEFUSED</p>
+          <p className={styles.defusedText}>拆除成功</p>
         </div>
       )}
     </main>

--- a/packages/game/src/pages/HomePage.tsx
+++ b/packages/game/src/pages/HomePage.tsx
@@ -6,10 +6,10 @@ import { buildAssistantPrompt, type PromptMode } from '@/utils/assistant-prompt'
 import styles from './HomePage.module.css'
 
 const HOW_TO_STEPS = [
-  'Open your AI (Claude, ChatGPT, Gemini…) in voice mode on another device or tab.',
-  'Pick Practice Prompt or Daily Prompt, then send the copied prompt to your AI. Wait for it to confirm it has read the manual.',
-  'Click Practice or Daily Challenge, then hit Start when your AI is ready.',
-  'Describe what you see — your AI will guide you. Shorter time = higher rank.',
+  '在另一个窗口/设备打开你的 AI（Claude、ChatGPT、Gemini…）并切到语音模式。',
+  '选「练习 Prompt」或「每日 Prompt」，复制后发给 AI。等它说读完手册了。',
+  'AI 就位后，点「练习」或「每日挑战」，然后按「开始」。',
+  '描述你看到的场景，AI 会告诉你怎么操作。用时越短，排名越高。',
 ]
 
 export default function HomePage() {
@@ -32,29 +32,26 @@ export default function HomePage() {
   return (
     <main className={styles.page}>
       <h1 className={styles.title}>BOMBSQUAD</h1>
-      <p className={styles.subtitle}>Human + AI · Voice-based bomb defusal</p>
+      <p className={styles.subtitle}>人机协作 · 语音拆弹挑战</p>
 
       <div className={styles.ctaRow}>
-        <button
-          className={styles.btnSecondary}
-          onClick={() => navigate('/game?mode=practice')}
-        >
-          PRACTICE
+        <button className={styles.btnSecondary} onClick={() => navigate('/game?mode=practice')}>
+          练习
         </button>
         <button
           className={styles.btnPrimary}
           onClick={() => navigate(`/game?mode=daily&url=${encodeURIComponent(dailyUrl)}`)}
         >
-          DAILY CHALLENGE
+          每日挑战
         </button>
       </div>
 
       <Link to="/leaderboard" className={styles.leaderboardLink}>
-        Leaderboard →
+        排行榜 →
       </Link>
 
-      <section className={styles.howTo} aria-label="How to start">
-        <h2 className={styles.howToTitle}>How to Start</h2>
+      <section className={styles.howTo} aria-label="怎么开始">
+        <h2 className={styles.howToTitle}>怎么开始</h2>
         <ol className={styles.howToList}>
           {HOW_TO_STEPS.map((step, i) => (
             <li key={i}>
@@ -65,16 +62,16 @@ export default function HomePage() {
         </ol>
       </section>
 
-      <section className={styles.promptSection} aria-label="AI prompt">
-        <div className={styles.promptLabel}>Copy this prompt for your AI</div>
-        <div className={styles.promptModeRow} role="group" aria-label="Prompt mode">
+      <section className={styles.promptSection} aria-label="AI Prompt">
+        <div className={styles.promptLabel}>复制这段 Prompt 给你的 AI</div>
+        <div className={styles.promptModeRow} role="group" aria-label="Prompt 模式">
           <button
             type="button"
             className={`${styles.promptModeBtn} ${promptMode === 'practice' ? styles.promptModeActive : ''}`}
             onClick={() => setPromptMode('practice')}
             aria-pressed={promptMode === 'practice'}
           >
-            Practice Prompt
+            练习 Prompt
           </button>
           <button
             type="button"
@@ -82,7 +79,7 @@ export default function HomePage() {
             onClick={() => setPromptMode('daily')}
             aria-pressed={promptMode === 'daily'}
           >
-            Daily Prompt
+            每日 Prompt
           </button>
         </div>
         <div className={styles.promptBox}>
@@ -90,14 +87,14 @@ export default function HomePage() {
           <button
             className={`${styles.copyBtn} ${copied ? styles.copied : ''}`}
             onClick={handleCopy}
-            aria-label="Copy prompt to clipboard"
+            aria-label="复制 Prompt 到剪贴板"
           >
-            {copied ? 'COPIED!' : 'COPY'}
+            {copied ? '已复制！' : '复制'}
           </button>
         </div>
       </section>
 
-      <p className={styles.footer}>Works with Claude · ChatGPT · Gemini · any voice AI</p>
+      <p className={styles.footer}>支持 Claude · ChatGPT · Gemini 或任意语音 AI</p>
     </main>
   )
 }

--- a/packages/game/src/pages/LeaderboardPage.tsx
+++ b/packages/game/src/pages/LeaderboardPage.tsx
@@ -19,7 +19,7 @@ export default function LeaderboardPage() {
   const [error, setError] = useState(false)
 
   useEffect(() => {
-    fetchLeaderboard(today).then(data => {
+    fetchLeaderboard(today).then((data) => {
       setLoading(false)
       if (data) {
         setEntries(data.entries)
@@ -31,28 +31,28 @@ export default function LeaderboardPage() {
 
   return (
     <main className={styles.page}>
-      <h1 className={styles.title}>LEADERBOARD</h1>
-      <p className={styles.notice}>DAILY — {today}</p>
+      <h1 className={styles.title}>排行榜</h1>
+      <p className={styles.notice}>每日 — {today}</p>
 
-      {loading && <p className={styles.status}>Loading…</p>}
-      {error && <p className={styles.status}>Leaderboard unavailable. Check back later.</p>}
+      {loading && <p className={styles.status}>加载中…</p>}
+      {error && <p className={styles.status}>排行榜暂不可用，稍后再试。</p>}
 
       {!loading && !error && entries.length === 0 && (
-        <p className={styles.status}>No scores yet today. Be the first!</p>
+        <p className={styles.status}>今日还没有成绩，来抢第一！</p>
       )}
 
       {entries.length > 0 && (
         <table className={styles.table}>
           <thead>
             <tr>
-              <th>Rank</th>
-              <th>Nickname</th>
-              <th>Time</th>
-              <th>Attempts</th>
+              <th>排名</th>
+              <th>昵称</th>
+              <th>用时</th>
+              <th>次数</th>
             </tr>
           </thead>
           <tbody>
-            {entries.map(row => (
+            {entries.map((row) => (
               <tr key={row.rank}>
                 <td className={styles.rank}>#{row.rank}</td>
                 <td>{row.nickname}</td>
@@ -64,7 +64,9 @@ export default function LeaderboardPage() {
         </table>
       )}
 
-      <Link to="/" className={styles.link}>← Home</Link>
+      <Link to="/" className={styles.link}>
+        ← 首页
+      </Link>
     </main>
   )
 }

--- a/packages/game/src/pages/ResultPage.tsx
+++ b/packages/game/src/pages/ResultPage.tsx
@@ -8,7 +8,7 @@ import { submitScore } from '@/utils/leaderboard-api'
 import type { ScoreSubmissionResponse } from '@shared/leaderboard-types'
 import styles from './ResultPage.module.css'
 
-const MODULE_LABELS = ['Wire', 'Dial', 'Button', 'Keypad']
+const MODULE_LABELS = ['线路', '密码盘', '按钮', '键盘']
 
 function formatMs(ms: number): string {
   const total = Math.floor(ms / 1000)
@@ -110,32 +110,29 @@ export default function ResultPage() {
 
   const buildSummary = useCallback(() => {
     const date = getTodayString()
-    const modeLabel =
-      state.mode === 'daily' ? `Daily Challenge (Attempt #${state.attemptNumber})` : 'Practice'
+    const modeLabel = state.mode === 'daily' ? `每日挑战（第 ${state.attemptNumber} 次）` : '练习'
     const timeStr = totalMs !== null ? formatMs(totalMs) : '--:--'
     const breakdown = state.moduleStats
       .map((s, i) => {
         const name = MODULE_LABELS[i] ?? s.moduleType
         const t = formatMs(s.timeMs)
         const resets = s.errorCount
-        return `${i + 1}. ${name.padEnd(7)} — ${t}  (${resets} reset${resets !== 1 ? 's' : ''})`
+        return `${i + 1}. ${name} — ${t}（重置 ${resets} 次）`
       })
       .join('\n')
-    const rankLine = rankResult
-      ? `Global Rank: #${rankResult.rank} of ${rankResult.total_players}`
-      : ''
+    const rankLine = rankResult ? `全球排名：#${rankResult.rank} / ${rankResult.total_players}` : ''
 
-    return `=== BombSquad Result ===
-Date: ${date}
-Mode: ${modeLabel}
-Result: Success ✓
-Total Time: ${timeStr}
+    return `=== BombSquad 赛后摘要 ===
+日期：${date}
+模式：${modeLabel}
+结果：拆弹成功 ✓
+总用时：${timeStr}
 ${rankLine ? `${rankLine}\n` : ''}
-Module Breakdown:
+模块详情：
 ${breakdown}
 
-Debrief prompt:
-Review our run and tell me: what caused the most delays, and what should we add to our strategy?`
+复盘提问：
+帮我看看这一局 —— 哪一块拖了最多时间？我们下次该怎么改进沟通？`
   }, [state, totalMs, rankResult])
 
   const handleCopySummary = async () => {
@@ -150,9 +147,9 @@ Review our run and tell me: what caused the most delays, and what should we add 
     return (
       <main className={styles.page}>
         <p className={styles.noData}>
-          No game data.{' '}
+          暂无数据。{' '}
           <Link to="/" className={styles.link}>
-            Go Home
+            返回首页
           </Link>
         </p>
       </main>
@@ -161,28 +158,28 @@ Review our run and tell me: what caused the most delays, and what should we add 
 
   return (
     <main className={styles.page}>
-      <h1 className={`${styles.header} ${styles.headerDefused}`}>DEFUSED</h1>
+      <h1 className={`${styles.header} ${styles.headerDefused}`}>拆弹成功</h1>
 
       {totalMs !== null && <div className={styles.totalTime}>{formatMs(totalMs)}</div>}
 
       <p className={styles.meta}>
-        {state.mode === 'daily' ? `Daily Challenge — Attempt #${state.attemptNumber}` : 'Practice'}
+        {state.mode === 'daily' ? `每日挑战 — 第 ${state.attemptNumber} 次` : '练习'}
       </p>
 
       {state.mode === 'daily' && (
         <div className={styles.rankBlock}>
-          {submitting && <span className={styles.rankMuted}>Submitting score…</span>}
+          {submitting && <span className={styles.rankMuted}>提交成绩中…</span>}
           {rankResult && (
             <span className={styles.rankValue}>
-              Global Rank: <strong>#{rankResult.rank}</strong> / {rankResult.total_players}
+              全球排名：<strong>#{rankResult.rank}</strong> / {rankResult.total_players}
             </span>
           )}
           {submitFailed && (
             <span className={styles.rankMuted}>
-              Could not submit score (offline?)
+              提交失败（可能离线）
               {!retried && (
                 <button className={styles.retryBtn} onClick={handleRetrySubmit}>
-                  Try again
+                  重试
                 </button>
               )}
             </span>
@@ -191,14 +188,14 @@ Review our run and tell me: what caused the most delays, and what should we add 
       )}
 
       <section className={styles.section}>
-        <h2 className={styles.sectionTitle}>Module Breakdown</h2>
+        <h2 className={styles.sectionTitle}>模块用时</h2>
         <table className={styles.table}>
           <thead>
             <tr>
               <th>#</th>
-              <th>Module</th>
-              <th>Time</th>
-              <th>Resets</th>
+              <th>模块</th>
+              <th>用时</th>
+              <th>重置</th>
             </tr>
           </thead>
           <tbody>
@@ -216,20 +213,20 @@ Review our run and tell me: what caused the most delays, and what should we add 
 
       <div className={styles.actions}>
         <button className={styles.btnPlayAgain} onClick={handlePlayAgain}>
-          PLAY AGAIN
+          再来一局
         </button>
         <button
           className={`${styles.copyBtn} ${copied ? styles.copied : ''}`}
           onClick={handleCopySummary}
         >
-          {copied ? 'COPIED!' : 'Copy Run Summary'}
+          {copied ? '已复制！' : '复制赛后摘要'}
         </button>
         <div className={styles.secondaryLinks}>
           <Link to="/leaderboard" className={styles.link}>
-            Leaderboard
+            排行榜
           </Link>
           <Link to="/" className={styles.link}>
-            Home
+            首页
           </Link>
         </div>
       </div>

--- a/packages/game/src/utils/assistant-prompt.test.ts
+++ b/packages/game/src/utils/assistant-prompt.test.ts
@@ -9,7 +9,7 @@ describe('buildAssistantPrompt', () => {
     })
 
     expect(prompt).toContain('https://bombsquad.amio.fans/manual/practice')
-    expect(prompt).toContain('This is practice mode.')
+    expect(prompt).toContain('这是练习模式')
   })
 
   it('uses the dated manual URL in daily prompts', () => {
@@ -19,6 +19,15 @@ describe('buildAssistantPrompt', () => {
     })
 
     expect(prompt).toContain('https://bombsquad.amio.fans/manual/2026-03-27')
-    expect(prompt).toContain('This is the daily challenge.')
+    expect(prompt).toContain('这是每日挑战')
+  })
+
+  it('includes the Scene Info opening move for both modes', () => {
+    for (const mode of ['practice', 'daily'] as const) {
+      const prompt = buildAssistantPrompt({ mode, manualUrl: 'x' })
+      expect(prompt).toContain('场景信息栏')
+      expect(prompt).toContain('序列号')
+      expect(prompt).toContain('指示灯')
+    }
   })
 })

--- a/packages/game/src/utils/assistant-prompt.ts
+++ b/packages/game/src/utils/assistant-prompt.ts
@@ -8,23 +8,23 @@ interface PromptOptions {
 export function buildAssistantPrompt({ mode, manualUrl }: PromptOptions): string {
   const modeBrief =
     mode === 'daily'
-      ? 'This is the daily challenge. The manual stays fixed for the whole day, but each run generates a new puzzle.'
-      : 'This is practice mode. Use it to learn the communication flow before attempting the daily challenge.'
+      ? '这是每日挑战。手册一整天不变，但每一局会随机生成新的谜题。'
+      : '这是练习模式。用它来熟悉沟通节奏，再去挑战每日关卡。'
 
-  return `You are a bomb disposal expert. Your partner is facing a bomb and needs your guidance.
+  return `你是一位拆弹专家，你的搭档正面对一颗炸弹，需要你通过手册指导她拆除。
 
-The operations manual is here: ${manualUrl}
+操作手册在这里：${manualUrl}
 
-Please read the complete manual first, then tell your partner you are ready.
+请先完整读完手册，然后告诉你的搭档你已准备好。
 
 ${modeBrief}
 
-Opening move (do this BEFORE the first module):
-Ask your partner to read the entire Scene Info bar at the bottom of the screen. It contains the serial number, the battery count, and zero or more indicator lights. For each indicator they must tell you the label AND whether it is lit or unlit — many rules depend on the unlit ones too. These values stay the same for the whole run, so note them once and reuse across modules.
+开局第一步（在进入第一个模块之前必须完成）：
+让搭档读出屏幕底部"场景信息栏"里的全部内容——序列号、电池数，以及零个或多个指示灯。每个指示灯都要告诉你标签名和它是**亮**还是**灭**，因为很多规则对"灭"的指示灯也有依赖。这些值整局不变，记一次就可以在所有模块里复用。
 
-Rules:
-- They will describe what they see via voice
-- You find the matching rules and tell them what to do
-- Shorter time = higher global rank on daily runs
-- Give concise instructions; ask follow-up questions if unsure`
+几条通则：
+- 搭档会用语音描述她在屏幕上看到的
+- 你从手册里查规则，再简洁地告诉她怎么操作
+- 用时越短，每日挑战的全球排名越高
+- 不确定时先复述确认，不要靠猜`
 }

--- a/packages/manual/data/practice.yaml
+++ b/packages/manual/data/practice.yaml
@@ -1,177 +1,177 @@
 meta:
-  version: "practice"
+  version: 'practice'
   type: practice
 
 modules:
   wire_routing:
     rules:
-      - condition: { wire_count: 4, color_at_last: "red" }
-        action: "cut_wire"
-        target: { position: "last" }
-      - condition: { wire_count: 4, color_at_last: "blue" }
-        action: "cut_wire"
-        target: { position: "first" }
-      - condition: { wire_count: 4, color_at_last: "yellow" }
-        action: "cut_wire"
-        target: { position: "last", color: "red" }
-      - condition: { wire_count: 4, color_at_last: "white" }
-        action: "cut_wire"
+      - condition: { wire_count: 4, color_at_last: 'red' }
+        action: 'cut_wire'
+        target: { position: 'last' }
+      - condition: { wire_count: 4, color_at_last: 'blue' }
+        action: 'cut_wire'
+        target: { position: 'first' }
+      - condition: { wire_count: 4, color_at_last: 'yellow' }
+        action: 'cut_wire'
+        target: { position: 'last', color: 'red' }
+      - condition: { wire_count: 4, color_at_last: 'white' }
+        action: 'cut_wire'
         target: { position: 1 }
-      - condition: { wire_count: 4, color_at_last: "green" }
-        action: "cut_wire"
-        target: { position: "last" }
-      - condition: { wire_count: 4, color_at_last: "black" }
-        action: "cut_wire"
-        target: { position: "first" }
+      - condition: { wire_count: 4, color_at_last: 'green' }
+        action: 'cut_wire'
+        target: { position: 'last' }
+      - condition: { wire_count: 4, color_at_last: 'black' }
+        action: 'cut_wire'
+        target: { position: 'first' }
       - condition: { wire_count: 4, count_red: { gt: 1 } }
-        action: "cut_wire"
-        target: { position: "last", color: "red" }
+        action: 'cut_wire'
+        target: { position: 'last', color: 'red' }
       - condition: { wire_count: 4, battery_count: { gt: 2 } }
-        action: "cut_wire"
+        action: 'cut_wire'
         target: { position: 2 }
       - condition: { wire_count: 4 }
-        action: "cut_wire"
-        target: { position: "first" }
-      - condition: { wire_count: 5, color_at_last: "red" }
-        action: "cut_wire"
+        action: 'cut_wire'
+        target: { position: 'first' }
+      - condition: { wire_count: 5, color_at_last: 'red' }
+        action: 'cut_wire'
         target: { position: 3 }
-      - condition: { wire_count: 5, color_at_last: "blue" }
-        action: "cut_wire"
-        target: { position: "last" }
-      - condition: { wire_count: 5, color_at_last: "yellow" }
-        action: "cut_wire"
-        target: { position: "first" }
+      - condition: { wire_count: 5, color_at_last: 'blue' }
+        action: 'cut_wire'
+        target: { position: 'last' }
+      - condition: { wire_count: 5, color_at_last: 'yellow' }
+        action: 'cut_wire'
+        target: { position: 'first' }
       - condition: { wire_count: 5, count_blue: { gt: 1 } }
-        action: "cut_wire"
-        target: { position: "first", color: "blue" }
+        action: 'cut_wire'
+        target: { position: 'first', color: 'blue' }
       - condition: { wire_count: 5, indicator_FRK_lit: true }
-        action: "cut_wire"
+        action: 'cut_wire'
         target: { position: 2 }
       - condition: { wire_count: 5 }
-        action: "cut_wire"
+        action: 'cut_wire'
         target: { position: 2 }
       - condition: {}
-        action: "cut_wire"
-        target: { position: "first" }
+        action: 'cut_wire'
+        target: { position: 'first' }
 
   symbol_dial:
     columns:
-      - ["omega", "psi", "star", "delta", "xi", "diamond"]
-      - ["psi", "diamond", "omega", "trident", "xi", "delta"]
-      - ["star", "xi", "delta", "psi", "diamond", "omega"]
-      - ["delta", "star", "diamond", "xi", "omega", "psi"]
-      - ["xi", "delta", "psi", "omega", "star", "trident"]
-      - ["diamond", "omega", "xi", "star", "psi", "delta"]
-    rule: "Find the column containing all 3 dial symbols. Set each dial to that symbol's position in the column."
+      - ['omega', 'psi', 'star', 'delta', 'xi', 'diamond']
+      - ['psi', 'diamond', 'omega', 'trident', 'xi', 'delta']
+      - ['star', 'xi', 'delta', 'psi', 'diamond', 'omega']
+      - ['delta', 'star', 'diamond', 'xi', 'omega', 'psi']
+      - ['xi', 'delta', 'psi', 'omega', 'star', 'trident']
+      - ['diamond', 'omega', 'xi', 'star', 'psi', 'delta']
+    rule: '找到同时包含场景中全部 3 个轮盘符号的那一列，按该列从上到下的顺序把每个轮盘转到对应位置。'
 
   button:
     rules:
-      - condition: { color: "blue", label: "ABORT" }
-        action: { type: "hold", release_on_light: "white" }
-      - condition: { color: "blue", label: "DETONATE" }
-        action: { type: "tap" }
-      - condition: { color: "red", label: "HOLD" }
-        action: { type: "tap" }
-      - condition: { color: "red", indicator_FRK_lit: true }
-        action: { type: "tap" }
-      - condition: { color: "yellow", battery_count: { gt: 2 } }
-        action: { type: "hold", release_on_light: "yellow" }
-      - condition: { color: "yellow" }
-        action: { type: "tap" }
-      - condition: { color: "white", label: "PRESS" }
-        action: { type: "hold", release_on_light: "blue" }
-      - condition: { color: "white" }
-        action: { type: "tap" }
-      - condition: { battery_count: { gt: 2 }, label: "DETONATE" }
-        action: { type: "tap" }
+      - condition: { color: 'blue', label: 'ABORT' }
+        action: { type: 'hold', release_on_light: 'white' }
+      - condition: { color: 'blue', label: 'DETONATE' }
+        action: { type: 'tap' }
+      - condition: { color: 'red', label: 'HOLD' }
+        action: { type: 'tap' }
+      - condition: { color: 'red', indicator_FRK_lit: true }
+        action: { type: 'tap' }
+      - condition: { color: 'yellow', battery_count: { gt: 2 } }
+        action: { type: 'hold', release_on_light: 'yellow' }
+      - condition: { color: 'yellow' }
+        action: { type: 'tap' }
+      - condition: { color: 'white', label: 'PRESS' }
+        action: { type: 'hold', release_on_light: 'blue' }
+      - condition: { color: 'white' }
+        action: { type: 'tap' }
+      - condition: { battery_count: { gt: 2 }, label: 'DETONATE' }
+        action: { type: 'tap' }
       - condition: { battery_count: { lte: 2 } }
-        action: { type: "hold", release_on_light: "red" }
-      - condition: { label: "ABORT" }
-        action: { type: "hold", release_on_light: "white" }
+        action: { type: 'hold', release_on_light: 'red' }
+      - condition: { label: 'ABORT' }
+        action: { type: 'hold', release_on_light: 'white' }
       - condition: {}
-        action: { type: "tap" }
+        action: { type: 'tap' }
 
   keypad:
     sequences:
-      - ["omega", "delta", "psi", "xi", "diamond", "star"]
-      - ["star", "xi", "omega", "delta", "diamond", "psi"]
-      - ["psi", "diamond", "star", "omega", "delta", "xi"]
-      - ["delta", "omega", "xi", "diamond", "psi", "star"]
-      - ["diamond", "psi", "delta", "star", "xi", "omega"]
-      - ["xi", "star", "diamond", "psi", "omega", "delta"]
-    rule: "Find the sequence containing all 4 keypad symbols. Press them in the order they appear in that sequence."
+      - ['omega', 'delta', 'psi', 'xi', 'diamond', 'star']
+      - ['star', 'xi', 'omega', 'delta', 'diamond', 'psi']
+      - ['psi', 'diamond', 'star', 'omega', 'delta', 'xi']
+      - ['delta', 'omega', 'xi', 'diamond', 'psi', 'star']
+      - ['diamond', 'psi', 'delta', 'star', 'xi', 'omega']
+      - ['xi', 'star', 'diamond', 'psi', 'omega', 'delta']
+    rule: '找到同时包含场景中全部 4 个键盘符号的那一条序列，按该序列里出现的先后顺序依次点击它们。'
 
 decoy_modules:
   morse_code:
     rules:
-      - pattern: "... --- ..."
-        word: "SOS"
-        action: "transmit"
-      - pattern: ".... . .-.. .-.. ---"
-        word: "HELLO"
-        action: "transmit"
-      - pattern: "-... --- -- -..."
-        word: "BOMB"
-        action: "transmit"
-      - pattern: ".-- .. .-. ."
-        word: "WIRE"
-        action: "cut"
-      - pattern: "-.. . - --- -. .- - ."
-        word: "DETONATE"
-        action: "abort"
-      - pattern: ".- .-. -- ."
-        word: "ARME"
-        action: "transmit"
+      - pattern: '... --- ...'
+        word: 'SOS'
+        action: 'transmit'
+      - pattern: '.... . .-.. .-.. ---'
+        word: 'HELLO'
+        action: 'transmit'
+      - pattern: '-... --- -- -...'
+        word: 'BOMB'
+        action: 'transmit'
+      - pattern: '.-- .. .-. .'
+        word: 'WIRE'
+        action: 'cut'
+      - pattern: '-.. . - --- -. .- - .'
+        word: 'DETONATE'
+        action: 'abort'
+      - pattern: '.- .-. -- .'
+        word: 'ARME'
+        action: 'transmit'
   maze:
     grid_size: 6
     rules:
       - start: [0, 0]
         end: [5, 5]
-        path: "RRRRRUUUUU"
+        path: 'RRRRRUUUUU'
       - start: [2, 3]
         end: [0, 0]
-        path: "LLLUUU"
+        path: 'LLLUUU'
       - start: [1, 1]
         end: [4, 4]
-        path: "RRRRUUU"
+        path: 'RRRRUUU'
       - start: [3, 0]
         end: [3, 5]
-        path: "UUUUU"
+        path: 'UUUUU'
       - start: [0, 2]
         end: [5, 2]
-        path: "RRRRR"
+        path: 'RRRRR'
   memory:
     stages: 5
     rules:
       - stage: 1
         display: 1
-        action: "press_position_2"
+        action: 'press_position_2'
       - stage: 1
         display: 2
-        action: "press_position_2"
+        action: 'press_position_2'
       - stage: 2
         display: 3
-        action: "press_label_4"
+        action: 'press_label_4'
       - stage: 3
         display: 1
-        action: "press_same_position"
+        action: 'press_same_position'
       - stage: 4
         display: 4
-        action: "press_same_label"
+        action: 'press_same_label'
       - stage: 5
         display: 2
-        action: "press_same_position_as_stage_1"
+        action: 'press_same_position_as_stage_1'
   simon_says:
     rules:
       - has_vowel_in_serial: true
-        color_map: { red: "blue", blue: "red", green: "yellow", yellow: "green" }
+        color_map: { red: 'blue', blue: 'red', green: 'yellow', yellow: 'green' }
       - has_vowel_in_serial: false
-        color_map: { red: "blue", blue: "yellow", green: "green", yellow: "red" }
+        color_map: { red: 'blue', blue: 'yellow', green: 'green', yellow: 'red' }
       - strikes: 1
         has_vowel_in_serial: true
-        color_map: { red: "blue", blue: "red", green: "yellow", yellow: "green" }
+        color_map: { red: 'blue', blue: 'red', green: 'yellow', yellow: 'green' }
       - strikes: 1
         has_vowel_in_serial: false
-        color_map: { red: "red", blue: "blue", green: "yellow", yellow: "green" }
+        color_map: { red: 'red', blue: 'blue', green: 'yellow', yellow: 'green' }
       - strikes: 2
-        color_map: { red: "yellow", blue: "green", green: "blue", yellow: "red" }
+        color_map: { red: 'yellow', blue: 'green', green: 'blue', yellow: 'red' }

--- a/packages/manual/src/template.html
+++ b/packages/manual/src/template.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>BombSquad Manual</title>
+  <title>BombSquad 拆弹手册</title>
   <link rel="stylesheet" href="/manual/anti-human.css" />
 </head>
 <body>
 
 <!-- HUMAN-READABLE SECTION -->
 <div class="human-notice">
-  <h1>🤖 This manual is designed for AI</h1>
-  <p>Humans cannot effectively read the following content.</p>
-  <p>Please send this page's URL to your AI assistant and let it be your bomb-disposal expert.</p>
-  <p>💡 Not sure how to start? <a href="https://bombsquad.amio.fans">Return to the game page</a> for instructions.</p>
+  <h1>🤖 这份手册是给 AI 读的</h1>
+  <p>人类无法有效阅读以下内容。</p>
+  <p>请把本页 URL 发给你的 AI 助手，让它来当你的拆弹专家。</p>
+  <p>💡 不知道怎么开始？<a href="https://bombsquad.amio.fans">返回游戏首页</a>查看说明。</p>
 </div>
 <hr class="divider" />
-<p class="divider-label">↓ The following content is for AI use only ↓</p>
+<p class="divider-label">↓ 以下内容仅供 AI 读取 ↓</p>
 
 <!-- ANTI-HUMAN YAML SECTION — rendered by build script -->
 <pre class="anti-human">{{YAML_CONTENT}}</pre>


### PR DESCRIPTION
Replaces closed PR #36 (auto-closed when its stacking base branch was deleted on merge). Content unchanged.

Every player-facing string is now Simplified Chinese. Schema values (wire colors, symbol ids, module slugs) stay English as exact-match enum keys.

- [x] 67/67 tests passing
- [x] Lint clean
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)