### PR TITLE
test(manual): enforce character-equal symbol descriptions across SSOTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ Versions follow [Semantic Versioning](https://semver.org).
   `symbol_dial.columns` or `keypad.sequences` lacks a description (or if
   the block declares an unused entry). The assistant prompt's "符号视觉
   对照" section is generated from the same SSOT so the prompt and the
-  manual stay in lockstep.
+  manual stay in lockstep, and a vitest assertion now also enforces that
+  every shipped yaml `symbols.<id>.description` is character-equal to the
+  `SYMBOLS` registry entry, catching silent drift between the two surfaces
+  before it reaches deploy.
 - **Leaderboard live update** Submitted scores now appear in the leaderboard
   immediately, replacing the previous up-to-60-second cache-invalidation lag.
   After a successful POST the result page persists an optimistic entry in

--- a/packages/game/src/utils/manual-schema.test.ts
+++ b/packages/game/src/utils/manual-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { collectReferencedSymbols, validateManualSymbols, type Manual } from '@shared/manual-schema'
+import { SYMBOLS } from '@shared/symbols'
 import yaml from 'js-yaml'
 import { readFileSync, readdirSync } from 'fs'
 import { resolve, join } from 'path'
@@ -101,5 +102,57 @@ describe('shipped manual YAMLs', () => {
     for (const [id, entry] of Object.entries(manual.symbols)) {
       expect(entry.description.length, `symbol ${id} description too short`).toBeGreaterThan(4)
     }
+  })
+})
+
+describe('manual symbol descriptions match shared/symbols.ts SSOT', () => {
+  function loadYaml(path: string): Manual {
+    return yaml.load(readFileSync(path, 'utf8')) as Manual
+  }
+
+  // Build a Map<id, description> from the SYMBOLS registry. SYMBOLS is the
+  // SSOT for symbol metadata (id, name, description, SVG path); each manual
+  // YAML re-states `symbols.<id>.description` so the AI partner sees it when
+  // reading the manual. This test catches drift between the two surfaces.
+  const SSOT_DESCRIPTIONS: Map<string, string> = new Map(SYMBOLS.map((s) => [s.id, s.description]))
+
+  function diffYamlAgainstSSOT(label: string, manual: Manual): string[] {
+    const errors: string[] = []
+    for (const [id, entry] of Object.entries(manual.symbols ?? {})) {
+      const yamlDesc = entry.description
+      const ssotDesc = SSOT_DESCRIPTIONS.get(id)
+      if (ssotDesc === undefined) {
+        errors.push(
+          `${label}: symbol id '${id}' is NOT registered in shared/symbols.ts SYMBOLS — yaml should not ship descriptions for unregistered ids.\n` +
+            `  yaml description: ${JSON.stringify(yamlDesc)}`
+        )
+        continue
+      }
+      if (yamlDesc !== ssotDesc) {
+        errors.push(
+          `${label}: symbol '${id}' description differs from shared/symbols.ts SSOT (character-level mismatch).\n` +
+            `  yaml:    ${JSON.stringify(yamlDesc)}\n` +
+            `  SYMBOLS: ${JSON.stringify(ssotDesc)}`
+        )
+      }
+    }
+    return errors
+  }
+
+  it('practice.yaml symbol descriptions character-equal to SYMBOLS', () => {
+    const manual = loadYaml(PRACTICE_YAML)
+    const errors = diffYamlAgainstSSOT('practice.yaml', manual)
+    expect(errors, `\n${errors.join('\n')}`).toEqual([])
+  })
+
+  it('every daily YAML symbol descriptions character-equal to SYMBOLS', () => {
+    const dailyFiles = readdirSync(DAILY_DIR).filter((f) => f.endsWith('.yaml'))
+    expect(dailyFiles.length).toBeGreaterThan(0)
+    const errors: string[] = []
+    for (const file of dailyFiles) {
+      const manual = loadYaml(join(DAILY_DIR, file))
+      errors.push(...diffYamlAgainstSSOT(`daily/${file}`, manual))
+    }
+    expect(errors, `\n${errors.join('\n')}`).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

- Add a vitest assertion that walks every shipped manual yaml (`practice.yaml` + `daily/*.yaml`) and compares each `symbols.<id>.description` against `SYMBOLS[id].description` from `shared/symbols.ts` character-by-character; any drift fails with a diagnostic that prints the filename, symbol id, and **both** full strings.
- Also fail when a yaml carries a description for an id that is not registered in `SYMBOLS` (the registry stays the source of truth for the symbol set).
- CHANGELOG: extend the existing **Manual symbol vocabulary** entry to mention the new test guard so the lockstep claim in the existing note is now literally enforced.

Why this matters: the two surfaces existed by design (the prompt builder reads `SYMBOLS`; the manual page reads the yaml `symbols` block) but the previous schema validator only enforced non-emptiness + reference parity. A typo in one surface would silently drift from the other and only surface as confused AI guidance in production.

## Type of change

- [x] New tests added if behavior changed
- [x] Documentation (CHANGELOG entry)

## Testing

- [x] Existing tests pass
- [x] New tests added — 2 new \`it\` cases (`practice.yaml symbol descriptions character-equal to SYMBOLS`, `every daily YAML symbol descriptions character-equal to SYMBOLS`); full suite now 105/105 (was 103/103)
- [x] Mutation tests verified the new test catches both classes of drift:
  - description drift (single-character append in `daily/2026-03-16.yaml` `psi`) → fails with both full strings + filename + id
  - unregistered id (`fakesymbol` added to `practice.yaml symbols:` block) → fails with "NOT registered in shared/symbols.ts SYMBOLS" + filename + id + yaml description
- [x] yaml restoration verified clean after each mutation
- [x] ESLint clean: \`pnpm exec eslint packages/game/src/utils/manual-schema.test.ts\` 0 output

## Checklist

- [x] Code follows the project style (prettier + eslint + markdownlint all clean)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated (CHANGELOG)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)