### PR TITLE
fix(recap): align copy summary wording with MVP section 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ### Improvements
 
+- **Recap copy wording** Result-page summary text aligned with the MVP
+  section 5.3 example wording (header, result, module rows, retro intro).
 - **Manual symbol vocabulary** Each abstract symbol (omega, psi, trident,
   etc.) now ships with a visual description so AI partners can disambiguate
   player descriptions ("三叉戟" vs psi, "扇子" vs trident, etc.) without

--- a/packages/game/src/pages/ResultPage.tsx
+++ b/packages/game/src/pages/ResultPage.tsx
@@ -133,21 +133,21 @@ export default function ResultPage() {
         const name = MODULE_LABELS[i] ?? s.moduleType
         const t = formatMs(s.timeMs)
         const resets = s.errorCount
-        return `${i + 1}. ${name} — ${t}（重置 ${resets} 次）`
+        return `${i + 1}. ${name}模块 - ${t} - 成功 (${resets} 次重置)`
       })
       .join('\n')
     const rankLine = rankResult ? `全球排名：#${rankResult.rank} / ${rankResult.total_players}` : ''
 
-    return `=== BombSquad 赛后摘要 ===
+    return `=== BombSquad 结果摘要 ===
 日期：${date}
 模式：${modeLabel}
-结果：拆弹成功 ✓
+结果：成功 ✅
 总用时：${timeStr}
 ${rankLine ? `${rankLine}\n` : ''}
 模块详情：
 ${breakdown}
 
-复盘提问：
+请和我一起复盘：
 帮我看看这一局 —— 哪一块拖了最多时间？我们下次该怎么改进沟通？`
   }, [state, totalMs, rankResult])
 


### PR DESCRIPTION
## Summary

- Align `buildSummary()` recap text in `ResultPage.tsx` with the MVP section 5.3 example: header, result line, module-row template, retro-intro line.
- Add CHANGELOG entry under `## [Unreleased]` → `### Improvements`.
- Scope strictly limited to `ResultPage.tsx::buildSummary`. `HomePage`, `skills.md`, `retro-questions.ts`, `post-score.ts`, `shared/leaderboard-types.ts`, and the result-page H1 (`拆弹成功`) are intentionally untouched — only the copyable post-game summary text changes, since that text is the canonical thing players paste into AI tools for review.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (`pnpm --filter game test --run`: 75/75 across 16 test files; pre-commit hook re-ran them on commit)
- [ ] New tests added if behavior changed (no test file changes — change is text-only inside a template literal)
- [ ] Tested manually and documented below

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (CHANGELOG)
- [x] Breaking changes documented if any (none)

## Test plan

- [x] `pnpm --filter game test --run` 75/75 pass
- [x] `game-flow.test.tsx` references the H1 `拆弹成功` and passes — confirms the H1 was not accidentally touched
- [ ] Manual: load the result page in dev mode, click "复制赛后摘要" (button label intentionally unchanged), paste into a notes app, eyeball the four target lines against MVP §5.3 example