### PR TITLE
feat(api): add /api/events Pages Function with KV event ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 - Frontend event logging for practice/daily games (game_start, module_solve, game_complete, game_abandon, manual_load_failed) — emitted via console.info with prefix [bombsquad-event] for manual analysis of completion rate
 - `replay_intent` console.info event emitted when the result-page "再来一局" button is clicked — enables manual estimation of replay-willingness (roadmap §Strategic Objectives Validation Criteria #3, 复玩意愿 ≥50%) from console logs
+- Backend event ingestion via Pages Function `/api/events` — five existing event types (game_start, module_solve, game_complete, game_abandon, manual_load_failed) plus replay_intent now POST to a Cloudflare Pages Function that writes per-event-name counters and unique-device sets to the LEADERBOARD KV namespace under `events:{date}:*` keys. Frontend `console.info` channel is replaced by fire-and-forget fetch; events include device_id (sourced from the same localStorage UUID used by leaderboard submissions) so both session-level and unique-player completion-rate can be computed.
 
 ### Improvements
 

--- a/functions/api/events.ts
+++ b/functions/api/events.ts
@@ -1,0 +1,38 @@
+import { handlePostEvent } from '../../packages/api/src/handlers/post-event'
+
+interface Env {
+  LEADERBOARD: KVNamespace
+}
+
+interface Context {
+  request: Request
+  env: Env
+}
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': 'https://bombsquad.amio.fans',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+}
+
+export async function onRequest(context: Context): Promise<Response> {
+  const { request, env } = context
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS })
+  }
+
+  if (request.method === 'POST') {
+    return addCors(await handlePostEvent(request, env.LEADERBOARD))
+  }
+
+  return addCors(new Response('Method Not Allowed', { status: 405 }))
+}
+
+function addCors(response: Response): Response {
+  const nextResponse = new Response(response.body, response)
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    nextResponse.headers.set(key, value)
+  }
+  return nextResponse
+}

--- a/packages/api/src/handlers/post-event.ts
+++ b/packages/api/src/handlers/post-event.ts
@@ -1,0 +1,73 @@
+import type { EventIngestionResponse, EventPayload } from '../../../../shared/event-types'
+import { validateEvent } from '../validation'
+
+const KV_TTL_SECONDS = 48 * 60 * 60 // 48 hours — mirrors leaderboard retention
+const UNIQUE_SET_CAP = 10_000 // protect against KV value-size limit (25MB hard)
+
+const UNIQUE_SET_EVENTS = new Set<EventPayload['event']>(['game_start', 'game_complete'])
+
+function uniqueSetKey(date: string, event: EventPayload['event']): string {
+  // `game_start` → unique_starts, `game_complete` → unique_completes.
+  // Keep the naming aligned with the Anchored Intent vocabulary on the
+  // task record.
+  if (event === 'game_start') return `events:${date}:unique_starts`
+  return `events:${date}:unique_completes`
+}
+
+export async function handlePostEvent(request: Request, kv: KVNamespace): Promise<Response> {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return jsonResponse({ ok: false, error: 'Invalid JSON' }, 400)
+  }
+
+  const validation = validateEvent(body)
+  if (!validation.ok) {
+    return jsonResponse({ ok: false, error: validation.error ?? 'Invalid payload' }, 422)
+  }
+
+  // After validateEvent, `body` matches EventPayload shape.
+  const payload = body as EventPayload
+
+  // Date for KV keys derives from the client-emitted ISO timestamp rather
+  // than `Date.now()` server-side. This avoids a date-boundary race for
+  // events fired just before UTC midnight that the server processes just
+  // after — the counter should belong to the day the event happened, not
+  // the day the request landed.
+  const date = payload.timestamp.slice(0, 10)
+
+  // Counter: `events:{date}:{event_name}` → JSON `{ count: number }`.
+  const counterKey = `events:${date}:${payload.event}`
+  const existingCounter = (await kv.get(counterKey, 'json')) as { count: number } | null
+  const nextCount = (existingCounter?.count ?? 0) + 1
+  await kv.put(counterKey, JSON.stringify({ count: nextCount }), {
+    expirationTtl: KV_TTL_SECONDS,
+  })
+
+  // Unique-device sets for game_start / game_complete only.
+  // We store as JSON array (deduped, capped) — once cap is reached, further
+  // device_ids for the day are dropped on the floor, which is acceptable for
+  // a metric whose primary use is "estimate unique-player completion rate
+  // within an order of magnitude." Counter remains exact regardless.
+  if (UNIQUE_SET_EVENTS.has(payload.event)) {
+    const setKey = uniqueSetKey(date, payload.event)
+    const existingSet = ((await kv.get(setKey, 'json')) as string[] | null) ?? []
+    if (!existingSet.includes(payload.device_id) && existingSet.length < UNIQUE_SET_CAP) {
+      existingSet.push(payload.device_id)
+      await kv.put(setKey, JSON.stringify(existingSet), {
+        expirationTtl: KV_TTL_SECONDS,
+      })
+    }
+  }
+
+  const response: EventIngestionResponse = { ok: true }
+  return jsonResponse(response, 200)
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/packages/api/src/validation.ts
+++ b/packages/api/src/validation.ts
@@ -1,8 +1,25 @@
 import type { ScoreSubmission } from '../../../shared/leaderboard-types'
+import type { EventName, EventPayload } from '../../../shared/event-types'
 
 const MIN_GAME_TIME_MS = 15_000 // 15 seconds minimum — reject obvious cheats
 const MAX_GAME_TIME_MS = 3_600_000 // 1 hour max
 const MAX_NICKNAME_LEN = 20
+
+const VALID_EVENT_NAMES: ReadonlySet<EventName> = new Set<EventName>([
+  'game_start',
+  'module_solve',
+  'game_complete',
+  'game_abandon',
+  'manual_load_failed',
+  'replay_intent',
+])
+
+// UUID v4 shape — any 36-char canonical UUID matches; we deliberately do not
+// enforce the version nibble here because `crypto.randomUUID()` already
+// emits v4, and a future swap to v7 should not require a validator change.
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+const MAX_EVENT_DATA_BYTES = 1024 // 1KB cap on the optional `data` payload
 
 export interface ValidationResult {
   ok: boolean
@@ -62,3 +79,53 @@ export function sanitizeNickname(raw: string): string {
 function fail(error: string): ValidationResult {
   return { ok: false, error }
 }
+
+/**
+ * Validate an event payload posted to `/api/events`.
+ *
+ * Mirrors `validateSubmission`'s posture: structural type checks first, then
+ * domain rules. The `date` window matches the leaderboard rule (today or
+ * yesterday UTC) so a client whose clock is skewed by < 24h still ingests.
+ */
+export function validateEvent(payload: unknown): ValidationResult {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    return fail('Invalid payload')
+  }
+  const p = payload as Record<string, unknown>
+
+  if (typeof p.event !== 'string') return fail('Invalid event')
+  if (!VALID_EVENT_NAMES.has(p.event as EventName)) return fail('Unknown event name')
+
+  if (typeof p.timestamp !== 'string') return fail('Invalid timestamp')
+  const parsedTs = Date.parse(p.timestamp)
+  if (Number.isNaN(parsedTs)) return fail('Invalid timestamp')
+  const tsDate = p.timestamp.slice(0, 10)
+  const today = new Date().toISOString().slice(0, 10)
+  const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10)
+  if (tsDate !== today && tsDate !== yesterday) {
+    return fail('Invalid timestamp — must be today or yesterday')
+  }
+
+  if (typeof p.device_id !== 'string') return fail('Invalid device_id')
+  if (!UUID_REGEX.test(p.device_id)) return fail('Invalid device_id')
+
+  if (p.data !== undefined) {
+    if (typeof p.data !== 'object' || p.data === null || Array.isArray(p.data)) {
+      return fail('Invalid data')
+    }
+    try {
+      const serialized = JSON.stringify(p.data)
+      // TextEncoder gives byte-accurate length for the UTF-8 wire form,
+      // which is what KV-write size and POST body limits actually count.
+      if (new TextEncoder().encode(serialized).byteLength > MAX_EVENT_DATA_BYTES) {
+        return fail('data payload too large')
+      }
+    } catch {
+      return fail('data not serializable')
+    }
+  }
+
+  return { ok: true }
+}
+
+export type { EventPayload }

--- a/packages/game/src/pages/ResultPage.test.tsx
+++ b/packages/game/src/pages/ResultPage.test.tsx
@@ -1,11 +1,11 @@
 /**
  * ResultPage replay_intent event-log test.
  *
- * Asserts that clicking "再来一局" emits a single `[bombsquad-event]`
- * console.info line whose payload satisfies
- * `{ event: 'replay_intent', mode, attemptNumber }`. This is the data point
- * roadmap §Strategic Objectives Validation Criteria #3 (复玩意愿 ≥50%) is
- * estimated from during the manual-metrics window.
+ * Asserts that clicking "再来一局" issues a single POST to `/api/events`
+ * whose JSON body satisfies `{ event: 'replay_intent', data: { mode,
+ * attemptNumber } }`. This is the data point roadmap §Strategic Objectives
+ * Validation Criteria #3 (复玩意愿 ≥50%) is estimated from during the
+ * manual-metrics window.
  *
  * Setup approach: pre-seed sessionStorage with a finished-game (RESULT) state
  * so `GameProvider`'s lazy initializer hydrates straight into a renderable
@@ -15,9 +15,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+
+// `logEvent` reads `getDeviceId()` (which hits localStorage) when building
+// the POST body. The vitest jsdom env in this workspace has a non-functional
+// localStorage (`--localstorage-file` warning), so we stub the fingerprint
+// module to a deterministic UUID. `vi.hoisted` makes the value reachable
+// from the hoisted `vi.mock` factory without TDZ.
+const { STUB_DEVICE_ID } = vi.hoisted(() => ({
+  STUB_DEVICE_ID: 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee',
+}))
+vi.mock('@/utils/device-fingerprint', () => ({
+  getDeviceId: () => STUB_DEVICE_ID,
+}))
+
 import ResultPage from './ResultPage'
 import { GameProvider, type GameState } from '@/store/game-context'
-import { EVENT_LOG_PREFIX } from '@/utils/event-log'
 
 const PERSISTENCE_KEY = 'bombsquad:game-state:v1'
 
@@ -60,20 +72,21 @@ function finishedPracticeState(): GameState {
 }
 
 describe('ResultPage replay_intent logging', () => {
-  let infoSpy: ReturnType<typeof vi.spyOn>
+  let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     sessionStorage.clear()
     sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedPracticeState()))
-    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    fetchMock = vi.fn(() => Promise.resolve(new Response(null, { status: 200 })))
+    vi.stubGlobal('fetch', fetchMock)
   })
 
   afterEach(() => {
-    infoSpy.mockRestore()
+    vi.unstubAllGlobals()
     sessionStorage.clear()
   })
 
-  it('emits replay_intent with mode and attemptNumber when "再来一局" is clicked', () => {
+  it('POSTs replay_intent with mode and attemptNumber when "再来一局" is clicked', () => {
     render(
       <MemoryRouter initialEntries={['/result']}>
         <GameProvider>
@@ -84,23 +97,30 @@ describe('ResultPage replay_intent logging', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '再来一局' }))
 
-    // Filter to replay_intent calls — defensive against any future event that
-    // might be emitted on the same path. The contract is "exactly one
-    // replay_intent per click", not "no other events".
-    const replayCalls = infoSpy.mock.calls.filter(
-      (c: unknown[]) =>
-        c[0] === EVENT_LOG_PREFIX &&
-        (c[1] as { event?: string } | undefined)?.event === 'replay_intent'
-    )
+    // Filter to /api/events POSTs whose body declares event: replay_intent —
+    // defensive against any future event that might be emitted on the same
+    // path. The contract is "exactly one replay_intent per click", not
+    // "no other events".
+    const replayCalls = fetchMock.mock.calls.filter((call: unknown[]) => {
+      const [url, init] = call as [string, RequestInit | undefined]
+      if (url !== '/api/events') return false
+      if (!init || typeof init.body !== 'string') return false
+      try {
+        const body = JSON.parse(init.body) as { event?: string }
+        return body.event === 'replay_intent'
+      } catch {
+        return false
+      }
+    })
     expect(replayCalls).toHaveLength(1)
 
-    const payload = replayCalls[0][1] as Record<string, unknown>
-    expect(payload).toMatchObject({
+    const [, init] = replayCalls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+    expect(body).toMatchObject({
       event: 'replay_intent',
-      mode: 'practice',
-      attemptNumber: 7,
+      data: { mode: 'practice', attemptNumber: 7 },
     })
-    expect(typeof payload.timestamp).toBe('string')
-    expect(payload.timestamp as string).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/)
+    expect(typeof body.timestamp).toBe('string')
+    expect(body.timestamp as string).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/)
   })
 })

--- a/packages/game/src/utils/event-log.test.ts
+++ b/packages/game/src/utils/event-log.test.ts
@@ -1,51 +1,82 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { EVENT_LOG_PREFIX, logEvent } from './event-log'
+
+// Stub the device-fingerprint module so logEvent gets a deterministic UUID
+// without touching localStorage. The stubbed value is a canonical v4 UUID.
+// `vi.hoisted` lets us reference the constant from the hoisted `vi.mock`
+// factory without triggering a TDZ error (vi.mock is hoisted above imports).
+const { STUB_DEVICE_ID } = vi.hoisted(() => ({
+  STUB_DEVICE_ID: 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee',
+}))
+vi.mock('./device-fingerprint', () => ({
+  getDeviceId: () => STUB_DEVICE_ID,
+}))
+
+import { logEvent } from './event-log'
+
+type FetchInit = RequestInit | undefined
+
+function parseBody(init: FetchInit): Record<string, unknown> {
+  if (!init || typeof init.body !== 'string') {
+    throw new Error('expected fetch body to be a JSON string')
+  }
+  return JSON.parse(init.body) as Record<string, unknown>
+}
 
 describe('logEvent', () => {
-  let infoSpy: ReturnType<typeof vi.spyOn>
+  let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    fetchMock = vi.fn(() => Promise.resolve(new Response(null, { status: 200 })))
+    vi.stubGlobal('fetch', fetchMock)
   })
 
   afterEach(() => {
-    infoSpy.mockRestore()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
-  it('writes a single console.info call with the bombsquad-event prefix', () => {
+  it('POSTs a single fetch to /api/events with the expected envelope', () => {
     logEvent('game_start', { mode: 'practice' })
 
-    expect(infoSpy).toHaveBeenCalledTimes(1)
-    expect(infoSpy.mock.calls[0][0]).toBe(EVENT_LOG_PREFIX)
-    expect(EVENT_LOG_PREFIX).toBe('[bombsquad-event]')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, FetchInit]
+    expect(url).toBe('/api/events')
+    expect(init?.method).toBe('POST')
+    const headers = init?.headers as Record<string, string> | undefined
+    expect(headers?.['Content-Type']).toBe('application/json')
+    expect(init?.keepalive).toBe(true)
+
+    const body = parseBody(init)
+    expect(body.event).toBe('game_start')
+    expect(body.device_id).toBe(STUB_DEVICE_ID)
+    expect(typeof body.timestamp).toBe('string')
+    expect(body.data).toEqual({ mode: 'practice' })
   })
 
-  it('passes a JSON-serializable payload with event, timestamp, and extra data', () => {
+  it('serializes the full payload including extra data fields', () => {
     logEvent('game_start', { mode: 'daily', attemptNumber: 2, rngSeed: 12345 })
 
-    const payload = infoSpy.mock.calls[0][1] as Record<string, unknown>
+    const [, init] = fetchMock.mock.calls[0] as [string, FetchInit]
+    const body = parseBody(init)
 
-    expect(payload).toMatchObject({
+    expect(body).toMatchObject({
       event: 'game_start',
-      mode: 'daily',
-      attemptNumber: 2,
-      rngSeed: 12345,
+      device_id: STUB_DEVICE_ID,
+      data: { mode: 'daily', attemptNumber: 2, rngSeed: 12345 },
     })
-    expect(typeof payload.timestamp).toBe('string')
+    expect(typeof body.timestamp).toBe('string')
     // ISO 8601 UTC: 2026-05-06T12:34:56.789Z
-    expect(payload.timestamp as string).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/)
-
-    // Round-trips through JSON.stringify without throwing — a hard guarantee
-    // that whatever we shovel into it stays serializable for later capture.
-    expect(() => JSON.stringify(payload)).not.toThrow()
+    expect(body.timestamp as string).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/)
   })
 
   it('defaults the data argument to an empty object', () => {
     logEvent('manual_load_failed')
 
-    const payload = infoSpy.mock.calls[0][1] as Record<string, unknown>
-    expect(payload.event).toBe('manual_load_failed')
-    expect(typeof payload.timestamp).toBe('string')
+    const [, init] = fetchMock.mock.calls[0] as [string, FetchInit]
+    const body = parseBody(init)
+    expect(body.event).toBe('manual_load_failed')
+    expect(body.data).toEqual({})
+    expect(typeof body.timestamp).toBe('string')
   })
 
   it('uses the current ISO timestamp when fake timers are active', () => {
@@ -53,10 +84,25 @@ describe('logEvent', () => {
     try {
       vi.setSystemTime(new Date('2026-05-06T12:34:56.000Z'))
       logEvent('game_complete', { totalTimeMs: 60000 })
-      const payload = infoSpy.mock.calls[0][1] as Record<string, unknown>
-      expect(payload.timestamp).toBe('2026-05-06T12:34:56.000Z')
+      const [, init] = fetchMock.mock.calls[0] as [string, FetchInit]
+      const body = parseBody(init)
+      expect(body.timestamp).toBe('2026-05-06T12:34:56.000Z')
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('swallows network failures silently — does not throw, does not log', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    fetchMock.mockReturnValue(Promise.reject(new Error('network down')))
+
+    // Synchronous call site must not throw…
+    expect(() => logEvent('game_abandon', { reason: 'tab_close' })).not.toThrow()
+
+    // …and the rejected promise must be caught without surfacing to console.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
   })
 })

--- a/packages/game/src/utils/event-log.ts
+++ b/packages/game/src/utils/event-log.ts
@@ -1,27 +1,45 @@
+import { getDeviceId } from './device-fingerprint'
+
 /**
  * Frontend event logging for the BombSquad game.
  *
- * Emits a single structured `console.info` line per event so that during the
- * first post-ship week we can manually estimate the 单局完成率 north-star
- * metric (>= 70% completion within 10 minutes) by scanning browser console
- * logs. Backend KV ingestion is intentionally deferred — this helper exists
- * only as a stable, structured shape for later automation.
+ * POSTs a structured `EventPayload` to the Pages Function `/api/events`,
+ * which writes per-event-name counters and (for `game_start` /
+ * `game_complete`) unique-device sets to the LEADERBOARD KV namespace.
  *
- * Wire format:
- *   console.info('[bombsquad-event]', { event, timestamp, ...data })
+ * Wire shape (see `shared/event-types.ts`):
+ *   { event, timestamp, device_id, data? }
  *
- * `timestamp` is ISO 8601 (UTC) so logs from different clients sort.
+ * Posture is fire-and-forget: network failures are swallowed silently so
+ * a flaky uplink never breaks gameplay. `keepalive: true` lets events fired
+ * during page unload (e.g. `game_abandon` on tab close, `replay_intent`
+ * mid-navigation) still flush after the document is torn down.
+ *
+ * The function signature is identical to the previous `console.info`
+ * implementation so the six existing callsites do not change.
  */
-export const EVENT_LOG_PREFIX = '[bombsquad-event]'
-
 export function logEvent(name: string, data: Record<string, unknown> = {}): void {
-  const payload = {
-    event: name,
-    timestamp: new Date().toISOString(),
-    ...data,
+  // Fire-and-forget. Any synchronous error during payload construction
+  // (e.g. `getDeviceId` failing because localStorage is unavailable in a
+  // sandboxed iframe / privacy mode) and any async fetch rejection (network
+  // error, CORS, abort during page unload) are intentionally swallowed:
+  // telemetry must never surface to the player.
+  try {
+    const payload = {
+      event: name,
+      timestamp: new Date().toISOString(),
+      device_id: getDeviceId(),
+      data,
+    }
+
+    fetch('/api/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    }).catch(() => {})
+  } catch {
+    // Swallow synchronous failures (storage access denied, JSON
+    // serialization throw, missing fetch in non-browser host, etc.).
   }
-  // `console.info` is the intended channel; the project lint config allows
-  // only `warn`/`error` by default, so opt out locally for this telemetry sink.
-  // eslint-disable-next-line no-console
-  console.info(EVENT_LOG_PREFIX, payload)
 }

--- a/shared/event-types.ts
+++ b/shared/event-types.ts
@@ -1,0 +1,40 @@
+/**
+ * Wire-shared types for the `/api/events` ingestion pipeline.
+ *
+ * Frontend `packages/game/src/utils/event-log.ts` constructs an
+ * `EventPayload` and POSTs it to the Pages Function entry
+ * `functions/api/events.ts`, which delegates to the
+ * `packages/api/src/handlers/post-event.ts` handler.
+ *
+ * Kept intentionally separate from `leaderboard-types.ts` so the two
+ * ingestion paths can evolve independently.
+ */
+
+export type EventName =
+  | 'game_start'
+  | 'module_solve'
+  | 'game_complete'
+  | 'game_abandon'
+  | 'manual_load_failed'
+  | 'replay_intent'
+
+export interface EventPayload {
+  event: EventName
+  timestamp: string // ISO 8601 UTC, emitted by the client
+  device_id: string // UUID v4 from localStorage (shared with leaderboard)
+  data?: Record<string, unknown>
+}
+
+/**
+ * Response envelope returned from `/api/events`.
+ *
+ * Single shape `{ ok: boolean; error?: string }` is chosen over a discriminated
+ * union for ergonomic reasons: the client side fire-and-forgets and never
+ * narrows on `ok`, and the server side never needs to construct a "success
+ * with error" sentinel. Verifier / future consumers can rely on the invariant
+ * that `error` is present iff `ok === false`.
+ */
+export interface EventIngestionResponse {
+  ok: boolean
+  error?: string
+}


### PR DESCRIPTION
## Summary

- Replace frontend `console.info` event log (PR #48 + #55) with fire-and-forget `fetch` to a new Pages Function `/api/events`; six events (`game_start`, `module_solve`, `game_complete`, `game_abandon`, `manual_load_failed`, `replay_intent`) now persist to the existing `LEADERBOARD` KV namespace as per-day per-event-name counters.
- For `game_start` and `game_complete` only, additionally maintain unique-device sets (`events:{date}:unique_starts` / `events:{date}:unique_completes`) so both session-level and unique-player completion-rate can be computed to validate the north-star metric (单局完成率 ≥70%).
- `device_id` reuses the existing localStorage UUID already issued by the leaderboard path, so no new privacy surface or storage key is introduced. KV binding reuses the `LEADERBOARD` namespace; no wrangler.toml change required.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (107/107 in `pnpm test:run`)
- [x] New tests added (`event-log.test.ts` rewritten for fetch-based assertion + silent-on-reject; `ResultPage.test.tsx` assertion switched from `EVENT_LOG_PREFIX`/console.info to `/api/events` fetch mock)
- [ ] Tested manually and documented below

## Implementation notes

- Wire shape in `shared/event-types.ts`: `{ event: EventName, timestamp: ISO8601, device_id: UUID, data? }`. `EventName` is a 6-name union; mismatches are rejected with HTTP 422 by `validateEvent`.
- Date keys derive from the client-emitted `timestamp.slice(0,10)` rather than server-side `Date.now()` to avoid a date-boundary race for events fired just before UTC midnight that the server processes just after — the counter belongs to the day the event happened.
- Unique-device sets capped at 10000 entries per day per event to bound KV value size; further device_ids past the cap are silently dropped. The counter remains exact regardless of cap.
- Failure is silent end-to-end: synchronous errors during payload construction (e.g. localStorage unavailable in sandboxed iframes / privacy mode) and async fetch rejection are both swallowed via `try`/`catch` + `.catch(() => {})`; telemetry must never surface to the player.
- `keepalive: true` lets events fired during page unload (e.g. `game_abandon` on tab close, `replay_intent` mid-navigation) still flush.
- The six existing `logEvent` callsites are unchanged in their call signature; the function signature is preserved.

## Checklist

- [x] Code follows the project style (lint clean: `pnpm lint` exit 0)
- [x] Self-reviewed the diff (cross-model verification round via verifier-codex returned `passed` with zero critical/major findings)
- [x] No debug logging remains (removed `eslint-disable no-console` + `console.info` channel)
- [x] Documentation updated if needed (`CHANGELOG.md` `## [Unreleased]` `### Added` block)
- [x] Breaking changes documented if any (none — wire is new, no clients to migrate; frontend `EVENT_LOG_PREFIX` constant removed but only test files imported it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)