### PR TITLE
docs(readme): align packages/api description with retired Worker reality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Versions follow [Semantic Versioning](https://semver.org).
   the authoritative copy.
 - **API package cleanup** Removed dormant standalone Worker entry from
   `packages/api`; Pages Functions remains the sole leaderboard API path.
+  README workspace note also updated to reflect the new shape: `packages/api`
+  is now described as the leaderboard handler module imported by Pages
+  Functions.
 - **Refresh resilience** An accidental F5 / Cmd+R mid-run no longer wipes
   the current game. GameState is mirrored into sessionStorage on every
   transition, the timer is now driven by wall-clock `Date.now()` so the

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Workspace notes:
 
 - `packages/game` contains the React + Vite game client
 - `packages/manual` builds the static manual pages and YAML data
-- `packages/api` contains the Cloudflare Workers leaderboard API
+- `packages/api` contains the leaderboard handler module imported by Pages Functions
 
 See [`docs/plans/`](./docs/plans/) for implementation plans and
 [`CONTRIBUTING.md`](./CONTRIBUTING.md) for contribution and release guidance.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You (browser) <-> voice <-> AI (reads manual URL)
 amiclaw/
 ├── docs/                    # Design documents and plans
 ├── packages/
-│   ├── api/                 # Cloudflare Workers leaderboard API
+│   ├── api/                 # Leaderboard handler module (Pages Functions)
 │   ├── game/                # BombSquad React SPA
 │   └── manual/              # Manual static pages and YAML data
 ├── prompts/                 # Prompt and skill templates


### PR DESCRIPTION
## Summary

- README workspace note for `packages/api` still described the retired standalone Cloudflare Worker; updated to reflect the current shape (handler module imported by Pages Functions)
- Extended the existing CHANGELOG "API package cleanup" Unreleased bullet so the release notes for this cleanup stay in one narrative thread

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [ ] New tests added if behavior changed
- [x] Tested manually and documented below

Pre-commit ran lint-staged (prettier + markdownlint-fix on the two changed files) and the full vitest suite (103/103 passed). No code paths touched — docs-only.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

Followup of [#46 (commit 4837859)](https://github.com/amio-love/amiclaw/commit/4837859) — that commit retired `packages/api/wrangler.toml` and `src/index.ts`, but the README workspace-notes line still pointed at the old shape. This PR fixes that line; no source-tree changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)