### PR TITLE
feat(game): add frontend event logging for north-star metric estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+### Added
+
+- Frontend event logging for practice/daily games (game_start, module_solve, game_complete, game_abandon, manual_load_failed) — emitted via console.info with prefix [bombsquad-event] for manual analysis of completion rate
+
 ### Improvements
 
 - **Refresh resilience** An accidental F5 / Cmd+R mid-run no longer wipes

--- a/packages/game/src/pages/GamePage.tsx
+++ b/packages/game/src/pages/GamePage.tsx
@@ -6,6 +6,7 @@ import { useGame } from '@/store/game-context'
 import { useTimer } from '@/hooks/useTimer'
 import { createRng, type Rng } from '@/engine/rng'
 import { loadManual, ManualNotFoundError } from '@/utils/yaml-loader'
+import { logEvent } from '@/utils/event-log'
 import { generateWire } from '@/modules/wire/generator'
 import { generateDial } from '@/modules/dial/generator'
 import { generateButton } from '@/modules/button/generator'
@@ -212,9 +213,15 @@ export default function GamePage() {
 
   const handleExitRun = useCallback(() => {
     if (!window.confirm('退出当前关卡？进度会清空。')) return
+    const elapsedMs = state.totalStartTime !== null ? Date.now() - state.totalStartTime : null
+    logEvent('game_abandon', {
+      currentModuleIndex: state.currentModuleIndex,
+      elapsedMs,
+      mode: state.mode,
+    })
     dispatch({ type: 'RESET' })
     navigate('/')
-  }, [dispatch, navigate])
+  }, [dispatch, navigate, state.currentModuleIndex, state.mode, state.totalStartTime])
 
   const handleModuleError = useCallback(() => {
     const rng = rngRef.current

--- a/packages/game/src/store/game-context.tsx
+++ b/packages/game/src/store/game-context.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useReducer, type ReactNode } from 'react'
 import type { ModuleConfig, ModuleAnswer, Manual, SceneInfo } from '@shared/manual-schema'
 import { clearPersistedState, loadPersistedState, savePersistedState } from './persistence'
+import { logEvent } from '@/utils/event-log'
 
 // ---------------------------------------------------------------------------
 // Status & State
@@ -122,13 +123,27 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         errorKind: null,
       }
 
-    case 'LOAD_ERROR':
+    // Note on logEvent calls inside this reducer: in dev, React.StrictMode
+    // double-invokes reducers to detect impurity, so each event below will
+    // appear twice in the local browser console. Production builds invoke
+    // reducers once, so Cloudflare Pages logs (the actual metric source) see
+    // exactly one event per state transition. If dev-mode noise becomes a
+    // problem we can gate calls on `import.meta.env.PROD` or relocate to an
+    // effect — for now the production guarantee is what matters.
+    case 'LOAD_ERROR': {
+      const kind = action.kind ?? 'generic'
+      logEvent('manual_load_failed', {
+        kind,
+        message: action.message,
+        mode: state.mode,
+      })
       return {
         ...state,
         status: 'LOADING', // stays on loading screen, shows error
         errorMessage: action.message,
-        errorKind: action.kind ?? 'generic',
+        errorKind: kind,
       }
+    }
 
     case 'START_GAME': {
       if (import.meta.env.DEV) {
@@ -138,6 +153,11 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         }
       }
       const now = Date.now()
+      logEvent('game_start', {
+        mode: state.mode,
+        attemptNumber: state.attemptNumber,
+        rngSeed: state.rngSeed,
+      })
       return {
         ...state,
         status: 'PLAYING',
@@ -153,6 +173,13 @@ function gameReducer(state: GameState, action: GameAction): GameState {
     case 'MODULE_COMPLETE': {
       const now = Date.now()
       const startedAt = state.currentModuleStartTime ?? now
+      const timeMs = now - startedAt
+      logEvent('module_solve', {
+        moduleType: action.moduleType,
+        moduleIndex: state.currentModuleIndex,
+        timeMs,
+        errorCount: state.currentModuleErrorCount,
+      })
       return {
         ...state,
         status: 'MODULE_COMPLETE',
@@ -160,7 +187,7 @@ function gameReducer(state: GameState, action: GameAction): GameState {
           ...state.moduleStats,
           {
             moduleType: action.moduleType,
-            timeMs: now - startedAt,
+            timeMs,
             errorCount: state.currentModuleErrorCount,
           },
         ],
@@ -189,12 +216,21 @@ function gameReducer(state: GameState, action: GameAction): GameState {
       }
     }
 
-    case 'ALL_MODULES_COMPLETE':
+    case 'ALL_MODULES_COMPLETE': {
+      const endedAt = state.totalEndTime ?? Date.now()
+      const totalTimeMs = state.totalStartTime !== null ? endedAt - state.totalStartTime : 0
+      logEvent('game_complete', {
+        totalTimeMs,
+        attemptNumber: state.attemptNumber,
+        moduleStats: state.moduleStats,
+        mode: state.mode,
+      })
       return {
         ...state,
         status: 'RESULT',
-        totalEndTime: state.totalEndTime ?? Date.now(),
+        totalEndTime: endedAt,
       }
+    }
 
     case 'REGENERATE_MODULE': {
       const configs = [...state.moduleConfigs] as (ModuleConfig | null)[]

--- a/packages/game/src/utils/event-log.test.ts
+++ b/packages/game/src/utils/event-log.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EVENT_LOG_PREFIX, logEvent } from './event-log'
+
+describe('logEvent', () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    infoSpy.mockRestore()
+  })
+
+  it('writes a single console.info call with the bombsquad-event prefix', () => {
+    logEvent('game_start', { mode: 'practice' })
+
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy.mock.calls[0][0]).toBe(EVENT_LOG_PREFIX)
+    expect(EVENT_LOG_PREFIX).toBe('[bombsquad-event]')
+  })
+
+  it('passes a JSON-serializable payload with event, timestamp, and extra data', () => {
+    logEvent('game_start', { mode: 'daily', attemptNumber: 2, rngSeed: 12345 })
+
+    const payload = infoSpy.mock.calls[0][1] as Record<string, unknown>
+
+    expect(payload).toMatchObject({
+      event: 'game_start',
+      mode: 'daily',
+      attemptNumber: 2,
+      rngSeed: 12345,
+    })
+    expect(typeof payload.timestamp).toBe('string')
+    // ISO 8601 UTC: 2026-05-06T12:34:56.789Z
+    expect(payload.timestamp as string).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/)
+
+    // Round-trips through JSON.stringify without throwing — a hard guarantee
+    // that whatever we shovel into it stays serializable for later capture.
+    expect(() => JSON.stringify(payload)).not.toThrow()
+  })
+
+  it('defaults the data argument to an empty object', () => {
+    logEvent('manual_load_failed')
+
+    const payload = infoSpy.mock.calls[0][1] as Record<string, unknown>
+    expect(payload.event).toBe('manual_load_failed')
+    expect(typeof payload.timestamp).toBe('string')
+  })
+
+  it('uses the current ISO timestamp when fake timers are active', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-05-06T12:34:56.000Z'))
+      logEvent('game_complete', { totalTimeMs: 60000 })
+      const payload = infoSpy.mock.calls[0][1] as Record<string, unknown>
+      expect(payload.timestamp).toBe('2026-05-06T12:34:56.000Z')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/game/src/utils/event-log.ts
+++ b/packages/game/src/utils/event-log.ts
@@ -1,0 +1,27 @@
+/**
+ * Frontend event logging for the BombSquad game.
+ *
+ * Emits a single structured `console.info` line per event so that during the
+ * first post-ship week we can manually estimate the 单局完成率 north-star
+ * metric (>= 70% completion within 10 minutes) by scanning browser console
+ * logs. Backend KV ingestion is intentionally deferred — this helper exists
+ * only as a stable, structured shape for later automation.
+ *
+ * Wire format:
+ *   console.info('[bombsquad-event]', { event, timestamp, ...data })
+ *
+ * `timestamp` is ISO 8601 (UTC) so logs from different clients sort.
+ */
+export const EVENT_LOG_PREFIX = '[bombsquad-event]'
+
+export function logEvent(name: string, data: Record<string, unknown> = {}): void {
+  const payload = {
+    event: name,
+    timestamp: new Date().toISOString(),
+    ...data,
+  }
+  // `console.info` is the intended channel; the project lint config allows
+  // only `warn`/`error` by default, so opt out locally for this telemetry sink.
+  // eslint-disable-next-line no-console
+  console.info(EVENT_LOG_PREFIX, payload)
+}


### PR DESCRIPTION
## Summary

- Adds a `logEvent(name, data)` helper that emits a structured `console.info` line with prefix `[bombsquad-event]` so the first post-ship week can manually estimate the 单局完成率 north-star metric (≥70% completion within 10 minutes) by scanning Cloudflare Pages browser logs.
- Instruments 5 events: `game_start`, `module_solve`, `game_complete`, `manual_load_failed` (in the `game-context.tsx` reducer) and `game_abandon` (in `GamePage.tsx#handleExitRun`).
- Backend KV ingestion is **deferred** to a later task — this PR is intentionally frontend-only and keeps the helper as a single replacement point for future automation.
- Game mechanics are **unchanged**: no new fail terminal state, no 10-minute timeout timer. The 10-minute completion rate is derived post-hoc from `totalTimeMs` in `game_complete`.

## Implementation notes

- All log calls live inside reducer cases. The `useReducer` lazy initializer at `game-context.tsx:249` bypasses the reducer when restoring sessionStorage state, so a refresh during PLAYING does not re-emit `game_start`.
- `React.StrictMode` (enabled in `main.tsx`) double-invokes reducers in dev to detect impurity, so each event appears twice in the local browser console. Production builds invoke once — Cloudflare Pages logs see exactly one event per state transition. A comment in `game-context.tsx` flags this for future readers.
- Event field names map cleanly to the existing reducer state (`mode`, `attemptNumber`, `rngSeed`, `moduleType`, `moduleIndex`, `timeMs`, `errorCount`, `totalTimeMs`, `moduleStats`, `kind`, `message`, `currentModuleIndex`, `elapsedMs`).

## Test plan

- [x] `pnpm lint` passes (eslint + markdownlint)
- [x] `pnpm test:run` passes (94/94 tests, including 4 new cases for `event-log.ts`)
- [ ] Manual smoke test: open the game in dev, click 练习 → 开始, observe `[bombsquad-event] {event: "game_start", ...}` in the browser console. Solve a module, observe `module_solve`. Solve all 4, observe `game_complete` and the navigation to `/result`.
- [ ] Manual smoke test: open the game in dev, click 练习 → 开始, click 退出 in the top bar, confirm the dialog, observe `[bombsquad-event] {event: "game_abandon", ...}`.
- [ ] After deploy to Cloudflare Pages, sample one practice run on the live site and confirm exactly one `[bombsquad-event]` line per state transition (no StrictMode double-fire in production).

## Followup candidates (out of scope for this PR)

- If `manual_load_failed` proves too broad (it currently fires for both initial load failures and mid-game generator-exhaustion regen failures), split into `manual_load_failed` + `module_regen_failed`.
- Wire `logEvent` to a backend ingestion path (Cloudflare KV or Workers Analytics) — scheduled for 5/12-15 per roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)