### PR TITLE
ci: bump Node to 22 in ci.yml to align with pages-deploy.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           version: 10
 
-      - name: Set up Node.js 20
+      - name: Set up Node.js 22
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Bumps `actions/setup-node` in `.github/workflows/ci.yml` from Node 20 to Node 22, mirroring commit `2a8e140` which already did the same on `pages-deploy.yml` for wrangler 4.x compatibility.
- ci.yml does not invoke wrangler today, so it was not blocked — but keeping the two workflow files on different Node majors invites silent divergence the next time a test or build step picks up wrangler.
- Also moves CI off Node 20 ahead of its EOL countdown.

## Type of change

- [x] CI or configuration

## Testing

- [x] Existing tests pass (99/99 locally on Node v25)
- [ ] CI (this PR) must come up green on Node 22 before merge

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff (2 lines: comment + `node-version` value)
- [x] No debug logging remains
- [x] No CHANGELOG entry — matches `2a8e140` precedent for CI-only workflow bumps
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)