### PR TITLE
refactor(manual): collapse symbol description dual-SSOT to build-time injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ Versions follow [Semantic Versioning](https://semver.org).
   every shipped yaml `symbols.<id>.description` is character-equal to the
   `SYMBOLS` registry entry, catching silent drift between the two surfaces
   before it reaches deploy.
+- **Manual symbol description SSOT** Symbol descriptions now live in only
+  one place — `shared/symbols.ts`. The source manual YAMLs and the dist
+  raw YAMLs no longer carry a `symbols:` block; instead `packages/manual/build.ts`
+  derives each referenced symbol's description from the `SYMBOLS` registry
+  at build time and injects them into the YAML embedded in the rendered
+  manual HTML. The cross-SSOT character-equal guard now reads the embedded
+  HTML YAML instead of the source files, and a new test locks in that
+  neither the source nor the dist raw YAMLs ever re-introduce a `symbols:`
+  block. Developers edit a description in one file; CI continues to catch
+  any manual reference to an unregistered symbol id. Known trade-off: the
+  `?format=yaml` AI path no longer ships descriptions in the raw asset —
+  the assistant prompt remains the SSOT for consumers on that path.
 - **Leaderboard live update** Submitted scores now appear in the leaderboard
   immediately, replacing the previous up-to-60-second cache-invalidation lag.
   After a successful POST the result page persists an optimistic entry in

--- a/packages/game/src/utils/manual-schema.test.ts
+++ b/packages/game/src/utils/manual-schema.test.ts
@@ -1,13 +1,29 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeAll } from 'vitest'
 import { collectReferencedSymbols, validateManualSymbols, type Manual } from '@shared/manual-schema'
 import { SYMBOLS } from '@shared/symbols'
 import yaml from 'js-yaml'
 import { readFileSync, readdirSync } from 'fs'
 import { resolve, join } from 'path'
+import { execFileSync } from 'child_process'
 
 const REPO_ROOT = resolve(__dirname, '../../../..')
 const PRACTICE_YAML = join(REPO_ROOT, 'packages/manual/data/practice.yaml')
 const DAILY_DIR = join(REPO_ROOT, 'packages/manual/data/daily')
+const MANUAL_DIST = join(REPO_ROOT, 'packages/manual/dist')
+
+/**
+ * Build the manual package once for tests that need the rendered HTML
+ * (`dist/<slug>/index.html`) and the dist raw yaml (`dist/data/<slug>.yaml`)
+ * to exist. CI runs `pnpm test:run` BEFORE `pnpm build`, so we must
+ * trigger the build ourselves; using `execFileSync` (not `exec`) keeps
+ * argv literal — no shell, no injection surface.
+ */
+function buildManualForTests(): void {
+  execFileSync('pnpm', ['--filter', 'manual', 'build'], {
+    cwd: REPO_ROOT,
+    stdio: 'pipe',
+  })
+}
 
 function makeManual(overrides: Partial<Manual> = {}): Manual {
   return {
@@ -24,14 +40,6 @@ function makeManual(overrides: Partial<Manual> = {}): Manual {
         rule: '',
       },
     },
-    symbols: {
-      omega: { description: 'horseshoe' },
-      psi: { description: 'forked fork' },
-      star: { description: 'star' },
-      delta: { description: 'triangle' },
-      xi: { description: 'three lines' },
-      diamond: { description: 'diamond' },
-    },
     ...overrides,
   }
 }
@@ -45,34 +53,44 @@ describe('collectReferencedSymbols', () => {
 })
 
 describe('validateManualSymbols', () => {
-  it('passes when every referenced symbol has a non-empty description', () => {
-    expect(() => validateManualSymbols(makeManual())).not.toThrow()
+  it('passes when every referenced id is registered in SYMBOLS', () => {
+    expect(() => validateManualSymbols(makeManual(), SYMBOLS)).not.toThrow()
   })
 
-  it('throws when a referenced symbol lacks a description entry', () => {
+  it('throws when a dial-referenced id is not registered in SYMBOLS', () => {
     const manual = makeManual({
-      symbols: {
-        // psi referenced in dial+keypad but missing here
-        omega: { description: 'horseshoe' },
-        star: { description: 'star' },
-        delta: { description: 'triangle' },
-        xi: { description: 'three lines' },
-        diamond: { description: 'diamond' },
+      modules: {
+        wire_routing: { rules: [] },
+        symbol_dial: {
+          columns: [['omega', 'unknown_sym', 'star', 'delta', 'xi', 'diamond']],
+          rule: '',
+        },
+        button: { rules: [] },
+        keypad: {
+          sequences: [['omega', 'psi', 'star', 'delta']],
+          rule: '',
+        },
       },
     })
-    expect(() => validateManualSymbols(manual)).toThrow(/psi/)
+    expect(() => validateManualSymbols(manual, SYMBOLS)).toThrow(/unknown_sym/)
   })
 
-  it('throws when a referenced symbol has an empty description', () => {
-    const manual = makeManual()
-    manual.symbols.psi = { description: '   ' }
-    expect(() => validateManualSymbols(manual)).toThrow(/psi/)
-  })
-
-  it('throws when symbols block declares an unused entry', () => {
-    const manual = makeManual()
-    manual.symbols.crescent = { description: 'moon' }
-    expect(() => validateManualSymbols(manual)).toThrow(/crescent/)
+  it('throws when a keypad-referenced id is not registered in SYMBOLS', () => {
+    const manual = makeManual({
+      modules: {
+        wire_routing: { rules: [] },
+        symbol_dial: {
+          columns: [['omega', 'psi', 'star', 'delta', 'xi', 'diamond']],
+          rule: '',
+        },
+        button: { rules: [] },
+        keypad: {
+          sequences: [['omega', 'psi', 'star', 'fake_id']],
+          rule: '',
+        },
+      },
+    })
+    expect(() => validateManualSymbols(manual, SYMBOLS)).toThrow(/fake_id/)
   })
 })
 
@@ -81,77 +99,131 @@ describe('shipped manual YAMLs', () => {
     return yaml.load(readFileSync(path, 'utf8')) as Manual
   }
 
-  it('practice.yaml loads and validates against the symbols invariant', () => {
+  it('practice.yaml loads and references only registered symbols', () => {
     const manual = loadYaml(PRACTICE_YAML)
-    expect(manual.symbols).toBeDefined()
-    expect(() => validateManualSymbols(manual)).not.toThrow()
+    expect(() => validateManualSymbols(manual, SYMBOLS)).not.toThrow()
   })
 
-  it('every daily YAML loads and validates against the symbols invariant', () => {
+  it('every daily YAML loads and references only registered symbols', () => {
     const dailyFiles = readdirSync(DAILY_DIR).filter((f) => f.endsWith('.yaml'))
     expect(dailyFiles.length).toBeGreaterThan(0)
     for (const file of dailyFiles) {
       const manual = loadYaml(join(DAILY_DIR, file))
-      expect(manual.symbols, `${file} missing symbols block`).toBeDefined()
-      expect(() => validateManualSymbols(manual), `${file} validation failed`).not.toThrow()
+      expect(
+        () => validateManualSymbols(manual, SYMBOLS),
+        `${file} validation failed`
+      ).not.toThrow()
     }
   })
 
-  it('every shipped description calls out a canonical shape (basic sanity)', () => {
-    const manual = loadYaml(PRACTICE_YAML)
-    for (const [id, entry] of Object.entries(manual.symbols)) {
-      expect(entry.description.length, `symbol ${id} description too short`).toBeGreaterThan(4)
+  it('every registered SYMBOLS description is non-trivially long (basic sanity)', () => {
+    for (const sym of SYMBOLS) {
+      expect(sym.description.length, `symbol ${sym.id} description too short`).toBeGreaterThan(4)
     }
   })
 })
 
-describe('manual symbol descriptions match shared/symbols.ts SSOT', () => {
-  function loadYaml(path: string): Manual {
-    return yaml.load(readFileSync(path, 'utf8')) as Manual
-  }
+describe('source YAMLs and dist raw YAMLs ship no symbols block (Option C invariant)', () => {
+  beforeAll(() => {
+    buildManualForTests()
+  })
 
-  // Build a Map<id, description> from the SYMBOLS registry. SYMBOLS is the
-  // SSOT for symbol metadata (id, name, description, SVG path); each manual
-  // YAML re-states `symbols.<id>.description` so the AI partner sees it when
-  // reading the manual. This test catches drift between the two surfaces.
+  it('practice.yaml source has no top-level symbols block', () => {
+    const parsed = yaml.load(readFileSync(PRACTICE_YAML, 'utf8')) as Record<string, unknown>
+    expect(parsed.symbols).toBeUndefined()
+  })
+
+  it('practice.yaml dist raw has no top-level symbols block', () => {
+    const parsed = yaml.load(
+      readFileSync(join(MANUAL_DIST, 'data/practice.yaml'), 'utf8')
+    ) as Record<string, unknown>
+    expect(parsed.symbols).toBeUndefined()
+  })
+
+  it('every daily YAML source/dist raw has no top-level symbols block', () => {
+    const dailyFiles = readdirSync(DAILY_DIR).filter((f) => f.endsWith('.yaml'))
+    expect(dailyFiles.length).toBeGreaterThan(0)
+    for (const file of dailyFiles) {
+      const sourceParsed = yaml.load(readFileSync(join(DAILY_DIR, file), 'utf8')) as Record<
+        string,
+        unknown
+      >
+      expect(sourceParsed.symbols, `source ${file} should not ship a symbols block`).toBeUndefined()
+
+      const distRawParsed = yaml.load(
+        readFileSync(join(MANUAL_DIST, 'data', file), 'utf8')
+      ) as Record<string, unknown>
+      expect(
+        distRawParsed.symbols,
+        `dist raw ${file} should not ship a symbols block`
+      ).toBeUndefined()
+    }
+  })
+})
+
+describe('manual HTML embedded yaml descriptions match shared/symbols.ts SSOT', () => {
+  beforeAll(() => {
+    buildManualForTests()
+  })
+
+  // SYMBOLS is the SSOT for symbol metadata (id, name, description, SVG
+  // path). The build pipeline injects the descriptions into the cloned
+  // YAML embedded in each rendered manual HTML; this test checks that the
+  // injection lines up character-for-character with SYMBOLS — Option C's
+  // last-mile guard against silent drift.
   const SSOT_DESCRIPTIONS: Map<string, string> = new Map(SYMBOLS.map((s) => [s.id, s.description]))
 
-  function diffYamlAgainstSSOT(label: string, manual: Manual): string[] {
+  function extractEmbeddedYaml(htmlPath: string): Manual {
+    const html = readFileSync(htmlPath, 'utf8')
+    const m = html.match(/<pre class="anti-human">([\s\S]*?)<\/pre>/)
+    if (!m) throw new Error(`No <pre class="anti-human"> block found in ${htmlPath}`)
+    return yaml.load(m[1]) as Manual
+  }
+
+  function diffEmbeddedAgainstSSOT(label: string, manual: Manual): string[] {
     const errors: string[] = []
-    for (const [id, entry] of Object.entries(manual.symbols ?? {})) {
-      const yamlDesc = entry.description
+    const referenced = collectReferencedSymbols(manual.modules)
+    const embedded = manual.symbols ?? {}
+    for (const id of referenced) {
       const ssotDesc = SSOT_DESCRIPTIONS.get(id)
       if (ssotDesc === undefined) {
         errors.push(
-          `${label}: symbol id '${id}' is NOT registered in shared/symbols.ts SYMBOLS — yaml should not ship descriptions for unregistered ids.\n` +
-            `  yaml description: ${JSON.stringify(yamlDesc)}`
+          `${label}: symbol id '${id}' referenced in modules but NOT registered in shared/symbols.ts SYMBOLS.`
         )
         continue
       }
-      if (yamlDesc !== ssotDesc) {
+      const entry = embedded[id]
+      if (!entry) {
+        errors.push(
+          `${label}: symbol '${id}' referenced in modules but missing from HTML-embedded yaml symbols block (build did not inject).`
+        )
+        continue
+      }
+      if (entry.description !== ssotDesc) {
         errors.push(
           `${label}: symbol '${id}' description differs from shared/symbols.ts SSOT (character-level mismatch).\n` +
-            `  yaml:    ${JSON.stringify(yamlDesc)}\n` +
-            `  SYMBOLS: ${JSON.stringify(ssotDesc)}`
+            `  embedded: ${JSON.stringify(entry.description)}\n` +
+            `  SYMBOLS:  ${JSON.stringify(ssotDesc)}`
         )
       }
     }
     return errors
   }
 
-  it('practice.yaml symbol descriptions character-equal to SYMBOLS', () => {
-    const manual = loadYaml(PRACTICE_YAML)
-    const errors = diffYamlAgainstSSOT('practice.yaml', manual)
+  it('practice manual HTML symbol descriptions character-equal to SYMBOLS', () => {
+    const manual = extractEmbeddedYaml(join(MANUAL_DIST, 'practice/index.html'))
+    const errors = diffEmbeddedAgainstSSOT('practice/index.html', manual)
     expect(errors, `\n${errors.join('\n')}`).toEqual([])
   })
 
-  it('every daily YAML symbol descriptions character-equal to SYMBOLS', () => {
+  it('every daily manual HTML symbol descriptions character-equal to SYMBOLS', () => {
     const dailyFiles = readdirSync(DAILY_DIR).filter((f) => f.endsWith('.yaml'))
     expect(dailyFiles.length).toBeGreaterThan(0)
     const errors: string[] = []
     for (const file of dailyFiles) {
-      const manual = loadYaml(join(DAILY_DIR, file))
-      errors.push(...diffYamlAgainstSSOT(`daily/${file}`, manual))
+      const slug = file.replace(/\.yaml$/, '')
+      const manual = extractEmbeddedYaml(join(MANUAL_DIST, slug, 'index.html'))
+      errors.push(...diffEmbeddedAgainstSSOT(`${slug}/index.html`, manual))
     }
     expect(errors, `\n${errors.join('\n')}`).toEqual([])
   })

--- a/packages/manual/build.ts
+++ b/packages/manual/build.ts
@@ -2,6 +2,15 @@ import { copyFileSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSy
 import { resolve, join, dirname, basename } from 'path'
 import { fileURLToPath } from 'url'
 import yaml from 'js-yaml'
+// On Node 25 + tsx, `shared/*.ts` files load as CJS-via-default because
+// `shared/` has no `package.json` with `"type": "module"` to opt into
+// native ESM. The named exports therefore live under the default import
+// rather than at the namespace top level. Pulling SYMBOLS through the
+// default import is the most localised workaround — no scope creep into
+// the shared package, and we still rely on the SYMBOLS SSOT (no inlined
+// description copy).
+import sharedSymbolsModule from '../../shared/symbols.ts'
+const { SYMBOLS } = sharedSymbolsModule
 
 /**
  * Local copy of the Manual / validator types to avoid the ESM+CJS interop
@@ -10,6 +19,10 @@ import yaml from 'js-yaml'
  * build-time validator needs. The full schema lives in
  * `shared/manual-schema.ts`; the `manual-schema.test.ts` suite in the game
  * package exercises the real `validateManualSymbols` against shipped YAMLs.
+ *
+ * NOTE: `shared/symbols.ts` is a leaf module (no imports of its own) and
+ * imports cleanly via tsx, which is why we pull SYMBOLS directly above
+ * instead of inlining a copy.
  */
 interface MinimalModules {
   symbol_dial?: { columns?: string[][] }
@@ -21,34 +34,33 @@ interface MinimalManual {
   symbols?: Record<string, { description?: string }>
 }
 
-function validateManualSymbolsLocal(manual: MinimalManual): void {
+function collectReferencedSymbolIds(modules: MinimalModules): Set<string> {
   const referenced = new Set<string>()
-  for (const col of manual.modules.symbol_dial?.columns ?? []) {
+  for (const col of modules.symbol_dial?.columns ?? []) {
     for (const s of col) referenced.add(s)
   }
-  for (const seq of manual.modules.keypad?.sequences ?? []) {
+  for (const seq of modules.keypad?.sequences ?? []) {
     for (const s of seq) referenced.add(s)
   }
-  const declared = new Set(Object.keys(manual.symbols ?? {}))
+  return referenced
+}
+
+/**
+ * Verify every symbol id referenced by `modules` is registered in the
+ * shared SYMBOLS SSOT. The descriptions themselves are NOT carried by the
+ * source yaml under Option C — they are injected from SYMBOLS at build
+ * time and embedded only in the rendered HTML.
+ */
+function validateReferencedSymbolsAgainstSSOT(manual: MinimalManual): void {
+  const referenced = collectReferencedSymbolIds(manual.modules)
+  const registered = new Set(SYMBOLS.map((s) => s.id))
   const missing: string[] = []
   for (const id of referenced) {
-    const entry = manual.symbols?.[id]
-    if (!entry || typeof entry.description !== 'string' || entry.description.trim() === '') {
-      missing.push(id)
-    }
+    if (!registered.has(id)) missing.push(id)
   }
   if (missing.length > 0) {
     throw new Error(
-      `Manual ${manual.meta?.version ?? '<unknown>'}: missing symbols.<id>.description for: ${missing.join(', ')}`
-    )
-  }
-  const stale: string[] = []
-  for (const id of declared) {
-    if (!referenced.has(id)) stale.push(id)
-  }
-  if (stale.length > 0) {
-    throw new Error(
-      `Manual ${manual.meta?.version ?? '<unknown>'}: symbols block declares unused entries: ${stale.join(', ')}`
+      `Manual ${manual.meta?.version ?? '<unknown>'}: symbol id(s) referenced in modules but not registered in shared/symbols.ts SYMBOLS: ${missing.join(', ')}`
     )
   }
 }
@@ -70,24 +82,48 @@ function buildPage(yamlPath: string, slug: string) {
   const content = readFileSync(yamlPath, 'utf8')
   const parsed = yaml.load(content) as MinimalManual
 
-  // Fail loud if any symbol referenced in modules has no description in the
-  // `symbols` block (or vice versa). Caught here before anything ships.
-  validateManualSymbolsLocal(parsed)
+  // Fail loud if any symbol referenced in modules is not in the shared
+  // SYMBOLS registry. Caught here before anything ships.
+  validateReferencedSymbolsAgainstSSOT(parsed)
 
-  // Minify YAML: collapse to a single line for anti-human rendering
+  // Build the injected variant: a deep-clone of `parsed` augmented with a
+  // `symbols` block derived from SYMBOLS. Only this variant is embedded in
+  // the rendered HTML; the source yaml and the dist raw yaml never carry
+  // descriptions (Option C: hybrid HTML-only inline).
+  const referenced = collectReferencedSymbolIds(parsed.modules)
+  const injected = structuredClone(parsed)
+  injected.symbols = Object.fromEntries(
+    [...referenced].map((id) => {
+      const sym = SYMBOLS.find((s) => s.id === id)
+      if (!sym) {
+        // Unreachable — validateReferencedSymbolsAgainstSSOT ran above.
+        throw new Error(`Symbol id "${id}" referenced but not in SYMBOLS`)
+      }
+      return [id, { description: sym.description }]
+    })
+  )
+
+  // Minify YAML: emit fully-flow (JSON-like) on a single line for
+  // anti-human rendering. `flowLevel: 0` forces flow style at every
+  // depth, producing one dense `{...}` blob that is both visually
+  // anti-human and round-trippable through `yaml.load` — required for
+  // the cross-SSOT test that re-parses the HTML-embedded yaml.
   const minified = yaml
-    .dump(parsed, {
-      flowLevel: 5,
+    .dump(injected, {
+      flowLevel: 0,
       lineWidth: -1,
     })
-    .replace(/\n/g, ' ')
     .trim()
 
   const html = template.replace('{{YAML_CONTENT}}', minified)
   const pageDir = join(outDir, slug)
   mkdirSync(pageDir, { recursive: true })
   writeFileSync(join(pageDir, 'index.html'), html)
-  writeFileSync(join(dataOutDir, `${slug}.yaml`), content)
+
+  // Dist raw yaml: serialise the un-injected `parsed` object (no symbols
+  // block) so the `?format=yaml` AI path and any downstream consumer of
+  // the raw asset stays consistent with the source-yaml shape.
+  writeFileSync(join(dataOutDir, `${slug}.yaml`), yaml.dump(parsed))
   console.log(`Built manual route: /manual/${slug}`)
 }
 

--- a/packages/manual/data/daily/2026-03-16.yaml
+++ b/packages/manual/data/daily/2026-03-16.yaml
@@ -2,22 +2,6 @@ meta:
   version: '2026-03-16'
   type: daily
 
-symbols:
-  omega:
-    description: '马蹄铁形 / 倒 U 形,底部两个向外的小脚,中间无竖线穿过'
-  psi:
-    description: "类似 U 形碗中间一根长竖线穿过、并向下延伸超出碗底,容易被误描述为'三叉戟'"
-  star:
-    description: '标准五角星 ☆,五个等长尖角向外'
-  delta:
-    description: '等边三角形 △,三条直边围成封闭三角'
-  xi:
-    description: '三条等长的平行横线,Ξ 形,无竖线无圆弧'
-  trident:
-    description: "三根并排竖向尖刺,顶部两条弧分别连接左-中和中-右刺(像折扇展开,n|n 模式),容易被误描述为'扇子'"
-  crescent:
-    description: '弯月形 / 月牙形,一弯朝同一方向开口的弧线,内外两条弧近乎平行'
-
 modules:
   wire_routing:
     rules:

--- a/packages/manual/data/practice.yaml
+++ b/packages/manual/data/practice.yaml
@@ -2,22 +2,6 @@ meta:
   version: 'practice'
   type: practice
 
-symbols:
-  omega:
-    description: '马蹄铁形 / 倒 U 形,底部两个向外的小脚,中间无竖线穿过'
-  psi:
-    description: "类似 U 形碗中间一根长竖线穿过、并向下延伸超出碗底,容易被误描述为'三叉戟'"
-  star:
-    description: '标准五角星 ☆,五个等长尖角向外'
-  delta:
-    description: '等边三角形 △,三条直边围成封闭三角'
-  xi:
-    description: '三条等长的平行横线,Ξ 形,无竖线无圆弧'
-  diamond:
-    description: '正方形旋转 45 度后的菱形 ◇,四条等长边对角对称'
-  trident:
-    description: "三根并排竖向尖刺,顶部两条弧分别连接左-中和中-右刺(像折扇展开,n|n 模式),容易被误描述为'扇子'"
-
 modules:
   wire_routing:
     rules:

--- a/shared/manual-schema.ts
+++ b/shared/manual-schema.ts
@@ -109,11 +109,14 @@ export interface ManualModules {
 }
 
 /**
- * Per-symbol visual description shipped in the manual so the AI partner has
- * a vocabulary alignment between the abstract symbol id (e.g. `psi`) and the
- * shape the player will actually try to describe ("三叉戟" / "扇子"). The
- * build pipeline validates that every symbol referenced in `modules` has an
- * entry here.
+ * Per-symbol visual description embedded in each rendered manual HTML so
+ * the AI partner has a vocabulary alignment between the abstract symbol id
+ * (e.g. `psi`) and the shape the player will actually try to describe
+ * ("三叉戟" / "扇子"). Under the unified-SSOT architecture the descriptions
+ * live solely in `shared/symbols.ts` and the build pipeline injects them
+ * into the HTML-embedded yaml at build time — neither the source yaml nor
+ * the dist raw yaml carries them. The injected post-build shape still
+ * conforms to this interface, so it stays here as the canonical type.
  */
 export interface SymbolEntry {
   description: string
@@ -122,14 +125,25 @@ export interface SymbolEntry {
 export interface Manual {
   meta: ManualMeta
   modules: ManualModules
-  symbols: Record<string, SymbolEntry>
+  /**
+   * Optional in source yaml (Option C: descriptions live only in HTML
+   * after build-time injection from SYMBOLS). The build script populates
+   * this field on the cloned object that gets embedded in the HTML.
+   */
+  symbols?: Record<string, SymbolEntry>
   decoy_modules?: Record<string, unknown>
+}
+
+/** Minimal registry shape consumed by `validateManualSymbols`. */
+export interface SymbolRegistryEntry {
+  id: string
 }
 
 /**
  * Walk a manual and collect every symbol id referenced by rule data
  * (`symbol_dial.columns` + `keypad.sequences`). Used by the build-time
- * validator to enforce 1:1 coverage with the `symbols` block.
+ * validator to enforce that every reference resolves to a known symbol in
+ * the shared SYMBOLS registry.
  */
 export function collectReferencedSymbols(modules: ManualModules): Set<string> {
   const seen = new Set<string>()
@@ -143,34 +157,27 @@ export function collectReferencedSymbols(modules: ManualModules): Set<string> {
 }
 
 /**
- * Throw if the manual's `symbols` block is missing entries for any symbol
- * referenced in `modules` (or contains stale entries no longer used).
- * Pure function so tests can call it directly with parsed YAML.
+ * Throw if the manual references any symbol id not registered in the
+ * shared SYMBOLS registry (the SSOT). Descriptions are no longer
+ * authoritative on the manual side — they are injected from `registry`
+ * during the manual build pipeline — so this validator's only job is to
+ * confirm the manual's referenced ids are a subset of the registry's ids.
+ * Pure function so tests can call it directly with parsed YAML + SYMBOLS.
  */
-export function validateManualSymbols(manual: Manual): void {
+export function validateManualSymbols(
+  manual: Manual,
+  registry: readonly SymbolRegistryEntry[]
+): void {
   const referenced = collectReferencedSymbols(manual.modules)
-  const declared = new Set(Object.keys(manual.symbols ?? {}))
+  const registered = new Set(registry.map((s) => s.id))
 
   const missing: string[] = []
   for (const id of referenced) {
-    const entry = manual.symbols?.[id]
-    if (!entry || typeof entry.description !== 'string' || entry.description.trim() === '') {
-      missing.push(id)
-    }
+    if (!registered.has(id)) missing.push(id)
   }
   if (missing.length > 0) {
     throw new Error(
-      `Manual ${manual.meta?.version ?? '<unknown>'}: missing symbols.<id>.description for: ${missing.join(', ')}`
-    )
-  }
-
-  const stale: string[] = []
-  for (const id of declared) {
-    if (!referenced.has(id)) stale.push(id)
-  }
-  if (stale.length > 0) {
-    throw new Error(
-      `Manual ${manual.meta?.version ?? '<unknown>'}: symbols block declares unused entries: ${stale.join(', ')}`
+      `Manual ${manual.meta?.version ?? '<unknown>'}: symbol id(s) referenced in modules but not registered in shared/symbols.ts SYMBOLS: ${missing.join(', ')}`
     )
   }
 }

--- a/shared/symbols.ts
+++ b/shared/symbols.ts
@@ -5,9 +5,18 @@
  *
  * `description` is Chinese and tuned for AI-to-player visual disambiguation:
  * canonical shape FIRST, then the most likely user-confusion phrasing in
- * "易被误描述为'X'" form. The same descriptions ship inside each manual
- * YAML's `symbols:` block so the AI sees them when reading the manual; this
- * registry is the source of the strings injected into the assistant prompt.
+ * "易被误描述为'X'" form. This file is the single source of truth for those
+ * strings — both downstream consumers derive from here at build / render
+ * time:
+ *   - `packages/manual/build.ts` injects each referenced symbol's
+ *     description into the YAML embedded in the rendered manual HTML
+ *     (`dist/<slug>/index.html`). The source YAML and the dist raw YAML
+ *     never carry a `symbols:` block.
+ *   - `packages/game/src/utils/assistant-prompt.ts` reads SYMBOLS at
+ *     runtime to populate the prompt's "## 符号视觉对照" section.
+ * A vitest guard (`manual-schema.test.ts`) enforces character-equal
+ * descriptions between SYMBOLS and the HTML-embedded YAML so the two
+ * surfaces cannot drift silently.
  */
 
 export interface Symbol {


### PR DESCRIPTION
## Summary

- Collapses the `shared/symbols.ts` SYMBOLS ↔ `packages/manual/data/*.yaml` symbol description dual-SSOT — yaml files (source AND dist raw) no longer carry a `symbols:` block; descriptions live solely in SYMBOLS and are injected at build time into the rendered manual HTML's embedded yaml.
- Implements **Option C** of the design paper (`/tmp/unify-symbol-description-ssot-options-v2.md`), chosen by the user after Design phase. Trade-off: AI clients hitting `?format=yaml` no longer get descriptions in raw yaml — the assistant prompt remains the SSOT for that path.
- Builds on top of #54 (cross-SSOT character-equal guard); the test there is retargeted to read `dist/<slug>/index.html` and parse the embed instead of reading source yaml.

## Type of change

- [x] Refactor or cleanup
- [x] Documentation (CHANGELOG entry, JSDoc on `shared/symbols.ts`, inline comment on `assistant-prompt.ts`)

## Testing

- [x] Existing tests pass (`pnpm --filter game test`: 107/107 across 20 files; reruns under pre-commit hook also green)
- [x] New tests added — Option C invariant: source + dist raw yaml ship no `symbols:` block; HTML-embedded yaml's symbols block character-equal to SYMBOLS for every referenced id

## Checklist

- [x] Code follows the project style (eslint + prettier + markdownlint clean per implementer report)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated (`CHANGELOG.md` `Manual symbol description SSOT` entry, JSDoc, inline comment)
- [x] Breaking changes documented — `?format=yaml` AI path no longer ships descriptions; flagged in CHANGELOG entry

## Implementation notes

- `packages/manual/build.ts`: imports SYMBOLS via default-import shim (Node 25 + tsx loads `shared/*.ts` as CJS-via-default because `shared/` lacks a `package.json` with `"type": "module"`); `validateReferencedSymbolsAgainstSSOT` rejects modules-referenced ids absent from SYMBOLS at build; clones `parsed`, injects SYMBOLS-derived `symbols` into the clone, embeds clone in HTML, writes raw yaml from un-injected `parsed`.
- Embed minification switched from `flowLevel:5 + strip-newlines` (which produced unparseable yaml — broken under `yaml.load`) to `flowLevel:0` with `lineWidth:-1` — equivalently dense single-line flow yaml that round-trips correctly. Required for the cross-SSOT test which re-parses the embed.
- `shared/manual-schema.ts` `validateManualSymbols` signature changed to `(manual, registry)`; semantics now "every referenced id ⊆ registry ids" rather than "yaml.symbols block self-coverage".

🤖 Generated with [Claude Code](https://claude.com/claude-code)