### PR TITLE
fix(game,manual): unblock daily challenge with 365 derived manuals + _routes.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,20 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- **Daily challenge no longer crashes on missing dates** Every date for the
+  next year now serves a real daily manual derived deterministically from
+  the practice rulebook, so opening "每日挑战" on any date through
+  2027-05-11 loads a playable bomb instead of throwing
+  "谜题生成失败". Generator script `scripts/generate-daily-from-practice.mjs`
+  permutes the practice rules with a date-seeded RNG and writes one YAML
+  per day; same date always produces the same bomb.
+- **Friendly fallback for unpublished dates** Cloudflare now routes
+  `/manual/<date>` through the Pages Function before the SPA catch-all,
+  so requests for dates without a published manual return a clean 404
+  and the game renders the existing "今天的手册还没发布" UI with the
+  "去练习" CTA instead of a broken SPA shell that crashed puzzle
+  generation. The fix is a new `_routes.json` alongside the existing
+  `_redirects`; the SPA continues to handle every other route.
 - **Manual URL self-heals across domains** The prompt players copy into
   their AI, and the URL the game fetches daily manuals from, both now
   use `window.location.origin` instead of a hardcoded

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format": "pnpm exec prettier . --write",
     "format:check": "pnpm exec prettier --check .",
     "build": "pnpm --filter manual build && pnpm --filter game build && node scripts/assemble-pages.mjs",
+    "gen:daily": "node scripts/generate-daily-from-practice.mjs",
     "test": "pnpm -r run test",
     "test:run": "pnpm -r run test:run",
     "prepare": "husky"

--- a/packages/game/public/_routes.json
+++ b/packages/game/public/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/manual/*", "/api/*"],
+  "exclude": []
+}

--- a/packages/manual/data/daily/2026-05-12.yaml
+++ b/packages/manual/data/daily/2026-05-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - delta
+        - omega
+        - star
+        - xi
+        - diamond
+      - - diamond
+        - xi
+        - psi
+        - star
+        - omega
+        - delta
+      - - delta
+        - xi
+        - psi
+        - omega
+        - star
+        - trident
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - omega
+        - star
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - diamond
+        - xi
+        - psi
+        - trident
+        - omega
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - omega
+        - diamond
+        - star
+        - xi
+        - delta
+        - psi
+      - - omega
+        - delta
+        - diamond
+        - psi
+        - xi
+        - star
+      - - omega
+        - psi
+        - xi
+        - diamond
+        - star
+        - delta
+      - - xi
+        - psi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - diamond
+        - omega
+        - delta
+        - xi
+        - psi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-13.yaml
+++ b/packages/manual/data/daily/2026-05-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - psi
+        - omega
+        - xi
+        - delta
+        - diamond
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+        - star
+      - - trident
+        - star
+        - delta
+        - xi
+        - psi
+        - omega
+      - - delta
+        - psi
+        - xi
+        - trident
+        - omega
+        - diamond
+      - - delta
+        - diamond
+        - xi
+        - omega
+        - psi
+        - star
+      - - delta
+        - omega
+        - xi
+        - psi
+        - star
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - delta
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - star
+        - psi
+      - - diamond
+        - psi
+        - omega
+        - delta
+        - xi
+        - star
+      - - diamond
+        - psi
+        - delta
+        - star
+        - xi
+        - omega
+      - - xi
+        - psi
+        - star
+        - diamond
+        - omega
+        - delta
+      - - xi
+        - delta
+        - psi
+        - star
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-14.yaml
+++ b/packages/manual/data/daily/2026-05-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - star
+        - diamond
+        - psi
+        - delta
+        - xi
+      - - xi
+        - star
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - psi
+        - star
+        - xi
+        - omega
+        - delta
+        - diamond
+      - - star
+        - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+      - - omega
+        - trident
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - psi
+        - star
+        - omega
+        - xi
+        - delta
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - delta
+        - psi
+        - star
+        - diamond
+        - xi
+      - - xi
+        - delta
+        - omega
+        - diamond
+        - star
+        - psi
+      - - star
+        - diamond
+        - omega
+        - xi
+        - psi
+        - delta
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - star
+        - psi
+      - - omega
+        - star
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - diamond
+        - star
+        - psi
+        - xi
+        - omega
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-15.yaml
+++ b/packages/manual/data/daily/2026-05-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - star
+        - delta
+        - trident
+        - omega
+        - xi
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - omega
+        - trident
+      - - psi
+        - omega
+        - star
+        - delta
+        - diamond
+        - xi
+      - - omega
+        - psi
+        - star
+        - diamond
+        - delta
+        - xi
+      - - omega
+        - psi
+        - xi
+        - diamond
+        - star
+        - delta
+      - - omega
+        - xi
+        - delta
+        - psi
+        - star
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+        - star
+      - - diamond
+        - delta
+        - xi
+        - omega
+        - psi
+        - star
+      - - star
+        - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+      - - xi
+        - delta
+        - star
+        - psi
+        - diamond
+        - omega
+      - - omega
+        - delta
+        - diamond
+        - psi
+        - star
+        - xi
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - star
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-16.yaml
+++ b/packages/manual/data/daily/2026-05-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - psi
+        - delta
+        - xi
+        - star
+        - omega
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+      - - omega
+        - xi
+        - diamond
+        - star
+        - delta
+        - psi
+      - - xi
+        - diamond
+        - omega
+        - delta
+        - star
+        - psi
+      - - star
+        - delta
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - xi
+        - diamond
+        - psi
+        - trident
+        - omega
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - star
+        - xi
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - star
+        - delta
+      - - diamond
+        - psi
+        - xi
+        - star
+        - omega
+        - delta
+      - - diamond
+        - psi
+        - delta
+        - xi
+        - omega
+        - star
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+        - star
+      - - delta
+        - diamond
+        - star
+        - xi
+        - psi
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-17.yaml
+++ b/packages/manual/data/daily/2026-05-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - star
+        - psi
+        - omega
+        - diamond
+        - xi
+      - - omega
+        - xi
+        - diamond
+        - trident
+        - psi
+        - delta
+      - - xi
+        - star
+        - delta
+        - omega
+        - diamond
+        - psi
+      - - xi
+        - trident
+        - omega
+        - psi
+        - delta
+        - star
+      - - delta
+        - omega
+        - psi
+        - star
+        - diamond
+        - xi
+      - - diamond
+        - xi
+        - star
+        - psi
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - star
+        - omega
+      - - diamond
+        - omega
+        - xi
+        - psi
+        - delta
+        - star
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - delta
+        - star
+      - - star
+        - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - diamond
+        - omega
+        - xi
+        - star
+        - psi
+        - delta
+      - - star
+        - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-18.yaml
+++ b/packages/manual/data/daily/2026-05-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - delta
+        - diamond
+        - omega
+        - psi
+        - xi
+      - - diamond
+        - omega
+        - xi
+        - trident
+        - delta
+        - psi
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - star
+        - xi
+      - - trident
+        - star
+        - omega
+        - xi
+        - delta
+        - psi
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+        - star
+      - - diamond
+        - delta
+        - psi
+        - star
+        - omega
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+        - star
+      - - diamond
+        - star
+        - omega
+        - psi
+        - delta
+        - xi
+      - - omega
+        - psi
+        - delta
+        - star
+        - diamond
+        - xi
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+        - star
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - omega
+        - star
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-19.yaml
+++ b/packages/manual/data/daily/2026-05-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - trident
+        - xi
+        - psi
+        - omega
+      - - diamond
+        - delta
+        - xi
+        - omega
+        - star
+        - psi
+      - - omega
+        - xi
+        - delta
+        - psi
+        - star
+        - trident
+      - - omega
+        - diamond
+        - xi
+        - star
+        - delta
+        - psi
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - star
+        - delta
+      - - star
+        - omega
+        - diamond
+        - delta
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - star
+        - delta
+        - diamond
+        - xi
+        - psi
+      - - omega
+        - delta
+        - psi
+        - star
+        - diamond
+        - xi
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - xi
+        - star
+      - - star
+        - omega
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - psi
+        - star
+        - omega
+        - delta
+        - diamond
+        - xi
+      - - psi
+        - omega
+        - star
+        - diamond
+        - delta
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-20.yaml
+++ b/packages/manual/data/daily/2026-05-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - diamond
+        - delta
+        - omega
+        - star
+        - psi
+        - xi
+      - - omega
+        - star
+        - trident
+        - delta
+        - psi
+        - xi
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+        - trident
+      - - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+        - star
+      - - star
+        - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - diamond
+        - omega
+        - star
+        - psi
+        - xi
+      - - omega
+        - star
+        - psi
+        - xi
+        - delta
+        - diamond
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - star
+        - xi
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - star
+        - psi
+      - - star
+        - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-21.yaml
+++ b/packages/manual/data/daily/2026-05-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - star
+        - delta
+        - trident
+        - psi
+        - xi
+      - - delta
+        - star
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - omega
+        - delta
+        - diamond
+        - psi
+        - star
+        - xi
+      - - diamond
+        - trident
+        - xi
+        - delta
+        - omega
+        - psi
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+        - star
+      - - star
+        - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+      - - omega
+        - diamond
+        - star
+        - delta
+        - psi
+        - xi
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - xi
+        - star
+      - - omega
+        - star
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - star
+        - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-22.yaml
+++ b/packages/manual/data/daily/2026-05-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - omega
+        - star
+        - psi
+        - delta
+      - - omega
+        - star
+        - xi
+        - delta
+        - psi
+        - diamond
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - trident
+        - delta
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - star
+        - xi
+        - psi
+        - trident
+        - delta
+        - omega
+      - - psi
+        - star
+        - xi
+        - omega
+        - delta
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - xi
+        - delta
+        - star
+        - diamond
+      - - omega
+        - star
+        - diamond
+        - psi
+        - delta
+        - xi
+      - - star
+        - diamond
+        - psi
+        - omega
+        - delta
+        - xi
+      - - delta
+        - xi
+        - omega
+        - star
+        - psi
+        - diamond
+      - - psi
+        - delta
+        - star
+        - xi
+        - omega
+        - diamond
+      - - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-23.yaml
+++ b/packages/manual/data/daily/2026-05-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - trident
+        - psi
+        - xi
+        - omega
+        - star
+      - - diamond
+        - omega
+        - xi
+        - psi
+        - star
+        - delta
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+        - star
+      - - omega
+        - xi
+        - trident
+        - diamond
+        - delta
+        - psi
+      - - omega
+        - delta
+        - star
+        - psi
+        - xi
+        - diamond
+      - - diamond
+        - star
+        - psi
+        - delta
+        - xi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - diamond
+        - delta
+        - star
+        - xi
+        - psi
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - star
+        - delta
+      - - delta
+        - star
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - psi
+        - omega
+        - star
+        - diamond
+        - xi
+        - delta
+      - - xi
+        - psi
+        - omega
+        - star
+        - delta
+        - diamond
+      - - star
+        - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-24.yaml
+++ b/packages/manual/data/daily/2026-05-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - psi
+        - star
+        - omega
+        - trident
+      - - omega
+        - delta
+        - star
+        - psi
+        - diamond
+        - xi
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+        - star
+      - - diamond
+        - psi
+        - omega
+        - xi
+        - star
+        - delta
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - trident
+        - delta
+      - - xi
+        - psi
+        - star
+        - delta
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - star
+        - delta
+      - - star
+        - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - star
+        - omega
+        - delta
+        - diamond
+        - xi
+        - psi
+      - - diamond
+        - star
+        - delta
+        - psi
+        - xi
+        - omega
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-25.yaml
+++ b/packages/manual/data/daily/2026-05-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - psi
+        - star
+        - omega
+        - delta
+        - xi
+      - - delta
+        - star
+        - diamond
+        - xi
+        - omega
+        - psi
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+        - star
+      - - psi
+        - diamond
+        - star
+        - delta
+        - omega
+        - xi
+      - - star
+        - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - diamond
+        - psi
+        - xi
+        - trident
+        - omega
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - star
+        - delta
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - xi
+        - star
+      - - star
+        - xi
+        - diamond
+        - omega
+        - delta
+        - psi
+      - - star
+        - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+      - - xi
+        - omega
+        - psi
+        - delta
+        - diamond
+        - star
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-26.yaml
+++ b/packages/manual/data/daily/2026-05-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - delta
+        - diamond
+        - omega
+        - star
+        - xi
+      - - delta
+        - diamond
+        - psi
+        - trident
+        - omega
+        - xi
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+        - star
+      - - star
+        - psi
+        - omega
+        - diamond
+        - delta
+        - xi
+      - - omega
+        - trident
+        - xi
+        - psi
+        - star
+        - delta
+      - - omega
+        - psi
+        - diamond
+        - star
+        - xi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - delta
+        - star
+        - psi
+        - xi
+        - diamond
+      - - diamond
+        - delta
+        - psi
+        - xi
+        - star
+        - omega
+      - - omega
+        - diamond
+        - delta
+        - star
+        - xi
+        - psi
+      - - omega
+        - star
+        - delta
+        - psi
+        - diamond
+        - xi
+      - - omega
+        - diamond
+        - psi
+        - xi
+        - star
+        - delta
+      - - diamond
+        - delta
+        - omega
+        - star
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-27.yaml
+++ b/packages/manual/data/daily/2026-05-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - star
+        - diamond
+        - delta
+        - xi
+        - omega
+      - - diamond
+        - xi
+        - omega
+        - star
+        - delta
+        - psi
+      - - star
+        - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+      - - delta
+        - diamond
+        - omega
+        - trident
+        - psi
+        - xi
+      - - omega
+        - diamond
+        - psi
+        - star
+        - delta
+        - xi
+      - - omega
+        - delta
+        - psi
+        - star
+        - trident
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - star
+        - delta
+        - xi
+        - omega
+        - diamond
+      - - delta
+        - xi
+        - diamond
+        - psi
+        - star
+        - omega
+      - - xi
+        - omega
+        - star
+        - psi
+        - diamond
+        - delta
+      - - star
+        - psi
+        - diamond
+        - omega
+        - delta
+        - xi
+      - - xi
+        - omega
+        - diamond
+        - delta
+        - star
+        - psi
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-28.yaml
+++ b/packages/manual/data/daily/2026-05-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - diamond
+        - delta
+        - star
+        - omega
+        - xi
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - star
+        - xi
+      - - psi
+        - xi
+        - star
+        - omega
+        - delta
+        - diamond
+      - - omega
+        - delta
+        - xi
+        - psi
+        - diamond
+        - trident
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - omega
+        - star
+      - - xi
+        - trident
+        - star
+        - omega
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - delta
+        - omega
+        - star
+        - psi
+        - diamond
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - star
+        - delta
+      - - delta
+        - star
+        - psi
+        - omega
+        - xi
+        - diamond
+      - - omega
+        - diamond
+        - star
+        - psi
+        - delta
+        - xi
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+        - star
+      - - star
+        - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-29.yaml
+++ b/packages/manual/data/daily/2026-05-29.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-29'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - star
+        - psi
+        - delta
+        - xi
+      - - star
+        - delta
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - psi
+        - star
+        - xi
+        - omega
+        - diamond
+        - delta
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - trident
+        - delta
+      - - trident
+        - delta
+        - star
+        - psi
+        - xi
+        - omega
+      - - xi
+        - diamond
+        - star
+        - omega
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - omega
+        - delta
+        - xi
+        - psi
+      - - diamond
+        - xi
+        - delta
+        - star
+        - omega
+        - psi
+      - - psi
+        - diamond
+        - delta
+        - star
+        - omega
+        - xi
+      - - diamond
+        - star
+        - xi
+        - omega
+        - psi
+        - delta
+      - - delta
+        - psi
+        - star
+        - xi
+        - omega
+        - diamond
+      - - star
+        - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-30.yaml
+++ b/packages/manual/data/daily/2026-05-30.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-30'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - psi
+        - star
+        - omega
+        - xi
+        - delta
+      - - omega
+        - diamond
+        - psi
+        - star
+        - delta
+        - xi
+      - - star
+        - diamond
+        - xi
+        - psi
+        - omega
+        - delta
+      - - star
+        - trident
+        - delta
+        - xi
+        - omega
+        - psi
+      - - psi
+        - diamond
+        - omega
+        - delta
+        - trident
+        - xi
+      - - omega
+        - star
+        - delta
+        - diamond
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - star
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - psi
+        - star
+        - diamond
+        - xi
+        - omega
+        - delta
+      - - star
+        - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+      - - psi
+        - star
+        - delta
+        - xi
+        - diamond
+        - omega
+      - - star
+        - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - star
+        - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-05-31.yaml
+++ b/packages/manual/data/daily/2026-05-31.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-05-31'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - diamond
+        - xi
+        - star
+        - psi
+      - - psi
+        - trident
+        - omega
+        - delta
+        - star
+        - xi
+      - - diamond
+        - omega
+        - trident
+        - delta
+        - xi
+        - psi
+      - - psi
+        - xi
+        - star
+        - delta
+        - diamond
+        - omega
+      - - diamond
+        - delta
+        - psi
+        - star
+        - xi
+        - omega
+      - - omega
+        - delta
+        - diamond
+        - star
+        - psi
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - omega
+        - delta
+        - star
+        - psi
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+        - star
+      - - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+        - star
+      - - omega
+        - diamond
+        - star
+        - xi
+        - delta
+        - psi
+      - - psi
+        - diamond
+        - delta
+        - star
+        - xi
+        - omega
+      - - star
+        - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-01.yaml
+++ b/packages/manual/data/daily/2026-06-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - delta
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - trident
+        - xi
+        - star
+        - omega
+        - psi
+        - delta
+      - - star
+        - diamond
+        - delta
+        - xi
+        - omega
+        - psi
+      - - psi
+        - omega
+        - xi
+        - delta
+        - star
+        - diamond
+      - - xi
+        - psi
+        - trident
+        - diamond
+        - omega
+        - delta
+      - - star
+        - delta
+        - diamond
+        - psi
+        - xi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - star
+        - delta
+      - - delta
+        - psi
+        - diamond
+        - omega
+        - star
+        - xi
+      - - diamond
+        - delta
+        - star
+        - omega
+        - psi
+        - xi
+      - - star
+        - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - delta
+        - star
+      - - star
+        - xi
+        - omega
+        - diamond
+        - psi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-02.yaml
+++ b/packages/manual/data/daily/2026-06-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - star
+        - xi
+      - - omega
+        - delta
+        - xi
+        - psi
+        - trident
+        - diamond
+      - - delta
+        - xi
+        - star
+        - trident
+        - omega
+        - psi
+      - - star
+        - diamond
+        - omega
+        - delta
+        - xi
+        - psi
+      - - delta
+        - psi
+        - xi
+        - star
+        - omega
+        - diamond
+      - - diamond
+        - xi
+        - star
+        - omega
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - star
+        - xi
+      - - omega
+        - star
+        - diamond
+        - psi
+        - delta
+        - xi
+      - - diamond
+        - star
+        - xi
+        - psi
+        - omega
+        - delta
+      - - star
+        - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+      - - psi
+        - star
+        - xi
+        - delta
+        - omega
+        - diamond
+      - - psi
+        - diamond
+        - star
+        - delta
+        - omega
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-03.yaml
+++ b/packages/manual/data/daily/2026-06-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - psi
+        - xi
+        - delta
+        - trident
+        - omega
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+        - star
+      - - xi
+        - star
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+        - trident
+      - - omega
+        - xi
+        - star
+        - psi
+        - diamond
+        - delta
+      - - xi
+        - diamond
+        - star
+        - psi
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - psi
+        - delta
+        - xi
+        - omega
+      - - diamond
+        - psi
+        - delta
+        - xi
+        - omega
+        - star
+      - - diamond
+        - omega
+        - star
+        - psi
+        - xi
+        - delta
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - star
+        - psi
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - xi
+        - star
+      - - xi
+        - omega
+        - psi
+        - delta
+        - star
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-04.yaml
+++ b/packages/manual/data/daily/2026-06-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - psi
+        - delta
+        - trident
+        - omega
+        - diamond
+      - - delta
+        - psi
+        - omega
+        - xi
+        - diamond
+        - star
+      - - psi
+        - xi
+        - star
+        - delta
+        - diamond
+        - omega
+      - - delta
+        - xi
+        - diamond
+        - star
+        - omega
+        - psi
+      - - star
+        - xi
+        - omega
+        - delta
+        - trident
+        - psi
+      - - psi
+        - omega
+        - delta
+        - star
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - psi
+        - omega
+        - delta
+        - xi
+      - - diamond
+        - psi
+        - star
+        - xi
+        - delta
+        - omega
+      - - xi
+        - star
+        - diamond
+        - psi
+        - delta
+        - omega
+      - - xi
+        - psi
+        - star
+        - delta
+        - diamond
+        - omega
+      - - xi
+        - delta
+        - star
+        - diamond
+        - omega
+        - psi
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-05.yaml
+++ b/packages/manual/data/daily/2026-06-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - omega
+        - xi
+        - trident
+        - psi
+        - delta
+      - - xi
+        - delta
+        - psi
+        - diamond
+        - omega
+        - star
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - star
+        - delta
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - trident
+        - psi
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - star
+        - delta
+      - - omega
+        - diamond
+        - star
+        - psi
+        - xi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - psi
+        - xi
+        - delta
+        - star
+        - omega
+        - diamond
+      - - delta
+        - xi
+        - star
+        - diamond
+        - omega
+        - psi
+      - - psi
+        - star
+        - xi
+        - diamond
+        - delta
+        - omega
+      - - xi
+        - psi
+        - star
+        - diamond
+        - omega
+        - delta
+      - - psi
+        - xi
+        - omega
+        - star
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-06.yaml
+++ b/packages/manual/data/daily/2026-06-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - xi
+        - trident
+        - omega
+        - star
+        - psi
+      - - psi
+        - star
+        - delta
+        - omega
+        - xi
+        - diamond
+      - - trident
+        - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+      - - diamond
+        - star
+        - omega
+        - delta
+        - xi
+        - psi
+      - - diamond
+        - psi
+        - omega
+        - xi
+        - star
+        - delta
+      - - diamond
+        - omega
+        - psi
+        - star
+        - xi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - delta
+        - star
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+        - star
+      - - omega
+        - delta
+        - diamond
+        - star
+        - xi
+        - psi
+      - - psi
+        - diamond
+        - xi
+        - star
+        - delta
+        - omega
+      - - star
+        - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - diamond
+        - star
+        - delta
+        - xi
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-07.yaml
+++ b/packages/manual/data/daily/2026-06-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - trident
+        - xi
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - omega
+        - star
+      - - diamond
+        - omega
+        - delta
+        - xi
+        - star
+        - psi
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - star
+        - delta
+      - - delta
+        - omega
+        - star
+        - trident
+        - psi
+        - xi
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - diamond
+        - psi
+        - xi
+        - delta
+        - omega
+        - star
+      - - diamond
+        - psi
+        - omega
+        - star
+        - delta
+        - xi
+      - - omega
+        - star
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - psi
+        - xi
+        - star
+        - diamond
+        - omega
+        - delta
+      - - delta
+        - star
+        - psi
+        - omega
+        - diamond
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-08.yaml
+++ b/packages/manual/data/daily/2026-06-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - star
+        - xi
+        - psi
+        - trident
+        - omega
+      - - trident
+        - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+      - - xi
+        - omega
+        - psi
+        - delta
+        - star
+        - diamond
+      - - delta
+        - xi
+        - psi
+        - star
+        - omega
+        - diamond
+      - - xi
+        - delta
+        - star
+        - psi
+        - diamond
+        - omega
+      - - omega
+        - diamond
+        - psi
+        - xi
+        - star
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+      - - psi
+        - diamond
+        - star
+        - omega
+        - delta
+        - xi
+      - - psi
+        - diamond
+        - delta
+        - xi
+        - omega
+        - star
+      - - psi
+        - xi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+        - star
+      - - star
+        - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-09.yaml
+++ b/packages/manual/data/daily/2026-06-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - diamond
+        - trident
+        - delta
+        - psi
+        - omega
+      - - delta
+        - star
+        - diamond
+        - xi
+        - omega
+        - psi
+      - - delta
+        - star
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - star
+        - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+      - - star
+        - xi
+        - psi
+        - omega
+        - delta
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - star
+        - omega
+      - - omega
+        - xi
+        - delta
+        - diamond
+        - star
+        - psi
+      - - star
+        - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - omega
+        - delta
+        - xi
+        - star
+        - diamond
+        - psi
+      - - xi
+        - delta
+        - omega
+        - diamond
+        - star
+        - psi
+      - - omega
+        - delta
+        - star
+        - xi
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-10.yaml
+++ b/packages/manual/data/daily/2026-06-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - psi
+        - star
+        - trident
+        - xi
+        - delta
+      - - diamond
+        - psi
+        - star
+        - xi
+        - omega
+        - delta
+      - - diamond
+        - star
+        - delta
+        - xi
+        - omega
+        - psi
+      - - delta
+        - omega
+        - xi
+        - star
+        - psi
+        - diamond
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+        - trident
+      - - psi
+        - star
+        - delta
+        - xi
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - xi
+        - star
+        - omega
+        - delta
+      - - psi
+        - diamond
+        - star
+        - xi
+        - omega
+        - delta
+      - - star
+        - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - omega
+        - star
+        - psi
+        - delta
+        - diamond
+        - xi
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - star
+        - xi
+      - - diamond
+        - star
+        - xi
+        - psi
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-11.yaml
+++ b/packages/manual/data/daily/2026-06-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - psi
+        - xi
+        - star
+        - omega
+        - delta
+      - - xi
+        - delta
+        - star
+        - psi
+        - diamond
+        - omega
+      - - xi
+        - omega
+        - diamond
+        - star
+        - psi
+        - delta
+      - - xi
+        - delta
+        - diamond
+        - psi
+        - trident
+        - omega
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - star
+        - psi
+      - - delta
+        - omega
+        - star
+        - psi
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+      - - diamond
+        - omega
+        - delta
+        - xi
+        - star
+        - psi
+      - - diamond
+        - psi
+        - star
+        - omega
+        - xi
+        - delta
+      - - xi
+        - star
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - star
+        - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - xi
+        - omega
+        - star
+        - psi
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-12.yaml
+++ b/packages/manual/data/daily/2026-06-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - omega
+        - xi
+        - psi
+        - trident
+        - delta
+      - - psi
+        - diamond
+        - omega
+        - delta
+        - star
+        - xi
+      - - diamond
+        - star
+        - xi
+        - omega
+        - delta
+        - psi
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - omega
+        - psi
+        - delta
+        - trident
+        - xi
+        - diamond
+      - - star
+        - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - star
+        - delta
+      - - star
+        - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+      - - psi
+        - star
+        - delta
+        - omega
+        - diamond
+        - xi
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - diamond
+        - omega
+        - xi
+        - star
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-13.yaml
+++ b/packages/manual/data/daily/2026-06-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - omega
+        - delta
+        - psi
+        - trident
+        - diamond
+        - xi
+      - - psi
+        - star
+        - omega
+        - delta
+        - diamond
+        - xi
+      - - omega
+        - psi
+        - star
+        - delta
+        - xi
+        - diamond
+      - - trident
+        - delta
+        - xi
+        - star
+        - psi
+        - omega
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - xi
+        - delta
+        - omega
+        - star
+      - - omega
+        - xi
+        - star
+        - psi
+        - diamond
+        - delta
+      - - omega
+        - delta
+        - psi
+        - star
+        - diamond
+        - xi
+      - - star
+        - omega
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - psi
+        - diamond
+        - star
+        - delta
+        - xi
+        - omega
+      - - psi
+        - star
+        - omega
+        - xi
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-14.yaml
+++ b/packages/manual/data/daily/2026-06-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+        - star
+      - - trident
+        - omega
+        - star
+        - psi
+        - xi
+        - delta
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - trident
+      - - diamond
+        - delta
+        - star
+        - omega
+        - xi
+        - psi
+      - - star
+        - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - omega
+        - psi
+        - star
+        - xi
+        - delta
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - star
+        - omega
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - star
+        - delta
+      - - psi
+        - diamond
+        - delta
+        - xi
+        - star
+        - omega
+      - - star
+        - diamond
+        - psi
+        - omega
+        - delta
+        - xi
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+        - star
+      - - diamond
+        - delta
+        - xi
+        - star
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-15.yaml
+++ b/packages/manual/data/daily/2026-06-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - psi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - omega
+        - diamond
+        - xi
+        - delta
+        - star
+        - psi
+      - - trident
+        - delta
+        - star
+        - xi
+        - psi
+        - omega
+      - - omega
+        - star
+        - psi
+        - diamond
+        - delta
+        - xi
+      - - xi
+        - omega
+        - psi
+        - delta
+        - star
+        - diamond
+      - - delta
+        - trident
+        - psi
+        - xi
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - star
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - star
+        - delta
+      - - psi
+        - delta
+        - diamond
+        - star
+        - xi
+        - omega
+      - - xi
+        - star
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - star
+        - omega
+        - delta
+        - xi
+        - psi
+        - diamond
+      - - psi
+        - omega
+        - diamond
+        - star
+        - delta
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-16.yaml
+++ b/packages/manual/data/daily/2026-06-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - omega
+        - xi
+        - trident
+        - star
+      - - delta
+        - star
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - omega
+        - diamond
+        - psi
+        - xi
+        - delta
+        - star
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - trident
+        - psi
+      - - delta
+        - omega
+        - star
+        - diamond
+        - xi
+        - psi
+      - - psi
+        - delta
+        - diamond
+        - omega
+        - xi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - xi
+        - diamond
+        - psi
+        - star
+      - - omega
+        - psi
+        - xi
+        - star
+        - delta
+        - diamond
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - delta
+        - xi
+        - diamond
+        - omega
+        - star
+        - psi
+      - - star
+        - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - diamond
+        - delta
+        - star
+        - omega
+        - psi
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-17.yaml
+++ b/packages/manual/data/daily/2026-06-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - psi
+        - xi
+        - trident
+        - diamond
+      - - diamond
+        - psi
+        - delta
+        - xi
+        - star
+        - omega
+      - - delta
+        - omega
+        - psi
+        - star
+        - xi
+        - trident
+      - - omega
+        - psi
+        - xi
+        - star
+        - delta
+        - diamond
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - star
+        - psi
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+      - - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+        - star
+      - - psi
+        - xi
+        - delta
+        - omega
+        - star
+        - diamond
+      - - omega
+        - star
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - delta
+        - psi
+        - star
+        - diamond
+        - omega
+        - xi
+      - - omega
+        - psi
+        - star
+        - xi
+        - diamond
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-18.yaml
+++ b/packages/manual/data/daily/2026-06-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - psi
+        - xi
+        - delta
+        - trident
+        - omega
+      - - delta
+        - psi
+        - omega
+        - trident
+        - star
+        - xi
+      - - diamond
+        - delta
+        - psi
+        - star
+        - omega
+        - xi
+      - - star
+        - delta
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - delta
+        - diamond
+        - star
+        - xi
+        - psi
+        - omega
+      - - star
+        - delta
+        - diamond
+        - psi
+        - omega
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - star
+        - psi
+      - - psi
+        - diamond
+        - star
+        - delta
+        - omega
+        - xi
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+        - star
+      - - star
+        - psi
+        - delta
+        - omega
+        - xi
+        - diamond
+      - - delta
+        - diamond
+        - psi
+        - star
+        - omega
+        - xi
+      - - delta
+        - omega
+        - xi
+        - diamond
+        - psi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-19.yaml
+++ b/packages/manual/data/daily/2026-06-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - xi
+        - trident
+        - psi
+        - delta
+        - omega
+        - star
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+        - star
+      - - xi
+        - delta
+        - psi
+        - diamond
+        - star
+        - omega
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+        - trident
+      - - diamond
+        - omega
+        - star
+        - xi
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - delta
+        - omega
+        - xi
+        - diamond
+        - psi
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+        - star
+      - - xi
+        - delta
+        - star
+        - diamond
+        - psi
+        - omega
+      - - xi
+        - star
+        - diamond
+        - delta
+        - omega
+        - psi
+      - - omega
+        - diamond
+        - star
+        - delta
+        - psi
+        - xi
+      - - xi
+        - psi
+        - delta
+        - star
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-20.yaml
+++ b/packages/manual/data/daily/2026-06-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - star
+        - xi
+        - diamond
+        - omega
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - omega
+        - star
+      - - omega
+        - psi
+        - star
+        - delta
+        - xi
+        - trident
+      - - diamond
+        - delta
+        - star
+        - xi
+        - omega
+        - psi
+      - - xi
+        - omega
+        - psi
+        - delta
+        - diamond
+        - star
+      - - omega
+        - psi
+        - xi
+        - trident
+        - diamond
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - delta
+        - xi
+        - diamond
+        - omega
+      - - star
+        - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - star
+        - psi
+      - - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+        - star
+      - - star
+        - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+      - - star
+        - omega
+        - delta
+        - xi
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-21.yaml
+++ b/packages/manual/data/daily/2026-06-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - psi
+        - diamond
+        - trident
+        - omega
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - star
+        - delta
+      - - omega
+        - psi
+        - star
+        - delta
+        - xi
+        - diamond
+      - - omega
+        - diamond
+        - star
+        - xi
+        - delta
+        - psi
+      - - psi
+        - trident
+        - omega
+        - star
+        - xi
+        - delta
+      - - diamond
+        - star
+        - delta
+        - psi
+        - omega
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - omega
+        - star
+        - delta
+        - xi
+      - - diamond
+        - star
+        - omega
+        - xi
+        - delta
+        - psi
+      - - delta
+        - star
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - omega
+        - diamond
+        - star
+        - delta
+        - xi
+        - psi
+      - - diamond
+        - star
+        - xi
+        - omega
+        - delta
+        - psi
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-22.yaml
+++ b/packages/manual/data/daily/2026-06-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - trident
+        - delta
+        - psi
+        - star
+        - xi
+      - - star
+        - omega
+        - delta
+        - xi
+        - psi
+        - diamond
+      - - psi
+        - trident
+        - omega
+        - diamond
+        - delta
+        - xi
+      - - star
+        - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - psi
+        - diamond
+        - omega
+        - star
+        - delta
+        - xi
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - delta
+        - psi
+        - star
+        - omega
+        - diamond
+      - - star
+        - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - diamond
+        - xi
+        - star
+        - delta
+        - psi
+        - omega
+      - - xi
+        - omega
+        - star
+        - psi
+        - delta
+        - diamond
+      - - diamond
+        - omega
+        - star
+        - psi
+        - delta
+        - xi
+      - - omega
+        - xi
+        - psi
+        - star
+        - diamond
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-23.yaml
+++ b/packages/manual/data/daily/2026-06-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - star
+        - xi
+      - - diamond
+        - xi
+        - star
+        - delta
+        - omega
+        - psi
+      - - omega
+        - delta
+        - xi
+        - diamond
+        - star
+        - psi
+      - - diamond
+        - xi
+        - trident
+        - delta
+        - psi
+        - omega
+      - - xi
+        - trident
+        - delta
+        - star
+        - psi
+        - omega
+      - - omega
+        - psi
+        - star
+        - diamond
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - xi
+        - star
+        - diamond
+        - psi
+        - delta
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - star
+        - xi
+      - - omega
+        - delta
+        - psi
+        - star
+        - xi
+        - diamond
+      - - psi
+        - star
+        - diamond
+        - xi
+        - delta
+        - omega
+      - - xi
+        - delta
+        - omega
+        - star
+        - psi
+        - diamond
+      - - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-24.yaml
+++ b/packages/manual/data/daily/2026-06-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+      - - star
+        - diamond
+        - xi
+        - omega
+        - delta
+        - psi
+      - - xi
+        - star
+        - psi
+        - trident
+        - omega
+        - delta
+      - - diamond
+        - omega
+        - psi
+        - trident
+        - xi
+        - delta
+      - - star
+        - diamond
+        - psi
+        - omega
+        - xi
+        - delta
+      - - star
+        - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - star
+        - diamond
+        - psi
+        - omega
+        - xi
+        - delta
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - diamond
+      - - xi
+        - psi
+        - diamond
+        - star
+        - omega
+        - delta
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+        - star
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-25.yaml
+++ b/packages/manual/data/daily/2026-06-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - omega
+        - delta
+        - star
+        - psi
+        - xi
+      - - psi
+        - star
+        - xi
+        - delta
+        - trident
+        - omega
+      - - delta
+        - omega
+        - psi
+        - xi
+        - star
+        - diamond
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - trident
+        - omega
+      - - star
+        - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - psi
+        - delta
+        - star
+        - xi
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - xi
+        - delta
+        - diamond
+        - star
+        - psi
+      - - star
+        - delta
+        - diamond
+        - xi
+        - omega
+        - psi
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+        - star
+      - - xi
+        - star
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - psi
+        - diamond
+        - star
+        - delta
+        - omega
+        - xi
+      - - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-26.yaml
+++ b/packages/manual/data/daily/2026-06-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+      - - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+        - star
+      - - omega
+        - diamond
+        - trident
+        - xi
+        - delta
+        - psi
+      - - psi
+        - star
+        - delta
+        - xi
+        - omega
+        - trident
+      - - star
+        - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+      - - psi
+        - diamond
+        - delta
+        - omega
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - psi
+        - delta
+        - omega
+        - star
+        - diamond
+      - - omega
+        - xi
+        - psi
+        - delta
+        - star
+        - diamond
+      - - omega
+        - diamond
+        - star
+        - delta
+        - psi
+        - xi
+      - - omega
+        - star
+        - psi
+        - xi
+        - diamond
+        - delta
+      - - star
+        - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+      - - xi
+        - delta
+        - psi
+        - omega
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-27.yaml
+++ b/packages/manual/data/daily/2026-06-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - trident
+        - star
+        - xi
+        - psi
+        - delta
+      - - psi
+        - star
+        - xi
+        - diamond
+        - delta
+        - omega
+      - - star
+        - omega
+        - diamond
+        - delta
+        - xi
+        - psi
+      - - psi
+        - omega
+        - delta
+        - diamond
+        - trident
+        - xi
+      - - star
+        - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - star
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+      - - diamond
+        - star
+        - omega
+        - delta
+        - psi
+        - xi
+      - - omega
+        - delta
+        - star
+        - diamond
+        - psi
+        - xi
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+        - star
+      - - delta
+        - diamond
+        - xi
+        - star
+        - omega
+        - psi
+      - - omega
+        - psi
+        - star
+        - xi
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-28.yaml
+++ b/packages/manual/data/daily/2026-06-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - trident
+        - xi
+        - diamond
+        - delta
+      - - star
+        - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+      - - star
+        - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+      - - star
+        - omega
+        - psi
+        - xi
+        - delta
+        - diamond
+      - - psi
+        - xi
+        - omega
+        - trident
+        - star
+        - delta
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - diamond
+        - psi
+        - star
+        - xi
+        - delta
+      - - xi
+        - diamond
+        - star
+        - psi
+        - delta
+        - omega
+      - - star
+        - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+      - - psi
+        - diamond
+        - omega
+        - star
+        - delta
+        - xi
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - star
+        - xi
+      - - diamond
+        - star
+        - psi
+        - delta
+        - xi
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-29.yaml
+++ b/packages/manual/data/daily/2026-06-29.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-29'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - trident
+      - - delta
+        - diamond
+        - star
+        - omega
+        - xi
+        - psi
+      - - psi
+        - omega
+        - star
+        - xi
+        - diamond
+        - delta
+      - - diamond
+        - star
+        - psi
+        - xi
+        - omega
+        - delta
+      - - xi
+        - psi
+        - delta
+        - trident
+        - diamond
+        - omega
+      - - star
+        - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - xi
+        - diamond
+        - star
+        - omega
+      - - delta
+        - star
+        - diamond
+        - omega
+        - xi
+        - psi
+      - - psi
+        - diamond
+        - star
+        - delta
+        - omega
+        - xi
+      - - xi
+        - star
+        - psi
+        - omega
+        - diamond
+        - delta
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - star
+        - xi
+      - - xi
+        - star
+        - diamond
+        - omega
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-06-30.yaml
+++ b/packages/manual/data/daily/2026-06-30.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-06-30'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - star
+        - omega
+        - delta
+        - xi
+        - psi
+      - - star
+        - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - star
+        - xi
+      - - xi
+        - delta
+        - omega
+        - diamond
+        - psi
+        - star
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - omega
+        - trident
+      - - star
+        - omega
+        - xi
+        - psi
+        - trident
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - star
+        - delta
+      - - star
+        - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+        - star
+      - - delta
+        - star
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - star
+        - omega
+        - delta
+        - xi
+        - diamond
+        - psi
+      - - delta
+        - star
+        - diamond
+        - omega
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-01.yaml
+++ b/packages/manual/data/daily/2026-07-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - psi
+        - delta
+        - trident
+        - star
+      - - delta
+        - omega
+        - diamond
+        - xi
+        - trident
+        - psi
+      - - star
+        - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - omega
+        - psi
+        - star
+        - xi
+        - delta
+        - diamond
+      - - star
+        - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+      - - delta
+        - psi
+        - xi
+        - star
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+        - star
+      - - xi
+        - star
+        - diamond
+        - omega
+        - delta
+        - psi
+      - - diamond
+        - delta
+        - omega
+        - star
+        - xi
+        - psi
+      - - delta
+        - omega
+        - diamond
+        - star
+        - xi
+        - psi
+      - - xi
+        - star
+        - diamond
+        - delta
+        - omega
+        - psi
+      - - omega
+        - psi
+        - star
+        - diamond
+        - xi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-02.yaml
+++ b/packages/manual/data/daily/2026-07-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - star
+        - omega
+      - - omega
+        - star
+        - delta
+        - trident
+        - psi
+        - xi
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - star
+        - xi
+      - - star
+        - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - omega
+        - diamond
+        - delta
+        - xi
+        - psi
+        - star
+      - - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - star
+        - xi
+        - omega
+        - delta
+      - - delta
+        - omega
+        - star
+        - psi
+        - xi
+        - diamond
+      - - star
+        - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+        - star
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - star
+        - xi
+      - - psi
+        - omega
+        - delta
+        - xi
+        - star
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-03.yaml
+++ b/packages/manual/data/daily/2026-07-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+      - - star
+        - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - star
+        - delta
+        - omega
+        - psi
+        - xi
+        - diamond
+      - - xi
+        - omega
+        - star
+        - delta
+        - trident
+        - psi
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - trident
+        - omega
+      - - star
+        - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - star
+        - diamond
+        - xi
+        - psi
+      - - delta
+        - omega
+        - diamond
+        - star
+        - psi
+        - xi
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+        - star
+      - - psi
+        - star
+        - delta
+        - xi
+        - diamond
+        - omega
+      - - omega
+        - xi
+        - star
+        - psi
+        - diamond
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-04.yaml
+++ b/packages/manual/data/daily/2026-07-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - trident
+        - omega
+        - psi
+        - delta
+        - xi
+      - - xi
+        - delta
+        - psi
+        - star
+        - diamond
+        - omega
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - star
+        - xi
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - trident
+        - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - psi
+        - omega
+        - star
+        - delta
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - xi
+        - star
+        - delta
+        - omega
+      - - star
+        - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+      - - xi
+        - diamond
+        - star
+        - psi
+        - omega
+        - delta
+      - - star
+        - delta
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - star
+        - psi
+      - - psi
+        - delta
+        - diamond
+        - omega
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-05.yaml
+++ b/packages/manual/data/daily/2026-07-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - trident
+        - delta
+        - psi
+        - star
+        - omega
+      - - star
+        - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - psi
+        - omega
+        - star
+        - diamond
+        - xi
+        - delta
+      - - star
+        - omega
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+        - star
+      - - trident
+        - psi
+        - omega
+        - diamond
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - omega
+        - star
+        - delta
+        - xi
+        - psi
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - star
+        - xi
+      - - psi
+        - diamond
+        - star
+        - delta
+        - omega
+        - xi
+      - - omega
+        - xi
+        - delta
+        - star
+        - diamond
+        - psi
+      - - diamond
+        - star
+        - xi
+        - psi
+        - delta
+        - omega
+      - - delta
+        - star
+        - xi
+        - psi
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-06.yaml
+++ b/packages/manual/data/daily/2026-07-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - omega
+        - psi
+        - delta
+        - xi
+        - diamond
+      - - xi
+        - omega
+        - psi
+        - trident
+        - star
+        - delta
+      - - diamond
+        - trident
+        - psi
+        - xi
+        - delta
+        - omega
+      - - diamond
+        - omega
+        - xi
+        - star
+        - psi
+        - delta
+      - - omega
+        - diamond
+        - delta
+        - xi
+        - star
+        - psi
+      - - diamond
+        - xi
+        - omega
+        - delta
+        - star
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - star
+        - delta
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+      - - psi
+        - delta
+        - omega
+        - xi
+        - star
+        - diamond
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - star
+        - delta
+      - - psi
+        - delta
+        - diamond
+        - star
+        - omega
+        - xi
+      - - xi
+        - delta
+        - star
+        - diamond
+        - psi
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-07.yaml
+++ b/packages/manual/data/daily/2026-07-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+        - star
+      - - star
+        - psi
+        - diamond
+        - delta
+        - xi
+        - omega
+      - - diamond
+        - trident
+        - xi
+        - omega
+        - psi
+        - delta
+      - - xi
+        - diamond
+        - star
+        - delta
+        - psi
+        - omega
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+      - - xi
+        - trident
+        - delta
+        - star
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+        - star
+      - - omega
+        - star
+        - diamond
+        - delta
+        - xi
+        - psi
+      - - xi
+        - star
+        - diamond
+        - psi
+        - omega
+        - delta
+      - - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+        - star
+      - - xi
+        - star
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - omega
+        - star
+        - psi
+        - xi
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-08.yaml
+++ b/packages/manual/data/daily/2026-07-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+        - star
+      - - xi
+        - psi
+        - delta
+        - trident
+        - omega
+        - star
+      - - omega
+        - psi
+        - xi
+        - trident
+        - delta
+        - diamond
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - xi
+        - star
+      - - star
+        - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+      - - star
+        - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - omega
+        - star
+        - psi
+        - delta
+        - diamond
+      - - star
+        - delta
+        - omega
+        - psi
+        - xi
+        - diamond
+      - - star
+        - psi
+        - omega
+        - diamond
+        - delta
+        - xi
+      - - omega
+        - xi
+        - delta
+        - diamond
+        - star
+        - psi
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - star
+        - xi
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-09.yaml
+++ b/packages/manual/data/daily/2026-07-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - psi
+        - delta
+        - omega
+        - star
+        - xi
+      - - omega
+        - delta
+        - star
+        - psi
+        - xi
+        - diamond
+      - - xi
+        - diamond
+        - psi
+        - trident
+        - delta
+        - omega
+      - - psi
+        - xi
+        - star
+        - delta
+        - omega
+        - diamond
+      - - star
+        - psi
+        - omega
+        - delta
+        - diamond
+        - xi
+      - - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - diamond
+        - psi
+        - omega
+        - delta
+      - - omega
+        - star
+        - xi
+        - psi
+        - diamond
+        - delta
+      - - omega
+        - star
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - xi
+        - star
+        - diamond
+        - delta
+        - omega
+        - psi
+      - - star
+        - delta
+        - diamond
+        - xi
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-10.yaml
+++ b/packages/manual/data/daily/2026-07-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - delta
+        - diamond
+        - omega
+        - xi
+        - star
+      - - xi
+        - trident
+        - psi
+        - star
+        - omega
+        - delta
+      - - diamond
+        - psi
+        - delta
+        - xi
+        - omega
+        - star
+      - - diamond
+        - xi
+        - star
+        - delta
+        - psi
+        - omega
+      - - diamond
+        - star
+        - omega
+        - xi
+        - delta
+        - psi
+      - - diamond
+        - psi
+        - delta
+        - trident
+        - xi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - xi
+        - psi
+        - omega
+        - delta
+        - star
+        - diamond
+      - - xi
+        - star
+        - delta
+        - omega
+        - diamond
+        - psi
+      - - delta
+        - psi
+        - omega
+        - xi
+        - star
+        - diamond
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+        - star
+      - - diamond
+        - star
+        - xi
+        - psi
+        - omega
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-11.yaml
+++ b/packages/manual/data/daily/2026-07-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - xi
+        - omega
+        - diamond
+        - star
+        - psi
+        - delta
+      - - xi
+        - psi
+        - delta
+        - trident
+        - star
+        - omega
+      - - xi
+        - star
+        - psi
+        - omega
+        - diamond
+        - delta
+      - - xi
+        - star
+        - psi
+        - delta
+        - diamond
+        - omega
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+        - star
+      - - star
+        - xi
+        - omega
+        - psi
+        - delta
+        - diamond
+      - - omega
+        - psi
+        - star
+        - xi
+        - delta
+        - diamond
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - star
+        - xi
+      - - omega
+        - diamond
+        - psi
+        - star
+        - delta
+        - xi
+      - - delta
+        - star
+        - psi
+        - xi
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-12.yaml
+++ b/packages/manual/data/daily/2026-07-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - star
+        - xi
+        - delta
+        - omega
+        - psi
+      - - delta
+        - diamond
+        - star
+        - xi
+        - psi
+        - omega
+      - - delta
+        - star
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - delta
+        - xi
+        - omega
+        - psi
+        - trident
+        - star
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - trident
+        - omega
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - delta
+        - diamond
+        - psi
+        - xi
+      - - diamond
+        - xi
+        - star
+        - omega
+        - delta
+        - psi
+      - - psi
+        - omega
+        - star
+        - diamond
+        - xi
+        - delta
+      - - star
+        - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+      - - omega
+        - star
+        - delta
+        - psi
+        - diamond
+        - xi
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-13.yaml
+++ b/packages/manual/data/daily/2026-07-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - trident
+        - diamond
+        - delta
+        - omega
+        - xi
+      - - xi
+        - delta
+        - diamond
+        - star
+        - omega
+        - psi
+      - - star
+        - omega
+        - psi
+        - xi
+        - delta
+        - diamond
+      - - trident
+        - psi
+        - star
+        - xi
+        - omega
+        - delta
+      - - star
+        - delta
+        - omega
+        - diamond
+        - psi
+        - xi
+      - - psi
+        - omega
+        - star
+        - delta
+        - diamond
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - diamond
+        - delta
+        - star
+        - xi
+      - - delta
+        - diamond
+        - psi
+        - star
+        - omega
+        - xi
+      - - xi
+        - delta
+        - diamond
+        - star
+        - psi
+        - omega
+      - - diamond
+        - xi
+        - star
+        - psi
+        - omega
+        - delta
+      - - star
+        - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-14.yaml
+++ b/packages/manual/data/daily/2026-07-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - trident
+        - xi
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - star
+        - omega
+      - - delta
+        - omega
+        - star
+        - diamond
+        - psi
+        - xi
+      - - xi
+        - psi
+        - star
+        - trident
+        - omega
+        - delta
+      - - star
+        - delta
+        - diamond
+        - xi
+        - omega
+        - psi
+      - - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - star
+        - xi
+        - diamond
+        - psi
+      - - diamond
+        - xi
+        - omega
+        - star
+        - delta
+        - psi
+      - - omega
+        - xi
+        - psi
+        - star
+        - diamond
+        - delta
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - star
+        - psi
+      - - delta
+        - xi
+        - omega
+        - star
+        - psi
+        - diamond
+      - - delta
+        - star
+        - omega
+        - psi
+        - xi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-15.yaml
+++ b/packages/manual/data/daily/2026-07-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - star
+        - delta
+        - diamond
+        - xi
+      - - psi
+        - star
+        - xi
+        - omega
+        - delta
+        - diamond
+      - - trident
+        - xi
+        - omega
+        - star
+        - psi
+        - delta
+      - - diamond
+        - omega
+        - xi
+        - psi
+        - trident
+        - delta
+      - - delta
+        - psi
+        - star
+        - omega
+        - diamond
+        - xi
+      - - psi
+        - omega
+        - delta
+        - star
+        - diamond
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - psi
+        - diamond
+        - delta
+        - omega
+      - - xi
+        - star
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - star
+        - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+        - star
+      - - diamond
+        - delta
+        - star
+        - omega
+        - xi
+        - psi
+      - - delta
+        - psi
+        - xi
+        - star
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-16.yaml
+++ b/packages/manual/data/daily/2026-07-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - star
+        - omega
+        - psi
+        - xi
+        - trident
+      - - psi
+        - star
+        - delta
+        - xi
+        - omega
+        - diamond
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - trident
+        - omega
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - omega
+        - xi
+        - psi
+        - delta
+        - star
+        - diamond
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - delta
+        - diamond
+        - psi
+        - omega
+        - xi
+      - - star
+        - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - star
+        - xi
+      - - omega
+        - star
+        - delta
+        - diamond
+        - xi
+        - psi
+      - - diamond
+        - delta
+        - star
+        - xi
+        - psi
+        - omega
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-17.yaml
+++ b/packages/manual/data/daily/2026-07-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - trident
+        - star
+        - psi
+        - xi
+        - delta
+      - - delta
+        - xi
+        - diamond
+        - psi
+        - star
+        - omega
+      - - psi
+        - trident
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - omega
+        - star
+        - delta
+        - xi
+        - psi
+        - diamond
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - star
+        - xi
+      - - xi
+        - diamond
+        - star
+        - psi
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - omega
+        - delta
+        - xi
+        - psi
+      - - delta
+        - star
+        - diamond
+        - psi
+        - omega
+        - xi
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - star
+        - omega
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - star
+        - omega
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+      - - omega
+        - star
+        - diamond
+        - psi
+        - delta
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-18.yaml
+++ b/packages/manual/data/daily/2026-07-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - psi
+        - star
+        - omega
+        - delta
+        - xi
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - delta
+        - star
+      - - diamond
+        - star
+        - delta
+        - psi
+        - xi
+        - omega
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+        - star
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+        - trident
+      - - delta
+        - trident
+        - star
+        - xi
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - diamond
+        - delta
+        - psi
+        - omega
+        - star
+        - xi
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - star
+        - delta
+      - - star
+        - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+      - - star
+        - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+      - - psi
+        - diamond
+        - xi
+        - star
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-19.yaml
+++ b/packages/manual/data/daily/2026-07-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - xi
+        - trident
+        - psi
+        - delta
+      - - omega
+        - diamond
+        - xi
+        - star
+        - psi
+        - delta
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - star
+        - omega
+      - - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+        - star
+      - - omega
+        - trident
+        - psi
+        - star
+        - delta
+        - xi
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - star
+        - xi
+        - diamond
+        - omega
+      - - star
+        - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+      - - psi
+        - star
+        - diamond
+        - xi
+        - delta
+        - omega
+      - - diamond
+        - star
+        - xi
+        - delta
+        - omega
+        - psi
+      - - psi
+        - star
+        - xi
+        - diamond
+        - delta
+        - omega
+      - - omega
+        - xi
+        - star
+        - delta
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-20.yaml
+++ b/packages/manual/data/daily/2026-07-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - trident
+        - delta
+      - - psi
+        - star
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - star
+        - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+      - - star
+        - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - delta
+        - omega
+        - trident
+        - xi
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - star
+        - omega
+      - - delta
+        - psi
+        - omega
+        - xi
+        - star
+        - diamond
+      - - psi
+        - diamond
+        - xi
+        - star
+        - delta
+        - omega
+      - - psi
+        - xi
+        - omega
+        - star
+        - delta
+        - diamond
+      - - diamond
+        - delta
+        - psi
+        - star
+        - omega
+        - xi
+      - - omega
+        - psi
+        - delta
+        - xi
+        - star
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-21.yaml
+++ b/packages/manual/data/daily/2026-07-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - star
+        - psi
+        - delta
+        - diamond
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - trident
+        - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+      - - star
+        - trident
+        - delta
+        - psi
+        - xi
+        - omega
+      - - star
+        - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+      - - star
+        - psi
+        - delta
+        - omega
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - diamond
+        - omega
+        - xi
+        - psi
+        - delta
+        - star
+      - - omega
+        - psi
+        - delta
+        - xi
+        - star
+        - diamond
+      - - star
+        - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+      - - xi
+        - star
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - star
+        - omega
+        - delta
+        - diamond
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-22.yaml
+++ b/packages/manual/data/daily/2026-07-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - omega
+        - psi
+        - xi
+        - delta
+        - diamond
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - star
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - trident
+        - xi
+      - - omega
+        - diamond
+        - star
+        - xi
+        - psi
+        - delta
+      - - omega
+        - delta
+        - star
+        - trident
+        - psi
+        - xi
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - star
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - xi
+        - psi
+        - diamond
+        - star
+        - delta
+      - - diamond
+        - omega
+        - delta
+        - star
+        - psi
+        - xi
+      - - star
+        - omega
+        - delta
+        - diamond
+        - psi
+        - xi
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - star
+        - delta
+      - - psi
+        - delta
+        - diamond
+        - star
+        - xi
+        - omega
+      - - star
+        - diamond
+        - xi
+        - omega
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-23.yaml
+++ b/packages/manual/data/daily/2026-07-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - psi
+        - delta
+        - xi
+        - trident
+        - diamond
+      - - psi
+        - omega
+        - star
+        - delta
+        - xi
+        - diamond
+      - - omega
+        - psi
+        - delta
+        - star
+        - xi
+        - trident
+      - - delta
+        - diamond
+        - xi
+        - star
+        - psi
+        - omega
+      - - star
+        - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - diamond
+        - delta
+        - star
+        - xi
+        - psi
+      - - omega
+        - delta
+        - star
+        - diamond
+        - xi
+        - psi
+      - - delta
+        - omega
+        - star
+        - xi
+        - psi
+        - diamond
+      - - star
+        - omega
+        - diamond
+        - delta
+        - xi
+        - psi
+      - - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+        - star
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-24.yaml
+++ b/packages/manual/data/daily/2026-07-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - psi
+        - star
+        - diamond
+        - xi
+      - - delta
+        - star
+        - psi
+        - omega
+        - diamond
+        - xi
+      - - psi
+        - delta
+        - xi
+        - star
+        - trident
+        - omega
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - xi
+        - star
+      - - omega
+        - star
+        - xi
+        - psi
+        - delta
+        - diamond
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - trident
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - xi
+        - psi
+        - delta
+        - diamond
+      - - delta
+        - psi
+        - diamond
+        - star
+        - omega
+        - xi
+      - - omega
+        - delta
+        - psi
+        - xi
+        - star
+        - diamond
+      - - xi
+        - star
+        - omega
+        - diamond
+        - psi
+        - delta
+      - - star
+        - delta
+        - psi
+        - omega
+        - xi
+        - diamond
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-25.yaml
+++ b/packages/manual/data/daily/2026-07-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - psi
+        - star
+        - trident
+        - omega
+      - - star
+        - diamond
+        - delta
+        - psi
+        - xi
+        - omega
+      - - omega
+        - delta
+        - trident
+        - psi
+        - diamond
+        - xi
+      - - omega
+        - star
+        - xi
+        - psi
+        - delta
+        - diamond
+      - - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+        - star
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - star
+        - psi
+      - - star
+        - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+      - - star
+        - diamond
+        - psi
+        - omega
+        - xi
+        - delta
+      - - psi
+        - xi
+        - star
+        - diamond
+        - delta
+        - omega
+      - - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+        - star
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-26.yaml
+++ b/packages/manual/data/daily/2026-07-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - omega
+        - psi
+        - delta
+        - diamond
+      - - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+        - trident
+      - - psi
+        - xi
+        - star
+        - diamond
+        - delta
+        - omega
+      - - omega
+        - delta
+        - star
+        - psi
+        - xi
+        - trident
+      - - psi
+        - diamond
+        - xi
+        - star
+        - delta
+        - omega
+      - - star
+        - psi
+        - diamond
+        - omega
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+      - - delta
+        - psi
+        - star
+        - omega
+        - diamond
+        - xi
+      - - star
+        - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - omega
+        - delta
+        - star
+        - xi
+        - diamond
+        - psi
+      - - delta
+        - psi
+        - diamond
+        - omega
+        - xi
+        - star
+      - - psi
+        - xi
+        - star
+        - diamond
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-27.yaml
+++ b/packages/manual/data/daily/2026-07-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+      - - omega
+        - star
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - delta
+        - xi
+        - omega
+        - trident
+        - psi
+        - star
+      - - trident
+        - omega
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - xi
+        - psi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - diamond
+        - star
+        - xi
+        - psi
+        - omega
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - xi
+        - star
+        - psi
+        - omega
+      - - omega
+        - diamond
+        - star
+        - psi
+        - xi
+        - delta
+      - - star
+        - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+      - - star
+        - delta
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - psi
+        - star
+        - diamond
+        - delta
+        - omega
+        - xi
+      - - psi
+        - diamond
+        - delta
+        - omega
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-28.yaml
+++ b/packages/manual/data/daily/2026-07-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - diamond
+        - omega
+        - delta
+        - psi
+        - star
+      - - star
+        - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - psi
+        - omega
+        - xi
+        - delta
+        - diamond
+        - star
+      - - trident
+        - star
+        - xi
+        - omega
+        - psi
+        - delta
+      - - psi
+        - diamond
+        - delta
+        - xi
+        - omega
+        - star
+      - - psi
+        - xi
+        - trident
+        - delta
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - star
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - delta
+        - psi
+        - omega
+        - star
+        - xi
+        - diamond
+      - - star
+        - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+      - - star
+        - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - psi
+        - star
+      - - star
+        - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-29.yaml
+++ b/packages/manual/data/daily/2026-07-29.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-29'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - xi
+        - delta
+        - omega
+        - star
+        - psi
+      - - diamond
+        - xi
+        - psi
+        - omega
+        - delta
+        - trident
+      - - omega
+        - xi
+        - star
+        - psi
+        - diamond
+        - delta
+      - - delta
+        - xi
+        - star
+        - psi
+        - omega
+        - diamond
+      - - psi
+        - delta
+        - star
+        - omega
+        - diamond
+        - xi
+      - - psi
+        - omega
+        - xi
+        - delta
+        - diamond
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - omega
+        - xi
+        - star
+        - diamond
+      - - star
+        - xi
+        - diamond
+        - psi
+        - omega
+        - delta
+      - - diamond
+        - xi
+        - star
+        - delta
+        - psi
+        - omega
+      - - omega
+        - psi
+        - diamond
+        - star
+        - delta
+        - xi
+      - - omega
+        - psi
+        - star
+        - delta
+        - xi
+        - diamond
+      - - diamond
+        - psi
+        - delta
+        - xi
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-30.yaml
+++ b/packages/manual/data/daily/2026-07-30.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-30'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - trident
+        - omega
+        - psi
+        - delta
+        - xi
+      - - xi
+        - omega
+        - diamond
+        - trident
+        - delta
+        - psi
+      - - delta
+        - psi
+        - star
+        - xi
+        - diamond
+        - omega
+      - - diamond
+        - star
+        - psi
+        - omega
+        - xi
+        - delta
+      - - omega
+        - diamond
+        - star
+        - psi
+        - xi
+        - delta
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - star
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - omega
+        - star
+        - psi
+        - xi
+        - delta
+        - diamond
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+      - - star
+        - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+      - - star
+        - delta
+        - omega
+        - xi
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-07-31.yaml
+++ b/packages/manual/data/daily/2026-07-31.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-07-31'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - star
+        - omega
+        - delta
+        - diamond
+        - psi
+      - - delta
+        - xi
+        - diamond
+        - star
+        - psi
+        - omega
+      - - xi
+        - star
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - psi
+        - omega
+        - star
+        - delta
+        - diamond
+        - xi
+      - - trident
+        - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+      - - delta
+        - xi
+        - omega
+        - star
+        - psi
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+        - star
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - xi
+        - diamond
+        - omega
+        - star
+        - psi
+        - delta
+      - - psi
+        - xi
+        - delta
+        - star
+        - diamond
+        - omega
+      - - diamond
+        - xi
+        - delta
+        - omega
+        - psi
+        - star
+      - - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-01.yaml
+++ b/packages/manual/data/daily/2026-08-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - delta
+        - star
+        - xi
+        - psi
+      - - psi
+        - omega
+        - delta
+        - star
+        - diamond
+        - xi
+      - - trident
+        - psi
+        - star
+        - omega
+        - xi
+        - delta
+      - - psi
+        - delta
+        - trident
+        - diamond
+        - xi
+        - omega
+      - - omega
+        - star
+        - psi
+        - delta
+        - xi
+        - diamond
+      - - diamond
+        - xi
+        - star
+        - omega
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - diamond
+        - star
+        - psi
+        - xi
+      - - delta
+        - omega
+        - xi
+        - psi
+        - star
+        - diamond
+      - - diamond
+        - omega
+        - star
+        - xi
+        - psi
+        - delta
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+        - star
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - star
+        - delta
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-02.yaml
+++ b/packages/manual/data/daily/2026-08-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - delta
+        - diamond
+        - star
+        - xi
+      - - star
+        - omega
+        - delta
+        - diamond
+        - psi
+        - xi
+      - - trident
+        - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+      - - xi
+        - delta
+        - star
+        - psi
+        - trident
+        - omega
+      - - psi
+        - omega
+        - diamond
+        - xi
+        - star
+        - delta
+      - - diamond
+        - star
+        - delta
+        - xi
+        - psi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - delta
+        - diamond
+        - psi
+        - omega
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+        - star
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - star
+        - psi
+      - - delta
+        - star
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+        - star
+      - - xi
+        - delta
+        - star
+        - diamond
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-03.yaml
+++ b/packages/manual/data/daily/2026-08-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - trident
+        - omega
+      - - diamond
+        - psi
+        - omega
+        - delta
+        - star
+        - xi
+      - - delta
+        - omega
+        - xi
+        - trident
+        - psi
+        - star
+      - - delta
+        - xi
+        - omega
+        - psi
+        - star
+        - diamond
+      - - omega
+        - psi
+        - star
+        - diamond
+        - xi
+        - delta
+      - - star
+        - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - star
+        - omega
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+        - star
+      - - star
+        - delta
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - xi
+        - delta
+        - psi
+        - star
+        - omega
+        - diamond
+      - - psi
+        - diamond
+        - delta
+        - omega
+        - star
+        - xi
+      - - psi
+        - xi
+        - star
+        - delta
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-04.yaml
+++ b/packages/manual/data/daily/2026-08-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - star
+        - xi
+        - diamond
+        - omega
+      - - psi
+        - star
+        - diamond
+        - xi
+        - omega
+        - delta
+      - - omega
+        - diamond
+        - xi
+        - star
+        - psi
+        - delta
+      - - psi
+        - omega
+        - xi
+        - delta
+        - diamond
+        - star
+      - - omega
+        - delta
+        - xi
+        - psi
+        - trident
+        - star
+      - - diamond
+        - xi
+        - trident
+        - delta
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - xi
+        - star
+        - omega
+        - psi
+      - - xi
+        - psi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - psi
+        - omega
+        - star
+        - delta
+        - diamond
+        - xi
+      - - delta
+        - star
+        - diamond
+        - psi
+        - xi
+        - omega
+      - - star
+        - xi
+        - omega
+        - delta
+        - diamond
+        - psi
+      - - psi
+        - diamond
+        - delta
+        - xi
+        - star
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-05.yaml
+++ b/packages/manual/data/daily/2026-08-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - xi
+        - omega
+        - star
+        - trident
+        - delta
+      - - star
+        - delta
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - omega
+        - delta
+        - psi
+        - trident
+        - xi
+        - diamond
+      - - xi
+        - star
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - omega
+        - psi
+        - delta
+        - xi
+        - diamond
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - delta
+        - diamond
+        - star
+        - xi
+        - psi
+      - - xi
+        - star
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - delta
+        - star
+        - xi
+        - omega
+        - diamond
+        - psi
+      - - diamond
+        - omega
+        - star
+        - psi
+        - xi
+        - delta
+      - - omega
+        - delta
+        - star
+        - diamond
+        - psi
+        - xi
+      - - diamond
+        - psi
+        - xi
+        - star
+        - omega
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-06.yaml
+++ b/packages/manual/data/daily/2026-08-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - xi
+        - trident
+        - psi
+        - diamond
+      - - psi
+        - star
+        - diamond
+        - delta
+        - omega
+        - xi
+      - - star
+        - omega
+        - delta
+        - psi
+        - xi
+        - trident
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - star
+        - psi
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - star
+        - psi
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - xi
+        - psi
+        - delta
+        - diamond
+      - - diamond
+        - xi
+        - star
+        - omega
+        - delta
+        - psi
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - star
+        - delta
+      - - delta
+        - psi
+        - omega
+        - xi
+        - diamond
+        - star
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - star
+        - delta
+      - - diamond
+        - delta
+        - omega
+        - star
+        - psi
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-07.yaml
+++ b/packages/manual/data/daily/2026-08-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - omega
+        - delta
+        - diamond
+        - psi
+        - star
+      - - psi
+        - xi
+        - trident
+        - diamond
+        - delta
+        - omega
+      - - xi
+        - trident
+        - delta
+        - star
+        - psi
+        - omega
+      - - xi
+        - omega
+        - delta
+        - star
+        - diamond
+        - psi
+      - - xi
+        - delta
+        - psi
+        - star
+        - omega
+        - diamond
+      - - delta
+        - diamond
+        - xi
+        - star
+        - psi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - xi
+        - star
+        - delta
+        - psi
+        - diamond
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+        - star
+      - - xi
+        - omega
+        - star
+        - psi
+        - delta
+        - diamond
+      - - delta
+        - star
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - psi
+        - xi
+        - star
+        - delta
+        - omega
+        - diamond
+      - - xi
+        - star
+        - psi
+        - diamond
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-08.yaml
+++ b/packages/manual/data/daily/2026-08-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - star
+        - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - delta
+        - trident
+        - star
+        - xi
+        - psi
+        - omega
+      - - diamond
+        - star
+        - delta
+        - psi
+        - omega
+        - xi
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+        - star
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - xi
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - star
+        - xi
+        - diamond
+        - delta
+      - - diamond
+        - delta
+        - psi
+        - star
+        - xi
+        - omega
+      - - star
+        - diamond
+        - omega
+        - psi
+        - xi
+        - delta
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - star
+        - xi
+      - - omega
+        - star
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - delta
+        - xi
+        - omega
+        - star
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-09.yaml
+++ b/packages/manual/data/daily/2026-08-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - omega
+        - delta
+        - trident
+        - xi
+        - psi
+      - - delta
+        - psi
+        - star
+        - diamond
+        - omega
+        - xi
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - trident
+        - omega
+      - - star
+        - xi
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+      - - delta
+        - star
+        - omega
+        - psi
+        - xi
+        - diamond
+      - - omega
+        - diamond
+        - star
+        - xi
+        - delta
+        - psi
+      - - diamond
+        - delta
+        - omega
+        - xi
+        - star
+        - psi
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - star
+        - omega
+      - - delta
+        - psi
+        - omega
+        - xi
+        - star
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-10.yaml
+++ b/packages/manual/data/daily/2026-08-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - star
+        - xi
+      - - psi
+        - delta
+        - omega
+        - star
+        - xi
+        - diamond
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - omega
+        - star
+      - - trident
+        - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+      - - xi
+        - omega
+        - delta
+        - trident
+        - psi
+        - star
+      - - xi
+        - psi
+        - omega
+        - delta
+        - star
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - psi
+        - omega
+        - star
+        - xi
+        - diamond
+      - - xi
+        - psi
+        - star
+        - delta
+        - diamond
+        - omega
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - omega
+        - delta
+        - xi
+        - psi
+        - star
+        - diamond
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+        - star
+      - - diamond
+        - omega
+        - psi
+        - star
+        - delta
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-11.yaml
+++ b/packages/manual/data/daily/2026-08-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - psi
+        - delta
+        - xi
+        - star
+        - omega
+      - - psi
+        - xi
+        - omega
+        - delta
+        - trident
+        - star
+      - - psi
+        - diamond
+        - omega
+        - delta
+        - star
+        - xi
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+        - star
+      - - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+        - trident
+      - - psi
+        - delta
+        - xi
+        - omega
+        - star
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - delta
+        - omega
+        - diamond
+        - psi
+      - - star
+        - omega
+        - delta
+        - diamond
+        - xi
+        - psi
+      - - xi
+        - psi
+        - delta
+        - star
+        - diamond
+        - omega
+      - - delta
+        - star
+        - omega
+        - psi
+        - diamond
+        - xi
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - xi
+        - star
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-12.yaml
+++ b/packages/manual/data/daily/2026-08-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - omega
+        - delta
+        - trident
+        - psi
+        - star
+      - - star
+        - diamond
+        - psi
+        - omega
+        - xi
+        - delta
+      - - omega
+        - xi
+        - star
+        - delta
+        - diamond
+        - psi
+      - - diamond
+        - xi
+        - delta
+        - omega
+        - psi
+        - star
+      - - psi
+        - delta
+        - star
+        - diamond
+        - xi
+        - omega
+      - - psi
+        - omega
+        - trident
+        - diamond
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - omega
+        - psi
+        - delta
+        - xi
+      - - omega
+        - diamond
+        - xi
+        - star
+        - psi
+        - delta
+      - - star
+        - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+      - - omega
+        - xi
+        - psi
+        - delta
+        - diamond
+        - star
+      - - star
+        - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-13.yaml
+++ b/packages/manual/data/daily/2026-08-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - psi
+        - xi
+        - star
+        - diamond
+      - - xi
+        - psi
+        - trident
+        - star
+        - delta
+        - omega
+      - - diamond
+        - delta
+        - xi
+        - star
+        - psi
+        - omega
+      - - delta
+        - diamond
+        - star
+        - xi
+        - omega
+        - psi
+      - - trident
+        - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - diamond
+        - xi
+        - delta
+        - omega
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - psi
+        - delta
+        - diamond
+        - omega
+      - - xi
+        - delta
+        - star
+        - omega
+        - diamond
+        - psi
+      - - delta
+        - psi
+        - star
+        - diamond
+        - xi
+        - omega
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+        - star
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+        - star
+      - - star
+        - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-14.yaml
+++ b/packages/manual/data/daily/2026-08-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - star
+        - psi
+      - - delta
+        - xi
+        - psi
+        - star
+        - omega
+        - diamond
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - delta
+        - star
+      - - xi
+        - psi
+        - delta
+        - star
+        - trident
+        - omega
+      - - trident
+        - omega
+        - delta
+        - xi
+        - diamond
+        - psi
+      - - xi
+        - diamond
+        - delta
+        - star
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - diamond
+        - psi
+        - delta
+        - omega
+      - - star
+        - delta
+        - omega
+        - xi
+        - diamond
+        - psi
+      - - xi
+        - psi
+        - diamond
+        - star
+        - omega
+        - delta
+      - - psi
+        - diamond
+        - omega
+        - delta
+        - xi
+        - star
+      - - xi
+        - omega
+        - star
+        - psi
+        - diamond
+        - delta
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-15.yaml
+++ b/packages/manual/data/daily/2026-08-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - star
+        - diamond
+        - delta
+        - omega
+        - psi
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - star
+        - omega
+      - - diamond
+        - psi
+        - star
+        - xi
+        - delta
+        - omega
+      - - diamond
+        - xi
+        - star
+        - delta
+        - psi
+        - omega
+      - - omega
+        - psi
+        - diamond
+        - delta
+        - trident
+        - xi
+      - - trident
+        - psi
+        - star
+        - delta
+        - omega
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - star
+        - xi
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - star
+        - omega
+      - - diamond
+        - star
+        - xi
+        - omega
+        - delta
+        - psi
+      - - diamond
+        - star
+        - psi
+        - xi
+        - delta
+        - omega
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+        - star
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-16.yaml
+++ b/packages/manual/data/daily/2026-08-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - star
+        - diamond
+        - delta
+        - xi
+        - psi
+      - - delta
+        - omega
+        - xi
+        - psi
+        - star
+        - diamond
+      - - xi
+        - psi
+        - omega
+        - trident
+        - star
+        - delta
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - star
+        - omega
+      - - xi
+        - omega
+        - psi
+        - star
+        - diamond
+        - delta
+      - - delta
+        - omega
+        - trident
+        - xi
+        - diamond
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - star
+        - omega
+        - xi
+        - diamond
+      - - star
+        - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+        - star
+      - - star
+        - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - star
+        - xi
+      - - xi
+        - omega
+        - star
+        - diamond
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-17.yaml
+++ b/packages/manual/data/daily/2026-08-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - psi
+        - star
+        - trident
+        - xi
+      - - diamond
+        - delta
+        - star
+        - omega
+        - psi
+        - xi
+      - - psi
+        - xi
+        - diamond
+        - star
+        - omega
+        - delta
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - star
+        - xi
+      - - trident
+        - xi
+        - diamond
+        - psi
+        - omega
+        - delta
+      - - omega
+        - diamond
+        - delta
+        - xi
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - psi
+        - delta
+        - star
+        - diamond
+        - omega
+      - - delta
+        - diamond
+        - star
+        - xi
+        - psi
+        - omega
+      - - omega
+        - star
+        - delta
+        - xi
+        - psi
+        - diamond
+      - - delta
+        - xi
+        - psi
+        - star
+        - omega
+        - diamond
+      - - xi
+        - diamond
+        - psi
+        - star
+        - omega
+        - delta
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-18.yaml
+++ b/packages/manual/data/daily/2026-08-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+        - star
+      - - diamond
+        - psi
+        - xi
+        - star
+        - omega
+        - delta
+      - - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+        - trident
+      - - delta
+        - omega
+        - psi
+        - star
+        - diamond
+        - xi
+      - - xi
+        - delta
+        - psi
+        - diamond
+        - omega
+        - star
+      - - trident
+        - psi
+        - star
+        - omega
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+      - - xi
+        - star
+        - diamond
+        - psi
+        - omega
+        - delta
+      - - psi
+        - delta
+        - xi
+        - star
+        - diamond
+        - omega
+      - - xi
+        - diamond
+        - psi
+        - omega
+        - star
+        - delta
+      - - star
+        - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+      - - omega
+        - delta
+        - star
+        - xi
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-19.yaml
+++ b/packages/manual/data/daily/2026-08-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - omega
+        - xi
+        - delta
+        - star
+        - psi
+      - - diamond
+        - delta
+        - xi
+        - trident
+        - omega
+        - psi
+      - - xi
+        - psi
+        - star
+        - delta
+        - omega
+        - diamond
+      - - psi
+        - omega
+        - star
+        - diamond
+        - delta
+        - xi
+      - - diamond
+        - delta
+        - omega
+        - star
+        - psi
+        - xi
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - star
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - star
+        - psi
+      - - star
+        - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+      - - delta
+        - psi
+        - star
+        - xi
+        - diamond
+        - omega
+      - - star
+        - omega
+        - delta
+        - diamond
+        - xi
+        - psi
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - diamond
+      - - omega
+        - xi
+        - psi
+        - star
+        - diamond
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-20.yaml
+++ b/packages/manual/data/daily/2026-08-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - xi
+        - delta
+        - star
+        - omega
+        - diamond
+      - - trident
+        - diamond
+        - delta
+        - psi
+        - xi
+        - omega
+      - - star
+        - psi
+        - delta
+        - omega
+        - xi
+        - trident
+      - - star
+        - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+      - - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+        - star
+      - - delta
+        - star
+        - xi
+        - psi
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+        - star
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+        - star
+      - - star
+        - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+      - - psi
+        - diamond
+        - star
+        - omega
+        - delta
+        - xi
+      - - delta
+        - psi
+        - star
+        - omega
+        - diamond
+        - xi
+      - - xi
+        - psi
+        - diamond
+        - star
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-21.yaml
+++ b/packages/manual/data/daily/2026-08-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - delta
+        - psi
+        - trident
+        - xi
+        - omega
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+        - star
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+        - star
+      - - star
+        - omega
+        - xi
+        - delta
+        - psi
+        - trident
+      - - diamond
+        - star
+        - omega
+        - delta
+        - xi
+        - psi
+      - - delta
+        - psi
+        - omega
+        - star
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - star
+        - delta
+        - omega
+        - xi
+      - - star
+        - diamond
+        - delta
+        - psi
+        - xi
+        - omega
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+        - star
+      - - psi
+        - omega
+        - diamond
+        - star
+        - xi
+        - delta
+      - - star
+        - omega
+        - diamond
+        - psi
+        - xi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-22.yaml
+++ b/packages/manual/data/daily/2026-08-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - star
+        - diamond
+        - xi
+        - psi
+      - - delta
+        - star
+        - omega
+        - diamond
+        - psi
+        - xi
+      - - omega
+        - psi
+        - delta
+        - trident
+        - xi
+        - diamond
+      - - xi
+        - delta
+        - psi
+        - omega
+        - star
+        - diamond
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - star
+        - omega
+      - - omega
+        - trident
+        - psi
+        - star
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+      - - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+        - star
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - psi
+        - star
+        - xi
+        - delta
+        - diamond
+        - omega
+      - - star
+        - xi
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-23.yaml
+++ b/packages/manual/data/daily/2026-08-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - star
+        - trident
+        - psi
+        - delta
+      - - trident
+        - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - omega
+        - diamond
+        - xi
+        - star
+        - delta
+        - psi
+      - - xi
+        - star
+        - delta
+        - omega
+        - diamond
+        - psi
+      - - psi
+        - star
+        - omega
+        - delta
+        - diamond
+        - xi
+      - - psi
+        - star
+        - delta
+        - xi
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - star
+        - xi
+        - diamond
+        - delta
+        - omega
+      - - omega
+        - delta
+        - star
+        - psi
+        - xi
+        - diamond
+      - - delta
+        - diamond
+        - star
+        - psi
+        - omega
+        - xi
+      - - star
+        - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - omega
+        - star
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-24.yaml
+++ b/packages/manual/data/daily/2026-08-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - star
+        - omega
+      - - xi
+        - star
+        - diamond
+        - omega
+        - psi
+        - delta
+      - - omega
+        - trident
+        - delta
+        - xi
+        - diamond
+        - psi
+      - - psi
+        - xi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - star
+        - omega
+        - xi
+        - delta
+        - psi
+        - trident
+      - - delta
+        - psi
+        - omega
+        - xi
+        - star
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+        - star
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - star
+        - omega
+      - - psi
+        - diamond
+        - star
+        - omega
+        - delta
+        - xi
+      - - omega
+        - star
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - star
+        - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+      - - star
+        - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-25.yaml
+++ b/packages/manual/data/daily/2026-08-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - omega
+        - delta
+        - diamond
+        - star
+        - psi
+      - - xi
+        - star
+        - delta
+        - omega
+        - psi
+        - diamond
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - omega
+        - star
+        - trident
+        - psi
+        - xi
+        - delta
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+        - star
+      - - psi
+        - omega
+        - diamond
+        - trident
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - xi
+        - diamond
+        - omega
+        - star
+      - - star
+        - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+      - - omega
+        - xi
+        - delta
+        - star
+        - diamond
+        - psi
+      - - psi
+        - xi
+        - diamond
+        - star
+        - omega
+        - delta
+      - - delta
+        - diamond
+        - psi
+        - star
+        - xi
+        - omega
+      - - diamond
+        - xi
+        - delta
+        - omega
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-26.yaml
+++ b/packages/manual/data/daily/2026-08-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - star
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - delta
+        - omega
+        - trident
+        - xi
+        - psi
+        - star
+      - - delta
+        - omega
+        - diamond
+        - star
+        - psi
+        - xi
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - trident
+        - xi
+      - - omega
+        - star
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - delta
+        - psi
+        - omega
+        - xi
+        - star
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - xi
+        - psi
+        - delta
+        - omega
+      - - delta
+        - star
+        - diamond
+        - omega
+        - psi
+        - xi
+      - - diamond
+        - delta
+        - star
+        - xi
+        - psi
+        - omega
+      - - psi
+        - omega
+        - xi
+        - star
+        - delta
+        - diamond
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - star
+        - delta
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-27.yaml
+++ b/packages/manual/data/daily/2026-08-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - omega
+        - trident
+        - delta
+        - xi
+        - psi
+      - - xi
+        - diamond
+        - star
+        - psi
+        - delta
+        - omega
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+      - - trident
+        - xi
+        - star
+        - omega
+        - delta
+        - psi
+      - - xi
+        - star
+        - omega
+        - diamond
+        - psi
+        - delta
+      - - omega
+        - delta
+        - star
+        - diamond
+        - psi
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - star
+        - xi
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+        - star
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+        - star
+      - - star
+        - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+      - - star
+        - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - xi
+        - star
+        - omega
+        - delta
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-28.yaml
+++ b/packages/manual/data/daily/2026-08-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - omega
+        - xi
+        - psi
+        - diamond
+        - delta
+      - - star
+        - xi
+        - psi
+        - delta
+        - trident
+        - omega
+      - - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+        - trident
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - star
+        - delta
+      - - star
+        - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+      - - xi
+        - omega
+        - psi
+        - star
+        - diamond
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - omega
+        - star
+        - diamond
+        - psi
+        - delta
+      - - star
+        - xi
+        - omega
+        - diamond
+        - psi
+        - delta
+      - - star
+        - delta
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - psi
+        - delta
+        - star
+        - omega
+        - xi
+        - diamond
+      - - delta
+        - psi
+        - star
+        - diamond
+        - omega
+        - xi
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - star
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-29.yaml
+++ b/packages/manual/data/daily/2026-08-29.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-29'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+        - star
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+        - star
+      - - star
+        - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+      - - psi
+        - trident
+        - delta
+        - omega
+        - xi
+        - star
+      - - diamond
+        - xi
+        - delta
+        - omega
+        - psi
+        - trident
+      - - omega
+        - psi
+        - xi
+        - delta
+        - diamond
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - star
+        - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+      - - omega
+        - xi
+        - star
+        - delta
+        - psi
+        - diamond
+      - - psi
+        - omega
+        - delta
+        - xi
+        - star
+        - diamond
+      - - delta
+        - star
+        - diamond
+        - xi
+        - psi
+        - omega
+      - - delta
+        - omega
+        - psi
+        - xi
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-30.yaml
+++ b/packages/manual/data/daily/2026-08-30.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-30'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - star
+        - xi
+        - psi
+        - diamond
+      - - diamond
+        - star
+        - psi
+        - xi
+        - omega
+        - delta
+      - - omega
+        - delta
+        - psi
+        - trident
+        - diamond
+        - xi
+      - - star
+        - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+      - - star
+        - delta
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - star
+        - psi
+        - trident
+        - delta
+        - omega
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - xi
+        - delta
+        - psi
+        - omega
+        - star
+        - diamond
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - star
+        - omega
+      - - xi
+        - psi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - diamond
+        - omega
+        - psi
+        - star
+        - xi
+        - delta
+      - - omega
+        - psi
+        - xi
+        - delta
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-08-31.yaml
+++ b/packages/manual/data/daily/2026-08-31.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-08-31'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - delta
+        - star
+        - xi
+        - omega
+        - psi
+      - - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+        - star
+      - - delta
+        - omega
+        - diamond
+        - star
+        - psi
+        - xi
+      - - trident
+        - psi
+        - omega
+        - star
+        - xi
+        - delta
+      - - delta
+        - trident
+        - xi
+        - omega
+        - diamond
+        - psi
+      - - delta
+        - psi
+        - star
+        - diamond
+        - xi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+      - - star
+        - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+        - star
+      - - delta
+        - omega
+        - psi
+        - star
+        - xi
+        - diamond
+      - - xi
+        - star
+        - delta
+        - omega
+        - psi
+        - diamond
+      - - psi
+        - omega
+        - star
+        - diamond
+        - xi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-01.yaml
+++ b/packages/manual/data/daily/2026-09-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - psi
+        - star
+        - xi
+        - delta
+        - omega
+      - - psi
+        - star
+        - xi
+        - delta
+        - omega
+        - diamond
+      - - xi
+        - star
+        - psi
+        - omega
+        - delta
+        - trident
+      - - diamond
+        - star
+        - omega
+        - psi
+        - delta
+        - xi
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - delta
+        - star
+      - - diamond
+        - psi
+        - omega
+        - delta
+        - xi
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+      - - diamond
+        - omega
+        - delta
+        - star
+        - xi
+        - psi
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - star
+        - xi
+      - - omega
+        - delta
+        - diamond
+        - star
+        - psi
+        - xi
+      - - star
+        - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+      - - xi
+        - star
+        - diamond
+        - delta
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-02.yaml
+++ b/packages/manual/data/daily/2026-09-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+      - - star
+        - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+      - - xi
+        - psi
+        - trident
+        - diamond
+        - omega
+        - delta
+      - - delta
+        - star
+        - xi
+        - psi
+        - diamond
+        - omega
+      - - trident
+        - xi
+        - star
+        - omega
+        - psi
+        - delta
+      - - delta
+        - omega
+        - xi
+        - diamond
+        - star
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+      - - delta
+        - xi
+        - diamond
+        - omega
+        - psi
+        - star
+      - - delta
+        - omega
+        - xi
+        - psi
+        - star
+        - diamond
+      - - psi
+        - omega
+        - xi
+        - star
+        - diamond
+        - delta
+      - - omega
+        - diamond
+        - psi
+        - star
+        - delta
+        - xi
+      - - omega
+        - delta
+        - star
+        - diamond
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-03.yaml
+++ b/packages/manual/data/daily/2026-09-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - star
+        - xi
+        - diamond
+        - psi
+      - - omega
+        - star
+        - diamond
+        - xi
+        - delta
+        - psi
+      - - diamond
+        - star
+        - omega
+        - xi
+        - psi
+        - delta
+      - - diamond
+        - trident
+        - omega
+        - xi
+        - psi
+        - delta
+      - - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+        - star
+      - - psi
+        - delta
+        - xi
+        - omega
+        - trident
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - omega
+        - delta
+        - diamond
+        - psi
+      - - star
+        - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+        - star
+      - - psi
+        - star
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - star
+        - omega
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-04.yaml
+++ b/packages/manual/data/daily/2026-09-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - xi
+        - star
+        - diamond
+        - psi
+        - omega
+      - - xi
+        - diamond
+        - star
+        - omega
+        - delta
+        - psi
+      - - star
+        - delta
+        - psi
+        - omega
+        - xi
+        - diamond
+      - - trident
+        - diamond
+        - psi
+        - omega
+        - xi
+        - delta
+      - - xi
+        - trident
+        - psi
+        - omega
+        - delta
+        - star
+      - - omega
+        - star
+        - psi
+        - delta
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - star
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - xi
+        - omega
+        - star
+        - diamond
+        - psi
+        - delta
+      - - psi
+        - xi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - xi
+        - star
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - psi
+        - diamond
+        - delta
+        - star
+        - omega
+        - xi
+      - - xi
+        - psi
+        - star
+        - delta
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-05.yaml
+++ b/packages/manual/data/daily/2026-09-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - trident
+        - delta
+      - - diamond
+        - delta
+        - xi
+        - star
+        - omega
+        - psi
+      - - delta
+        - star
+        - psi
+        - trident
+        - omega
+        - xi
+      - - star
+        - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+        - star
+      - - delta
+        - xi
+        - star
+        - psi
+        - omega
+        - diamond
+      - - delta
+        - star
+        - psi
+        - omega
+        - diamond
+        - xi
+      - - delta
+        - diamond
+        - star
+        - omega
+        - xi
+        - psi
+      - - omega
+        - psi
+        - diamond
+        - delta
+        - star
+        - xi
+      - - star
+        - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-06.yaml
+++ b/packages/manual/data/daily/2026-09-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - psi
+        - omega
+        - diamond
+        - delta
+        - xi
+      - - star
+        - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - delta
+        - psi
+        - diamond
+        - omega
+        - star
+        - xi
+      - - psi
+        - diamond
+        - delta
+        - xi
+        - omega
+        - star
+      - - star
+        - xi
+        - diamond
+        - omega
+        - delta
+        - psi
+      - - omega
+        - trident
+        - delta
+        - psi
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+        - star
+      - - xi
+        - diamond
+        - psi
+        - star
+        - omega
+        - delta
+      - - diamond
+        - psi
+        - xi
+        - star
+        - delta
+        - omega
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - star
+        - omega
+      - - psi
+        - star
+        - delta
+        - omega
+        - diamond
+        - xi
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-07.yaml
+++ b/packages/manual/data/daily/2026-09-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - psi
+        - xi
+        - trident
+        - delta
+        - diamond
+      - - omega
+        - xi
+        - star
+        - psi
+        - diamond
+        - delta
+      - - star
+        - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+      - - omega
+        - psi
+        - delta
+        - star
+        - diamond
+        - xi
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - star
+        - xi
+      - - omega
+        - star
+        - psi
+        - xi
+        - trident
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - psi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - star
+        - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+      - - diamond
+        - star
+        - omega
+        - delta
+        - psi
+        - xi
+      - - omega
+        - psi
+        - star
+        - xi
+        - diamond
+        - delta
+      - - xi
+        - omega
+        - delta
+        - psi
+        - star
+        - diamond
+      - - xi
+        - star
+        - omega
+        - diamond
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-08.yaml
+++ b/packages/manual/data/daily/2026-09-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - star
+        - delta
+      - - trident
+        - star
+        - omega
+        - psi
+        - xi
+        - delta
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - star
+        - xi
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - omega
+        - trident
+      - - star
+        - diamond
+        - xi
+        - psi
+        - omega
+        - delta
+      - - diamond
+        - omega
+        - delta
+        - star
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - delta
+        - diamond
+        - psi
+        - omega
+      - - psi
+        - xi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - xi
+        - delta
+        - psi
+        - omega
+        - diamond
+        - star
+      - - omega
+        - delta
+        - diamond
+        - star
+        - xi
+        - psi
+      - - star
+        - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+      - - psi
+        - diamond
+        - xi
+        - star
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-09.yaml
+++ b/packages/manual/data/daily/2026-09-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+        - star
+      - - trident
+        - omega
+        - psi
+        - star
+        - xi
+        - delta
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - star
+        - delta
+      - - diamond
+        - psi
+        - star
+        - xi
+        - delta
+        - omega
+      - - omega
+        - delta
+        - diamond
+        - psi
+        - xi
+        - star
+      - - psi
+        - trident
+        - omega
+        - delta
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - delta
+        - diamond
+        - star
+        - psi
+        - xi
+      - - diamond
+        - star
+        - xi
+        - omega
+        - psi
+        - delta
+      - - psi
+        - xi
+        - omega
+        - delta
+        - star
+        - diamond
+      - - star
+        - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+      - - diamond
+        - star
+        - psi
+        - xi
+        - delta
+        - omega
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-10.yaml
+++ b/packages/manual/data/daily/2026-09-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - omega
+        - xi
+        - trident
+        - psi
+        - delta
+      - - xi
+        - delta
+        - psi
+        - diamond
+        - trident
+        - omega
+      - - star
+        - xi
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - star
+        - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+      - - star
+        - psi
+        - diamond
+        - delta
+        - omega
+        - xi
+      - - diamond
+        - delta
+        - omega
+        - star
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - star
+        - delta
+        - xi
+        - psi
+        - diamond
+      - - psi
+        - omega
+        - diamond
+        - star
+        - delta
+        - xi
+      - - delta
+        - omega
+        - psi
+        - xi
+        - diamond
+        - star
+      - - delta
+        - xi
+        - omega
+        - star
+        - diamond
+        - psi
+      - - diamond
+        - xi
+        - psi
+        - omega
+        - delta
+        - star
+      - - psi
+        - delta
+        - omega
+        - xi
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-11.yaml
+++ b/packages/manual/data/daily/2026-09-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - diamond
+        - omega
+        - delta
+        - star
+        - psi
+      - - delta
+        - star
+        - trident
+        - psi
+        - omega
+        - xi
+      - - omega
+        - diamond
+        - delta
+        - trident
+        - xi
+        - psi
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - star
+        - omega
+      - - diamond
+        - omega
+        - delta
+        - xi
+        - psi
+        - star
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - omega
+        - psi
+        - delta
+        - xi
+      - - star
+        - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+      - - diamond
+        - delta
+        - omega
+        - xi
+        - star
+        - psi
+      - - diamond
+        - psi
+        - star
+        - xi
+        - omega
+        - delta
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - star
+        - delta
+      - - psi
+        - diamond
+        - star
+        - xi
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-12.yaml
+++ b/packages/manual/data/daily/2026-09-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+      - - psi
+        - trident
+        - delta
+        - xi
+        - star
+        - omega
+      - - delta
+        - star
+        - diamond
+        - psi
+        - omega
+        - xi
+      - - psi
+        - xi
+        - star
+        - omega
+        - delta
+        - diamond
+      - - star
+        - omega
+        - delta
+        - xi
+        - diamond
+        - psi
+      - - psi
+        - trident
+        - xi
+        - diamond
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - xi
+        - diamond
+        - star
+        - psi
+        - omega
+      - - psi
+        - diamond
+        - delta
+        - star
+        - omega
+        - xi
+      - - star
+        - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+      - - delta
+        - psi
+        - star
+        - diamond
+        - xi
+        - omega
+      - - xi
+        - psi
+        - star
+        - diamond
+        - delta
+        - omega
+      - - delta
+        - psi
+        - star
+        - diamond
+        - xi
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-13.yaml
+++ b/packages/manual/data/daily/2026-09-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - trident
+        - xi
+        - omega
+        - psi
+        - star
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - star
+        - omega
+      - - omega
+        - psi
+        - xi
+        - star
+        - diamond
+        - delta
+      - - delta
+        - psi
+        - star
+        - xi
+        - diamond
+        - omega
+      - - diamond
+        - trident
+        - delta
+        - omega
+        - psi
+        - xi
+      - - psi
+        - star
+        - diamond
+        - delta
+        - xi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - star
+        - psi
+        - omega
+        - delta
+      - - diamond
+        - delta
+        - star
+        - xi
+        - psi
+        - omega
+      - - delta
+        - star
+        - diamond
+        - omega
+        - xi
+        - psi
+      - - psi
+        - omega
+        - xi
+        - delta
+        - diamond
+        - star
+      - - star
+        - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+      - - omega
+        - star
+        - delta
+        - psi
+        - diamond
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-14.yaml
+++ b/packages/manual/data/daily/2026-09-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - psi
+        - trident
+        - diamond
+        - delta
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - star
+        - delta
+      - - omega
+        - star
+        - xi
+        - psi
+        - delta
+        - trident
+      - - xi
+        - psi
+        - star
+        - delta
+        - omega
+        - diamond
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - omega
+        - star
+      - - omega
+        - psi
+        - star
+        - delta
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - omega
+        - delta
+        - psi
+        - xi
+      - - star
+        - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+      - - diamond
+        - psi
+        - delta
+        - xi
+        - star
+        - omega
+      - - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+        - star
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - omega
+        - star
+      - - delta
+        - psi
+        - omega
+        - xi
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-15.yaml
+++ b/packages/manual/data/daily/2026-09-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - star
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - star
+        - omega
+        - psi
+        - xi
+        - trident
+        - delta
+      - - diamond
+        - xi
+        - trident
+        - psi
+        - delta
+        - omega
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - star
+        - psi
+      - - diamond
+        - omega
+        - delta
+        - xi
+        - star
+        - psi
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - omega
+        - diamond
+        - star
+        - delta
+        - xi
+      - - delta
+        - star
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+        - star
+      - - omega
+        - xi
+        - star
+        - delta
+        - diamond
+        - psi
+      - - psi
+        - diamond
+        - omega
+        - star
+        - xi
+        - delta
+      - - omega
+        - delta
+        - xi
+        - star
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-16.yaml
+++ b/packages/manual/data/daily/2026-09-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - delta
+        - omega
+        - xi
+        - diamond
+        - psi
+      - - psi
+        - omega
+        - xi
+        - delta
+        - diamond
+        - trident
+      - - delta
+        - psi
+        - diamond
+        - omega
+        - star
+        - xi
+      - - star
+        - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - star
+        - psi
+        - delta
+        - omega
+        - xi
+        - diamond
+      - - trident
+        - omega
+        - star
+        - xi
+        - delta
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - delta
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - psi
+        - star
+        - omega
+        - diamond
+        - delta
+        - xi
+      - - diamond
+        - star
+        - psi
+        - omega
+        - delta
+        - xi
+      - - delta
+        - psi
+        - omega
+        - star
+        - diamond
+        - xi
+      - - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+        - star
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-17.yaml
+++ b/packages/manual/data/daily/2026-09-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - xi
+        - star
+        - psi
+        - trident
+      - - trident
+        - xi
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+        - star
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - delta
+        - star
+      - - xi
+        - star
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - diamond
+        - xi
+        - star
+        - psi
+        - omega
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+        - star
+      - - xi
+        - omega
+        - delta
+        - star
+        - diamond
+        - psi
+      - - diamond
+        - delta
+        - omega
+        - star
+        - xi
+        - psi
+      - - delta
+        - omega
+        - star
+        - diamond
+        - xi
+        - psi
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+        - star
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-18.yaml
+++ b/packages/manual/data/daily/2026-09-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - star
+        - psi
+        - omega
+        - xi
+        - delta
+      - - omega
+        - diamond
+        - delta
+        - xi
+        - star
+        - psi
+      - - star
+        - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+      - - star
+        - trident
+        - xi
+        - psi
+        - omega
+        - delta
+      - - delta
+        - xi
+        - psi
+        - trident
+        - omega
+        - diamond
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - star
+        - omega
+        - diamond
+        - delta
+        - xi
+      - - omega
+        - star
+        - psi
+        - delta
+        - xi
+        - diamond
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - star
+        - psi
+      - - omega
+        - xi
+        - diamond
+        - star
+        - psi
+        - delta
+      - - omega
+        - xi
+        - delta
+        - star
+        - psi
+        - diamond
+      - - delta
+        - star
+        - xi
+        - diamond
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-19.yaml
+++ b/packages/manual/data/daily/2026-09-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - diamond
+        - xi
+        - psi
+        - omega
+        - delta
+      - - xi
+        - omega
+        - delta
+        - star
+        - psi
+        - diamond
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - star
+        - psi
+      - - delta
+        - psi
+        - star
+        - omega
+        - xi
+        - diamond
+      - - xi
+        - star
+        - delta
+        - trident
+        - psi
+        - omega
+      - - omega
+        - delta
+        - xi
+        - psi
+        - trident
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - psi
+        - omega
+        - delta
+        - diamond
+      - - xi
+        - delta
+        - omega
+        - psi
+        - star
+        - diamond
+      - - diamond
+        - omega
+        - psi
+        - star
+        - xi
+        - delta
+      - - diamond
+        - xi
+        - psi
+        - omega
+        - delta
+        - star
+      - - diamond
+        - omega
+        - star
+        - delta
+        - xi
+        - psi
+      - - delta
+        - xi
+        - omega
+        - star
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-20.yaml
+++ b/packages/manual/data/daily/2026-09-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - star
+        - xi
+        - psi
+        - diamond
+        - omega
+      - - omega
+        - star
+        - psi
+        - delta
+        - diamond
+        - xi
+      - - star
+        - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+      - - star
+        - omega
+        - xi
+        - trident
+        - delta
+        - psi
+      - - star
+        - omega
+        - xi
+        - psi
+        - diamond
+        - delta
+      - - psi
+        - omega
+        - trident
+        - diamond
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - delta
+        - omega
+        - diamond
+        - psi
+      - - xi
+        - star
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+        - star
+      - - omega
+        - diamond
+        - xi
+        - delta
+        - star
+        - psi
+      - - psi
+        - diamond
+        - xi
+        - star
+        - delta
+        - omega
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-21.yaml
+++ b/packages/manual/data/daily/2026-09-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - star
+        - delta
+        - trident
+        - xi
+      - - psi
+        - star
+        - xi
+        - diamond
+        - delta
+        - omega
+      - - star
+        - psi
+        - diamond
+        - omega
+        - delta
+        - xi
+      - - star
+        - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - diamond
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - trident
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - psi
+        - diamond
+        - omega
+        - star
+        - xi
+      - - star
+        - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+      - - xi
+        - star
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - xi
+        - psi
+        - star
+        - delta
+        - diamond
+        - omega
+      - - delta
+        - xi
+        - diamond
+        - star
+        - psi
+        - omega
+      - - star
+        - delta
+        - psi
+        - diamond
+        - omega
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-22.yaml
+++ b/packages/manual/data/daily/2026-09-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - diamond
+        - omega
+        - star
+        - xi
+      - - star
+        - xi
+        - trident
+        - delta
+        - psi
+        - omega
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - star
+        - psi
+      - - star
+        - xi
+        - omega
+        - psi
+        - delta
+        - diamond
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - trident
+        - delta
+      - - diamond
+        - psi
+        - omega
+        - xi
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - star
+        - xi
+        - delta
+        - omega
+      - - omega
+        - delta
+        - xi
+        - psi
+        - diamond
+        - star
+      - - psi
+        - star
+        - xi
+        - delta
+        - diamond
+        - omega
+      - - delta
+        - star
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+      - - delta
+        - xi
+        - omega
+        - psi
+        - star
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-23.yaml
+++ b/packages/manual/data/daily/2026-09-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+        - trident
+      - - delta
+        - xi
+        - diamond
+        - star
+        - omega
+        - psi
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - star
+        - xi
+      - - star
+        - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - star
+        - psi
+      - - xi
+        - delta
+        - psi
+        - omega
+        - star
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+        - star
+      - - delta
+        - star
+        - diamond
+        - xi
+        - psi
+        - omega
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+        - star
+      - - star
+        - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+      - - psi
+        - diamond
+        - omega
+        - delta
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-24.yaml
+++ b/packages/manual/data/daily/2026-09-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+      - - diamond
+        - psi
+        - xi
+        - delta
+        - omega
+        - star
+      - - star
+        - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+      - - xi
+        - trident
+        - star
+        - delta
+        - psi
+        - omega
+      - - diamond
+        - xi
+        - psi
+        - star
+        - omega
+        - delta
+      - - omega
+        - diamond
+        - star
+        - delta
+        - psi
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - diamond
+        - star
+        - psi
+        - xi
+      - - diamond
+        - star
+        - psi
+        - delta
+        - xi
+        - omega
+      - - omega
+        - star
+        - xi
+        - delta
+        - psi
+        - diamond
+      - - omega
+        - psi
+        - star
+        - xi
+        - delta
+        - diamond
+      - - delta
+        - omega
+        - psi
+        - star
+        - xi
+        - diamond
+      - - diamond
+        - xi
+        - star
+        - delta
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-25.yaml
+++ b/packages/manual/data/daily/2026-09-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - star
+        - xi
+        - psi
+        - delta
+        - trident
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+        - star
+      - - psi
+        - delta
+        - xi
+        - star
+        - diamond
+        - omega
+      - - star
+        - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+      - - delta
+        - psi
+        - trident
+        - xi
+        - diamond
+        - omega
+      - - star
+        - xi
+        - omega
+        - diamond
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - diamond
+        - star
+        - delta
+        - xi
+      - - star
+        - delta
+        - diamond
+        - xi
+        - psi
+        - omega
+      - - diamond
+        - star
+        - xi
+        - delta
+        - omega
+        - psi
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - psi
+        - delta
+        - omega
+        - xi
+        - diamond
+        - star
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-26.yaml
+++ b/packages/manual/data/daily/2026-09-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - omega
+        - delta
+        - trident
+        - psi
+      - - star
+        - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+      - - psi
+        - xi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - delta
+        - psi
+        - xi
+        - trident
+        - omega
+        - star
+      - - omega
+        - psi
+        - xi
+        - diamond
+        - star
+        - delta
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - delta
+        - omega
+        - psi
+        - xi
+      - - delta
+        - star
+        - psi
+        - xi
+        - diamond
+        - omega
+      - - diamond
+        - star
+        - psi
+        - xi
+        - omega
+        - delta
+      - - diamond
+        - star
+        - omega
+        - psi
+        - delta
+        - xi
+      - - star
+        - xi
+        - diamond
+        - omega
+        - delta
+        - psi
+      - - diamond
+        - omega
+        - xi
+        - psi
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-27.yaml
+++ b/packages/manual/data/daily/2026-09-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - star
+        - delta
+        - diamond
+        - xi
+      - - star
+        - xi
+        - delta
+        - omega
+        - diamond
+        - psi
+      - - diamond
+        - xi
+        - psi
+        - delta
+        - star
+        - omega
+      - - xi
+        - trident
+        - diamond
+        - psi
+        - delta
+        - omega
+      - - delta
+        - xi
+        - omega
+        - psi
+        - star
+        - trident
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - star
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+      - - psi
+        - omega
+        - xi
+        - star
+        - delta
+        - diamond
+      - - psi
+        - star
+        - diamond
+        - omega
+        - delta
+        - xi
+      - - xi
+        - omega
+        - delta
+        - diamond
+        - psi
+        - star
+      - - psi
+        - star
+        - xi
+        - delta
+        - omega
+        - diamond
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-28.yaml
+++ b/packages/manual/data/daily/2026-09-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - psi
+        - star
+        - trident
+        - omega
+        - delta
+      - - diamond
+        - delta
+        - star
+        - psi
+        - xi
+        - omega
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - delta
+        - star
+      - - diamond
+        - xi
+        - psi
+        - omega
+        - trident
+        - delta
+      - - psi
+        - delta
+        - star
+        - xi
+        - omega
+        - diamond
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - psi
+        - star
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - star
+        - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - psi
+        - delta
+        - diamond
+        - star
+        - xi
+        - omega
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - star
+        - xi
+      - - psi
+        - diamond
+        - star
+        - delta
+        - omega
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-29.yaml
+++ b/packages/manual/data/daily/2026-09-29.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-29'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - delta
+        - xi
+        - psi
+        - omega
+        - trident
+      - - psi
+        - delta
+        - xi
+        - diamond
+        - star
+        - omega
+      - - diamond
+        - trident
+        - omega
+        - delta
+        - psi
+        - xi
+      - - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+        - star
+      - - star
+        - delta
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - delta
+        - star
+        - diamond
+        - omega
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - star
+        - omega
+        - diamond
+        - xi
+        - delta
+      - - xi
+        - diamond
+        - star
+        - delta
+        - psi
+        - omega
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - star
+        - omega
+      - - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+        - star
+      - - delta
+        - star
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - star
+        - omega
+        - xi
+        - psi
+        - diamond
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-09-30.yaml
+++ b/packages/manual/data/daily/2026-09-30.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-09-30'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - xi
+        - star
+      - - delta
+        - star
+        - omega
+        - xi
+        - diamond
+        - psi
+      - - omega
+        - delta
+        - xi
+        - diamond
+        - trident
+        - psi
+      - - psi
+        - omega
+        - xi
+        - delta
+        - trident
+        - star
+      - - delta
+        - star
+        - psi
+        - xi
+        - omega
+        - diamond
+      - - star
+        - psi
+        - xi
+        - delta
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+        - star
+      - - delta
+        - star
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - delta
+        - psi
+        - star
+        - omega
+        - diamond
+        - xi
+      - - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+        - star
+      - - star
+        - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+      - - diamond
+        - star
+        - psi
+        - xi
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-01.yaml
+++ b/packages/manual/data/daily/2026-10-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - delta
+        - diamond
+        - trident
+        - psi
+      - - omega
+        - star
+        - diamond
+        - delta
+        - xi
+        - psi
+      - - delta
+        - xi
+        - star
+        - omega
+        - diamond
+        - psi
+      - - delta
+        - psi
+        - trident
+        - star
+        - xi
+        - omega
+      - - psi
+        - xi
+        - star
+        - omega
+        - delta
+        - diamond
+      - - star
+        - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - star
+        - xi
+        - diamond
+        - delta
+      - - psi
+        - omega
+        - delta
+        - diamond
+        - star
+        - xi
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - star
+        - delta
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+        - star
+      - - omega
+        - delta
+        - diamond
+        - star
+        - xi
+        - psi
+      - - star
+        - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-02.yaml
+++ b/packages/manual/data/daily/2026-10-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - star
+        - diamond
+        - omega
+        - xi
+        - delta
+      - - psi
+        - xi
+        - omega
+        - delta
+        - star
+        - diamond
+      - - xi
+        - star
+        - trident
+        - omega
+        - psi
+        - delta
+      - - xi
+        - delta
+        - psi
+        - diamond
+        - omega
+        - star
+      - - xi
+        - psi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - psi
+        - xi
+        - omega
+        - delta
+        - trident
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - xi
+        - star
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - star
+        - delta
+      - - diamond
+        - xi
+        - star
+        - psi
+        - delta
+        - omega
+      - - omega
+        - xi
+        - delta
+        - star
+        - psi
+        - diamond
+      - - diamond
+        - psi
+        - omega
+        - xi
+        - delta
+        - star
+      - - diamond
+        - star
+        - psi
+        - xi
+        - omega
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-03.yaml
+++ b/packages/manual/data/daily/2026-10-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - xi
+        - star
+        - diamond
+        - omega
+      - - star
+        - omega
+        - psi
+        - xi
+        - delta
+        - trident
+      - - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+        - star
+      - - xi
+        - omega
+        - diamond
+        - star
+        - delta
+        - psi
+      - - psi
+        - xi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - psi
+        - diamond
+        - omega
+        - trident
+        - xi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - xi
+        - omega
+        - star
+        - psi
+        - diamond
+      - - xi
+        - star
+        - diamond
+        - omega
+        - delta
+        - psi
+      - - star
+        - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+      - - delta
+        - omega
+        - diamond
+        - star
+        - psi
+        - xi
+      - - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+        - star
+      - - omega
+        - psi
+        - star
+        - delta
+        - diamond
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-04.yaml
+++ b/packages/manual/data/daily/2026-10-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - xi
+        - star
+        - psi
+        - omega
+        - delta
+        - trident
+      - - trident
+        - psi
+        - delta
+        - diamond
+        - omega
+        - xi
+      - - omega
+        - diamond
+        - star
+        - psi
+        - delta
+        - xi
+      - - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+        - star
+      - - delta
+        - omega
+        - diamond
+        - star
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - star
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - psi
+        - delta
+        - omega
+        - xi
+        - star
+        - diamond
+      - - star
+        - omega
+        - delta
+        - xi
+        - psi
+        - diamond
+      - - star
+        - diamond
+        - omega
+        - delta
+        - xi
+        - psi
+      - - delta
+        - star
+        - omega
+        - psi
+        - xi
+        - diamond
+      - - xi
+        - delta
+        - star
+        - psi
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-05.yaml
+++ b/packages/manual/data/daily/2026-10-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - delta
+        - omega
+        - xi
+        - star
+        - diamond
+      - - diamond
+        - psi
+        - xi
+        - delta
+        - star
+        - omega
+      - - star
+        - omega
+        - delta
+        - trident
+        - psi
+        - xi
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - trident
+        - omega
+      - - star
+        - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+      - - star
+        - delta
+        - diamond
+        - xi
+        - psi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - star
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - star
+        - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - star
+        - xi
+      - - diamond
+        - xi
+        - psi
+        - omega
+        - star
+        - delta
+      - - psi
+        - omega
+        - star
+        - diamond
+        - xi
+        - delta
+      - - psi
+        - xi
+        - omega
+        - star
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-06.yaml
+++ b/packages/manual/data/daily/2026-10-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - diamond
+        - psi
+        - delta
+        - xi
+        - omega
+      - - psi
+        - diamond
+        - xi
+        - star
+        - delta
+        - omega
+      - - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+        - star
+      - - diamond
+        - psi
+        - delta
+        - xi
+        - star
+        - omega
+      - - xi
+        - diamond
+        - omega
+        - trident
+        - psi
+        - delta
+      - - omega
+        - star
+        - psi
+        - xi
+        - trident
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - xi
+        - psi
+        - delta
+        - omega
+      - - xi
+        - psi
+        - diamond
+        - star
+        - delta
+        - omega
+      - - diamond
+        - delta
+        - psi
+        - xi
+        - omega
+        - star
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - star
+      - - omega
+        - psi
+        - diamond
+        - star
+        - xi
+        - delta
+      - - xi
+        - diamond
+        - omega
+        - delta
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-07.yaml
+++ b/packages/manual/data/daily/2026-10-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - diamond
+        - omega
+        - delta
+        - xi
+        - psi
+      - - xi
+        - diamond
+        - omega
+        - star
+        - delta
+        - psi
+      - - trident
+        - psi
+        - omega
+        - delta
+        - star
+        - xi
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - trident
+        - omega
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - star
+        - omega
+      - - psi
+        - delta
+        - diamond
+        - omega
+        - xi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - psi
+        - diamond
+        - delta
+        - omega
+      - - star
+        - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+      - - delta
+        - omega
+        - xi
+        - diamond
+        - star
+        - psi
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+        - star
+      - - delta
+        - xi
+        - diamond
+        - psi
+        - star
+        - omega
+      - - xi
+        - omega
+        - delta
+        - star
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-08.yaml
+++ b/packages/manual/data/daily/2026-10-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - star
+        - diamond
+        - omega
+        - xi
+      - - xi
+        - delta
+        - omega
+        - star
+        - trident
+        - psi
+      - - star
+        - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+      - - star
+        - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+      - - trident
+        - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+      - - star
+        - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+        - star
+      - - psi
+        - delta
+        - star
+        - diamond
+        - xi
+        - omega
+      - - psi
+        - omega
+        - delta
+        - xi
+        - star
+        - diamond
+      - - delta
+        - psi
+        - star
+        - diamond
+        - xi
+        - omega
+      - - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+        - star
+      - - star
+        - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-09.yaml
+++ b/packages/manual/data/daily/2026-10-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+        - star
+      - - xi
+        - delta
+        - psi
+        - omega
+        - trident
+        - star
+      - - diamond
+        - omega
+        - xi
+        - star
+        - psi
+        - delta
+      - - omega
+        - star
+        - delta
+        - diamond
+        - psi
+        - xi
+      - - delta
+        - diamond
+        - trident
+        - omega
+        - xi
+        - psi
+      - - psi
+        - omega
+        - star
+        - diamond
+        - xi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - omega
+        - diamond
+        - psi
+        - delta
+      - - delta
+        - star
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - diamond
+        - psi
+        - delta
+        - star
+        - omega
+        - xi
+      - - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+        - star
+      - - delta
+        - star
+        - diamond
+        - omega
+        - psi
+        - xi
+      - - delta
+        - star
+        - omega
+        - xi
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-10.yaml
+++ b/packages/manual/data/daily/2026-10-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - xi
+        - diamond
+        - trident
+        - psi
+      - - diamond
+        - delta
+        - xi
+        - star
+        - psi
+        - omega
+      - - psi
+        - diamond
+        - star
+        - xi
+        - delta
+        - omega
+      - - xi
+        - omega
+        - diamond
+        - delta
+        - star
+        - psi
+      - - delta
+        - diamond
+        - star
+        - xi
+        - psi
+        - omega
+      - - psi
+        - omega
+        - xi
+        - trident
+        - star
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - omega
+        - psi
+        - star
+        - delta
+        - diamond
+      - - star
+        - delta
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - delta
+        - xi
+        - diamond
+        - psi
+        - star
+        - omega
+      - - omega
+        - star
+        - psi
+        - diamond
+        - xi
+        - delta
+      - - diamond
+        - psi
+        - star
+        - xi
+        - delta
+        - omega
+      - - xi
+        - omega
+        - delta
+        - star
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-11.yaml
+++ b/packages/manual/data/daily/2026-10-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - delta
+        - star
+        - xi
+        - psi
+      - - trident
+        - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - star
+        - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - psi
+        - star
+        - delta
+        - xi
+        - diamond
+        - omega
+      - - star
+        - omega
+        - psi
+        - trident
+        - xi
+        - delta
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+        - star
+      - - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+        - star
+      - - omega
+        - diamond
+        - star
+        - psi
+        - delta
+        - xi
+      - - omega
+        - star
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - xi
+        - delta
+        - star
+        - psi
+        - omega
+        - diamond
+      - - star
+        - diamond
+        - psi
+        - xi
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-12.yaml
+++ b/packages/manual/data/daily/2026-10-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - star
+        - psi
+      - - omega
+        - delta
+        - xi
+        - psi
+        - star
+        - diamond
+      - - diamond
+        - omega
+        - star
+        - xi
+        - psi
+        - delta
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - star
+        - omega
+      - - delta
+        - xi
+        - omega
+        - psi
+        - star
+        - trident
+      - - omega
+        - xi
+        - psi
+        - diamond
+        - trident
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - star
+        - diamond
+        - omega
+        - delta
+        - xi
+      - - star
+        - omega
+        - psi
+        - delta
+        - xi
+        - diamond
+      - - xi
+        - delta
+        - diamond
+        - star
+        - omega
+        - psi
+      - - psi
+        - star
+        - xi
+        - delta
+        - omega
+        - diamond
+      - - star
+        - omega
+        - xi
+        - psi
+        - delta
+        - diamond
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-13.yaml
+++ b/packages/manual/data/daily/2026-10-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - trident
+        - delta
+      - - delta
+        - star
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - omega
+        - delta
+        - xi
+        - psi
+        - diamond
+        - star
+      - - trident
+        - star
+        - omega
+        - psi
+        - xi
+        - delta
+      - - diamond
+        - psi
+        - delta
+        - star
+        - xi
+        - omega
+      - - delta
+        - star
+        - omega
+        - diamond
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+      - - omega
+        - xi
+        - delta
+        - diamond
+        - star
+        - psi
+      - - delta
+        - diamond
+        - xi
+        - omega
+        - star
+        - psi
+      - - star
+        - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+      - - psi
+        - xi
+        - star
+        - omega
+        - delta
+        - diamond
+      - - xi
+        - psi
+        - star
+        - omega
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-14.yaml
+++ b/packages/manual/data/daily/2026-10-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - psi
+        - star
+        - delta
+        - omega
+      - - star
+        - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+      - - omega
+        - star
+        - psi
+        - diamond
+        - delta
+        - xi
+      - - delta
+        - psi
+        - xi
+        - star
+        - omega
+        - trident
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - trident
+        - omega
+      - - delta
+        - psi
+        - omega
+        - star
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - delta
+        - xi
+        - diamond
+        - star
+      - - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+        - star
+      - - star
+        - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - star
+        - delta
+        - omega
+        - diamond
+        - psi
+        - xi
+      - - omega
+        - star
+        - psi
+        - diamond
+        - delta
+        - xi
+      - - omega
+        - diamond
+        - star
+        - psi
+        - delta
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-15.yaml
+++ b/packages/manual/data/daily/2026-10-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - trident
+        - xi
+        - psi
+        - diamond
+      - - diamond
+        - star
+        - psi
+        - xi
+        - omega
+        - delta
+      - - omega
+        - xi
+        - star
+        - psi
+        - trident
+        - delta
+      - - star
+        - delta
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - psi
+        - delta
+        - star
+        - omega
+        - diamond
+        - xi
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - omega
+        - psi
+        - delta
+        - xi
+      - - omega
+        - diamond
+        - xi
+        - star
+        - delta
+        - psi
+      - - psi
+        - delta
+        - star
+        - xi
+        - omega
+        - diamond
+      - - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+        - star
+      - - omega
+        - diamond
+        - star
+        - xi
+        - delta
+        - psi
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-16.yaml
+++ b/packages/manual/data/daily/2026-10-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - xi
+        - omega
+        - star
+        - psi
+        - delta
+      - - psi
+        - diamond
+        - star
+        - delta
+        - xi
+        - omega
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - delta
+        - star
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - star
+        - delta
+      - - diamond
+        - xi
+        - star
+        - psi
+        - delta
+        - omega
+      - - trident
+        - diamond
+        - omega
+        - psi
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - omega
+        - xi
+        - star
+        - delta
+        - psi
+      - - omega
+        - xi
+        - psi
+        - delta
+        - star
+        - diamond
+      - - omega
+        - star
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - star
+        - diamond
+        - omega
+        - psi
+        - xi
+        - delta
+      - - star
+        - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - xi
+        - delta
+        - star
+        - omega
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-17.yaml
+++ b/packages/manual/data/daily/2026-10-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+      - - delta
+        - star
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - psi
+        - delta
+        - trident
+        - omega
+        - xi
+        - star
+      - - star
+        - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+      - - xi
+        - star
+        - psi
+        - delta
+        - diamond
+        - omega
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - trident
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - star
+        - diamond
+        - omega
+        - xi
+        - delta
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+      - - psi
+        - xi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - omega
+        - xi
+        - star
+        - diamond
+        - psi
+        - delta
+      - - delta
+        - star
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - delta
+        - diamond
+        - xi
+        - star
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-18.yaml
+++ b/packages/manual/data/daily/2026-10-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - psi
+        - delta
+        - diamond
+        - star
+      - - psi
+        - star
+        - delta
+        - xi
+        - diamond
+        - omega
+      - - diamond
+        - psi
+        - delta
+        - trident
+        - xi
+        - omega
+      - - delta
+        - diamond
+        - psi
+        - star
+        - xi
+        - omega
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+        - star
+      - - star
+        - delta
+        - omega
+        - xi
+        - trident
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - omega
+        - star
+        - psi
+        - delta
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - delta
+        - star
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - star
+        - omega
+      - - xi
+        - psi
+        - star
+        - omega
+        - delta
+        - diamond
+      - - psi
+        - diamond
+        - star
+        - xi
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-19.yaml
+++ b/packages/manual/data/daily/2026-10-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - xi
+        - psi
+        - star
+        - diamond
+        - omega
+      - - omega
+        - star
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+        - star
+      - - star
+        - xi
+        - trident
+        - psi
+        - omega
+        - delta
+      - - psi
+        - omega
+        - diamond
+        - xi
+        - trident
+        - delta
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - star
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - omega
+        - delta
+        - diamond
+        - psi
+      - - star
+        - diamond
+        - delta
+        - xi
+        - omega
+        - psi
+      - - star
+        - psi
+        - delta
+        - diamond
+        - omega
+        - xi
+      - - diamond
+        - omega
+        - star
+        - psi
+        - xi
+        - delta
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - star
+        - omega
+      - - omega
+        - star
+        - delta
+        - diamond
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-20.yaml
+++ b/packages/manual/data/daily/2026-10-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - trident
+        - xi
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - star
+        - xi
+      - - psi
+        - xi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - star
+        - psi
+      - - delta
+        - xi
+        - diamond
+        - star
+        - psi
+        - omega
+      - - xi
+        - delta
+        - trident
+        - psi
+        - omega
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - star
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - xi
+        - diamond
+        - star
+        - delta
+        - omega
+        - psi
+      - - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+        - star
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - delta
+        - star
+      - - omega
+        - diamond
+        - psi
+        - xi
+        - delta
+        - star
+      - - delta
+        - omega
+        - xi
+        - psi
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-21.yaml
+++ b/packages/manual/data/daily/2026-10-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - diamond
+        - trident
+        - xi
+        - delta
+      - - delta
+        - star
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - delta
+        - trident
+        - star
+        - omega
+        - xi
+        - psi
+      - - delta
+        - diamond
+        - xi
+        - omega
+        - star
+        - psi
+      - - omega
+        - delta
+        - star
+        - psi
+        - xi
+        - diamond
+      - - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - omega
+        - diamond
+        - psi
+        - delta
+      - - diamond
+        - psi
+        - star
+        - delta
+        - xi
+        - omega
+      - - diamond
+        - star
+        - psi
+        - delta
+        - omega
+        - xi
+      - - psi
+        - omega
+        - xi
+        - delta
+        - star
+        - diamond
+      - - psi
+        - star
+        - omega
+        - xi
+        - delta
+        - diamond
+      - - delta
+        - xi
+        - diamond
+        - star
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-22.yaml
+++ b/packages/manual/data/daily/2026-10-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - star
+        - delta
+        - omega
+        - xi
+        - psi
+      - - delta
+        - omega
+        - trident
+        - psi
+        - xi
+        - star
+      - - diamond
+        - omega
+        - delta
+        - star
+        - psi
+        - xi
+      - - xi
+        - star
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - delta
+        - diamond
+        - trident
+        - xi
+        - psi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - delta
+        - star
+        - diamond
+        - omega
+        - psi
+      - - diamond
+        - psi
+        - omega
+        - xi
+        - delta
+        - star
+      - - delta
+        - psi
+        - xi
+        - omega
+        - star
+        - diamond
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+        - star
+      - - delta
+        - omega
+        - star
+        - psi
+        - diamond
+        - xi
+      - - star
+        - omega
+        - delta
+        - diamond
+        - psi
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-23.yaml
+++ b/packages/manual/data/daily/2026-10-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - trident
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+        - star
+      - - omega
+        - diamond
+        - star
+        - xi
+        - psi
+        - delta
+      - - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+        - star
+      - - psi
+        - star
+        - omega
+        - trident
+        - delta
+        - xi
+      - - omega
+        - star
+        - xi
+        - delta
+        - diamond
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - psi
+        - diamond
+        - omega
+        - xi
+        - star
+      - - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+        - star
+      - - omega
+        - star
+        - delta
+        - xi
+        - psi
+        - diamond
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - omega
+        - delta
+        - star
+        - psi
+        - xi
+        - diamond
+      - - diamond
+        - psi
+        - omega
+        - delta
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-24.yaml
+++ b/packages/manual/data/daily/2026-10-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - psi
+        - star
+        - delta
+        - trident
+        - xi
+      - - star
+        - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+      - - star
+        - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+      - - omega
+        - psi
+        - xi
+        - delta
+        - trident
+        - diamond
+      - - psi
+        - xi
+        - delta
+        - star
+        - omega
+        - diamond
+      - - star
+        - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - psi
+        - xi
+        - omega
+        - delta
+      - - psi
+        - omega
+        - xi
+        - star
+        - diamond
+        - delta
+      - - psi
+        - delta
+        - star
+        - omega
+        - xi
+        - diamond
+      - - delta
+        - star
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - star
+        - psi
+        - delta
+        - xi
+        - diamond
+        - omega
+      - - omega
+        - xi
+        - delta
+        - star
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-25.yaml
+++ b/packages/manual/data/daily/2026-10-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+        - star
+      - - psi
+        - trident
+        - omega
+        - xi
+        - star
+        - delta
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - trident
+        - diamond
+        - xi
+        - omega
+        - delta
+        - psi
+      - - diamond
+        - psi
+        - omega
+        - star
+        - delta
+        - xi
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+      - - xi
+        - delta
+        - omega
+        - psi
+        - star
+        - diamond
+      - - omega
+        - xi
+        - star
+        - diamond
+        - psi
+        - delta
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - diamond
+        - omega
+        - star
+        - xi
+        - psi
+        - delta
+      - - psi
+        - xi
+        - omega
+        - star
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-26.yaml
+++ b/packages/manual/data/daily/2026-10-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - star
+        - psi
+      - - xi
+        - star
+        - psi
+        - omega
+        - diamond
+        - delta
+      - - diamond
+        - xi
+        - star
+        - delta
+        - psi
+        - omega
+      - - trident
+        - delta
+        - star
+        - omega
+        - xi
+        - psi
+      - - delta
+        - trident
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - star
+        - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - xi
+        - star
+        - omega
+        - psi
+        - diamond
+      - - star
+        - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+      - - star
+        - omega
+        - psi
+        - delta
+        - xi
+        - diamond
+      - - xi
+        - omega
+        - star
+        - delta
+        - diamond
+        - psi
+      - - omega
+        - psi
+        - star
+        - xi
+        - delta
+        - diamond
+      - - star
+        - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-27.yaml
+++ b/packages/manual/data/daily/2026-10-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - omega
+        - star
+        - psi
+        - delta
+      - - delta
+        - diamond
+        - xi
+        - omega
+        - psi
+        - star
+      - - delta
+        - xi
+        - star
+        - psi
+        - omega
+        - trident
+      - - delta
+        - psi
+        - diamond
+        - star
+        - xi
+        - omega
+      - - diamond
+        - psi
+        - star
+        - omega
+        - xi
+        - delta
+      - - psi
+        - xi
+        - delta
+        - trident
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+        - star
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - star
+        - diamond
+        - xi
+        - delta
+        - omega
+        - psi
+      - - omega
+        - star
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-28.yaml
+++ b/packages/manual/data/daily/2026-10-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - delta
+        - omega
+        - star
+        - diamond
+        - xi
+      - - omega
+        - star
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - psi
+        - xi
+        - delta
+        - star
+        - omega
+        - diamond
+      - - trident
+        - xi
+        - psi
+        - delta
+        - diamond
+        - omega
+      - - omega
+        - trident
+        - delta
+        - psi
+        - star
+        - xi
+      - - diamond
+        - star
+        - omega
+        - xi
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - psi
+        - delta
+        - diamond
+        - omega
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+        - star
+      - - psi
+        - delta
+        - star
+        - omega
+        - xi
+        - diamond
+      - - psi
+        - xi
+        - star
+        - delta
+        - diamond
+        - omega
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - star
+        - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-29.yaml
+++ b/packages/manual/data/daily/2026-10-29.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-29'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - xi
+        - delta
+        - star
+        - psi
+      - - omega
+        - star
+        - delta
+        - trident
+        - psi
+        - xi
+      - - star
+        - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - xi
+        - delta
+        - trident
+        - omega
+        - psi
+        - diamond
+      - - diamond
+        - delta
+        - xi
+        - star
+        - omega
+        - psi
+      - - delta
+        - star
+        - omega
+        - diamond
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - star
+        - diamond
+        - delta
+        - omega
+        - xi
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+        - star
+      - - star
+        - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+      - - omega
+        - psi
+        - delta
+        - xi
+        - diamond
+        - star
+      - - diamond
+        - star
+        - psi
+        - xi
+        - delta
+        - omega
+      - - star
+        - diamond
+        - psi
+        - omega
+        - delta
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-30.yaml
+++ b/packages/manual/data/daily/2026-10-30.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-30'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - omega
+        - star
+        - diamond
+        - xi
+      - - psi
+        - delta
+        - xi
+        - diamond
+        - star
+        - omega
+      - - diamond
+        - star
+        - psi
+        - xi
+        - delta
+        - omega
+      - - xi
+        - omega
+        - psi
+        - delta
+        - star
+        - trident
+      - - psi
+        - xi
+        - omega
+        - trident
+        - delta
+        - diamond
+      - - omega
+        - star
+        - diamond
+        - delta
+        - psi
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - star
+        - xi
+      - - omega
+        - psi
+        - delta
+        - star
+        - xi
+        - diamond
+      - - star
+        - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+      - - delta
+        - star
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - omega
+        - diamond
+        - delta
+        - xi
+        - psi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-10-31.yaml
+++ b/packages/manual/data/daily/2026-10-31.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-10-31'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - delta
+        - psi
+        - star
+        - diamond
+      - - psi
+        - xi
+        - star
+        - omega
+        - trident
+        - delta
+      - - xi
+        - diamond
+        - delta
+        - trident
+        - omega
+        - psi
+      - - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+        - star
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - star
+        - omega
+      - - delta
+        - omega
+        - psi
+        - star
+        - diamond
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+        - star
+      - - xi
+        - omega
+        - delta
+        - diamond
+        - star
+        - psi
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - star
+        - omega
+      - - star
+        - xi
+        - omega
+        - psi
+        - delta
+        - diamond
+      - - psi
+        - xi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - delta
+        - psi
+        - star
+        - diamond
+        - omega
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-01.yaml
+++ b/packages/manual/data/daily/2026-11-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - star
+        - omega
+      - - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+        - star
+      - - omega
+        - psi
+        - delta
+        - star
+        - xi
+        - diamond
+      - - omega
+        - trident
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - star
+        - omega
+        - trident
+        - xi
+        - psi
+        - delta
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - star
+        - psi
+        - delta
+        - omega
+      - - omega
+        - psi
+        - star
+        - xi
+        - delta
+        - diamond
+      - - omega
+        - xi
+        - star
+        - psi
+        - diamond
+        - delta
+      - - psi
+        - star
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - delta
+        - psi
+        - xi
+        - omega
+        - star
+        - diamond
+      - - delta
+        - star
+        - omega
+        - xi
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-02.yaml
+++ b/packages/manual/data/daily/2026-11-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - star
+        - xi
+      - - diamond
+        - star
+        - psi
+        - omega
+        - delta
+        - xi
+      - - diamond
+        - psi
+        - trident
+        - omega
+        - delta
+        - xi
+      - - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+        - star
+      - - psi
+        - xi
+        - diamond
+        - star
+        - delta
+        - omega
+      - - delta
+        - star
+        - trident
+        - xi
+        - psi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - diamond
+      - - psi
+        - omega
+        - delta
+        - diamond
+        - xi
+        - star
+      - - delta
+        - omega
+        - star
+        - diamond
+        - psi
+        - xi
+      - - star
+        - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+        - star
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-03.yaml
+++ b/packages/manual/data/daily/2026-11-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - xi
+        - psi
+        - star
+        - omega
+        - delta
+        - trident
+      - - trident
+        - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+      - - delta
+        - star
+        - omega
+        - psi
+        - diamond
+        - xi
+      - - omega
+        - star
+        - delta
+        - diamond
+        - psi
+        - xi
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+        - star
+      - - delta
+        - star
+        - omega
+        - diamond
+        - psi
+        - xi
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - star
+        - omega
+      - - xi
+        - diamond
+        - star
+        - omega
+        - psi
+        - delta
+      - - star
+        - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-04.yaml
+++ b/packages/manual/data/daily/2026-11-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - delta
+        - trident
+        - xi
+        - psi
+        - omega
+      - - star
+        - diamond
+        - delta
+        - xi
+        - omega
+        - psi
+      - - xi
+        - star
+        - delta
+        - omega
+        - psi
+        - diamond
+      - - psi
+        - delta
+        - omega
+        - trident
+        - diamond
+        - xi
+      - - omega
+        - diamond
+        - star
+        - delta
+        - psi
+        - xi
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - psi
+        - diamond
+        - xi
+        - star
+        - omega
+        - delta
+      - - star
+        - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+      - - star
+        - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - star
+        - delta
+      - - diamond
+        - omega
+        - star
+        - delta
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-05.yaml
+++ b/packages/manual/data/daily/2026-11-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - omega
+        - star
+        - trident
+        - xi
+      - - psi
+        - star
+        - diamond
+        - delta
+        - omega
+        - xi
+      - - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+        - star
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+        - star
+      - - trident
+        - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - star
+        - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - delta
+        - star
+        - omega
+        - diamond
+        - psi
+      - - diamond
+        - star
+        - psi
+        - delta
+        - xi
+        - omega
+      - - star
+        - delta
+        - psi
+        - omega
+        - xi
+        - diamond
+      - - xi
+        - omega
+        - diamond
+        - star
+        - psi
+        - delta
+      - - delta
+        - omega
+        - star
+        - xi
+        - diamond
+        - psi
+      - - psi
+        - delta
+        - star
+        - omega
+        - diamond
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-06.yaml
+++ b/packages/manual/data/daily/2026-11-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+      - - omega
+        - delta
+        - star
+        - xi
+        - trident
+        - psi
+      - - omega
+        - psi
+        - delta
+        - trident
+        - xi
+        - diamond
+      - - diamond
+        - star
+        - omega
+        - psi
+        - xi
+        - delta
+      - - star
+        - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - omega
+        - diamond
+        - star
+        - psi
+        - xi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+        - star
+      - - psi
+        - omega
+        - xi
+        - delta
+        - star
+        - diamond
+      - - diamond
+        - psi
+        - star
+        - omega
+        - xi
+        - delta
+      - - omega
+        - xi
+        - star
+        - diamond
+        - delta
+        - psi
+      - - psi
+        - delta
+        - diamond
+        - omega
+        - xi
+        - star
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-07.yaml
+++ b/packages/manual/data/daily/2026-11-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - omega
+        - xi
+        - psi
+        - delta
+        - diamond
+      - - delta
+        - xi
+        - star
+        - psi
+        - diamond
+        - omega
+      - - xi
+        - psi
+        - omega
+        - delta
+        - star
+        - diamond
+      - - psi
+        - diamond
+        - omega
+        - star
+        - xi
+        - delta
+      - - trident
+        - psi
+        - xi
+        - star
+        - delta
+        - omega
+      - - psi
+        - delta
+        - star
+        - xi
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - star
+        - omega
+      - - delta
+        - diamond
+        - star
+        - xi
+        - psi
+        - omega
+      - - psi
+        - delta
+        - star
+        - omega
+        - xi
+        - diamond
+      - - star
+        - omega
+        - psi
+        - delta
+        - xi
+        - diamond
+      - - psi
+        - star
+        - delta
+        - diamond
+        - omega
+        - xi
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-08.yaml
+++ b/packages/manual/data/daily/2026-11-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - omega
+        - trident
+        - delta
+        - psi
+      - - star
+        - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - star
+        - psi
+        - omega
+        - trident
+        - delta
+        - xi
+      - - diamond
+        - delta
+        - star
+        - xi
+        - omega
+        - psi
+      - - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+        - star
+      - - diamond
+        - psi
+        - star
+        - omega
+        - xi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - psi
+        - diamond
+        - star
+        - delta
+        - omega
+      - - diamond
+        - delta
+        - omega
+        - star
+        - psi
+        - xi
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+        - star
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+        - star
+      - - delta
+        - psi
+        - diamond
+        - omega
+        - star
+        - xi
+      - - diamond
+        - delta
+        - xi
+        - star
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-09.yaml
+++ b/packages/manual/data/daily/2026-11-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - omega
+        - trident
+        - delta
+        - diamond
+        - psi
+      - - omega
+        - xi
+        - psi
+        - delta
+        - diamond
+        - star
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - delta
+        - star
+      - - star
+        - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - diamond
+      - - delta
+        - psi
+        - xi
+        - omega
+        - star
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - psi
+        - star
+        - delta
+        - omega
+      - - delta
+        - star
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - xi
+        - delta
+        - omega
+        - diamond
+        - star
+        - psi
+      - - omega
+        - xi
+        - psi
+        - diamond
+        - star
+        - delta
+      - - delta
+        - star
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - xi
+        - psi
+        - delta
+        - star
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-10.yaml
+++ b/packages/manual/data/daily/2026-11-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - star
+        - psi
+        - trident
+        - xi
+        - omega
+      - - psi
+        - omega
+        - delta
+        - diamond
+        - trident
+        - xi
+      - - delta
+        - xi
+        - diamond
+        - omega
+        - star
+        - psi
+      - - star
+        - xi
+        - psi
+        - delta
+        - diamond
+        - omega
+      - - star
+        - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+      - - star
+        - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - xi
+        - psi
+        - star
+        - diamond
+        - omega
+      - - omega
+        - star
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - diamond
+        - xi
+        - delta
+        - omega
+        - star
+        - psi
+      - - xi
+        - star
+        - delta
+        - diamond
+        - psi
+        - omega
+      - - delta
+        - diamond
+        - xi
+        - star
+        - psi
+        - omega
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-11.yaml
+++ b/packages/manual/data/daily/2026-11-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - psi
+        - xi
+        - delta
+        - star
+        - omega
+      - - star
+        - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+      - - xi
+        - psi
+        - delta
+        - omega
+        - trident
+        - diamond
+      - - psi
+        - omega
+        - xi
+        - delta
+        - diamond
+        - star
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - star
+        - delta
+      - - star
+        - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - star
+        - omega
+      - - omega
+        - psi
+        - xi
+        - delta
+        - diamond
+        - star
+      - - omega
+        - delta
+        - xi
+        - psi
+        - star
+        - diamond
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - star
+        - psi
+      - - star
+        - psi
+        - delta
+        - diamond
+        - omega
+        - xi
+      - - xi
+        - star
+        - delta
+        - psi
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-12.yaml
+++ b/packages/manual/data/daily/2026-11-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - star
+        - xi
+      - - xi
+        - psi
+        - omega
+        - delta
+        - diamond
+        - trident
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+        - star
+      - - omega
+        - star
+        - diamond
+        - delta
+        - xi
+        - psi
+      - - star
+        - delta
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - star
+        - delta
+        - omega
+        - trident
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - xi
+        - diamond
+        - star
+        - delta
+        - omega
+      - - diamond
+        - star
+        - psi
+        - xi
+        - omega
+        - delta
+      - - omega
+        - psi
+        - delta
+        - xi
+        - star
+        - diamond
+      - - star
+        - xi
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - xi
+        - diamond
+        - psi
+        - star
+        - delta
+        - omega
+      - - diamond
+        - delta
+        - psi
+        - star
+        - omega
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-13.yaml
+++ b/packages/manual/data/daily/2026-11-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - star
+        - omega
+        - delta
+        - diamond
+        - xi
+      - - delta
+        - omega
+        - trident
+        - diamond
+        - psi
+        - xi
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+        - star
+      - - omega
+        - delta
+        - xi
+        - trident
+        - star
+        - psi
+      - - omega
+        - delta
+        - xi
+        - psi
+        - diamond
+        - star
+      - - psi
+        - omega
+        - xi
+        - star
+        - diamond
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+        - star
+      - - delta
+        - star
+        - xi
+        - psi
+        - diamond
+        - omega
+      - - diamond
+        - psi
+        - omega
+        - xi
+        - star
+        - delta
+      - - omega
+        - delta
+        - psi
+        - xi
+        - star
+        - diamond
+      - - delta
+        - diamond
+        - star
+        - psi
+        - xi
+        - omega
+      - - diamond
+        - psi
+        - xi
+        - delta
+        - star
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-14.yaml
+++ b/packages/manual/data/daily/2026-11-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - psi
+        - diamond
+        - star
+        - xi
+        - delta
+      - - omega
+        - psi
+        - xi
+        - trident
+        - diamond
+        - delta
+      - - delta
+        - xi
+        - psi
+        - star
+        - omega
+        - diamond
+      - - trident
+        - delta
+        - omega
+        - star
+        - psi
+        - xi
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - diamond
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - star
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - star
+        - diamond
+        - xi
+        - delta
+        - psi
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+        - star
+      - - star
+        - xi
+        - diamond
+        - psi
+        - omega
+        - delta
+      - - star
+        - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+        - star
+      - - xi
+        - diamond
+        - omega
+        - delta
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-15.yaml
+++ b/packages/manual/data/daily/2026-11-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - trident
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - star
+        - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+      - - star
+        - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - star
+        - psi
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - trident
+      - - omega
+        - diamond
+        - xi
+        - star
+        - delta
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - star
+        - omega
+      - - xi
+        - omega
+        - star
+        - delta
+        - psi
+        - diamond
+      - - diamond
+        - psi
+        - star
+        - xi
+        - delta
+        - omega
+      - - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+        - star
+      - - diamond
+        - star
+        - psi
+        - delta
+        - xi
+        - omega
+      - - star
+        - diamond
+        - omega
+        - xi
+        - psi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-16.yaml
+++ b/packages/manual/data/daily/2026-11-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - star
+        - omega
+        - diamond
+        - psi
+        - delta
+      - - omega
+        - star
+        - psi
+        - delta
+        - diamond
+        - xi
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - star
+      - - omega
+        - diamond
+        - star
+        - xi
+        - delta
+        - psi
+      - - star
+        - xi
+        - delta
+        - trident
+        - omega
+        - psi
+      - - diamond
+        - psi
+        - xi
+        - delta
+        - omega
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - star
+        - diamond
+        - delta
+        - xi
+        - psi
+      - - omega
+        - diamond
+        - delta
+        - xi
+        - star
+        - psi
+      - - xi
+        - star
+        - omega
+        - delta
+        - psi
+        - diamond
+      - - xi
+        - delta
+        - omega
+        - star
+        - psi
+        - diamond
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+        - star
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-17.yaml
+++ b/packages/manual/data/daily/2026-11-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - delta
+        - star
+        - omega
+        - xi
+        - psi
+      - - psi
+        - star
+        - xi
+        - omega
+        - delta
+        - diamond
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - omega
+        - star
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - omega
+        - star
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - delta
+        - psi
+        - omega
+        - trident
+        - diamond
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - delta
+        - xi
+        - star
+        - diamond
+      - - omega
+        - xi
+        - star
+        - psi
+        - delta
+        - diamond
+      - - delta
+        - xi
+        - star
+        - psi
+        - diamond
+        - omega
+      - - star
+        - xi
+        - psi
+        - delta
+        - diamond
+        - omega
+      - - star
+        - diamond
+        - delta
+        - psi
+        - xi
+        - omega
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-18.yaml
+++ b/packages/manual/data/daily/2026-11-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - psi
+        - xi
+        - star
+        - trident
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+        - star
+      - - diamond
+        - delta
+        - star
+        - xi
+        - omega
+        - psi
+      - - star
+        - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+      - - psi
+        - xi
+        - delta
+        - trident
+        - diamond
+        - omega
+      - - xi
+        - star
+        - delta
+        - omega
+        - psi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - omega
+        - delta
+        - psi
+        - star
+        - xi
+        - diamond
+      - - delta
+        - omega
+        - xi
+        - psi
+        - star
+        - diamond
+      - - psi
+        - delta
+        - star
+        - omega
+        - xi
+        - diamond
+      - - star
+        - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - star
+        - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-19.yaml
+++ b/packages/manual/data/daily/2026-11-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+        - star
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - trident
+        - xi
+      - - star
+        - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - delta
+        - diamond
+        - star
+        - xi
+        - omega
+        - psi
+      - - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+        - star
+      - - trident
+        - star
+        - psi
+        - xi
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - delta
+        - star
+        - psi
+        - omega
+      - - diamond
+        - delta
+        - star
+        - omega
+        - psi
+        - xi
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - star
+        - omega
+      - - star
+        - delta
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - diamond
+        - xi
+        - star
+        - delta
+        - omega
+        - psi
+      - - omega
+        - xi
+        - diamond
+        - star
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-20.yaml
+++ b/packages/manual/data/daily/2026-11-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - delta
+        - psi
+        - omega
+        - xi
+        - diamond
+      - - star
+        - xi
+        - delta
+        - psi
+        - trident
+        - omega
+      - - trident
+        - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - diamond
+        - omega
+        - xi
+        - psi
+        - star
+        - delta
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - star
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - omega
+        - psi
+        - star
+        - xi
+        - delta
+      - - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+        - star
+      - - delta
+        - xi
+        - psi
+        - star
+        - omega
+        - diamond
+      - - star
+        - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - star
+        - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+      - - star
+        - diamond
+        - omega
+        - xi
+        - psi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-21.yaml
+++ b/packages/manual/data/daily/2026-11-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - diamond
+        - psi
+        - delta
+        - xi
+        - omega
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - omega
+        - star
+      - - star
+        - delta
+        - psi
+        - xi
+        - trident
+        - omega
+      - - delta
+        - star
+        - diamond
+        - omega
+        - xi
+        - psi
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - star
+      - - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - delta
+        - xi
+        - psi
+        - diamond
+        - star
+      - - star
+        - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+      - - diamond
+        - omega
+        - delta
+        - star
+        - psi
+        - xi
+      - - delta
+        - omega
+        - star
+        - xi
+        - diamond
+        - psi
+      - - delta
+        - omega
+        - star
+        - diamond
+        - psi
+        - xi
+      - - psi
+        - diamond
+        - omega
+        - star
+        - xi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-22.yaml
+++ b/packages/manual/data/daily/2026-11-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - trident
+        - delta
+        - omega
+        - psi
+      - - omega
+        - xi
+        - delta
+        - psi
+        - star
+        - diamond
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - star
+        - psi
+      - - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+        - star
+      - - delta
+        - trident
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - psi
+        - omega
+        - delta
+        - star
+      - - star
+        - psi
+        - xi
+        - diamond
+        - delta
+        - omega
+      - - omega
+        - xi
+        - star
+        - delta
+        - diamond
+        - psi
+      - - delta
+        - psi
+        - diamond
+        - star
+        - xi
+        - omega
+      - - diamond
+        - xi
+        - star
+        - omega
+        - delta
+        - psi
+      - - diamond
+        - xi
+        - psi
+        - star
+        - omega
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-23.yaml
+++ b/packages/manual/data/daily/2026-11-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - diamond
+        - psi
+        - delta
+        - omega
+      - - xi
+        - psi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+        - trident
+      - - psi
+        - star
+        - omega
+        - diamond
+        - xi
+        - delta
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - star
+        - omega
+      - - omega
+        - delta
+        - trident
+        - xi
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+      - - diamond
+        - psi
+        - omega
+        - delta
+        - star
+        - xi
+      - - omega
+        - xi
+        - psi
+        - star
+        - diamond
+        - delta
+      - - delta
+        - diamond
+        - psi
+        - star
+        - omega
+        - xi
+      - - omega
+        - diamond
+        - star
+        - xi
+        - delta
+        - psi
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-24.yaml
+++ b/packages/manual/data/daily/2026-11-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - delta
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - diamond
+        - omega
+        - xi
+        - psi
+        - star
+        - delta
+      - - star
+        - xi
+        - psi
+        - delta
+        - diamond
+        - omega
+      - - diamond
+        - xi
+        - omega
+        - delta
+        - trident
+        - psi
+      - - omega
+        - xi
+        - star
+        - delta
+        - trident
+        - psi
+      - - star
+        - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - delta
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - delta
+        - psi
+        - xi
+        - star
+        - omega
+        - diamond
+      - - star
+        - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - delta
+        - psi
+        - xi
+        - star
+        - diamond
+        - omega
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-25.yaml
+++ b/packages/manual/data/daily/2026-11-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+        - star
+      - - xi
+        - psi
+        - trident
+        - omega
+        - delta
+        - diamond
+      - - omega
+        - xi
+        - star
+        - psi
+        - diamond
+        - delta
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - omega
+        - star
+      - - omega
+        - xi
+        - trident
+        - delta
+        - psi
+        - star
+      - - star
+        - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - star
+        - delta
+        - psi
+        - omega
+      - - omega
+        - psi
+        - diamond
+        - star
+        - delta
+        - xi
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+        - star
+      - - psi
+        - star
+        - delta
+        - xi
+        - omega
+        - diamond
+      - - delta
+        - omega
+        - xi
+        - diamond
+        - psi
+        - star
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-26.yaml
+++ b/packages/manual/data/daily/2026-11-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - xi
+        - trident
+        - star
+        - omega
+        - psi
+      - - omega
+        - star
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - diamond
+        - star
+        - psi
+        - delta
+        - xi
+        - omega
+      - - xi
+        - diamond
+        - star
+        - delta
+        - omega
+        - psi
+      - - diamond
+        - delta
+        - xi
+        - omega
+        - psi
+        - trident
+      - - star
+        - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - omega
+        - star
+        - psi
+        - diamond
+        - delta
+      - - delta
+        - psi
+        - star
+        - omega
+        - diamond
+        - xi
+      - - delta
+        - psi
+        - diamond
+        - omega
+        - star
+        - xi
+      - - omega
+        - diamond
+        - xi
+        - star
+        - psi
+        - delta
+      - - diamond
+        - omega
+        - star
+        - psi
+        - xi
+        - delta
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-27.yaml
+++ b/packages/manual/data/daily/2026-11-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - omega
+        - xi
+        - psi
+        - diamond
+        - delta
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+        - star
+      - - delta
+        - omega
+        - diamond
+        - star
+        - psi
+        - xi
+      - - star
+        - psi
+        - trident
+        - omega
+        - xi
+        - delta
+      - - psi
+        - diamond
+        - delta
+        - xi
+        - omega
+        - star
+      - - psi
+        - xi
+        - omega
+        - star
+        - delta
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - diamond
+        - star
+        - xi
+        - delta
+      - - xi
+        - diamond
+        - psi
+        - omega
+        - star
+        - delta
+      - - psi
+        - xi
+        - diamond
+        - star
+        - omega
+        - delta
+      - - diamond
+        - omega
+        - xi
+        - star
+        - psi
+        - delta
+      - - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+        - star
+      - - xi
+        - delta
+        - star
+        - psi
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-28.yaml
+++ b/packages/manual/data/daily/2026-11-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - star
+        - diamond
+        - xi
+        - psi
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - trident
+        - omega
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - trident
+      - - star
+        - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+      - - diamond
+        - psi
+        - xi
+        - star
+        - omega
+        - delta
+      - - star
+        - omega
+        - delta
+        - diamond
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - star
+        - omega
+        - delta
+        - psi
+      - - delta
+        - psi
+        - star
+        - omega
+        - xi
+        - diamond
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - star
+        - omega
+      - - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+        - star
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+        - star
+      - - omega
+        - xi
+        - psi
+        - delta
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-29.yaml
+++ b/packages/manual/data/daily/2026-11-29.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-29'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - diamond
+        - star
+        - psi
+        - omega
+      - - xi
+        - omega
+        - diamond
+        - star
+        - psi
+        - delta
+      - - psi
+        - delta
+        - diamond
+        - star
+        - xi
+        - omega
+      - - delta
+        - trident
+        - xi
+        - psi
+        - star
+        - omega
+      - - star
+        - xi
+        - omega
+        - diamond
+        - psi
+        - delta
+      - - trident
+        - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - star
+        - xi
+        - psi
+        - diamond
+      - - star
+        - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+        - star
+      - - omega
+        - xi
+        - psi
+        - delta
+        - diamond
+        - star
+      - - star
+        - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+      - - star
+        - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-11-30.yaml
+++ b/packages/manual/data/daily/2026-11-30.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-11-30'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - trident
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - delta
+        - star
+        - psi
+        - omega
+        - diamond
+        - xi
+      - - star
+        - delta
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - star
+        - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+      - - diamond
+        - delta
+        - xi
+        - star
+        - omega
+        - psi
+      - - star
+        - omega
+        - psi
+        - trident
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - psi
+        - diamond
+        - delta
+        - omega
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - delta
+        - star
+      - - star
+        - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+      - - xi
+        - psi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - star
+        - omega
+      - - delta
+        - star
+        - xi
+        - psi
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-01.yaml
+++ b/packages/manual/data/daily/2026-12-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - omega
+        - star
+        - xi
+        - delta
+        - psi
+      - - trident
+        - psi
+        - delta
+        - diamond
+        - omega
+        - xi
+      - - delta
+        - trident
+        - star
+        - omega
+        - psi
+        - xi
+      - - star
+        - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+      - - omega
+        - star
+        - psi
+        - delta
+        - diamond
+        - xi
+      - - xi
+        - psi
+        - diamond
+        - star
+        - omega
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - star
+        - omega
+      - - xi
+        - star
+        - diamond
+        - delta
+        - omega
+        - psi
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+      - - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+        - star
+      - - diamond
+        - psi
+        - delta
+        - xi
+        - omega
+        - star
+      - - delta
+        - xi
+        - psi
+        - star
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-02.yaml
+++ b/packages/manual/data/daily/2026-12-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - psi
+        - star
+        - xi
+        - delta
+      - - star
+        - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - trident
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - diamond
+      - - delta
+        - star
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - psi
+        - trident
+        - xi
+        - omega
+        - delta
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - diamond
+      - - xi
+        - star
+        - psi
+        - omega
+        - delta
+        - diamond
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - xi
+        - star
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - star
+        - omega
+      - - delta
+        - xi
+        - star
+        - omega
+        - diamond
+        - psi
+      - - xi
+        - star
+        - omega
+        - diamond
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-03.yaml
+++ b/packages/manual/data/daily/2026-12-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - star
+        - diamond
+        - xi
+        - delta
+      - - diamond
+        - xi
+        - delta
+        - star
+        - omega
+        - psi
+      - - delta
+        - omega
+        - diamond
+        - star
+        - psi
+        - xi
+      - - psi
+        - omega
+        - xi
+        - trident
+        - star
+        - delta
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - delta
+        - star
+      - - diamond
+        - trident
+        - xi
+        - omega
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+        - star
+      - - xi
+        - star
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - psi
+        - delta
+        - xi
+        - omega
+        - star
+        - diamond
+      - - diamond
+        - delta
+        - xi
+        - star
+        - psi
+        - omega
+      - - xi
+        - delta
+        - omega
+        - star
+        - diamond
+        - psi
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-04.yaml
+++ b/packages/manual/data/daily/2026-12-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - psi
+        - xi
+        - diamond
+        - star
+      - - delta
+        - star
+        - xi
+        - psi
+        - diamond
+        - omega
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+        - star
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+        - star
+      - - trident
+        - delta
+        - omega
+        - xi
+        - diamond
+        - psi
+      - - star
+        - psi
+        - xi
+        - delta
+        - omega
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+        - star
+      - - xi
+        - delta
+        - star
+        - diamond
+        - omega
+        - psi
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - star
+        - delta
+      - - delta
+        - xi
+        - star
+        - omega
+        - psi
+        - diamond
+      - - diamond
+        - delta
+        - star
+        - psi
+        - omega
+        - xi
+      - - diamond
+        - xi
+        - psi
+        - star
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-05.yaml
+++ b/packages/manual/data/daily/2026-12-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - star
+        - xi
+        - psi
+        - delta
+        - omega
+      - - psi
+        - diamond
+        - delta
+        - omega
+        - xi
+        - star
+      - - delta
+        - omega
+        - star
+        - psi
+        - xi
+        - diamond
+      - - omega
+        - star
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+        - trident
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+      - - psi
+        - omega
+        - star
+        - diamond
+        - xi
+        - delta
+      - - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+        - star
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+      - - omega
+        - psi
+        - star
+        - diamond
+        - xi
+        - delta
+      - - star
+        - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-06.yaml
+++ b/packages/manual/data/daily/2026-12-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - omega
+        - trident
+        - delta
+        - psi
+      - - psi
+        - trident
+        - xi
+        - omega
+        - delta
+        - star
+      - - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+        - star
+      - - psi
+        - star
+        - omega
+        - xi
+        - diamond
+        - delta
+      - - xi
+        - star
+        - psi
+        - omega
+        - diamond
+        - delta
+      - - psi
+        - omega
+        - star
+        - delta
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - star
+        - delta
+        - omega
+        - xi
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - star
+        - xi
+      - - delta
+        - star
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - diamond
+        - psi
+        - omega
+        - delta
+        - xi
+        - star
+      - - psi
+        - delta
+        - diamond
+        - star
+        - omega
+        - xi
+      - - star
+        - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-07.yaml
+++ b/packages/manual/data/daily/2026-12-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - diamond
+        - omega
+        - star
+        - delta
+        - psi
+      - - diamond
+        - star
+        - delta
+        - omega
+        - xi
+        - psi
+      - - delta
+        - psi
+        - omega
+        - star
+        - diamond
+        - xi
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+      - - trident
+        - delta
+        - star
+        - xi
+        - omega
+        - psi
+      - - omega
+        - delta
+        - diamond
+        - psi
+        - xi
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - xi
+        - star
+        - omega
+        - delta
+        - diamond
+      - - omega
+        - psi
+        - xi
+        - delta
+        - diamond
+        - star
+      - - star
+        - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+      - - omega
+        - star
+        - xi
+        - psi
+        - diamond
+        - delta
+      - - xi
+        - diamond
+        - star
+        - delta
+        - omega
+        - psi
+      - - psi
+        - star
+        - diamond
+        - omega
+        - xi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-08.yaml
+++ b/packages/manual/data/daily/2026-12-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - xi
+        - trident
+        - psi
+        - omega
+      - - omega
+        - delta
+        - xi
+        - star
+        - trident
+        - psi
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+        - star
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+        - star
+      - - star
+        - diamond
+        - xi
+        - delta
+        - omega
+        - psi
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+        - star
+      - - psi
+        - xi
+        - star
+        - diamond
+        - delta
+        - omega
+      - - omega
+        - diamond
+        - star
+        - delta
+        - psi
+        - xi
+      - - delta
+        - star
+        - psi
+        - xi
+        - diamond
+        - omega
+      - - omega
+        - delta
+        - xi
+        - diamond
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-09.yaml
+++ b/packages/manual/data/daily/2026-12-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - xi
+        - delta
+        - star
+        - trident
+      - - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+        - star
+      - - xi
+        - trident
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - star
+        - omega
+      - - omega
+        - star
+        - delta
+        - psi
+        - diamond
+        - xi
+      - - diamond
+        - delta
+        - xi
+        - star
+        - psi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - omega
+        - star
+        - psi
+        - delta
+      - - omega
+        - delta
+        - diamond
+        - star
+        - xi
+        - psi
+      - - delta
+        - star
+        - psi
+        - xi
+        - omega
+        - diamond
+      - - omega
+        - psi
+        - diamond
+        - delta
+        - xi
+        - star
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - star
+        - delta
+      - - star
+        - diamond
+        - delta
+        - psi
+        - xi
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-10.yaml
+++ b/packages/manual/data/daily/2026-12-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - star
+        - xi
+        - delta
+        - omega
+        - psi
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - star
+        - delta
+      - - psi
+        - diamond
+        - omega
+        - trident
+        - delta
+        - xi
+      - - omega
+        - diamond
+        - xi
+        - star
+        - delta
+        - psi
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - xi
+        - star
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - omega
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - diamond
+        - star
+        - psi
+        - xi
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - diamond
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - star
+      - - diamond
+        - xi
+        - psi
+        - star
+        - omega
+        - delta
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - star
+        - xi
+      - - delta
+        - diamond
+        - xi
+        - star
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-11.yaml
+++ b/packages/manual/data/daily/2026-12-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - star
+        - psi
+        - omega
+        - trident
+        - delta
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - trident
+        - xi
+      - - psi
+        - star
+        - omega
+        - xi
+        - delta
+        - diamond
+      - - delta
+        - star
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - xi
+        - diamond
+        - psi
+        - omega
+        - star
+        - delta
+      - - xi
+        - omega
+        - psi
+        - star
+        - diamond
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - psi
+        - diamond
+        - omega
+        - delta
+      - - xi
+        - omega
+        - delta
+        - psi
+        - star
+        - diamond
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - star
+        - omega
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - omega
+        - star
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - star
+        - omega
+      - - delta
+        - xi
+        - star
+        - omega
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-12.yaml
+++ b/packages/manual/data/daily/2026-12-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - star
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - star
+        - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - star
+        - omega
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - omega
+        - star
+      - - xi
+        - diamond
+        - delta
+        - trident
+        - omega
+        - psi
+      - - xi
+        - psi
+        - trident
+        - delta
+        - star
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - omega
+        - psi
+        - delta
+        - diamond
+      - - omega
+        - diamond
+        - delta
+        - star
+        - xi
+        - psi
+      - - delta
+        - xi
+        - star
+        - diamond
+        - omega
+        - psi
+      - - delta
+        - star
+        - omega
+        - psi
+        - diamond
+        - xi
+      - - xi
+        - delta
+        - diamond
+        - star
+        - omega
+        - psi
+      - - omega
+        - star
+        - xi
+        - delta
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-13.yaml
+++ b/packages/manual/data/daily/2026-12-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - delta
+        - psi
+        - omega
+        - star
+        - xi
+      - - xi
+        - omega
+        - psi
+        - delta
+        - star
+        - diamond
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+        - star
+      - - psi
+        - star
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - delta
+        - xi
+        - trident
+        - psi
+        - omega
+        - diamond
+      - - omega
+        - xi
+        - diamond
+        - star
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+      - - star
+        - diamond
+        - omega
+        - psi
+        - delta
+        - xi
+      - - xi
+        - psi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - xi
+        - star
+        - omega
+        - psi
+        - delta
+        - diamond
+      - - delta
+        - xi
+        - star
+        - diamond
+        - psi
+        - omega
+      - - diamond
+        - star
+        - xi
+        - psi
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-14.yaml
+++ b/packages/manual/data/daily/2026-12-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - star
+        - diamond
+        - xi
+        - psi
+      - - psi
+        - xi
+        - star
+        - delta
+        - diamond
+        - omega
+      - - psi
+        - diamond
+        - star
+        - delta
+        - omega
+        - xi
+      - - diamond
+        - omega
+        - delta
+        - xi
+        - psi
+        - trident
+      - - omega
+        - psi
+        - trident
+        - delta
+        - xi
+        - star
+      - - star
+        - diamond
+        - omega
+        - psi
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+        - star
+      - - psi
+        - xi
+        - diamond
+        - star
+        - delta
+        - omega
+      - - star
+        - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - star
+        - xi
+        - omega
+        - delta
+        - diamond
+        - psi
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - diamond
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-15.yaml
+++ b/packages/manual/data/daily/2026-12-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - diamond
+        - xi
+        - trident
+        - omega
+        - delta
+      - - xi
+        - delta
+        - psi
+        - omega
+        - star
+        - diamond
+      - - psi
+        - xi
+        - diamond
+        - star
+        - omega
+        - delta
+      - - omega
+        - psi
+        - xi
+        - diamond
+        - star
+        - delta
+      - - trident
+        - xi
+        - delta
+        - psi
+        - omega
+        - star
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - psi
+        - omega
+        - star
+        - delta
+      - - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+        - star
+      - - omega
+        - psi
+        - star
+        - xi
+        - diamond
+        - delta
+      - - star
+        - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+      - - diamond
+        - delta
+        - xi
+        - omega
+        - star
+        - psi
+      - - xi
+        - star
+        - delta
+        - omega
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-16.yaml
+++ b/packages/manual/data/daily/2026-12-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - star
+        - omega
+        - xi
+        - delta
+        - psi
+      - - xi
+        - delta
+        - diamond
+        - psi
+        - star
+        - omega
+      - - delta
+        - trident
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - star
+        - trident
+        - omega
+        - delta
+        - xi
+        - psi
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+      - - omega
+        - delta
+        - xi
+        - diamond
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - diamond
+        - psi
+        - star
+        - omega
+        - xi
+      - - delta
+        - omega
+        - psi
+        - xi
+        - diamond
+        - star
+      - - omega
+        - psi
+        - diamond
+        - star
+        - xi
+        - delta
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+        - star
+      - - psi
+        - star
+        - xi
+        - delta
+        - omega
+        - diamond
+      - - omega
+        - star
+        - psi
+        - diamond
+        - delta
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-17.yaml
+++ b/packages/manual/data/daily/2026-12-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+        - star
+      - - psi
+        - trident
+        - delta
+        - omega
+        - star
+        - xi
+      - - delta
+        - diamond
+        - xi
+        - omega
+        - psi
+        - star
+      - - psi
+        - star
+        - omega
+        - delta
+        - xi
+        - diamond
+      - - omega
+        - delta
+        - xi
+        - trident
+        - diamond
+        - psi
+      - - omega
+        - xi
+        - star
+        - delta
+        - psi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - star
+        - xi
+      - - delta
+        - diamond
+        - psi
+        - star
+        - xi
+        - omega
+      - - star
+        - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+      - - psi
+        - diamond
+        - omega
+        - delta
+        - star
+        - xi
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - star
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-18.yaml
+++ b/packages/manual/data/daily/2026-12-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - star
+        - delta
+        - psi
+        - omega
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+        - star
+      - - omega
+        - xi
+        - star
+        - psi
+        - trident
+        - delta
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - star
+        - xi
+      - - xi
+        - diamond
+        - psi
+        - trident
+        - omega
+        - delta
+      - - omega
+        - star
+        - xi
+        - diamond
+        - delta
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+      - - delta
+        - star
+        - omega
+        - xi
+        - diamond
+        - psi
+      - - xi
+        - star
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - omega
+        - star
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - star
+        - delta
+        - psi
+        - omega
+        - xi
+        - diamond
+      - - omega
+        - diamond
+        - delta
+        - xi
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-19.yaml
+++ b/packages/manual/data/daily/2026-12-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - omega
+        - psi
+        - xi
+        - delta
+        - diamond
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - trident
+        - xi
+      - - xi
+        - psi
+        - delta
+        - omega
+        - star
+        - diamond
+      - - star
+        - psi
+        - xi
+        - trident
+        - delta
+        - omega
+      - - star
+        - diamond
+        - xi
+        - omega
+        - delta
+        - psi
+      - - omega
+        - delta
+        - star
+        - psi
+        - diamond
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - omega
+        - star
+        - delta
+        - diamond
+        - psi
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - star
+        - psi
+      - - delta
+        - xi
+        - diamond
+        - omega
+        - psi
+        - star
+      - - psi
+        - diamond
+        - star
+        - omega
+        - xi
+        - delta
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+        - star
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - star
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-20.yaml
+++ b/packages/manual/data/daily/2026-12-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+        - star
+      - - delta
+        - psi
+        - xi
+        - omega
+        - trident
+        - star
+      - - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+        - star
+      - - star
+        - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - diamond
+        - psi
+        - trident
+        - omega
+        - delta
+        - xi
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - star
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - star
+        - omega
+      - - xi
+        - psi
+        - delta
+        - omega
+        - star
+        - diamond
+      - - diamond
+        - psi
+        - star
+        - xi
+        - delta
+        - omega
+      - - delta
+        - star
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - psi
+        - omega
+        - star
+        - delta
+        - xi
+        - diamond
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-21.yaml
+++ b/packages/manual/data/daily/2026-12-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - trident
+        - xi
+      - - omega
+        - diamond
+        - psi
+        - star
+        - xi
+        - delta
+      - - diamond
+        - psi
+        - star
+        - omega
+        - delta
+        - xi
+      - - star
+        - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+      - - diamond
+        - psi
+        - xi
+        - star
+        - omega
+        - delta
+      - - omega
+        - psi
+        - trident
+        - star
+        - xi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - psi
+        - xi
+        - delta
+        - omega
+      - - omega
+        - xi
+        - psi
+        - star
+        - diamond
+        - delta
+      - - omega
+        - psi
+        - delta
+        - star
+        - xi
+        - diamond
+      - - omega
+        - psi
+        - star
+        - xi
+        - diamond
+        - delta
+      - - diamond
+        - omega
+        - star
+        - psi
+        - delta
+        - xi
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-22.yaml
+++ b/packages/manual/data/daily/2026-12-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - star
+        - delta
+        - trident
+        - xi
+        - psi
+      - - delta
+        - omega
+        - star
+        - diamond
+        - xi
+        - psi
+      - - omega
+        - psi
+        - xi
+        - star
+        - diamond
+        - delta
+      - - trident
+        - diamond
+        - psi
+        - delta
+        - xi
+        - omega
+      - - omega
+        - psi
+        - delta
+        - xi
+        - star
+        - diamond
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - star
+        - delta
+        - omega
+        - psi
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - delta
+        - star
+      - - delta
+        - omega
+        - star
+        - xi
+        - diamond
+        - psi
+      - - omega
+        - delta
+        - diamond
+        - star
+        - psi
+        - xi
+      - - xi
+        - diamond
+        - star
+        - omega
+        - psi
+        - delta
+      - - delta
+        - xi
+        - star
+        - psi
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-23.yaml
+++ b/packages/manual/data/daily/2026-12-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - delta
+        - xi
+        - omega
+        - star
+        - psi
+      - - delta
+        - diamond
+        - psi
+        - star
+        - omega
+        - xi
+      - - star
+        - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+        - star
+      - - trident
+        - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+      - - delta
+        - omega
+        - xi
+        - psi
+        - star
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - delta
+        - psi
+        - diamond
+        - omega
+        - star
+        - xi
+      - - psi
+        - delta
+        - star
+        - diamond
+        - omega
+        - xi
+      - - omega
+        - psi
+        - star
+        - delta
+        - diamond
+        - xi
+      - - omega
+        - star
+        - psi
+        - diamond
+        - delta
+        - xi
+      - - star
+        - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-24.yaml
+++ b/packages/manual/data/daily/2026-12-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - delta
+        - trident
+        - psi
+        - omega
+      - - omega
+        - psi
+        - diamond
+        - delta
+        - xi
+        - star
+      - - xi
+        - psi
+        - diamond
+        - star
+        - delta
+        - omega
+      - - delta
+        - diamond
+        - xi
+        - omega
+        - star
+        - psi
+      - - delta
+        - psi
+        - xi
+        - omega
+        - trident
+        - diamond
+      - - omega
+        - diamond
+        - xi
+        - star
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - star
+        - psi
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - delta
+        - star
+      - - diamond
+        - psi
+        - star
+        - delta
+        - xi
+        - omega
+      - - omega
+        - diamond
+        - star
+        - xi
+        - delta
+        - psi
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+        - star
+      - - star
+        - xi
+        - omega
+        - psi
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-25.yaml
+++ b/packages/manual/data/daily/2026-12-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - star
+        - psi
+        - omega
+        - xi
+        - diamond
+      - - omega
+        - diamond
+        - xi
+        - star
+        - psi
+        - delta
+      - - omega
+        - star
+        - xi
+        - delta
+        - psi
+        - diamond
+      - - trident
+        - omega
+        - delta
+        - psi
+        - xi
+        - star
+      - - xi
+        - star
+        - diamond
+        - omega
+        - psi
+        - delta
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - star
+        - delta
+      - - diamond
+        - psi
+        - xi
+        - delta
+        - omega
+        - star
+      - - xi
+        - star
+        - delta
+        - diamond
+        - psi
+        - omega
+      - - delta
+        - omega
+        - star
+        - xi
+        - diamond
+        - psi
+      - - xi
+        - omega
+        - psi
+        - delta
+        - star
+        - diamond
+      - - xi
+        - diamond
+        - omega
+        - delta
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-26.yaml
+++ b/packages/manual/data/daily/2026-12-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - star
+        - trident
+        - omega
+        - xi
+        - psi
+      - - star
+        - diamond
+        - omega
+        - delta
+        - xi
+        - psi
+      - - diamond
+        - star
+        - psi
+        - omega
+        - delta
+        - xi
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - trident
+        - psi
+      - - diamond
+        - omega
+        - star
+        - xi
+        - psi
+        - delta
+      - - diamond
+        - star
+        - delta
+        - omega
+        - psi
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - delta
+        - star
+        - psi
+        - diamond
+        - xi
+      - - star
+        - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - psi
+        - delta
+        - star
+        - omega
+        - xi
+        - diamond
+      - - star
+        - omega
+        - psi
+        - diamond
+        - delta
+        - xi
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - psi
+        - star
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-27.yaml
+++ b/packages/manual/data/daily/2026-12-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - psi
+        - omega
+        - trident
+        - star
+      - - omega
+        - xi
+        - psi
+        - delta
+        - trident
+        - diamond
+      - - star
+        - delta
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - delta
+        - star
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+        - star
+      - - omega
+        - star
+        - diamond
+        - xi
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - star
+        - omega
+      - - psi
+        - delta
+        - star
+        - diamond
+        - omega
+        - xi
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - star
+        - psi
+      - - omega
+        - star
+        - psi
+        - xi
+        - delta
+        - diamond
+      - - omega
+        - psi
+        - delta
+        - star
+        - diamond
+        - xi
+      - - delta
+        - xi
+        - psi
+        - omega
+        - star
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-28.yaml
+++ b/packages/manual/data/daily/2026-12-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - psi
+        - omega
+        - delta
+        - diamond
+        - trident
+      - - xi
+        - diamond
+        - psi
+        - star
+        - delta
+        - omega
+      - - psi
+        - xi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - delta
+        - star
+        - diamond
+        - xi
+        - omega
+        - psi
+      - - psi
+        - xi
+        - trident
+        - omega
+        - star
+        - delta
+      - - psi
+        - omega
+        - star
+        - delta
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - delta
+        - psi
+        - xi
+        - star
+        - diamond
+      - - star
+        - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+      - - psi
+        - omega
+        - delta
+        - xi
+        - star
+        - diamond
+      - - xi
+        - star
+        - diamond
+        - delta
+        - omega
+        - psi
+      - - diamond
+        - star
+        - psi
+        - xi
+        - delta
+        - omega
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - star
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-29.yaml
+++ b/packages/manual/data/daily/2026-12-29.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-29'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - diamond
+        - xi
+        - delta
+        - omega
+        - psi
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+        - star
+      - - diamond
+        - xi
+        - delta
+        - omega
+        - trident
+        - psi
+      - - delta
+        - xi
+        - diamond
+        - omega
+        - star
+        - psi
+      - - psi
+        - diamond
+        - omega
+        - delta
+        - star
+        - xi
+      - - omega
+        - trident
+        - xi
+        - delta
+        - star
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - star
+        - omega
+      - - diamond
+        - star
+        - xi
+        - omega
+        - delta
+        - psi
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - star
+        - xi
+      - - psi
+        - star
+        - omega
+        - delta
+        - diamond
+        - xi
+      - - xi
+        - delta
+        - diamond
+        - psi
+        - star
+        - omega
+      - - diamond
+        - star
+        - delta
+        - omega
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-30.yaml
+++ b/packages/manual/data/daily/2026-12-30.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-30'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - trident
+        - psi
+        - xi
+        - omega
+        - star
+      - - omega
+        - diamond
+        - xi
+        - star
+        - psi
+        - delta
+      - - psi
+        - delta
+        - omega
+        - xi
+        - trident
+        - diamond
+      - - diamond
+        - star
+        - psi
+        - omega
+        - delta
+        - xi
+      - - psi
+        - xi
+        - star
+        - omega
+        - delta
+        - diamond
+      - - delta
+        - omega
+        - diamond
+        - xi
+        - star
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+        - star
+      - - omega
+        - xi
+        - psi
+        - diamond
+        - delta
+        - star
+      - - psi
+        - omega
+        - xi
+        - delta
+        - diamond
+        - star
+      - - omega
+        - star
+        - delta
+        - xi
+        - diamond
+        - psi
+      - - star
+        - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+      - - psi
+        - delta
+        - star
+        - omega
+        - xi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2026-12-31.yaml
+++ b/packages/manual/data/daily/2026-12-31.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2026-12-31'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - trident
+        - diamond
+        - psi
+        - delta
+      - - psi
+        - delta
+        - star
+        - diamond
+        - xi
+        - omega
+      - - omega
+        - psi
+        - delta
+        - xi
+        - star
+        - diamond
+      - - trident
+        - star
+        - delta
+        - omega
+        - xi
+        - psi
+      - - delta
+        - psi
+        - omega
+        - star
+        - diamond
+        - xi
+      - - star
+        - delta
+        - psi
+        - diamond
+        - omega
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - xi
+        - diamond
+        - psi
+        - star
+        - omega
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+        - star
+      - - omega
+        - delta
+        - xi
+        - psi
+        - star
+        - diamond
+      - - diamond
+        - psi
+        - star
+        - delta
+        - omega
+        - xi
+      - - xi
+        - delta
+        - psi
+        - star
+        - diamond
+        - omega
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-01.yaml
+++ b/packages/manual/data/daily/2027-01-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - omega
+        - star
+        - psi
+        - diamond
+      - - star
+        - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+        - star
+      - - xi
+        - psi
+        - star
+        - omega
+        - delta
+        - trident
+      - - psi
+        - trident
+        - omega
+        - delta
+        - diamond
+        - xi
+      - - xi
+        - omega
+        - star
+        - diamond
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - diamond
+        - xi
+        - star
+        - psi
+        - omega
+      - - diamond
+        - xi
+        - delta
+        - star
+        - psi
+        - omega
+      - - star
+        - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+      - - xi
+        - diamond
+        - star
+        - psi
+        - omega
+        - delta
+      - - diamond
+        - psi
+        - xi
+        - delta
+        - omega
+        - star
+      - - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-02.yaml
+++ b/packages/manual/data/daily/2027-01-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - star
+        - psi
+      - - trident
+        - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - star
+        - xi
+      - - psi
+        - diamond
+        - xi
+        - star
+        - delta
+        - omega
+      - - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+        - star
+      - - delta
+        - xi
+        - star
+        - omega
+        - trident
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - diamond
+        - psi
+        - xi
+        - delta
+        - star
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - star
+        - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - diamond
+        - delta
+        - psi
+        - xi
+        - star
+        - omega
+      - - omega
+        - diamond
+        - delta
+        - star
+        - xi
+        - psi
+      - - star
+        - diamond
+        - xi
+        - omega
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-03.yaml
+++ b/packages/manual/data/daily/2027-01-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+      - - omega
+        - diamond
+        - delta
+        - xi
+        - psi
+        - star
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+        - star
+      - - star
+        - psi
+        - delta
+        - xi
+        - diamond
+        - omega
+      - - psi
+        - delta
+        - xi
+        - omega
+        - trident
+        - star
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - star
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - xi
+        - delta
+        - diamond
+        - star
+        - omega
+        - psi
+      - - psi
+        - omega
+        - star
+        - delta
+        - diamond
+        - xi
+      - - diamond
+        - psi
+        - omega
+        - delta
+        - xi
+        - star
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - star
+        - xi
+      - - psi
+        - diamond
+        - star
+        - omega
+        - xi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-04.yaml
+++ b/packages/manual/data/daily/2027-01-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+        - star
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+        - star
+      - - xi
+        - psi
+        - star
+        - diamond
+        - delta
+        - omega
+      - - omega
+        - psi
+        - trident
+        - star
+        - delta
+        - xi
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+        - star
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - trident
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - psi
+        - star
+        - xi
+        - omega
+        - diamond
+      - - psi
+        - delta
+        - star
+        - xi
+        - diamond
+        - omega
+      - - diamond
+        - star
+        - omega
+        - delta
+        - xi
+        - psi
+      - - star
+        - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+      - - omega
+        - star
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - psi
+        - omega
+        - xi
+        - star
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-05.yaml
+++ b/packages/manual/data/daily/2027-01-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - diamond
+        - star
+        - psi
+        - delta
+      - - psi
+        - diamond
+        - trident
+        - delta
+        - omega
+        - xi
+      - - star
+        - delta
+        - psi
+        - omega
+        - xi
+        - trident
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - star
+        - xi
+      - - xi
+        - omega
+        - psi
+        - delta
+        - star
+        - diamond
+      - - psi
+        - omega
+        - delta
+        - star
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+      - - psi
+        - diamond
+        - delta
+        - omega
+        - star
+        - xi
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - star
+        - psi
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - star
+        - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-06.yaml
+++ b/packages/manual/data/daily/2027-01-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - diamond
+        - xi
+        - omega
+        - trident
+        - delta
+        - psi
+      - - omega
+        - psi
+        - delta
+        - star
+        - trident
+        - xi
+      - - xi
+        - star
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - delta
+        - diamond
+        - xi
+        - star
+        - psi
+        - omega
+      - - xi
+        - omega
+        - star
+        - psi
+        - delta
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - delta
+        - xi
+        - star
+        - psi
+        - diamond
+        - omega
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - star
+        - xi
+      - - star
+        - diamond
+        - psi
+        - omega
+        - xi
+        - delta
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+        - star
+      - - star
+        - delta
+        - omega
+        - diamond
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-07.yaml
+++ b/packages/manual/data/daily/2027-01-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - xi
+        - star
+        - diamond
+        - omega
+        - delta
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+        - star
+      - - delta
+        - omega
+        - star
+        - psi
+        - xi
+        - trident
+      - - psi
+        - xi
+        - omega
+        - star
+        - delta
+        - diamond
+      - - omega
+        - delta
+        - psi
+        - xi
+        - star
+        - diamond
+      - - psi
+        - xi
+        - diamond
+        - trident
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - star
+        - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+        - star
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - star
+        - xi
+        - delta
+        - omega
+        - diamond
+        - psi
+      - - xi
+        - omega
+        - star
+        - psi
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-08.yaml
+++ b/packages/manual/data/daily/2027-01-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - star
+        - xi
+      - - psi
+        - omega
+        - star
+        - trident
+        - xi
+        - delta
+      - - omega
+        - diamond
+        - xi
+        - delta
+        - trident
+        - psi
+      - - xi
+        - diamond
+        - star
+        - delta
+        - omega
+        - psi
+      - - star
+        - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+      - - diamond
+        - xi
+        - star
+        - omega
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - xi
+        - delta
+        - star
+        - diamond
+        - omega
+      - - diamond
+        - delta
+        - star
+        - psi
+        - xi
+        - omega
+      - - xi
+        - delta
+        - omega
+        - diamond
+        - psi
+        - star
+      - - star
+        - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+      - - xi
+        - star
+        - omega
+        - delta
+        - diamond
+        - psi
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-09.yaml
+++ b/packages/manual/data/daily/2027-01-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - xi
+        - star
+        - omega
+        - psi
+      - - xi
+        - delta
+        - psi
+        - omega
+        - trident
+        - diamond
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - star
+        - delta
+      - - psi
+        - delta
+        - omega
+        - xi
+        - diamond
+        - star
+      - - xi
+        - omega
+        - psi
+        - star
+        - diamond
+        - delta
+      - - psi
+        - trident
+        - delta
+        - star
+        - xi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+        - star
+      - - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+        - star
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - xi
+        - star
+      - - psi
+        - delta
+        - omega
+        - star
+        - diamond
+        - xi
+      - - omega
+        - star
+        - diamond
+        - psi
+        - delta
+        - xi
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-10.yaml
+++ b/packages/manual/data/daily/2027-01-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - omega
+        - psi
+        - star
+        - delta
+        - xi
+      - - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+        - star
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+        - star
+      - - omega
+        - diamond
+        - trident
+        - xi
+        - delta
+        - psi
+      - - xi
+        - star
+        - omega
+        - delta
+        - psi
+        - trident
+      - - xi
+        - omega
+        - star
+        - psi
+        - delta
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - diamond
+        - star
+        - delta
+        - xi
+      - - delta
+        - psi
+        - omega
+        - star
+        - xi
+        - diamond
+      - - delta
+        - psi
+        - xi
+        - star
+        - diamond
+        - omega
+      - - diamond
+        - xi
+        - psi
+        - omega
+        - delta
+        - star
+      - - xi
+        - delta
+        - omega
+        - star
+        - diamond
+        - psi
+      - - psi
+        - delta
+        - star
+        - xi
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-11.yaml
+++ b/packages/manual/data/daily/2027-01-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - star
+        - xi
+      - - star
+        - delta
+        - psi
+        - trident
+        - omega
+        - xi
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - trident
+        - xi
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - delta
+        - star
+      - - xi
+        - diamond
+        - star
+        - psi
+        - delta
+        - omega
+      - - omega
+        - star
+        - delta
+        - psi
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - omega
+        - xi
+        - star
+        - diamond
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+        - star
+      - - omega
+        - star
+        - delta
+        - diamond
+        - xi
+        - psi
+      - - star
+        - delta
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - omega
+        - psi
+        - star
+        - delta
+        - diamond
+        - xi
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-12.yaml
+++ b/packages/manual/data/daily/2027-01-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - trident
+        - omega
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - star
+        - xi
+      - - delta
+        - star
+        - trident
+        - xi
+        - omega
+        - psi
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+        - star
+      - - omega
+        - diamond
+        - star
+        - xi
+        - delta
+        - psi
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - star
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - diamond
+        - star
+        - xi
+        - psi
+      - - star
+        - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+      - - omega
+        - psi
+        - xi
+        - delta
+        - star
+        - diamond
+      - - star
+        - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+      - - xi
+        - omega
+        - star
+        - diamond
+        - delta
+        - psi
+      - - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-13.yaml
+++ b/packages/manual/data/daily/2027-01-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - trident
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - omega
+        - star
+        - diamond
+        - xi
+        - delta
+        - psi
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+        - star
+      - - trident
+        - star
+        - xi
+        - omega
+        - delta
+        - psi
+      - - star
+        - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+      - - psi
+        - xi
+        - star
+        - diamond
+        - omega
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - star
+        - omega
+        - xi
+        - diamond
+      - - star
+        - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+      - - omega
+        - delta
+        - psi
+        - star
+        - xi
+        - diamond
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - xi
+        - star
+      - - diamond
+        - psi
+        - star
+        - delta
+        - xi
+        - omega
+      - - omega
+        - xi
+        - delta
+        - star
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-14.yaml
+++ b/packages/manual/data/daily/2027-01-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - diamond
+        - star
+        - xi
+        - omega
+        - delta
+      - - delta
+        - trident
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - star
+        - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+      - - psi
+        - star
+        - diamond
+        - omega
+        - delta
+        - xi
+      - - trident
+        - star
+        - delta
+        - omega
+        - psi
+        - xi
+      - - star
+        - diamond
+        - omega
+        - psi
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - star
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - xi
+        - star
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - omega
+        - star
+      - - star
+        - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - star
+        - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+      - - psi
+        - delta
+        - star
+        - diamond
+        - omega
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-15.yaml
+++ b/packages/manual/data/daily/2027-01-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - psi
+        - diamond
+        - star
+        - delta
+        - xi
+      - - psi
+        - star
+        - omega
+        - trident
+        - delta
+        - xi
+      - - psi
+        - xi
+        - delta
+        - trident
+        - diamond
+        - omega
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+        - star
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - star
+        - xi
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - star
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - omega
+        - delta
+        - star
+        - psi
+      - - psi
+        - omega
+        - star
+        - diamond
+        - xi
+        - delta
+      - - star
+        - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+      - - omega
+        - star
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - delta
+        - star
+        - omega
+        - diamond
+        - psi
+        - xi
+      - - diamond
+        - xi
+        - delta
+        - omega
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-16.yaml
+++ b/packages/manual/data/daily/2027-01-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - xi
+        - psi
+        - star
+        - diamond
+      - - diamond
+        - omega
+        - xi
+        - trident
+        - psi
+        - delta
+      - - delta
+        - xi
+        - omega
+        - star
+        - diamond
+        - psi
+      - - trident
+        - xi
+        - omega
+        - delta
+        - star
+        - psi
+      - - star
+        - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+      - - xi
+        - omega
+        - delta
+        - diamond
+        - star
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - xi
+        - star
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+        - star
+      - - delta
+        - omega
+        - xi
+        - psi
+        - diamond
+        - star
+      - - star
+        - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+      - - omega
+        - diamond
+        - xi
+        - star
+        - psi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-17.yaml
+++ b/packages/manual/data/daily/2027-01-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - delta
+        - star
+        - xi
+        - psi
+        - omega
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+        - trident
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - star
+        - delta
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - star
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - star
+        - xi
+      - - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - star
+        - xi
+      - - delta
+        - psi
+        - xi
+        - omega
+        - star
+        - diamond
+      - - diamond
+        - xi
+        - omega
+        - star
+        - delta
+        - psi
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+        - star
+      - - delta
+        - omega
+        - psi
+        - xi
+        - star
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-18.yaml
+++ b/packages/manual/data/daily/2027-01-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+        - trident
+      - - star
+        - diamond
+        - omega
+        - psi
+        - delta
+        - xi
+      - - diamond
+        - star
+        - delta
+        - psi
+        - xi
+        - omega
+      - - delta
+        - xi
+        - diamond
+        - star
+        - psi
+        - omega
+      - - psi
+        - star
+        - trident
+        - xi
+        - delta
+        - omega
+      - - psi
+        - star
+        - diamond
+        - xi
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - star
+        - xi
+        - omega
+        - delta
+      - - psi
+        - star
+        - xi
+        - omega
+        - diamond
+        - delta
+      - - xi
+        - star
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - star
+        - psi
+        - delta
+        - diamond
+        - omega
+        - xi
+      - - star
+        - delta
+        - diamond
+        - omega
+        - psi
+        - xi
+      - - xi
+        - star
+        - delta
+        - omega
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-19.yaml
+++ b/packages/manual/data/daily/2027-01-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - xi
+        - omega
+        - star
+        - psi
+      - - xi
+        - omega
+        - diamond
+        - star
+        - psi
+        - delta
+      - - star
+        - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+      - - star
+        - psi
+        - diamond
+        - delta
+        - omega
+        - xi
+      - - diamond
+        - delta
+        - trident
+        - xi
+        - omega
+        - psi
+      - - delta
+        - star
+        - trident
+        - xi
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - omega
+        - xi
+        - delta
+        - star
+      - - star
+        - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+      - - star
+        - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+      - - omega
+        - xi
+        - star
+        - diamond
+        - delta
+        - psi
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - star
+        - xi
+      - - psi
+        - diamond
+        - omega
+        - delta
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-20.yaml
+++ b/packages/manual/data/daily/2027-01-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - trident
+        - delta
+        - xi
+        - psi
+        - omega
+      - - delta
+        - trident
+        - xi
+        - omega
+        - diamond
+        - psi
+      - - delta
+        - diamond
+        - star
+        - psi
+        - omega
+        - xi
+      - - delta
+        - omega
+        - psi
+        - star
+        - xi
+        - diamond
+      - - star
+        - delta
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - star
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - star
+        - delta
+        - omega
+        - xi
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - star
+        - delta
+      - - star
+        - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+      - - psi
+        - star
+        - diamond
+        - omega
+        - xi
+        - delta
+      - - delta
+        - xi
+        - star
+        - diamond
+        - psi
+        - omega
+      - - psi
+        - star
+        - xi
+        - diamond
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-21.yaml
+++ b/packages/manual/data/daily/2027-01-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - omega
+        - delta
+        - psi
+        - star
+        - diamond
+      - - trident
+        - delta
+        - omega
+        - psi
+        - star
+        - xi
+      - - omega
+        - diamond
+        - delta
+        - star
+        - psi
+        - xi
+      - - delta
+        - psi
+        - star
+        - xi
+        - diamond
+        - omega
+      - - diamond
+        - star
+        - omega
+        - delta
+        - xi
+        - psi
+      - - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - star
+        - omega
+        - xi
+        - diamond
+      - - diamond
+        - psi
+        - xi
+        - star
+        - delta
+        - omega
+      - - xi
+        - omega
+        - delta
+        - diamond
+        - star
+        - psi
+      - - star
+        - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - star
+        - xi
+      - - delta
+        - psi
+        - omega
+        - star
+        - diamond
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-22.yaml
+++ b/packages/manual/data/daily/2027-01-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - trident
+        - omega
+        - psi
+        - delta
+        - xi
+      - - star
+        - omega
+        - trident
+        - psi
+        - delta
+        - xi
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - delta
+        - star
+        - omega
+        - diamond
+        - psi
+        - xi
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+        - star
+      - - xi
+        - diamond
+        - star
+        - delta
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - star
+        - diamond
+        - omega
+        - xi
+      - - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+        - star
+      - - omega
+        - star
+        - delta
+        - diamond
+        - xi
+        - psi
+      - - diamond
+        - omega
+        - star
+        - delta
+        - xi
+        - psi
+      - - xi
+        - diamond
+        - psi
+        - star
+        - omega
+        - delta
+      - - psi
+        - delta
+        - xi
+        - omega
+        - star
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-23.yaml
+++ b/packages/manual/data/daily/2027-01-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - xi
+        - diamond
+        - star
+        - psi
+      - - delta
+        - omega
+        - diamond
+        - star
+        - psi
+        - xi
+      - - delta
+        - trident
+        - xi
+        - star
+        - psi
+        - omega
+      - - star
+        - delta
+        - diamond
+        - psi
+        - omega
+        - xi
+      - - diamond
+        - star
+        - xi
+        - omega
+        - psi
+        - delta
+      - - delta
+        - trident
+        - diamond
+        - xi
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - delta
+        - xi
+        - star
+        - omega
+      - - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+        - star
+      - - omega
+        - diamond
+        - psi
+        - star
+        - xi
+        - delta
+      - - omega
+        - diamond
+        - star
+        - psi
+        - xi
+        - delta
+      - - psi
+        - xi
+        - star
+        - diamond
+        - omega
+        - delta
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-24.yaml
+++ b/packages/manual/data/daily/2027-01-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - xi
+        - omega
+        - trident
+        - star
+        - psi
+        - delta
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - star
+        - omega
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+      - - xi
+        - trident
+        - omega
+        - psi
+        - delta
+        - diamond
+      - - diamond
+        - psi
+        - omega
+        - star
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - omega
+        - star
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - psi
+        - omega
+        - delta
+        - diamond
+        - xi
+        - star
+      - - psi
+        - delta
+        - star
+        - omega
+        - diamond
+        - xi
+      - - omega
+        - delta
+        - diamond
+        - star
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-25.yaml
+++ b/packages/manual/data/daily/2027-01-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - delta
+        - psi
+        - trident
+        - omega
+        - xi
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+        - star
+      - - delta
+        - omega
+        - xi
+        - psi
+        - diamond
+        - star
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - psi
+        - xi
+        - omega
+        - delta
+        - star
+        - trident
+      - - diamond
+        - delta
+        - psi
+        - xi
+        - star
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - xi
+        - delta
+        - star
+        - omega
+        - diamond
+      - - omega
+        - xi
+        - psi
+        - star
+        - diamond
+        - delta
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - star
+        - psi
+      - - diamond
+        - omega
+        - psi
+        - star
+        - delta
+        - xi
+      - - delta
+        - omega
+        - star
+        - psi
+        - diamond
+        - xi
+      - - psi
+        - delta
+        - omega
+        - star
+        - xi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-26.yaml
+++ b/packages/manual/data/daily/2027-01-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - psi
+        - omega
+        - star
+        - xi
+        - delta
+      - - delta
+        - psi
+        - diamond
+        - star
+        - omega
+        - xi
+      - - psi
+        - delta
+        - diamond
+        - star
+        - xi
+        - omega
+      - - xi
+        - diamond
+        - trident
+        - delta
+        - omega
+        - psi
+      - - star
+        - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+      - - xi
+        - star
+        - trident
+        - omega
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - star
+        - xi
+      - - delta
+        - star
+        - omega
+        - diamond
+        - psi
+        - xi
+      - - omega
+        - star
+        - xi
+        - delta
+        - psi
+        - diamond
+      - - diamond
+        - omega
+        - star
+        - delta
+        - xi
+        - psi
+      - - delta
+        - star
+        - omega
+        - diamond
+        - psi
+        - xi
+      - - star
+        - psi
+        - diamond
+        - delta
+        - omega
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-27.yaml
+++ b/packages/manual/data/daily/2027-01-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - delta
+        - omega
+        - xi
+        - diamond
+        - psi
+      - - diamond
+        - xi
+        - omega
+        - delta
+        - trident
+        - psi
+      - - diamond
+        - star
+        - psi
+        - delta
+        - xi
+        - omega
+      - - omega
+        - xi
+        - psi
+        - delta
+        - trident
+        - star
+      - - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+        - star
+      - - star
+        - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - star
+        - delta
+      - - delta
+        - star
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - xi
+        - diamond
+        - psi
+        - omega
+        - star
+        - delta
+      - - diamond
+        - star
+        - omega
+        - xi
+        - psi
+        - delta
+      - - diamond
+        - psi
+        - delta
+        - star
+        - xi
+        - omega
+      - - psi
+        - delta
+        - omega
+        - star
+        - diamond
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-28.yaml
+++ b/packages/manual/data/daily/2027-01-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - psi
+        - star
+        - delta
+        - omega
+        - xi
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - star
+        - delta
+        - trident
+        - xi
+        - psi
+        - omega
+      - - trident
+        - delta
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - star
+        - psi
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - star
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - omega
+        - delta
+        - xi
+        - diamond
+        - star
+        - psi
+      - - delta
+        - star
+        - psi
+        - xi
+        - omega
+        - diamond
+      - - delta
+        - diamond
+        - star
+        - omega
+        - xi
+        - psi
+      - - omega
+        - xi
+        - delta
+        - star
+        - diamond
+        - psi
+      - - delta
+        - diamond
+        - star
+        - xi
+        - psi
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-29.yaml
+++ b/packages/manual/data/daily/2027-01-29.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-29'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - omega
+        - delta
+        - star
+        - trident
+        - psi
+      - - diamond
+        - delta
+        - psi
+        - xi
+        - omega
+        - star
+      - - delta
+        - psi
+        - xi
+        - trident
+        - diamond
+        - omega
+      - - star
+        - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - diamond
+        - psi
+        - omega
+        - star
+        - delta
+        - xi
+      - - xi
+        - delta
+        - star
+        - diamond
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - xi
+        - star
+        - diamond
+        - omega
+        - delta
+      - - psi
+        - diamond
+        - star
+        - xi
+        - delta
+        - omega
+      - - omega
+        - star
+        - psi
+        - delta
+        - xi
+        - diamond
+      - - omega
+        - psi
+        - diamond
+        - star
+        - delta
+        - xi
+      - - delta
+        - omega
+        - star
+        - diamond
+        - psi
+        - xi
+      - - star
+        - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-30.yaml
+++ b/packages/manual/data/daily/2027-01-30.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-30'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - star
+        - xi
+      - - psi
+        - omega
+        - xi
+        - trident
+        - star
+        - delta
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - xi
+        - star
+      - - psi
+        - diamond
+        - trident
+        - xi
+        - omega
+        - delta
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - star
+        - delta
+      - - delta
+        - xi
+        - psi
+        - star
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+      - - xi
+        - delta
+        - psi
+        - omega
+        - diamond
+        - star
+      - - diamond
+        - delta
+        - xi
+        - star
+        - psi
+        - omega
+      - - diamond
+        - xi
+        - star
+        - delta
+        - omega
+        - psi
+      - - diamond
+        - psi
+        - xi
+        - delta
+        - omega
+        - star
+      - - star
+        - xi
+        - diamond
+        - psi
+        - omega
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-01-31.yaml
+++ b/packages/manual/data/daily/2027-01-31.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-01-31'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - star
+        - diamond
+        - delta
+        - xi
+      - - star
+        - psi
+        - trident
+        - delta
+        - omega
+        - xi
+      - - psi
+        - diamond
+        - trident
+        - omega
+        - xi
+        - delta
+      - - star
+        - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+      - - psi
+        - delta
+        - star
+        - diamond
+        - omega
+        - xi
+      - - omega
+        - star
+        - xi
+        - psi
+        - diamond
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - star
+        - delta
+        - psi
+        - omega
+      - - star
+        - delta
+        - diamond
+        - psi
+        - xi
+        - omega
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - xi
+        - star
+      - - star
+        - xi
+        - delta
+        - omega
+        - diamond
+        - psi
+      - - psi
+        - star
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-01.yaml
+++ b/packages/manual/data/daily/2027-02-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - star
+        - xi
+      - - trident
+        - omega
+        - xi
+        - star
+        - psi
+        - delta
+      - - omega
+        - xi
+        - delta
+        - star
+        - diamond
+        - psi
+      - - diamond
+        - omega
+        - xi
+        - psi
+        - delta
+        - star
+      - - psi
+        - omega
+        - diamond
+        - xi
+        - star
+        - delta
+      - - delta
+        - diamond
+        - xi
+        - trident
+        - psi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - diamond
+        - delta
+        - omega
+        - star
+        - psi
+        - xi
+      - - diamond
+        - star
+        - xi
+        - psi
+        - delta
+        - omega
+      - - psi
+        - xi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - delta
+        - xi
+        - star
+        - psi
+        - omega
+        - diamond
+      - - omega
+        - psi
+        - star
+        - xi
+        - diamond
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-02.yaml
+++ b/packages/manual/data/daily/2027-02-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - omega
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - star
+        - omega
+        - delta
+        - xi
+        - diamond
+        - psi
+      - - psi
+        - xi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - diamond
+        - omega
+        - xi
+        - star
+        - psi
+        - delta
+      - - diamond
+        - xi
+        - star
+        - omega
+        - delta
+        - psi
+      - - psi
+        - trident
+        - star
+        - delta
+        - omega
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - omega
+        - delta
+        - diamond
+        - star
+        - psi
+      - - star
+        - delta
+        - xi
+        - diamond
+        - omega
+        - psi
+      - - diamond
+        - star
+        - psi
+        - delta
+        - xi
+        - omega
+      - - diamond
+        - psi
+        - xi
+        - delta
+        - omega
+        - star
+      - - xi
+        - diamond
+        - omega
+        - delta
+        - psi
+        - star
+      - - diamond
+        - psi
+        - omega
+        - star
+        - delta
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-03.yaml
+++ b/packages/manual/data/daily/2027-02-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - psi
+        - xi
+        - star
+        - omega
+        - delta
+      - - trident
+        - diamond
+        - psi
+        - omega
+        - delta
+        - xi
+      - - omega
+        - psi
+        - delta
+        - xi
+        - trident
+        - star
+      - - delta
+        - psi
+        - star
+        - omega
+        - xi
+        - diamond
+      - - xi
+        - omega
+        - delta
+        - star
+        - diamond
+        - psi
+      - - star
+        - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - psi
+        - xi
+        - delta
+        - omega
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+        - star
+      - - omega
+        - diamond
+        - delta
+        - xi
+        - star
+        - psi
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - star
+        - xi
+      - - psi
+        - star
+        - delta
+        - omega
+        - diamond
+        - xi
+      - - xi
+        - star
+        - delta
+        - omega
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-04.yaml
+++ b/packages/manual/data/daily/2027-02-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - psi
+        - omega
+        - delta
+        - diamond
+      - - omega
+        - star
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - delta
+        - trident
+        - star
+        - xi
+        - psi
+        - omega
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - trident
+        - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+      - - omega
+        - star
+        - psi
+        - xi
+        - diamond
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+        - star
+      - - star
+        - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - psi
+        - delta
+        - star
+        - xi
+        - diamond
+        - omega
+      - - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-05.yaml
+++ b/packages/manual/data/daily/2027-02-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - star
+        - diamond
+        - delta
+        - xi
+        - omega
+      - - psi
+        - xi
+        - trident
+        - star
+        - omega
+        - delta
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - star
+        - delta
+      - - delta
+        - diamond
+        - psi
+        - star
+        - omega
+        - xi
+      - - star
+        - omega
+        - psi
+        - xi
+        - delta
+        - diamond
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - trident
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - omega
+        - xi
+        - star
+        - delta
+        - diamond
+      - - omega
+        - delta
+        - diamond
+        - psi
+        - xi
+        - star
+      - - diamond
+        - psi
+        - star
+        - xi
+        - delta
+        - omega
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - star
+        - delta
+      - - psi
+        - xi
+        - omega
+        - delta
+        - star
+        - diamond
+      - - xi
+        - omega
+        - diamond
+        - star
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-06.yaml
+++ b/packages/manual/data/daily/2027-02-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - star
+        - xi
+        - diamond
+        - omega
+      - - omega
+        - diamond
+        - psi
+        - xi
+        - star
+        - delta
+      - - star
+        - delta
+        - psi
+        - omega
+        - xi
+        - diamond
+      - - psi
+        - diamond
+        - trident
+        - omega
+        - xi
+        - delta
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - omega
+        - psi
+        - xi
+        - delta
+        - star
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - star
+        - delta
+      - - psi
+        - omega
+        - star
+        - diamond
+        - delta
+        - xi
+      - - xi
+        - star
+        - diamond
+        - psi
+        - delta
+        - omega
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - star
+        - delta
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - diamond
+      - - xi
+        - star
+        - diamond
+        - psi
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-07.yaml
+++ b/packages/manual/data/daily/2027-02-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - diamond
+        - star
+        - psi
+        - omega
+      - - omega
+        - trident
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - star
+        - xi
+        - omega
+        - delta
+        - diamond
+        - psi
+      - - delta
+        - xi
+        - omega
+        - psi
+        - star
+        - trident
+      - - star
+        - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+      - - star
+        - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - xi
+        - diamond
+        - psi
+        - star
+        - omega
+      - - diamond
+        - xi
+        - omega
+        - delta
+        - star
+        - psi
+      - - psi
+        - star
+        - diamond
+        - omega
+        - xi
+        - delta
+      - - xi
+        - omega
+        - delta
+        - psi
+        - star
+        - diamond
+      - - psi
+        - xi
+        - star
+        - omega
+        - delta
+        - diamond
+      - - star
+        - omega
+        - diamond
+        - delta
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-08.yaml
+++ b/packages/manual/data/daily/2027-02-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - star
+        - xi
+      - - diamond
+        - xi
+        - omega
+        - delta
+        - psi
+        - star
+      - - star
+        - psi
+        - omega
+        - xi
+        - delta
+        - diamond
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - trident
+      - - xi
+        - delta
+        - psi
+        - star
+        - diamond
+        - omega
+      - - delta
+        - omega
+        - star
+        - psi
+        - xi
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+        - star
+      - - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+        - star
+      - - diamond
+        - psi
+        - star
+        - xi
+        - omega
+        - delta
+      - - delta
+        - psi
+        - star
+        - diamond
+        - omega
+        - xi
+      - - delta
+        - star
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - psi
+        - star
+        - delta
+        - xi
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-09.yaml
+++ b/packages/manual/data/daily/2027-02-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - star
+        - omega
+        - delta
+        - psi
+      - - psi
+        - trident
+        - diamond
+        - xi
+        - delta
+        - omega
+      - - xi
+        - star
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+        - star
+      - - diamond
+        - star
+        - psi
+        - omega
+        - delta
+        - xi
+      - - omega
+        - psi
+        - trident
+        - delta
+        - xi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - star
+        - xi
+        - omega
+        - delta
+      - - xi
+        - star
+        - omega
+        - diamond
+        - psi
+        - delta
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - star
+        - delta
+      - - delta
+        - xi
+        - star
+        - psi
+        - omega
+        - diamond
+      - - xi
+        - omega
+        - delta
+        - diamond
+        - star
+        - psi
+      - - diamond
+        - omega
+        - star
+        - psi
+        - delta
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-10.yaml
+++ b/packages/manual/data/daily/2027-02-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - delta
+        - xi
+        - diamond
+        - star
+        - omega
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - trident
+        - xi
+      - - star
+        - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+      - - diamond
+        - delta
+        - psi
+        - xi
+        - star
+        - omega
+      - - delta
+        - xi
+        - omega
+        - psi
+        - trident
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - omega
+        - xi
+        - psi
+        - delta
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - star
+        - delta
+      - - diamond
+        - star
+        - omega
+        - psi
+        - xi
+        - delta
+      - - diamond
+        - xi
+        - psi
+        - omega
+        - delta
+        - star
+      - - star
+        - diamond
+        - xi
+        - psi
+        - omega
+        - delta
+      - - xi
+        - psi
+        - diamond
+        - star
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-11.yaml
+++ b/packages/manual/data/daily/2027-02-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+      - - delta
+        - trident
+        - xi
+        - omega
+        - psi
+        - star
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+      - - delta
+        - xi
+        - omega
+        - psi
+        - star
+        - diamond
+      - - psi
+        - delta
+        - trident
+        - xi
+        - diamond
+        - omega
+      - - psi
+        - omega
+        - star
+        - diamond
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+        - star
+      - - delta
+        - omega
+        - xi
+        - psi
+        - diamond
+        - star
+      - - star
+        - omega
+        - xi
+        - psi
+        - delta
+        - diamond
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - star
+        - delta
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - psi
+        - xi
+        - star
+        - delta
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-12.yaml
+++ b/packages/manual/data/daily/2027-02-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - psi
+        - xi
+        - star
+        - diamond
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - star
+        - delta
+      - - delta
+        - omega
+        - xi
+        - diamond
+        - star
+        - psi
+      - - xi
+        - delta
+        - star
+        - trident
+        - psi
+        - omega
+      - - trident
+        - delta
+        - omega
+        - diamond
+        - psi
+        - xi
+      - - delta
+        - diamond
+        - xi
+        - omega
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - star
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - xi
+        - star
+        - psi
+        - diamond
+        - delta
+        - omega
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - star
+        - xi
+      - - psi
+        - star
+        - omega
+        - delta
+        - diamond
+        - xi
+      - - omega
+        - delta
+        - psi
+        - star
+        - xi
+        - diamond
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-13.yaml
+++ b/packages/manual/data/daily/2027-02-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+        - star
+      - - omega
+        - star
+        - psi
+        - diamond
+        - delta
+        - xi
+      - - omega
+        - star
+        - xi
+        - delta
+        - psi
+        - diamond
+      - - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+        - star
+      - - trident
+        - delta
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - delta
+        - trident
+        - xi
+        - star
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - star
+        - delta
+      - - star
+        - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+      - - omega
+        - psi
+        - xi
+        - star
+        - diamond
+        - delta
+      - - xi
+        - psi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - xi
+        - delta
+        - psi
+        - omega
+        - star
+        - diamond
+      - - psi
+        - delta
+        - diamond
+        - omega
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-14.yaml
+++ b/packages/manual/data/daily/2027-02-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - star
+        - trident
+        - delta
+        - psi
+        - xi
+      - - xi
+        - delta
+        - star
+        - diamond
+        - psi
+        - omega
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+        - star
+      - - star
+        - omega
+        - delta
+        - xi
+        - diamond
+        - psi
+      - - delta
+        - xi
+        - omega
+        - psi
+        - star
+        - diamond
+      - - psi
+        - xi
+        - trident
+        - delta
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - star
+        - omega
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+        - star
+      - - omega
+        - xi
+        - delta
+        - star
+        - psi
+        - diamond
+      - - psi
+        - star
+        - diamond
+        - omega
+        - xi
+        - delta
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - star
+        - omega
+      - - delta
+        - psi
+        - omega
+        - star
+        - xi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-15.yaml
+++ b/packages/manual/data/daily/2027-02-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - psi
+        - trident
+        - delta
+        - omega
+        - xi
+        - diamond
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - star
+        - delta
+        - trident
+        - psi
+        - omega
+        - xi
+      - - psi
+        - xi
+        - diamond
+        - star
+        - delta
+        - omega
+      - - psi
+        - delta
+        - diamond
+        - omega
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - omega
+        - star
+        - xi
+        - psi
+      - - psi
+        - xi
+        - star
+        - diamond
+        - delta
+        - omega
+      - - psi
+        - xi
+        - diamond
+        - star
+        - delta
+        - omega
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - delta
+        - star
+      - - star
+        - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - delta
+        - psi
+        - diamond
+        - star
+        - omega
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-16.yaml
+++ b/packages/manual/data/daily/2027-02-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+      - - star
+        - omega
+        - psi
+        - trident
+        - xi
+        - delta
+      - - diamond
+        - delta
+        - star
+        - omega
+        - xi
+        - psi
+      - - diamond
+        - delta
+        - xi
+        - omega
+        - psi
+        - star
+      - - delta
+        - psi
+        - trident
+        - omega
+        - diamond
+        - xi
+      - - delta
+        - star
+        - xi
+        - psi
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+        - star
+      - - diamond
+        - star
+        - delta
+        - psi
+        - xi
+        - omega
+      - - psi
+        - diamond
+        - xi
+        - star
+        - omega
+        - delta
+      - - omega
+        - psi
+        - diamond
+        - star
+        - delta
+        - xi
+      - - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+        - star
+      - - diamond
+        - psi
+        - star
+        - xi
+        - omega
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-17.yaml
+++ b/packages/manual/data/daily/2027-02-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+        - trident
+      - - omega
+        - psi
+        - star
+        - diamond
+        - delta
+        - xi
+      - - psi
+        - star
+        - xi
+        - omega
+        - delta
+        - diamond
+      - - delta
+        - star
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - delta
+        - star
+        - omega
+        - diamond
+        - psi
+        - xi
+      - - omega
+        - star
+        - xi
+        - psi
+        - delta
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+        - star
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - diamond
+        - omega
+        - delta
+        - star
+        - psi
+        - xi
+      - - diamond
+        - delta
+        - psi
+        - star
+        - xi
+        - omega
+      - - xi
+        - star
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - xi
+        - omega
+        - star
+        - psi
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-18.yaml
+++ b/packages/manual/data/daily/2027-02-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - omega
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - omega
+        - star
+        - delta
+        - diamond
+        - psi
+        - xi
+      - - psi
+        - omega
+        - xi
+        - delta
+        - star
+        - trident
+      - - delta
+        - star
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - star
+        - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - star
+        - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - star
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - delta
+        - psi
+        - omega
+        - xi
+        - diamond
+        - star
+      - - star
+        - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - delta
+        - diamond
+        - star
+        - xi
+        - omega
+        - psi
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - star
+        - omega
+      - - psi
+        - star
+        - xi
+        - diamond
+        - delta
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-19.yaml
+++ b/packages/manual/data/daily/2027-02-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - star
+        - delta
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - xi
+        - star
+        - psi
+        - omega
+        - trident
+        - delta
+      - - diamond
+        - omega
+        - psi
+        - trident
+        - xi
+        - delta
+      - - diamond
+        - xi
+        - psi
+        - omega
+        - star
+        - delta
+      - - xi
+        - star
+        - psi
+        - delta
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - delta
+        - omega
+        - psi
+        - xi
+        - diamond
+      - - xi
+        - delta
+        - diamond
+        - star
+        - omega
+        - psi
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - star
+        - delta
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+        - star
+      - - star
+        - delta
+        - diamond
+        - psi
+        - xi
+        - omega
+      - - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-20.yaml
+++ b/packages/manual/data/daily/2027-02-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - delta
+        - star
+      - - star
+        - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+      - - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+        - star
+      - - psi
+        - trident
+        - star
+        - omega
+        - xi
+        - delta
+      - - xi
+        - psi
+        - omega
+        - delta
+        - star
+        - diamond
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - trident
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+        - star
+      - - xi
+        - omega
+        - psi
+        - delta
+        - diamond
+        - star
+      - - xi
+        - omega
+        - star
+        - diamond
+        - delta
+        - psi
+      - - omega
+        - psi
+        - diamond
+        - delta
+        - star
+        - xi
+      - - diamond
+        - delta
+        - star
+        - xi
+        - omega
+        - psi
+      - - diamond
+        - star
+        - omega
+        - xi
+        - psi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-21.yaml
+++ b/packages/manual/data/daily/2027-02-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - omega
+        - xi
+        - delta
+        - star
+        - psi
+      - - diamond
+        - xi
+        - psi
+        - star
+        - omega
+        - delta
+      - - star
+        - diamond
+        - xi
+        - omega
+        - delta
+        - psi
+      - - diamond
+        - omega
+        - xi
+        - star
+        - delta
+        - psi
+      - - omega
+        - delta
+        - star
+        - psi
+        - xi
+        - trident
+      - - trident
+        - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - delta
+        - xi
+        - diamond
+        - psi
+        - star
+      - - xi
+        - omega
+        - diamond
+        - star
+        - delta
+        - psi
+      - - delta
+        - star
+        - omega
+        - xi
+        - diamond
+        - psi
+      - - star
+        - diamond
+        - omega
+        - xi
+        - psi
+        - delta
+      - - diamond
+        - psi
+        - star
+        - omega
+        - delta
+        - xi
+      - - omega
+        - xi
+        - star
+        - delta
+        - diamond
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-22.yaml
+++ b/packages/manual/data/daily/2027-02-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - star
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - star
+        - psi
+        - trident
+        - omega
+        - xi
+        - delta
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - star
+        - psi
+      - - psi
+        - diamond
+        - trident
+        - xi
+        - delta
+        - omega
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+        - star
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - star
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - star
+        - delta
+      - - omega
+        - star
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - psi
+        - xi
+        - diamond
+        - star
+        - delta
+        - omega
+      - - star
+        - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+      - - delta
+        - xi
+        - psi
+        - star
+        - omega
+        - diamond
+      - - star
+        - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-23.yaml
+++ b/packages/manual/data/daily/2027-02-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - delta
+        - star
+        - psi
+        - xi
+        - omega
+      - - star
+        - psi
+        - delta
+        - diamond
+        - omega
+        - xi
+      - - omega
+        - psi
+        - delta
+        - trident
+        - xi
+        - star
+      - - delta
+        - star
+        - diamond
+        - xi
+        - omega
+        - psi
+      - - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+        - trident
+      - - psi
+        - star
+        - xi
+        - diamond
+        - omega
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - xi
+        - diamond
+        - star
+        - delta
+        - omega
+      - - omega
+        - psi
+        - diamond
+        - star
+        - xi
+        - delta
+      - - xi
+        - star
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - omega
+        - diamond
+        - psi
+        - star
+        - delta
+        - xi
+      - - delta
+        - xi
+        - psi
+        - star
+        - diamond
+        - omega
+      - - omega
+        - xi
+        - diamond
+        - star
+        - psi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-24.yaml
+++ b/packages/manual/data/daily/2027-02-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - xi
+        - star
+      - - delta
+        - psi
+        - trident
+        - omega
+        - diamond
+        - xi
+      - - delta
+        - psi
+        - diamond
+        - xi
+        - omega
+        - star
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - star
+        - xi
+      - - star
+        - trident
+        - delta
+        - psi
+        - xi
+        - omega
+      - - omega
+        - xi
+        - psi
+        - diamond
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - star
+        - delta
+        - omega
+        - xi
+      - - xi
+        - delta
+        - diamond
+        - star
+        - psi
+        - omega
+      - - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+        - star
+      - - diamond
+        - psi
+        - star
+        - xi
+        - omega
+        - delta
+      - - star
+        - delta
+        - diamond
+        - xi
+        - psi
+        - omega
+      - - diamond
+        - star
+        - xi
+        - delta
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-25.yaml
+++ b/packages/manual/data/daily/2027-02-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - star
+        - xi
+        - diamond
+        - psi
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - delta
+        - trident
+      - - psi
+        - omega
+        - diamond
+        - star
+        - delta
+        - xi
+      - - psi
+        - diamond
+        - omega
+        - delta
+        - star
+        - xi
+      - - delta
+        - psi
+        - star
+        - omega
+        - xi
+        - trident
+      - - psi
+        - diamond
+        - star
+        - xi
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - star
+        - omega
+        - xi
+        - psi
+      - - star
+        - delta
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - delta
+        - psi
+        - star
+        - omega
+        - diamond
+        - xi
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+        - star
+      - - omega
+        - psi
+        - diamond
+        - star
+        - xi
+        - delta
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-26.yaml
+++ b/packages/manual/data/daily/2027-02-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - xi
+        - star
+        - diamond
+        - omega
+      - - delta
+        - omega
+        - trident
+        - psi
+        - xi
+        - star
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - psi
+        - star
+      - - omega
+        - star
+        - diamond
+        - xi
+        - delta
+        - psi
+      - - delta
+        - psi
+        - omega
+        - trident
+        - diamond
+        - xi
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - xi
+        - omega
+        - delta
+        - psi
+      - - diamond
+        - psi
+        - xi
+        - star
+        - delta
+        - omega
+      - - psi
+        - xi
+        - star
+        - omega
+        - delta
+        - diamond
+      - - xi
+        - star
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - delta
+        - star
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-27.yaml
+++ b/packages/manual/data/daily/2027-02-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - trident
+        - psi
+        - diamond
+        - delta
+        - omega
+        - xi
+      - - delta
+        - omega
+        - psi
+        - star
+        - xi
+        - diamond
+      - - star
+        - diamond
+        - omega
+        - xi
+        - psi
+        - delta
+      - - psi
+        - delta
+        - star
+        - xi
+        - diamond
+        - omega
+      - - delta
+        - psi
+        - omega
+        - xi
+        - star
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+      - - diamond
+        - psi
+        - xi
+        - star
+        - delta
+        - omega
+      - - psi
+        - delta
+        - star
+        - xi
+        - omega
+        - diamond
+      - - omega
+        - psi
+        - star
+        - xi
+        - diamond
+        - delta
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - star
+        - delta
+      - - diamond
+        - xi
+        - psi
+        - omega
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-02-28.yaml
+++ b/packages/manual/data/daily/2027-02-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-02-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - trident
+        - omega
+      - - delta
+        - xi
+        - diamond
+        - psi
+        - star
+        - omega
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - star
+        - xi
+      - - diamond
+        - psi
+        - star
+        - xi
+        - delta
+        - omega
+      - - delta
+        - psi
+        - omega
+        - star
+        - xi
+        - trident
+      - - xi
+        - diamond
+        - star
+        - omega
+        - delta
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - delta
+        - star
+        - psi
+        - omega
+        - diamond
+      - - omega
+        - delta
+        - psi
+        - star
+        - diamond
+        - xi
+      - - delta
+        - omega
+        - star
+        - xi
+        - diamond
+        - psi
+      - - delta
+        - psi
+        - xi
+        - star
+        - omega
+        - diamond
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - star
+        - omega
+      - - diamond
+        - delta
+        - omega
+        - xi
+        - psi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-01.yaml
+++ b/packages/manual/data/daily/2027-03-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - trident
+        - delta
+        - omega
+        - psi
+        - diamond
+      - - star
+        - delta
+        - diamond
+        - xi
+        - omega
+        - psi
+      - - diamond
+        - xi
+        - omega
+        - delta
+        - star
+        - psi
+      - - xi
+        - delta
+        - psi
+        - omega
+        - star
+        - diamond
+      - - xi
+        - delta
+        - diamond
+        - star
+        - omega
+        - psi
+      - - omega
+        - xi
+        - star
+        - delta
+        - psi
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - psi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - star
+        - xi
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+        - star
+      - - xi
+        - omega
+        - psi
+        - delta
+        - diamond
+        - star
+      - - xi
+        - star
+        - diamond
+        - delta
+        - omega
+        - psi
+      - - xi
+        - psi
+        - delta
+        - star
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-02.yaml
+++ b/packages/manual/data/daily/2027-03-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - delta
+        - diamond
+        - psi
+        - omega
+        - xi
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+        - star
+      - - diamond
+        - star
+        - psi
+        - delta
+        - xi
+        - omega
+      - - xi
+        - psi
+        - omega
+        - delta
+        - diamond
+        - trident
+      - - psi
+        - xi
+        - star
+        - delta
+        - diamond
+        - omega
+      - - delta
+        - omega
+        - star
+        - trident
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - star
+        - omega
+        - psi
+        - diamond
+        - xi
+      - - star
+        - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+      - - diamond
+        - psi
+        - omega
+        - star
+        - delta
+        - xi
+      - - star
+        - psi
+        - delta
+        - xi
+        - diamond
+        - omega
+      - - diamond
+        - omega
+        - star
+        - delta
+        - xi
+        - psi
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-03.yaml
+++ b/packages/manual/data/daily/2027-03-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - psi
+        - trident
+        - diamond
+        - delta
+        - omega
+      - - delta
+        - omega
+        - star
+        - diamond
+        - psi
+        - xi
+      - - trident
+        - star
+        - delta
+        - omega
+        - psi
+        - xi
+      - - diamond
+        - psi
+        - omega
+        - star
+        - delta
+        - xi
+      - - xi
+        - psi
+        - delta
+        - star
+        - omega
+        - diamond
+      - - delta
+        - omega
+        - diamond
+        - star
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - psi
+        - star
+        - diamond
+        - delta
+        - omega
+      - - star
+        - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+      - - star
+        - psi
+        - xi
+        - diamond
+        - delta
+        - omega
+      - - diamond
+        - xi
+        - star
+        - omega
+        - delta
+        - psi
+      - - star
+        - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+      - - delta
+        - star
+        - diamond
+        - xi
+        - psi
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-04.yaml
+++ b/packages/manual/data/daily/2027-03-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - delta
+        - omega
+        - star
+        - xi
+        - psi
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - star
+        - psi
+      - - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+        - star
+      - - omega
+        - psi
+        - delta
+        - xi
+        - trident
+        - star
+      - - psi
+        - diamond
+        - trident
+        - delta
+        - omega
+        - xi
+      - - delta
+        - diamond
+        - xi
+        - star
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+        - star
+      - - diamond
+        - omega
+        - psi
+        - star
+        - xi
+        - delta
+      - - omega
+        - psi
+        - star
+        - delta
+        - xi
+        - diamond
+      - - xi
+        - psi
+        - star
+        - delta
+        - omega
+        - diamond
+      - - diamond
+        - omega
+        - star
+        - delta
+        - xi
+        - psi
+      - - omega
+        - diamond
+        - xi
+        - star
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-05.yaml
+++ b/packages/manual/data/daily/2027-03-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - star
+        - trident
+        - xi
+        - psi
+      - - psi
+        - star
+        - omega
+        - delta
+        - xi
+        - diamond
+      - - xi
+        - star
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+        - star
+      - - psi
+        - diamond
+        - star
+        - xi
+        - delta
+        - omega
+      - - diamond
+        - xi
+        - delta
+        - trident
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - psi
+        - xi
+        - delta
+        - diamond
+      - - star
+        - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+      - - star
+        - psi
+        - diamond
+        - xi
+        - omega
+        - delta
+      - - diamond
+        - star
+        - psi
+        - xi
+        - omega
+        - delta
+      - - diamond
+        - delta
+        - xi
+        - omega
+        - star
+        - psi
+      - - delta
+        - psi
+        - omega
+        - star
+        - xi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-06.yaml
+++ b/packages/manual/data/daily/2027-03-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - delta
+        - diamond
+        - psi
+        - omega
+        - xi
+      - - star
+        - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+      - - xi
+        - delta
+        - omega
+        - star
+        - trident
+        - psi
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - star
+        - delta
+      - - diamond
+        - omega
+        - delta
+        - xi
+        - star
+        - psi
+      - - xi
+        - diamond
+        - delta
+        - star
+        - psi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - xi
+        - diamond
+        - psi
+        - omega
+        - delta
+      - - omega
+        - psi
+        - star
+        - delta
+        - diamond
+        - xi
+      - - star
+        - delta
+        - diamond
+        - xi
+        - psi
+        - omega
+      - - xi
+        - star
+        - omega
+        - delta
+        - psi
+        - diamond
+      - - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+        - star
+      - - omega
+        - star
+        - psi
+        - xi
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-07.yaml
+++ b/packages/manual/data/daily/2027-03-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - xi
+        - trident
+        - diamond
+        - omega
+      - - delta
+        - omega
+        - star
+        - xi
+        - diamond
+        - psi
+      - - omega
+        - trident
+        - xi
+        - star
+        - psi
+        - delta
+      - - diamond
+        - psi
+        - star
+        - omega
+        - delta
+        - xi
+      - - xi
+        - star
+        - omega
+        - psi
+        - delta
+        - diamond
+      - - diamond
+        - xi
+        - psi
+        - delta
+        - star
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - omega
+        - psi
+        - delta
+        - diamond
+      - - delta
+        - omega
+        - star
+        - xi
+        - psi
+        - diamond
+      - - psi
+        - star
+        - omega
+        - delta
+        - diamond
+        - xi
+      - - delta
+        - omega
+        - star
+        - diamond
+        - xi
+        - psi
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - star
+        - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-08.yaml
+++ b/packages/manual/data/daily/2027-03-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - psi
+        - delta
+        - diamond
+        - omega
+      - - psi
+        - diamond
+        - trident
+        - xi
+        - omega
+        - delta
+      - - xi
+        - delta
+        - star
+        - omega
+        - diamond
+        - psi
+      - - star
+        - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+      - - delta
+        - psi
+        - star
+        - omega
+        - trident
+        - xi
+      - - xi
+        - diamond
+        - omega
+        - delta
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - star
+        - diamond
+        - psi
+        - xi
+      - - diamond
+        - star
+        - psi
+        - xi
+        - delta
+        - omega
+      - - psi
+        - star
+        - omega
+        - delta
+        - xi
+        - diamond
+      - - xi
+        - star
+        - psi
+        - omega
+        - delta
+        - diamond
+      - - star
+        - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+      - - star
+        - xi
+        - delta
+        - omega
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-09.yaml
+++ b/packages/manual/data/daily/2027-03-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - star
+        - delta
+        - diamond
+        - omega
+        - xi
+      - - xi
+        - star
+        - psi
+        - diamond
+        - delta
+        - omega
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+        - star
+      - - trident
+        - delta
+        - psi
+        - xi
+        - star
+        - omega
+      - - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+        - trident
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - diamond
+        - star
+        - omega
+        - xi
+      - - psi
+        - star
+        - xi
+        - delta
+        - omega
+        - diamond
+      - - psi
+        - diamond
+        - delta
+        - star
+        - xi
+        - omega
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - star
+      - - omega
+        - star
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-10.yaml
+++ b/packages/manual/data/daily/2027-03-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - star
+        - delta
+        - diamond
+        - omega
+        - xi
+      - - star
+        - psi
+        - omega
+        - xi
+        - delta
+        - diamond
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - trident
+        - delta
+      - - omega
+        - xi
+        - psi
+        - star
+        - delta
+        - diamond
+      - - delta
+        - psi
+        - star
+        - omega
+        - xi
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - omega
+        - star
+        - xi
+        - psi
+      - - xi
+        - star
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - delta
+        - star
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - psi
+        - xi
+        - star
+        - omega
+        - delta
+        - diamond
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+        - star
+      - - omega
+        - delta
+        - xi
+        - star
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-11.yaml
+++ b/packages/manual/data/daily/2027-03-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+      - - delta
+        - star
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - star
+        - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+      - - psi
+        - omega
+        - delta
+        - star
+        - xi
+        - trident
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - trident
+        - delta
+      - - xi
+        - omega
+        - star
+        - psi
+        - diamond
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - star
+        - xi
+        - omega
+        - psi
+      - - psi
+        - diamond
+        - omega
+        - delta
+        - xi
+        - star
+      - - psi
+        - star
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - delta
+        - diamond
+        - star
+        - omega
+        - xi
+        - psi
+      - - xi
+        - diamond
+        - star
+        - psi
+        - omega
+        - delta
+      - - psi
+        - delta
+        - star
+        - xi
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-12.yaml
+++ b/packages/manual/data/daily/2027-03-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - delta
+        - trident
+        - xi
+        - omega
+        - psi
+      - - xi
+        - omega
+        - star
+        - psi
+        - delta
+        - diamond
+      - - omega
+        - delta
+        - xi
+        - star
+        - diamond
+        - psi
+      - - xi
+        - omega
+        - delta
+        - trident
+        - psi
+        - star
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - star
+        - omega
+      - - omega
+        - diamond
+        - star
+        - delta
+        - psi
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - psi
+        - star
+        - xi
+        - diamond
+      - - delta
+        - xi
+        - diamond
+        - psi
+        - star
+        - omega
+      - - omega
+        - star
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - psi
+        - star
+        - diamond
+        - delta
+        - omega
+        - xi
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - delta
+        - star
+      - - star
+        - xi
+        - diamond
+        - psi
+        - omega
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-13.yaml
+++ b/packages/manual/data/daily/2027-03-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - star
+        - delta
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+        - star
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+        - star
+      - - diamond
+        - omega
+        - trident
+        - delta
+        - psi
+        - xi
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - star
+        - xi
+      - - delta
+        - xi
+        - psi
+        - trident
+        - star
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - diamond
+        - psi
+        - star
+        - delta
+        - xi
+      - - star
+        - diamond
+        - psi
+        - xi
+        - delta
+        - omega
+      - - star
+        - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+      - - omega
+        - delta
+        - diamond
+        - star
+        - psi
+        - xi
+      - - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+        - star
+      - - omega
+        - star
+        - delta
+        - xi
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-14.yaml
+++ b/packages/manual/data/daily/2027-03-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - omega
+        - psi
+        - delta
+        - diamond
+        - star
+      - - psi
+        - star
+        - delta
+        - xi
+        - diamond
+        - omega
+      - - xi
+        - psi
+        - delta
+        - omega
+        - star
+        - diamond
+      - - psi
+        - delta
+        - trident
+        - diamond
+        - omega
+        - xi
+      - - star
+        - delta
+        - xi
+        - psi
+        - trident
+        - omega
+      - - omega
+        - diamond
+        - psi
+        - star
+        - xi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+      - - psi
+        - delta
+        - omega
+        - xi
+        - star
+        - diamond
+      - - diamond
+        - star
+        - delta
+        - omega
+        - psi
+        - xi
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - star
+        - xi
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - omega
+        - star
+      - - psi
+        - xi
+        - delta
+        - star
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-15.yaml
+++ b/packages/manual/data/daily/2027-03-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - diamond
+        - psi
+        - omega
+        - delta
+        - star
+      - - psi
+        - xi
+        - omega
+        - trident
+        - delta
+        - star
+      - - psi
+        - diamond
+        - star
+        - omega
+        - xi
+        - delta
+      - - xi
+        - delta
+        - psi
+        - star
+        - diamond
+        - omega
+      - - omega
+        - diamond
+        - star
+        - delta
+        - psi
+        - xi
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - trident
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - diamond
+      - - omega
+        - star
+        - diamond
+        - psi
+        - delta
+        - xi
+      - - xi
+        - omega
+        - psi
+        - delta
+        - diamond
+        - star
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+        - star
+      - - delta
+        - star
+        - psi
+        - diamond
+        - xi
+        - omega
+      - - star
+        - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-16.yaml
+++ b/packages/manual/data/daily/2027-03-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+        - trident
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+        - star
+      - - delta
+        - psi
+        - star
+        - xi
+        - trident
+        - omega
+      - - diamond
+        - xi
+        - star
+        - delta
+        - omega
+        - psi
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - star
+        - omega
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - omega
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - omega
+        - star
+        - psi
+        - delta
+      - - diamond
+        - xi
+        - delta
+        - omega
+        - psi
+        - star
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+      - - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+        - star
+      - - diamond
+        - star
+        - omega
+        - psi
+        - xi
+        - delta
+      - - diamond
+        - omega
+        - psi
+        - delta
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-17.yaml
+++ b/packages/manual/data/daily/2027-03-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - delta
+        - star
+      - - delta
+        - star
+        - psi
+        - omega
+        - xi
+        - diamond
+      - - trident
+        - psi
+        - delta
+        - xi
+        - diamond
+        - omega
+      - - psi
+        - star
+        - omega
+        - delta
+        - trident
+        - xi
+      - - omega
+        - diamond
+        - xi
+        - star
+        - psi
+        - delta
+      - - psi
+        - star
+        - xi
+        - diamond
+        - omega
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - star
+        - delta
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - diamond
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - star
+        - psi
+      - - omega
+        - diamond
+        - star
+        - xi
+        - psi
+        - delta
+      - - xi
+        - diamond
+        - star
+        - psi
+        - delta
+        - omega
+      - - diamond
+        - delta
+        - psi
+        - xi
+        - star
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-18.yaml
+++ b/packages/manual/data/daily/2027-03-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - trident
+        - omega
+        - star
+        - delta
+        - xi
+      - - xi
+        - omega
+        - psi
+        - trident
+        - delta
+        - diamond
+      - - omega
+        - delta
+        - xi
+        - diamond
+        - psi
+        - star
+      - - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+        - star
+      - - star
+        - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - star
+        - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - star
+        - psi
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - diamond
+      - - xi
+        - diamond
+        - omega
+        - star
+        - psi
+        - delta
+      - - star
+        - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+      - - diamond
+        - star
+        - delta
+        - xi
+        - psi
+        - omega
+      - - xi
+        - star
+        - delta
+        - psi
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-19.yaml
+++ b/packages/manual/data/daily/2027-03-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - star
+        - xi
+        - trident
+        - psi
+      - - star
+        - xi
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - diamond
+        - omega
+        - star
+        - xi
+        - delta
+        - psi
+      - - diamond
+        - xi
+        - star
+        - delta
+        - psi
+        - omega
+      - - diamond
+        - psi
+        - omega
+        - xi
+        - star
+        - delta
+      - - xi
+        - omega
+        - delta
+        - trident
+        - psi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - diamond
+        - psi
+        - omega
+        - star
+        - delta
+      - - psi
+        - delta
+        - omega
+        - xi
+        - star
+        - diamond
+      - - star
+        - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - star
+        - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - omega
+        - psi
+        - star
+        - delta
+        - diamond
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-20.yaml
+++ b/packages/manual/data/daily/2027-03-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - delta
+        - xi
+        - psi
+        - star
+        - diamond
+        - omega
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+        - star
+      - - trident
+        - psi
+        - omega
+        - xi
+        - star
+        - delta
+      - - diamond
+        - xi
+        - trident
+        - omega
+        - psi
+        - delta
+      - - xi
+        - psi
+        - delta
+        - star
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - star
+        - xi
+      - - diamond
+        - psi
+        - star
+        - delta
+        - omega
+        - xi
+      - - star
+        - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+      - - delta
+        - xi
+        - star
+        - omega
+        - diamond
+        - psi
+      - - psi
+        - diamond
+        - star
+        - delta
+        - xi
+        - omega
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-21.yaml
+++ b/packages/manual/data/daily/2027-03-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - omega
+        - trident
+      - - omega
+        - diamond
+        - star
+        - xi
+        - delta
+        - psi
+      - - psi
+        - omega
+        - diamond
+        - star
+        - xi
+        - delta
+      - - psi
+        - star
+        - omega
+        - diamond
+        - delta
+        - xi
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+        - star
+      - - psi
+        - omega
+        - xi
+        - trident
+        - star
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - star
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - delta
+        - psi
+        - star
+        - omega
+        - xi
+        - diamond
+      - - psi
+        - delta
+        - star
+        - diamond
+        - omega
+        - xi
+      - - star
+        - diamond
+        - omega
+        - delta
+        - xi
+        - psi
+      - - omega
+        - diamond
+        - psi
+        - star
+        - xi
+        - delta
+      - - psi
+        - xi
+        - delta
+        - star
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-22.yaml
+++ b/packages/manual/data/daily/2027-03-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - omega
+        - psi
+        - diamond
+        - delta
+        - xi
+      - - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+        - trident
+      - - xi
+        - psi
+        - star
+        - delta
+        - diamond
+        - omega
+      - - trident
+        - star
+        - omega
+        - delta
+        - xi
+        - psi
+      - - xi
+        - omega
+        - psi
+        - star
+        - diamond
+        - delta
+      - - star
+        - omega
+        - diamond
+        - xi
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - delta
+        - omega
+        - xi
+        - psi
+      - - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+        - star
+      - - omega
+        - star
+        - psi
+        - delta
+        - xi
+        - diamond
+      - - psi
+        - star
+        - omega
+        - diamond
+        - xi
+        - delta
+      - - star
+        - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+      - - omega
+        - diamond
+        - xi
+        - delta
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-23.yaml
+++ b/packages/manual/data/daily/2027-03-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - omega
+        - delta
+        - psi
+        - star
+        - diamond
+      - - diamond
+        - trident
+        - psi
+        - omega
+        - xi
+        - delta
+      - - omega
+        - psi
+        - diamond
+        - delta
+        - star
+        - xi
+      - - omega
+        - star
+        - xi
+        - psi
+        - diamond
+        - delta
+      - - omega
+        - star
+        - psi
+        - diamond
+        - xi
+        - delta
+      - - trident
+        - delta
+        - xi
+        - psi
+        - omega
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - delta
+        - star
+        - omega
+        - xi
+      - - diamond
+        - xi
+        - omega
+        - star
+        - psi
+        - delta
+      - - delta
+        - omega
+        - xi
+        - diamond
+        - psi
+        - star
+      - - diamond
+        - psi
+        - star
+        - delta
+        - xi
+        - omega
+      - - omega
+        - xi
+        - diamond
+        - star
+        - delta
+        - psi
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - omega
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-24.yaml
+++ b/packages/manual/data/daily/2027-03-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - xi
+        - star
+        - delta
+        - trident
+      - - psi
+        - delta
+        - star
+        - diamond
+        - xi
+        - omega
+      - - xi
+        - delta
+        - diamond
+        - omega
+        - psi
+        - star
+      - - delta
+        - xi
+        - omega
+        - psi
+        - star
+        - diamond
+      - - trident
+        - diamond
+        - omega
+        - delta
+        - xi
+        - psi
+      - - delta
+        - omega
+        - diamond
+        - xi
+        - star
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - delta
+        - psi
+        - omega
+        - xi
+      - - omega
+        - diamond
+        - delta
+        - xi
+        - star
+        - psi
+      - - xi
+        - delta
+        - star
+        - diamond
+        - omega
+        - psi
+      - - omega
+        - psi
+        - delta
+        - star
+        - diamond
+        - xi
+      - - star
+        - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+      - - xi
+        - star
+        - diamond
+        - omega
+        - psi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-25.yaml
+++ b/packages/manual/data/daily/2027-03-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - star
+        - trident
+        - xi
+        - delta
+        - omega
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - star
+        - omega
+      - - diamond
+        - delta
+        - omega
+        - trident
+        - psi
+        - xi
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - delta
+        - star
+      - - delta
+        - star
+        - psi
+        - diamond
+        - omega
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - psi
+        - xi
+        - omega
+        - delta
+      - - delta
+        - star
+        - diamond
+        - psi
+        - xi
+        - omega
+      - - xi
+        - diamond
+        - star
+        - psi
+        - delta
+        - omega
+      - - diamond
+        - omega
+        - star
+        - xi
+        - psi
+        - delta
+      - - omega
+        - star
+        - delta
+        - diamond
+        - psi
+        - xi
+      - - psi
+        - delta
+        - omega
+        - star
+        - diamond
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-26.yaml
+++ b/packages/manual/data/daily/2027-03-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - delta
+        - psi
+        - omega
+        - trident
+        - xi
+        - star
+      - - diamond
+        - psi
+        - star
+        - omega
+        - delta
+        - xi
+      - - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+        - star
+      - - xi
+        - omega
+        - trident
+        - diamond
+        - delta
+        - psi
+      - - omega
+        - star
+        - diamond
+        - psi
+        - xi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - diamond
+        - psi
+        - omega
+        - delta
+      - - xi
+        - omega
+        - delta
+        - diamond
+        - star
+        - psi
+      - - delta
+        - xi
+        - omega
+        - star
+        - diamond
+        - psi
+      - - diamond
+        - omega
+        - delta
+        - star
+        - xi
+        - psi
+      - - psi
+        - omega
+        - star
+        - delta
+        - diamond
+        - xi
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-27.yaml
+++ b/packages/manual/data/daily/2027-03-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - trident
+        - delta
+      - - star
+        - psi
+        - diamond
+        - omega
+        - delta
+        - xi
+      - - xi
+        - omega
+        - diamond
+        - delta
+        - star
+        - psi
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - star
+        - xi
+      - - delta
+        - psi
+        - star
+        - xi
+        - diamond
+        - omega
+      - - star
+        - trident
+        - psi
+        - delta
+        - xi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - star
+        - omega
+      - - xi
+        - star
+        - diamond
+        - omega
+        - delta
+        - psi
+      - - delta
+        - omega
+        - diamond
+        - star
+        - xi
+        - psi
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+        - star
+      - - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-28.yaml
+++ b/packages/manual/data/daily/2027-03-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - psi
+        - star
+        - xi
+        - omega
+        - delta
+      - - xi
+        - trident
+        - psi
+        - star
+        - omega
+        - delta
+      - - diamond
+        - xi
+        - star
+        - delta
+        - psi
+        - omega
+      - - delta
+        - psi
+        - star
+        - xi
+        - diamond
+        - omega
+      - - xi
+        - trident
+        - delta
+        - psi
+        - omega
+        - diamond
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - omega
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+      - - xi
+        - omega
+        - star
+        - delta
+        - diamond
+        - psi
+      - - omega
+        - delta
+        - psi
+        - xi
+        - diamond
+        - star
+      - - diamond
+        - xi
+        - delta
+        - star
+        - psi
+        - omega
+      - - delta
+        - xi
+        - star
+        - diamond
+        - omega
+        - psi
+      - - xi
+        - delta
+        - omega
+        - psi
+        - star
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-29.yaml
+++ b/packages/manual/data/daily/2027-03-29.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-29'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - star
+        - delta
+      - - psi
+        - omega
+        - xi
+        - delta
+        - diamond
+        - star
+      - - delta
+        - psi
+        - star
+        - xi
+        - diamond
+        - omega
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+        - trident
+      - - xi
+        - trident
+        - psi
+        - omega
+        - star
+        - delta
+      - - star
+        - omega
+        - psi
+        - delta
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - xi
+        - star
+        - delta
+        - diamond
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - xi
+        - star
+      - - psi
+        - star
+        - xi
+        - delta
+        - diamond
+        - omega
+      - - omega
+        - diamond
+        - psi
+        - xi
+        - star
+        - delta
+      - - psi
+        - omega
+        - star
+        - xi
+        - delta
+        - diamond
+      - - delta
+        - star
+        - diamond
+        - omega
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-30.yaml
+++ b/packages/manual/data/daily/2027-03-30.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-30'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - xi
+        - trident
+        - omega
+        - psi
+        - star
+      - - xi
+        - delta
+        - omega
+        - psi
+        - star
+        - diamond
+      - - diamond
+        - star
+        - psi
+        - omega
+        - delta
+        - xi
+      - - delta
+        - xi
+        - trident
+        - diamond
+        - psi
+        - omega
+      - - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+        - star
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - xi
+        - star
+      - - psi
+        - diamond
+        - delta
+        - omega
+        - xi
+        - star
+      - - delta
+        - omega
+        - xi
+        - star
+        - diamond
+        - psi
+      - - omega
+        - xi
+        - star
+        - diamond
+        - delta
+        - psi
+      - - omega
+        - xi
+        - delta
+        - psi
+        - star
+        - diamond
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-03-31.yaml
+++ b/packages/manual/data/daily/2027-03-31.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-03-31'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - diamond
+        - psi
+        - star
+        - xi
+      - - psi
+        - xi
+        - trident
+        - diamond
+        - delta
+        - omega
+      - - star
+        - omega
+        - delta
+        - diamond
+        - psi
+        - xi
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - omega
+        - star
+      - - psi
+        - star
+        - omega
+        - xi
+        - delta
+        - diamond
+      - - delta
+        - xi
+        - psi
+        - omega
+        - star
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - delta
+        - star
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - star
+        - delta
+      - - delta
+        - star
+        - omega
+        - xi
+        - diamond
+        - psi
+      - - omega
+        - star
+        - delta
+        - diamond
+        - psi
+        - xi
+      - - diamond
+        - xi
+        - star
+        - psi
+        - omega
+        - delta
+      - - star
+        - omega
+        - psi
+        - diamond
+        - xi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-01.yaml
+++ b/packages/manual/data/daily/2027-04-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - star
+        - xi
+        - psi
+        - delta
+        - diamond
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - omega
+        - star
+      - - star
+        - psi
+        - xi
+        - trident
+        - delta
+        - omega
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+        - star
+      - - psi
+        - xi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - trident
+        - psi
+        - omega
+        - delta
+        - diamond
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - psi
+        - omega
+        - diamond
+        - delta
+      - - star
+        - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+      - - diamond
+        - psi
+        - omega
+        - star
+        - delta
+        - xi
+      - - delta
+        - omega
+        - psi
+        - star
+        - diamond
+        - xi
+      - - omega
+        - star
+        - diamond
+        - delta
+        - xi
+        - psi
+      - - omega
+        - star
+        - xi
+        - delta
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-02.yaml
+++ b/packages/manual/data/daily/2027-04-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - star
+        - psi
+        - omega
+        - delta
+        - xi
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - trident
+      - - omega
+        - star
+        - xi
+        - delta
+        - psi
+        - diamond
+      - - diamond
+        - xi
+        - omega
+        - delta
+        - psi
+        - trident
+      - - star
+        - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+      - - xi
+        - star
+        - psi
+        - omega
+        - diamond
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - star
+        - xi
+      - - psi
+        - delta
+        - star
+        - diamond
+        - xi
+        - omega
+      - - xi
+        - psi
+        - omega
+        - star
+        - delta
+        - diamond
+      - - delta
+        - xi
+        - psi
+        - star
+        - omega
+        - diamond
+      - - diamond
+        - psi
+        - star
+        - xi
+        - delta
+        - omega
+      - - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-03.yaml
+++ b/packages/manual/data/daily/2027-04-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - star
+        - trident
+        - omega
+        - psi
+        - xi
+      - - omega
+        - psi
+        - delta
+        - xi
+        - star
+        - diamond
+      - - omega
+        - delta
+        - diamond
+        - star
+        - xi
+        - psi
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - star
+        - omega
+      - - delta
+        - psi
+        - star
+        - omega
+        - xi
+        - diamond
+      - - psi
+        - trident
+        - delta
+        - xi
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - star
+        - psi
+        - omega
+        - xi
+        - delta
+      - - omega
+        - diamond
+        - star
+        - psi
+        - xi
+        - delta
+      - - delta
+        - xi
+        - star
+        - omega
+        - psi
+        - diamond
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+        - star
+      - - omega
+        - star
+        - delta
+        - xi
+        - psi
+        - diamond
+      - - delta
+        - psi
+        - star
+        - xi
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-04.yaml
+++ b/packages/manual/data/daily/2027-04-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - star
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - star
+        - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+      - - xi
+        - psi
+        - star
+        - diamond
+        - delta
+        - omega
+      - - omega
+        - trident
+        - star
+        - xi
+        - delta
+        - psi
+      - - psi
+        - delta
+        - omega
+        - trident
+        - diamond
+        - xi
+      - - xi
+        - delta
+        - star
+        - diamond
+        - psi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - diamond
+        - psi
+        - delta
+        - xi
+      - - omega
+        - diamond
+        - star
+        - xi
+        - psi
+        - delta
+      - - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+        - star
+      - - omega
+        - delta
+        - psi
+        - star
+        - diamond
+        - xi
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - xi
+        - star
+      - - xi
+        - star
+        - diamond
+        - omega
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-05.yaml
+++ b/packages/manual/data/daily/2027-04-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - omega
+        - star
+      - - star
+        - xi
+        - psi
+        - trident
+        - delta
+        - omega
+      - - omega
+        - delta
+        - xi
+        - diamond
+        - star
+        - psi
+      - - omega
+        - trident
+        - delta
+        - diamond
+        - xi
+        - psi
+      - - delta
+        - omega
+        - xi
+        - star
+        - diamond
+        - psi
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - psi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - star
+        - omega
+        - delta
+        - psi
+      - - psi
+        - xi
+        - star
+        - delta
+        - omega
+        - diamond
+      - - star
+        - omega
+        - delta
+        - xi
+        - diamond
+        - psi
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - star
+        - xi
+      - - psi
+        - xi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - star
+        - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-06.yaml
+++ b/packages/manual/data/daily/2027-04-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - star
+        - delta
+      - - diamond
+        - xi
+        - trident
+        - delta
+        - psi
+        - omega
+      - - star
+        - diamond
+        - xi
+        - delta
+        - omega
+        - psi
+      - - star
+        - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+      - - omega
+        - star
+        - diamond
+        - delta
+        - psi
+        - xi
+      - - xi
+        - psi
+        - trident
+        - delta
+        - star
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - delta
+        - diamond
+        - psi
+        - star
+        - xi
+      - - omega
+        - psi
+        - xi
+        - star
+        - diamond
+        - delta
+      - - omega
+        - star
+        - delta
+        - psi
+        - xi
+        - diamond
+      - - xi
+        - omega
+        - psi
+        - star
+        - delta
+        - diamond
+      - - star
+        - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+      - - star
+        - psi
+        - xi
+        - delta
+        - omega
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-07.yaml
+++ b/packages/manual/data/daily/2027-04-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - diamond
+        - delta
+        - omega
+        - xi
+        - star
+      - - xi
+        - delta
+        - star
+        - diamond
+        - omega
+        - psi
+      - - delta
+        - diamond
+        - star
+        - psi
+        - xi
+        - omega
+      - - psi
+        - xi
+        - diamond
+        - omega
+        - trident
+        - delta
+      - - diamond
+        - xi
+        - star
+        - delta
+        - omega
+        - psi
+      - - delta
+        - xi
+        - trident
+        - psi
+        - star
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+        - star
+      - - delta
+        - star
+        - xi
+        - diamond
+        - psi
+        - omega
+      - - diamond
+        - omega
+        - delta
+        - star
+        - xi
+        - psi
+      - - xi
+        - omega
+        - diamond
+        - psi
+        - delta
+        - star
+      - - psi
+        - delta
+        - diamond
+        - star
+        - omega
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-08.yaml
+++ b/packages/manual/data/daily/2027-04-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - delta
+        - omega
+        - xi
+        - psi
+        - trident
+      - - delta
+        - xi
+        - psi
+        - trident
+        - diamond
+        - omega
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - omega
+        - star
+      - - omega
+        - psi
+        - star
+        - diamond
+        - xi
+        - delta
+      - - delta
+        - xi
+        - star
+        - diamond
+        - psi
+        - omega
+      - - delta
+        - diamond
+        - omega
+        - psi
+        - star
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - diamond
+        - delta
+        - xi
+        - omega
+      - - omega
+        - star
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - delta
+        - omega
+        - xi
+        - diamond
+        - star
+        - psi
+      - - star
+        - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+      - - star
+        - omega
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - delta
+        - diamond
+        - psi
+        - star
+        - xi
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-09.yaml
+++ b/packages/manual/data/daily/2027-04-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+        - star
+      - - star
+        - diamond
+        - delta
+        - psi
+        - xi
+        - omega
+      - - omega
+        - star
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - xi
+        - omega
+        - diamond
+        - delta
+        - trident
+        - psi
+      - - omega
+        - star
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - trident
+        - xi
+        - psi
+        - omega
+        - star
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - omega
+        - delta
+        - diamond
+        - xi
+      - - star
+        - psi
+        - omega
+        - xi
+        - diamond
+        - delta
+      - - omega
+        - delta
+        - xi
+        - star
+        - diamond
+        - psi
+      - - star
+        - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+      - - omega
+        - star
+        - diamond
+        - xi
+        - psi
+        - delta
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-10.yaml
+++ b/packages/manual/data/daily/2027-04-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - psi
+        - star
+        - xi
+        - diamond
+      - - xi
+        - psi
+        - star
+        - diamond
+        - omega
+        - delta
+      - - diamond
+        - xi
+        - psi
+        - star
+        - omega
+        - delta
+      - - psi
+        - xi
+        - star
+        - trident
+        - omega
+        - delta
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - trident
+        - omega
+      - - diamond
+        - delta
+        - psi
+        - omega
+        - xi
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - star
+        - xi
+        - omega
+        - delta
+      - - omega
+        - psi
+        - delta
+        - star
+        - xi
+        - diamond
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - star
+        - delta
+      - - psi
+        - star
+        - delta
+        - omega
+        - diamond
+        - xi
+      - - psi
+        - star
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - xi
+        - delta
+        - star
+        - diamond
+        - omega
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-11.yaml
+++ b/packages/manual/data/daily/2027-04-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - diamond
+        - psi
+        - delta
+        - xi
+        - omega
+      - - psi
+        - xi
+        - omega
+        - delta
+        - star
+        - trident
+      - - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+        - trident
+      - - delta
+        - omega
+        - xi
+        - psi
+        - diamond
+        - star
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+      - - delta
+        - xi
+        - diamond
+        - star
+        - psi
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - diamond
+        - psi
+        - xi
+        - star
+        - delta
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - star
+        - xi
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+        - star
+      - - star
+        - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+      - - diamond
+        - omega
+        - psi
+        - star
+        - delta
+        - xi
+      - - omega
+        - delta
+        - diamond
+        - star
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-12.yaml
+++ b/packages/manual/data/daily/2027-04-12.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-12'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - xi
+        - diamond
+        - delta
+        - omega
+        - star
+      - - star
+        - delta
+        - psi
+        - omega
+        - diamond
+        - xi
+      - - xi
+        - star
+        - omega
+        - psi
+        - delta
+        - trident
+      - - omega
+        - xi
+        - star
+        - psi
+        - delta
+        - diamond
+      - - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+        - star
+      - - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - xi
+        - psi
+        - star
+        - omega
+        - diamond
+      - - diamond
+        - star
+        - omega
+        - delta
+        - psi
+        - xi
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - diamond
+      - - star
+        - psi
+        - xi
+        - diamond
+        - delta
+        - omega
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - star
+        - psi
+      - - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-13.yaml
+++ b/packages/manual/data/daily/2027-04-13.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-13'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - psi
+        - omega
+        - diamond
+        - trident
+      - - delta
+        - trident
+        - xi
+        - omega
+        - star
+        - psi
+      - - star
+        - delta
+        - diamond
+        - xi
+        - omega
+        - psi
+      - - star
+        - psi
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - delta
+        - xi
+        - omega
+        - psi
+        - diamond
+        - star
+      - - psi
+        - omega
+        - star
+        - delta
+        - xi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+        - star
+      - - delta
+        - star
+        - omega
+        - psi
+        - xi
+        - diamond
+      - - psi
+        - omega
+        - xi
+        - delta
+        - star
+        - diamond
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - xi
+        - star
+      - - star
+        - omega
+        - diamond
+        - psi
+        - xi
+        - delta
+      - - omega
+        - star
+        - diamond
+        - delta
+        - xi
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-14.yaml
+++ b/packages/manual/data/daily/2027-04-14.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-14'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - xi
+        - omega
+        - trident
+        - delta
+        - star
+      - - diamond
+        - omega
+        - psi
+        - star
+        - xi
+        - delta
+      - - psi
+        - diamond
+        - star
+        - xi
+        - omega
+        - delta
+      - - omega
+        - delta
+        - diamond
+        - star
+        - psi
+        - xi
+      - - delta
+        - omega
+        - star
+        - diamond
+        - xi
+        - psi
+      - - psi
+        - omega
+        - trident
+        - delta
+        - diamond
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - omega
+        - star
+        - psi
+        - xi
+      - - star
+        - delta
+        - xi
+        - psi
+        - diamond
+        - omega
+      - - omega
+        - diamond
+        - star
+        - delta
+        - psi
+        - xi
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+        - star
+      - - delta
+        - omega
+        - xi
+        - star
+        - diamond
+        - psi
+      - - omega
+        - star
+        - psi
+        - xi
+        - diamond
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-15.yaml
+++ b/packages/manual/data/daily/2027-04-15.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-15'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - trident
+        - star
+        - delta
+        - omega
+        - psi
+      - - delta
+        - trident
+        - omega
+        - diamond
+        - xi
+        - psi
+      - - delta
+        - star
+        - diamond
+        - omega
+        - xi
+        - psi
+      - - psi
+        - xi
+        - star
+        - diamond
+        - omega
+        - delta
+      - - xi
+        - delta
+        - psi
+        - diamond
+        - omega
+        - star
+      - - star
+        - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - psi
+        - xi
+        - star
+        - diamond
+      - - delta
+        - star
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - xi
+        - diamond
+        - psi
+        - star
+        - delta
+        - omega
+      - - diamond
+        - delta
+        - xi
+        - psi
+        - star
+        - omega
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+        - star
+      - - delta
+        - omega
+        - xi
+        - diamond
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-16.yaml
+++ b/packages/manual/data/daily/2027-04-16.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-16'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - delta
+        - omega
+        - star
+        - psi
+      - - delta
+        - xi
+        - diamond
+        - psi
+        - star
+        - omega
+      - - psi
+        - star
+        - omega
+        - delta
+        - trident
+        - xi
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - trident
+        - psi
+      - - xi
+        - diamond
+        - psi
+        - star
+        - omega
+        - delta
+      - - star
+        - diamond
+        - xi
+        - psi
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - star
+        - xi
+      - - diamond
+        - star
+        - omega
+        - psi
+        - delta
+        - xi
+      - - delta
+        - omega
+        - diamond
+        - psi
+        - star
+        - xi
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - star
+        - omega
+      - - xi
+        - psi
+        - delta
+        - omega
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-17.yaml
+++ b/packages/manual/data/daily/2027-04-17.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-17'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - delta
+        - psi
+        - xi
+        - omega
+        - star
+      - - diamond
+        - star
+        - xi
+        - omega
+        - psi
+        - delta
+      - - xi
+        - trident
+        - star
+        - delta
+        - psi
+        - omega
+      - - omega
+        - xi
+        - trident
+        - psi
+        - diamond
+        - delta
+      - - xi
+        - star
+        - delta
+        - omega
+        - diamond
+        - psi
+      - - delta
+        - omega
+        - diamond
+        - star
+        - psi
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - omega
+        - xi
+        - star
+        - psi
+      - - xi
+        - diamond
+        - omega
+        - psi
+        - star
+        - delta
+      - - star
+        - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+      - - diamond
+        - psi
+        - xi
+        - star
+        - delta
+        - omega
+      - - xi
+        - star
+        - delta
+        - diamond
+        - omega
+        - psi
+      - - diamond
+        - xi
+        - delta
+        - star
+        - psi
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-18.yaml
+++ b/packages/manual/data/daily/2027-04-18.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-18'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - psi
+        - omega
+        - diamond
+        - star
+        - xi
+      - - psi
+        - delta
+        - trident
+        - star
+        - omega
+        - xi
+      - - psi
+        - diamond
+        - delta
+        - xi
+        - trident
+        - omega
+      - - delta
+        - diamond
+        - star
+        - xi
+        - omega
+        - psi
+      - - omega
+        - xi
+        - star
+        - diamond
+        - psi
+        - delta
+      - - omega
+        - delta
+        - star
+        - xi
+        - psi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+      - - star
+        - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+      - - delta
+        - diamond
+        - psi
+        - xi
+        - omega
+        - star
+      - - omega
+        - star
+        - diamond
+        - delta
+        - xi
+        - psi
+      - - xi
+        - delta
+        - diamond
+        - star
+        - psi
+        - omega
+      - - omega
+        - star
+        - diamond
+        - psi
+        - xi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-19.yaml
+++ b/packages/manual/data/daily/2027-04-19.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-19'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - delta
+        - trident
+        - omega
+        - diamond
+        - psi
+      - - star
+        - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+      - - diamond
+        - star
+        - omega
+        - delta
+        - xi
+        - psi
+      - - xi
+        - diamond
+        - psi
+        - star
+        - delta
+        - omega
+      - - omega
+        - delta
+        - psi
+        - xi
+        - trident
+        - star
+      - - star
+        - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - star
+        - delta
+        - diamond
+        - omega
+        - xi
+      - - delta
+        - diamond
+        - star
+        - psi
+        - xi
+        - omega
+      - - diamond
+        - star
+        - omega
+        - delta
+        - xi
+        - psi
+      - - xi
+        - star
+        - omega
+        - diamond
+        - psi
+        - delta
+      - - star
+        - psi
+        - diamond
+        - delta
+        - omega
+        - xi
+      - - xi
+        - omega
+        - diamond
+        - delta
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-20.yaml
+++ b/packages/manual/data/daily/2027-04-20.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-20'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - psi
+        - star
+        - diamond
+        - delta
+      - - xi
+        - psi
+        - omega
+        - delta
+        - trident
+        - star
+      - - psi
+        - diamond
+        - xi
+        - delta
+        - star
+        - omega
+      - - diamond
+        - star
+        - psi
+        - omega
+        - delta
+        - xi
+      - - psi
+        - diamond
+        - star
+        - delta
+        - xi
+        - omega
+      - - diamond
+        - delta
+        - trident
+        - xi
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - delta
+        - xi
+        - star
+        - diamond
+      - - delta
+        - omega
+        - psi
+        - xi
+        - star
+        - diamond
+      - - omega
+        - star
+        - diamond
+        - xi
+        - delta
+        - psi
+      - - omega
+        - delta
+        - diamond
+        - star
+        - xi
+        - psi
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+        - star
+      - - xi
+        - star
+        - delta
+        - omega
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-21.yaml
+++ b/packages/manual/data/daily/2027-04-21.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-21'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - diamond
+        - trident
+        - delta
+        - xi
+      - - omega
+        - psi
+        - xi
+        - star
+        - delta
+        - diamond
+      - - psi
+        - star
+        - xi
+        - delta
+        - omega
+        - diamond
+      - - psi
+        - xi
+        - star
+        - delta
+        - omega
+        - trident
+      - - diamond
+        - delta
+        - omega
+        - star
+        - xi
+        - psi
+      - - star
+        - psi
+        - diamond
+        - omega
+        - delta
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - delta
+        - diamond
+        - psi
+        - omega
+        - star
+      - - omega
+        - delta
+        - diamond
+        - psi
+        - xi
+        - star
+      - - star
+        - psi
+        - delta
+        - xi
+        - omega
+        - diamond
+      - - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+        - star
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - star
+        - psi
+      - - xi
+        - delta
+        - star
+        - omega
+        - psi
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-22.yaml
+++ b/packages/manual/data/daily/2027-04-22.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-22'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - star
+        - xi
+      - - diamond
+        - psi
+        - star
+        - delta
+        - omega
+        - xi
+      - - psi
+        - star
+        - omega
+        - delta
+        - xi
+        - diamond
+      - - trident
+        - star
+        - psi
+        - omega
+        - xi
+        - delta
+      - - omega
+        - xi
+        - star
+        - diamond
+        - delta
+        - psi
+      - - psi
+        - delta
+        - diamond
+        - omega
+        - xi
+        - trident
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - psi
+        - xi
+        - star
+        - diamond
+        - delta
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - delta
+        - star
+      - - delta
+        - star
+        - psi
+        - diamond
+        - xi
+        - omega
+      - - star
+        - delta
+        - omega
+        - xi
+        - psi
+        - diamond
+      - - star
+        - psi
+        - diamond
+        - delta
+        - omega
+        - xi
+      - - delta
+        - diamond
+        - psi
+        - omega
+        - star
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-23.yaml
+++ b/packages/manual/data/daily/2027-04-23.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-23'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - omega
+        - delta
+        - xi
+        - diamond
+        - trident
+      - - delta
+        - xi
+        - star
+        - diamond
+        - omega
+        - psi
+      - - psi
+        - omega
+        - star
+        - xi
+        - diamond
+        - delta
+      - - omega
+        - xi
+        - star
+        - delta
+        - psi
+        - diamond
+      - - omega
+        - xi
+        - delta
+        - psi
+        - star
+        - diamond
+      - - trident
+        - xi
+        - psi
+        - star
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - diamond
+        - star
+        - xi
+        - psi
+        - delta
+      - - delta
+        - omega
+        - star
+        - psi
+        - diamond
+        - xi
+      - - omega
+        - delta
+        - psi
+        - star
+        - diamond
+        - xi
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+        - star
+      - - delta
+        - omega
+        - psi
+        - diamond
+        - xi
+        - star
+      - - star
+        - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-24.yaml
+++ b/packages/manual/data/daily/2027-04-24.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-24'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - diamond
+        - omega
+        - trident
+        - delta
+        - xi
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - omega
+        - star
+      - - star
+        - omega
+        - delta
+        - diamond
+        - xi
+        - psi
+      - - xi
+        - trident
+        - omega
+        - delta
+        - star
+        - psi
+      - - omega
+        - delta
+        - diamond
+        - xi
+        - star
+        - psi
+      - - xi
+        - psi
+        - omega
+        - delta
+        - star
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - star
+        - diamond
+        - psi
+        - xi
+      - - delta
+        - omega
+        - psi
+        - xi
+        - star
+        - diamond
+      - - xi
+        - delta
+        - omega
+        - psi
+        - star
+        - diamond
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - star
+        - xi
+      - - diamond
+        - psi
+        - star
+        - xi
+        - delta
+        - omega
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-25.yaml
+++ b/packages/manual/data/daily/2027-04-25.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-25'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - diamond
+        - omega
+        - xi
+        - trident
+        - delta
+      - - xi
+        - omega
+        - psi
+        - star
+        - delta
+        - diamond
+      - - psi
+        - xi
+        - omega
+        - star
+        - diamond
+        - delta
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+        - star
+      - - omega
+        - xi
+        - psi
+        - trident
+        - delta
+        - star
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - star
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - delta
+        - omega
+        - diamond
+        - star
+        - psi
+      - - xi
+        - psi
+        - star
+        - omega
+        - diamond
+        - delta
+      - - omega
+        - psi
+        - xi
+        - star
+        - diamond
+        - delta
+      - - psi
+        - delta
+        - star
+        - diamond
+        - xi
+        - omega
+      - - omega
+        - xi
+        - star
+        - delta
+        - psi
+        - diamond
+      - - psi
+        - star
+        - omega
+        - xi
+        - diamond
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-26.yaml
+++ b/packages/manual/data/daily/2027-04-26.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-26'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - xi
+        - omega
+        - diamond
+        - psi
+        - delta
+      - - trident
+        - omega
+        - star
+        - xi
+        - delta
+        - psi
+      - - trident
+        - diamond
+        - delta
+        - xi
+        - psi
+        - omega
+      - - delta
+        - star
+        - diamond
+        - xi
+        - omega
+        - psi
+      - - omega
+        - diamond
+        - xi
+        - star
+        - delta
+        - psi
+      - - delta
+        - xi
+        - psi
+        - omega
+        - diamond
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - delta
+        - star
+        - psi
+        - xi
+        - diamond
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+        - star
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - star
+        - xi
+      - - delta
+        - xi
+        - omega
+        - diamond
+        - psi
+        - star
+      - - psi
+        - xi
+        - delta
+        - diamond
+        - omega
+        - star
+      - - delta
+        - star
+        - diamond
+        - psi
+        - xi
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-27.yaml
+++ b/packages/manual/data/daily/2027-04-27.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-27'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - delta
+        - star
+        - xi
+        - psi
+      - - delta
+        - psi
+        - omega
+        - star
+        - xi
+        - diamond
+      - - psi
+        - star
+        - omega
+        - trident
+        - xi
+        - delta
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - star
+        - delta
+      - - star
+        - xi
+        - diamond
+        - delta
+        - psi
+        - omega
+      - - omega
+        - xi
+        - trident
+        - delta
+        - diamond
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - omega
+        - psi
+        - star
+        - diamond
+        - delta
+      - - xi
+        - star
+        - diamond
+        - omega
+        - delta
+        - psi
+      - - star
+        - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+      - - diamond
+        - omega
+        - star
+        - delta
+        - xi
+        - psi
+      - - omega
+        - delta
+        - star
+        - psi
+        - diamond
+        - xi
+      - - psi
+        - delta
+        - diamond
+        - xi
+        - star
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-28.yaml
+++ b/packages/manual/data/daily/2027-04-28.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-28'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - diamond
+        - xi
+        - omega
+        - star
+        - psi
+        - delta
+      - - trident
+        - xi
+        - delta
+        - psi
+        - diamond
+        - omega
+      - - star
+        - xi
+        - psi
+        - omega
+        - delta
+        - diamond
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - star
+        - xi
+      - - star
+        - trident
+        - xi
+        - psi
+        - omega
+        - delta
+      - - star
+        - psi
+        - xi
+        - diamond
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - xi
+        - omega
+        - star
+        - psi
+      - - star
+        - omega
+        - xi
+        - delta
+        - diamond
+        - psi
+      - - omega
+        - diamond
+        - xi
+        - psi
+        - star
+        - delta
+      - - delta
+        - star
+        - diamond
+        - psi
+        - omega
+        - xi
+      - - diamond
+        - psi
+        - xi
+        - omega
+        - star
+        - delta
+      - - diamond
+        - omega
+        - psi
+        - xi
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-29.yaml
+++ b/packages/manual/data/daily/2027-04-29.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-29'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - delta
+        - xi
+        - star
+        - omega
+        - diamond
+      - - diamond
+        - xi
+        - omega
+        - psi
+        - delta
+        - star
+      - - diamond
+        - xi
+        - trident
+        - psi
+        - omega
+        - delta
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+        - star
+      - - psi
+        - delta
+        - xi
+        - omega
+        - trident
+        - star
+      - - omega
+        - delta
+        - diamond
+        - star
+        - psi
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - psi
+        - xi
+        - omega
+        - star
+      - - star
+        - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+      - - delta
+        - omega
+        - xi
+        - star
+        - psi
+        - diamond
+      - - omega
+        - xi
+        - delta
+        - psi
+        - star
+        - diamond
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - diamond
+        - xi
+        - omega
+        - delta
+        - star
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-04-30.yaml
+++ b/packages/manual/data/daily/2027-04-30.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-04-30'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - xi
+        - delta
+        - diamond
+        - star
+        - psi
+      - - delta
+        - psi
+        - trident
+        - star
+        - omega
+        - xi
+      - - xi
+        - psi
+        - delta
+        - diamond
+        - trident
+        - omega
+      - - psi
+        - delta
+        - omega
+        - xi
+        - diamond
+        - star
+      - - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+        - star
+      - - delta
+        - star
+        - xi
+        - psi
+        - omega
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - diamond
+        - omega
+        - psi
+        - delta
+      - - star
+        - delta
+        - psi
+        - xi
+        - diamond
+        - omega
+      - - psi
+        - delta
+        - diamond
+        - omega
+        - star
+        - xi
+      - - omega
+        - xi
+        - delta
+        - psi
+        - diamond
+        - star
+      - - xi
+        - omega
+        - psi
+        - star
+        - diamond
+        - delta
+      - - diamond
+        - omega
+        - star
+        - psi
+        - xi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-05-01.yaml
+++ b/packages/manual/data/daily/2027-05-01.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-05-01'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - delta
+        - omega
+        - psi
+        - xi
+        - diamond
+        - star
+      - - star
+        - omega
+        - psi
+        - diamond
+        - delta
+        - xi
+      - - star
+        - psi
+        - xi
+        - trident
+        - omega
+        - delta
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - star
+        - xi
+      - - trident
+        - diamond
+        - xi
+        - delta
+        - omega
+        - psi
+      - - xi
+        - psi
+        - diamond
+        - omega
+        - delta
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - xi
+        - star
+        - diamond
+        - delta
+        - omega
+        - psi
+      - - star
+        - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+      - - xi
+        - diamond
+        - delta
+        - psi
+        - star
+        - omega
+      - - diamond
+        - star
+        - delta
+        - omega
+        - psi
+        - xi
+      - - psi
+        - delta
+        - diamond
+        - star
+        - xi
+        - omega
+      - - star
+        - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-05-02.yaml
+++ b/packages/manual/data/daily/2027-05-02.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-05-02'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - diamond
+        - xi
+        - omega
+        - delta
+        - psi
+      - - omega
+        - psi
+        - delta
+        - diamond
+        - xi
+        - star
+      - - diamond
+        - omega
+        - star
+        - delta
+        - psi
+        - xi
+      - - psi
+        - xi
+        - trident
+        - star
+        - omega
+        - delta
+      - - star
+        - omega
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - omega
+        - diamond
+        - trident
+        - xi
+        - psi
+        - delta
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - star
+        - delta
+        - xi
+        - diamond
+        - psi
+      - - xi
+        - omega
+        - star
+        - delta
+        - diamond
+        - psi
+      - - xi
+        - omega
+        - diamond
+        - delta
+        - psi
+        - star
+      - - delta
+        - star
+        - diamond
+        - omega
+        - psi
+        - xi
+      - - xi
+        - diamond
+        - star
+        - delta
+        - omega
+        - psi
+      - - omega
+        - diamond
+        - psi
+        - xi
+        - star
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-05-03.yaml
+++ b/packages/manual/data/daily/2027-05-03.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-05-03'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - star
+        - delta
+        - diamond
+        - psi
+        - xi
+        - omega
+      - - diamond
+        - psi
+        - delta
+        - omega
+        - xi
+        - star
+      - - xi
+        - diamond
+        - psi
+        - delta
+        - omega
+        - star
+      - - trident
+        - omega
+        - xi
+        - psi
+        - star
+        - delta
+      - - omega
+        - diamond
+        - delta
+        - psi
+        - trident
+        - xi
+      - - psi
+        - star
+        - delta
+        - xi
+        - diamond
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - diamond
+        - omega
+        - xi
+        - delta
+        - psi
+      - - delta
+        - psi
+        - diamond
+        - star
+        - omega
+        - xi
+      - - diamond
+        - delta
+        - omega
+        - xi
+        - star
+        - psi
+      - - omega
+        - diamond
+        - psi
+        - star
+        - xi
+        - delta
+      - - psi
+        - omega
+        - diamond
+        - delta
+        - xi
+        - star
+      - - xi
+        - omega
+        - psi
+        - star
+        - delta
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-05-04.yaml
+++ b/packages/manual/data/daily/2027-05-04.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-05-04'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - trident
+        - psi
+        - omega
+        - delta
+        - diamond
+      - - trident
+        - star
+        - psi
+        - xi
+        - delta
+        - omega
+      - - omega
+        - star
+        - diamond
+        - delta
+        - xi
+        - psi
+      - - diamond
+        - delta
+        - star
+        - omega
+        - xi
+        - psi
+      - - xi
+        - star
+        - psi
+        - diamond
+        - omega
+        - delta
+      - - omega
+        - star
+        - xi
+        - delta
+        - psi
+        - diamond
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - delta
+        - psi
+        - xi
+        - omega
+        - diamond
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - star
+        - xi
+      - - psi
+        - diamond
+        - star
+        - xi
+        - delta
+        - omega
+      - - omega
+        - xi
+        - delta
+        - diamond
+        - star
+        - psi
+      - - xi
+        - psi
+        - star
+        - omega
+        - delta
+        - diamond
+      - - psi
+        - omega
+        - delta
+        - xi
+        - star
+        - diamond
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-05-05.yaml
+++ b/packages/manual/data/daily/2027-05-05.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-05-05'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - diamond
+        - delta
+        - omega
+        - xi
+        - star
+      - - xi
+        - omega
+        - psi
+        - diamond
+        - delta
+        - star
+      - - diamond
+        - delta
+        - omega
+        - psi
+        - xi
+        - trident
+      - - omega
+        - xi
+        - diamond
+        - delta
+        - psi
+        - star
+      - - omega
+        - delta
+        - psi
+        - star
+        - diamond
+        - xi
+      - - psi
+        - trident
+        - star
+        - delta
+        - omega
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - omega
+        - diamond
+        - psi
+        - delta
+        - star
+        - xi
+      - - omega
+        - delta
+        - diamond
+        - psi
+        - star
+        - xi
+      - - star
+        - diamond
+        - xi
+        - delta
+        - psi
+        - omega
+      - - delta
+        - xi
+        - diamond
+        - psi
+        - star
+        - omega
+      - - psi
+        - star
+        - omega
+        - diamond
+        - delta
+        - xi
+      - - xi
+        - delta
+        - psi
+        - star
+        - diamond
+        - omega
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-05-06.yaml
+++ b/packages/manual/data/daily/2027-05-06.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-05-06'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - psi
+        - trident
+        - star
+        - omega
+        - delta
+      - - diamond
+        - star
+        - xi
+        - omega
+        - psi
+        - delta
+      - - omega
+        - star
+        - xi
+        - diamond
+        - psi
+        - delta
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - trident
+        - omega
+      - - omega
+        - delta
+        - xi
+        - star
+        - psi
+        - diamond
+      - - xi
+        - psi
+        - diamond
+        - delta
+        - omega
+        - star
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - delta
+        - xi
+        - star
+        - psi
+        - omega
+      - - diamond
+        - star
+        - xi
+        - omega
+        - delta
+        - psi
+      - - psi
+        - diamond
+        - xi
+        - omega
+        - star
+        - delta
+      - - xi
+        - psi
+        - omega
+        - delta
+        - star
+        - diamond
+      - - xi
+        - star
+        - diamond
+        - psi
+        - delta
+        - omega
+      - - diamond
+        - omega
+        - delta
+        - star
+        - psi
+        - xi
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-05-07.yaml
+++ b/packages/manual/data/daily/2027-05-07.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-05-07'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - trident
+        - omega
+        - psi
+        - xi
+        - diamond
+        - delta
+      - - star
+        - omega
+        - diamond
+        - xi
+        - delta
+        - psi
+      - - psi
+        - star
+        - delta
+        - diamond
+        - xi
+        - omega
+      - - diamond
+        - star
+        - xi
+        - delta
+        - omega
+        - psi
+      - - psi
+        - delta
+        - omega
+        - diamond
+        - star
+        - xi
+      - - xi
+        - star
+        - trident
+        - psi
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - xi
+        - star
+        - omega
+        - delta
+      - - omega
+        - psi
+        - star
+        - diamond
+        - delta
+        - xi
+      - - delta
+        - xi
+        - star
+        - psi
+        - diamond
+        - omega
+      - - psi
+        - star
+        - omega
+        - delta
+        - diamond
+        - xi
+      - - psi
+        - omega
+        - xi
+        - delta
+        - star
+        - diamond
+      - - omega
+        - xi
+        - star
+        - psi
+        - diamond
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-05-08.yaml
+++ b/packages/manual/data/daily/2027-05-08.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-05-08'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - delta
+        - xi
+        - diamond
+        - star
+        - psi
+      - - psi
+        - star
+        - omega
+        - xi
+        - trident
+        - delta
+      - - psi
+        - delta
+        - star
+        - omega
+        - xi
+        - diamond
+      - - xi
+        - psi
+        - star
+        - diamond
+        - omega
+        - delta
+      - - xi
+        - psi
+        - omega
+        - diamond
+        - delta
+        - star
+      - - delta
+        - omega
+        - psi
+        - trident
+        - diamond
+        - xi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - star
+        - psi
+        - xi
+        - delta
+        - diamond
+        - omega
+      - - psi
+        - star
+        - delta
+        - omega
+        - xi
+        - diamond
+      - - psi
+        - delta
+        - xi
+        - omega
+        - star
+        - diamond
+      - - star
+        - omega
+        - xi
+        - psi
+        - delta
+        - diamond
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-05-09.yaml
+++ b/packages/manual/data/daily/2027-05-09.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-05-09'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - psi
+        - xi
+        - omega
+        - delta
+        - diamond
+        - star
+      - - delta
+        - star
+        - xi
+        - psi
+        - omega
+        - diamond
+      - - delta
+        - xi
+        - trident
+        - psi
+        - star
+        - omega
+      - - delta
+        - omega
+        - star
+        - diamond
+        - xi
+        - psi
+      - - psi
+        - diamond
+        - omega
+        - star
+        - xi
+        - delta
+      - - trident
+        - delta
+        - diamond
+        - omega
+        - xi
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - diamond
+        - psi
+        - delta
+        - xi
+        - omega
+        - star
+      - - diamond
+        - xi
+        - delta
+        - psi
+        - star
+        - omega
+      - - delta
+        - diamond
+        - xi
+        - psi
+        - star
+        - omega
+      - - diamond
+        - delta
+        - omega
+        - xi
+        - star
+        - psi
+      - - xi
+        - star
+        - diamond
+        - omega
+        - psi
+        - delta
+      - - psi
+        - omega
+        - diamond
+        - xi
+        - delta
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-05-10.yaml
+++ b/packages/manual/data/daily/2027-05-10.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-05-10'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - xi
+        - star
+        - psi
+        - delta
+        - omega
+        - diamond
+      - - psi
+        - diamond
+        - xi
+        - star
+        - delta
+        - omega
+      - - psi
+        - star
+        - delta
+        - xi
+        - diamond
+        - omega
+      - - trident
+        - star
+        - delta
+        - omega
+        - psi
+        - xi
+      - - xi
+        - omega
+        - delta
+        - psi
+        - diamond
+        - star
+      - - delta
+        - diamond
+        - trident
+        - xi
+        - omega
+        - psi
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - psi
+        - xi
+        - omega
+        - diamond
+        - star
+        - delta
+      - - psi
+        - star
+        - diamond
+        - omega
+        - delta
+        - xi
+      - - diamond
+        - omega
+        - delta
+        - psi
+        - xi
+        - star
+      - - star
+        - delta
+        - psi
+        - diamond
+        - omega
+        - xi
+      - - star
+        - psi
+        - xi
+        - diamond
+        - omega
+        - delta
+      - - omega
+        - delta
+        - psi
+        - diamond
+        - xi
+        - star
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/data/daily/2027-05-11.yaml
+++ b/packages/manual/data/daily/2027-05-11.yaml
@@ -1,0 +1,360 @@
+meta:
+  version: '2027-05-11'
+  type: daily
+modules:
+  wire_routing:
+    rules:
+      - condition:
+          wire_count: 4
+          battery_count:
+            gt: 2
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 4
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          count_red:
+            gt: 1
+        action: cut_wire
+        target:
+          position: last
+          color: red
+      - condition:
+          wire_count: 4
+          color_at_last: green
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: black
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 4
+          color_at_last: white
+        action: cut_wire
+        target:
+          position: 1
+      - condition:
+          wire_count: 4
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 4
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+          indicator_FRK_lit: true
+        action: cut_wire
+        target:
+          position: 2
+      - condition:
+          wire_count: 5
+          count_blue:
+            gt: 1
+        action: cut_wire
+        target:
+          position: first
+          color: blue
+      - condition:
+          wire_count: 5
+          color_at_last: blue
+        action: cut_wire
+        target:
+          position: last
+      - condition:
+          wire_count: 5
+          color_at_last: red
+        action: cut_wire
+        target:
+          position: 3
+      - condition:
+          wire_count: 5
+          color_at_last: yellow
+        action: cut_wire
+        target:
+          position: first
+      - condition:
+          wire_count: 5
+        action: cut_wire
+        target:
+          position: 2
+      - condition: {}
+        action: cut_wire
+        target:
+          position: first
+  symbol_dial:
+    columns:
+      - - omega
+        - diamond
+        - psi
+        - xi
+        - delta
+        - star
+      - - xi
+        - star
+        - omega
+        - psi
+        - diamond
+        - delta
+      - - psi
+        - star
+        - xi
+        - delta
+        - trident
+        - omega
+      - - xi
+        - diamond
+        - delta
+        - omega
+        - psi
+        - star
+      - - psi
+        - xi
+        - omega
+        - trident
+        - delta
+        - diamond
+      - - xi
+        - star
+        - diamond
+        - psi
+        - delta
+        - omega
+    rule: 玩家报 3 个轮盘当前显示的符号 S1、S2、S3（都在位置 0）—— 生成器保证这 3 个起始符号互不相同，你可以信任玩家的描述。在下方 columns 里找那条同时包含 S1、S2、S3 的列。对第 i 个轮盘，目标位置 = S_i 在命中列中的 index（0=最上，5=最下）。指示玩家把每个轮盘从位置 0 按右箭头到达该 index 即可，不要说"让轮盘显示某个符号"——每个轮盘有自己独立的 6 符号池，跨轮盘不通用。
+  button:
+    rules:
+      - condition:
+          battery_count:
+            lte: 2
+        action:
+          type: hold
+          release_on_light: red
+      - condition:
+          color: yellow
+        action:
+          type: tap
+      - condition:
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: white
+          label: PRESS
+        action:
+          type: hold
+          release_on_light: blue
+      - condition:
+          color: blue
+          label: ABORT
+        action:
+          type: hold
+          release_on_light: white
+      - condition:
+          color: red
+          label: HOLD
+        action:
+          type: tap
+      - condition:
+          color: red
+          indicator_FRK_lit: true
+        action:
+          type: tap
+      - condition:
+          color: yellow
+          battery_count:
+            gt: 2
+        action:
+          type: hold
+          release_on_light: yellow
+      - condition:
+          color: blue
+          label: DETONATE
+        action:
+          type: tap
+      - condition:
+          color: white
+        action:
+          type: tap
+      - condition:
+          battery_count:
+            gt: 2
+          label: DETONATE
+        action:
+          type: tap
+      - condition: {}
+        action:
+          type: tap
+  keypad:
+    sequences:
+      - - delta
+        - omega
+        - xi
+        - star
+        - psi
+        - diamond
+      - - omega
+        - delta
+        - xi
+        - star
+        - diamond
+        - psi
+      - - xi
+        - delta
+        - star
+        - omega
+        - diamond
+        - psi
+      - - psi
+        - delta
+        - diamond
+        - star
+        - omega
+        - xi
+      - - star
+        - delta
+        - diamond
+        - omega
+        - psi
+        - xi
+      - - omega
+        - diamond
+        - xi
+        - star
+        - psi
+        - delta
+    rule: 键盘 2×2 共 4 个格子，符号全部可见。在下方 sequences 里找那条同时包含这 4 个符号的序列；让玩家按该序列里出现的先后顺序点击它们（玩家不需要理解"位置"，只需要说"点某某符号"即可）。
+decoy_modules:
+  morse_code:
+    rules:
+      - pattern: ... --- ...
+        word: SOS
+        action: transmit
+      - pattern: .... . .-.. .-.. ---
+        word: HELLO
+        action: transmit
+      - pattern: '-... --- -- -...'
+        word: BOMB
+        action: transmit
+      - pattern: .-- .. .-. .
+        word: WIRE
+        action: cut
+      - pattern: '-.. . - --- -. .- - .'
+        word: DETONATE
+        action: abort
+      - pattern: .- .-. -- .
+        word: ARME
+        action: transmit
+  maze:
+    grid_size: 6
+    rules:
+      - start:
+          - 0
+          - 0
+        end:
+          - 5
+          - 5
+        path: RRRRRUUUUU
+      - start:
+          - 2
+          - 3
+        end:
+          - 0
+          - 0
+        path: LLLUUU
+      - start:
+          - 1
+          - 1
+        end:
+          - 4
+          - 4
+        path: RRRRUUU
+      - start:
+          - 3
+          - 0
+        end:
+          - 3
+          - 5
+        path: UUUUU
+      - start:
+          - 0
+          - 2
+        end:
+          - 5
+          - 2
+        path: RRRRR
+  memory:
+    stages: 5
+    rules:
+      - stage: 1
+        display: 1
+        action: press_position_2
+      - stage: 1
+        display: 2
+        action: press_position_2
+      - stage: 2
+        display: 3
+        action: press_label_4
+      - stage: 3
+        display: 1
+        action: press_same_position
+      - stage: 4
+        display: 4
+        action: press_same_label
+      - stage: 5
+        display: 2
+        action: press_same_position_as_stage_1
+  simon_says:
+    rules:
+      - has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - has_vowel_in_serial: false
+        color_map:
+          red: blue
+          blue: yellow
+          green: green
+          yellow: red
+      - strikes: 1
+        has_vowel_in_serial: true
+        color_map:
+          red: blue
+          blue: red
+          green: yellow
+          yellow: green
+      - strikes: 1
+        has_vowel_in_serial: false
+        color_map:
+          red: red
+          blue: blue
+          green: yellow
+          yellow: green
+      - strikes: 2
+        color_map:
+          red: yellow
+          blue: green
+          green: blue
+          yellow: red

--- a/packages/manual/generate-daily.test.ts
+++ b/packages/manual/generate-daily.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the daily-manual generator script.
+ *
+ * The generator lives at `scripts/generate-daily-from-practice.mjs` (root) and
+ * exports pure helpers we exercise here. We do NOT shell out — we import the
+ * pure derivation function directly and assert determinism + structural
+ * invariants on a small set of dates.
+ */
+import { describe, expect, it } from 'vitest'
+import yaml from 'js-yaml'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import {
+  deriveDailyManual,
+  fnv1a32,
+  mulberry32,
+  seededShuffle,
+  // @ts-expect-error JS module imported from .mjs without types
+} from '../../scripts/generate-daily-from-practice.mjs'
+import { validateManualSymbols, type Manual } from '@shared/manual-schema'
+import { SYMBOLS } from '@shared/symbols'
+
+const PRACTICE_YAML = resolve(__dirname, 'data/practice.yaml')
+
+function loadPractice(): Manual {
+  return yaml.load(readFileSync(PRACTICE_YAML, 'utf8')) as Manual
+}
+
+describe('daily generator — deterministic RNG primitives', () => {
+  it('fnv1a32 is stable for a known input', () => {
+    // Pin the hash so a future implementation swap is loud, not silent.
+    const h = fnv1a32('2026-05-12') as number
+    expect(typeof h).toBe('number')
+    expect(h).toBeGreaterThanOrEqual(0)
+    expect(h).toBeLessThan(2 ** 32)
+    // Two different dates → different hashes
+    expect(fnv1a32('2026-05-12')).not.toBe(fnv1a32('2026-05-13'))
+  })
+
+  it('mulberry32 is reproducible for a given seed', () => {
+    const a = mulberry32(123) as () => number
+    const b = mulberry32(123) as () => number
+    for (let i = 0; i < 16; i++) {
+      expect(a()).toBe(b())
+    }
+  })
+
+  it('seededShuffle is deterministic per RNG seed and does not mutate input', () => {
+    const input = [1, 2, 3, 4, 5, 6, 7, 8]
+    const rngA = mulberry32(7) as () => number
+    const rngB = mulberry32(7) as () => number
+    const outA = seededShuffle(input, rngA) as number[]
+    const outB = seededShuffle(input, rngB) as number[]
+    expect(outA).toEqual(outB)
+    expect(outA).not.toBe(input)
+    // Input unchanged
+    expect(input).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+    // Permutation has same multiset
+    expect(outA.slice().sort()).toEqual(input.slice().sort())
+  })
+})
+
+describe('daily generator — deriveDailyManual', () => {
+  it('produces byte-equal output for the same date (determinism)', () => {
+    const practice = loadPractice()
+    const a = deriveDailyManual(practice, '2026-05-12')
+    const b = deriveDailyManual(practice, '2026-05-12')
+    expect(yaml.dump(a)).toBe(yaml.dump(b))
+  })
+
+  it('produces different output for different dates', () => {
+    const practice = loadPractice()
+    const a = deriveDailyManual(practice, '2026-05-12')
+    const b = deriveDailyManual(practice, '2026-05-13')
+    expect(yaml.dump(a)).not.toBe(yaml.dump(b))
+  })
+
+  it('sets meta correctly', () => {
+    const practice = loadPractice()
+    const m = deriveDailyManual(practice, '2026-07-04') as Manual
+    expect(m.meta.version).toBe('2026-07-04')
+    expect(m.meta.type).toBe('daily')
+  })
+
+  it('keeps wire_routing condition: {} catch-all last', () => {
+    const practice = loadPractice()
+    const m = deriveDailyManual(practice, '2026-05-12') as Manual
+    const rules = m.modules.wire_routing.rules
+    const last = rules[rules.length - 1]
+    expect(Object.keys(last.condition).length).toBe(0)
+  })
+
+  it('keeps trailing button condition: {} catch-all last', () => {
+    const practice = loadPractice()
+    const m = deriveDailyManual(practice, '2026-05-12') as Manual
+    const rules = m.modules.button.rules
+    const last = rules[rules.length - 1]
+    expect(Object.keys(last.condition).length).toBe(0)
+  })
+
+  it('keeps general wire-count fallthrough rules after their specific siblings', () => {
+    const practice = loadPractice()
+    const m = deriveDailyManual(practice, '2026-05-12') as Manual
+    const rules = m.modules.wire_routing.rules
+    // Find general rules: condition has wire_count and only wire_count.
+    const generalIndices: number[] = []
+    rules.forEach((r, i) => {
+      const keys = Object.keys(r.condition)
+      if (keys.length === 1 && keys[0] === 'wire_count') generalIndices.push(i)
+    })
+    // For each general rule, every preceding rule with the same wire_count
+    // must be a specific (additional-keys) rule, not a different general.
+    for (const gi of generalIndices) {
+      const wc = (rules[gi].condition as { wire_count: number }).wire_count
+      for (let i = 0; i < gi; i++) {
+        const condI = rules[i].condition as Record<string, unknown>
+        if (condI.wire_count === wc) {
+          expect(
+            Object.keys(condI).length,
+            `general fallthrough for wire_count=${wc} at index ${gi} was preceded by another bare general at index ${i}`
+          ).toBeGreaterThan(1)
+        }
+      }
+    }
+  })
+
+  it('preserves the rulebook symbol vocabulary (no new symbols introduced)', () => {
+    const practice = loadPractice()
+    const m = deriveDailyManual(practice, '2026-05-12') as Manual
+    expect(() => validateManualSymbols(m, SYMBOLS)).not.toThrow()
+  })
+
+  it('preserves symbol_dial column count and per-column length', () => {
+    const practice = loadPractice()
+    const m = deriveDailyManual(practice, '2026-05-12') as Manual
+    expect(m.modules.symbol_dial.columns.length).toBe(practice.modules.symbol_dial.columns.length)
+    for (const col of m.modules.symbol_dial.columns) {
+      expect(col.length).toBe(6)
+    }
+  })
+
+  it('preserves keypad sequence count and per-sequence length', () => {
+    const practice = loadPractice()
+    const m = deriveDailyManual(practice, '2026-05-12') as Manual
+    expect(m.modules.keypad.sequences.length).toBe(practice.modules.keypad.sequences.length)
+    for (const seq of m.modules.keypad.sequences) {
+      expect(seq.length).toBe(6)
+    }
+  })
+
+  it('does not mutate the input practice manual', () => {
+    const practice = loadPractice()
+    const before = yaml.dump(practice)
+    deriveDailyManual(practice, '2026-05-12')
+    deriveDailyManual(practice, '2026-08-01')
+    expect(yaml.dump(practice)).toBe(before)
+  })
+})

--- a/packages/manual/generate-daily.test.ts
+++ b/packages/manual/generate-daily.test.ts
@@ -6,15 +6,17 @@
  * pure derivation function directly and assert determinism + structural
  * invariants on a small set of dates.
  */
-import { describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 import yaml from 'js-yaml'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
 import {
   deriveDailyManual,
   fnv1a32,
   mulberry32,
   seededShuffle,
+  writeDailyIfChanged,
   // @ts-expect-error JS module imported from .mjs without types
 } from '../../scripts/generate-daily-from-practice.mjs'
 import { validateManualSymbols, type Manual } from '@shared/manual-schema'
@@ -35,6 +37,16 @@ describe('daily generator — deterministic RNG primitives', () => {
     expect(h).toBeLessThan(2 ** 32)
     // Two different dates → different hashes
     expect(fnv1a32('2026-05-12')).not.toBe(fnv1a32('2026-05-13'))
+  })
+
+  it('fnv1a32 emits the exact FNV-1a 32-bit values for pinned dates', () => {
+    // Pin the EXACT numeric output of FNV-1a/32 for three known dates so a
+    // silent swap to a different hash family (or a subtle off-by-one in the
+    // constants) fails this test instead of slipping into production and
+    // shifting every daily seed.
+    expect(fnv1a32('2026-05-12')).toBe(1656106231)
+    expect(fnv1a32('2026-12-31')).toBe(1294366724)
+    expect(fnv1a32('2027-01-01')).toBe(1431789288)
   })
 
   it('mulberry32 is reproducible for a given seed', () => {
@@ -154,5 +166,57 @@ describe('daily generator — deriveDailyManual', () => {
     deriveDailyManual(practice, '2026-05-12')
     deriveDailyManual(practice, '2026-08-01')
     expect(yaml.dump(practice)).toBe(before)
+  })
+})
+
+describe('daily generator — writeDailyIfChanged idempotency', () => {
+  // Each test uses its own tempdir to avoid coupling. The optional third
+  // `targetDir` arg lets us redirect away from the real
+  // `packages/manual/data/daily/` without changing behavior on the script's
+  // own callsite (which still defaults to DAILY_DIR).
+  const tempDirs: string[] = []
+  function makeTempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'amiclaw-daily-test-'))
+    tempDirs.push(dir)
+    return dir
+  }
+  afterAll(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes a new file on first call and returns "write"', () => {
+    const dir = makeTempDir()
+    const result = writeDailyIfChanged('2099-01-01', 'hello: world\n', dir) as 'write' | 'skip'
+    expect(result).toBe('write')
+    expect(readFileSync(join(dir, '2099-01-01.yaml'), 'utf8')).toBe('hello: world\n')
+  })
+
+  it('skips when existing content matches byte-for-byte and does not touch the file', () => {
+    const dir = makeTempDir()
+    const date = '2099-02-02'
+    const content = 'meta:\n  version: 2099-02-02\n  type: daily\n'
+    writeDailyIfChanged(date, content, dir)
+    const target = join(dir, `${date}.yaml`)
+    const mtimeBefore = statSync(target).mtimeMs
+    // Re-call with identical content: must return 'skip' and must not rewrite
+    // the file (mtime stays put, content stays byte-equal).
+    const result = writeDailyIfChanged(date, content, dir) as 'write' | 'skip'
+    expect(result).toBe('skip')
+    expect(readFileSync(target, 'utf8')).toBe(content)
+    expect(statSync(target).mtimeMs).toBe(mtimeBefore)
+  })
+
+  it('throws when existing content differs from new content (refuse to overwrite)', () => {
+    const dir = makeTempDir()
+    const date = '2099-03-03'
+    const target = join(dir, `${date}.yaml`)
+    // Seed the directory with content X via plain fs to simulate a committed
+    // file that diverges from what the generator would produce now.
+    writeFileSync(target, 'old: content\n')
+    expect(() => writeDailyIfChanged(date, 'new: content\n', dir)).toThrow(/Refusing to overwrite/)
+    // File on disk must remain the original — abort, do not overwrite.
+    expect(readFileSync(target, 'utf8')).toBe('old: content\n')
   })
 })

--- a/scripts/generate-daily-from-practice.mjs
+++ b/scripts/generate-daily-from-practice.mjs
@@ -248,9 +248,9 @@ function dumpYaml(obj) {
   return yaml.dump(obj, { lineWidth: -1 })
 }
 
-function writeDailyIfChanged(date, content) {
-  if (!existsSync(DAILY_DIR)) mkdirSync(DAILY_DIR, { recursive: true })
-  const target = join(DAILY_DIR, `${date}.yaml`)
+export function writeDailyIfChanged(date, content, targetDir = DAILY_DIR) {
+  if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true })
+  const target = join(targetDir, `${date}.yaml`)
   if (existsSync(target)) {
     const existing = readFileSync(target, 'utf8')
     if (existing === content) return 'skip'

--- a/scripts/generate-daily-from-practice.mjs
+++ b/scripts/generate-daily-from-practice.mjs
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+/**
+ * Generate daily manual YAML files by seed-permuting `packages/manual/data/practice.yaml`.
+ *
+ * Usage:
+ *   node scripts/generate-daily-from-practice.mjs --from YYYY-MM-DD --days N
+ *
+ * For each date in the range, produces a deterministic permutation of the
+ * practice rulebook:
+ *   - `wire_routing.rules` and `button.rules` are reordered while preserving
+ *     the precedence invariants required by the rule engine (general
+ *     fallthrough rules stay after their more-specific siblings; the absolute
+ *     `condition: {}` catch-all stays last).
+ *   - `symbol_dial.columns` and `keypad.sequences` are shuffled, and each
+ *     column / sequence's 6-symbol order is permuted.
+ *   - `decoy_modules` is carried over verbatim (opaque to the game engine).
+ *   - `meta` is rewritten to `{ version: <date>, type: daily }`.
+ *
+ * Idempotent:
+ *   - Same date → same seed → byte-equal YAML output.
+ *   - If `data/daily/<date>.yaml` already exists with matching content, skip.
+ *   - If it exists but content differs, abort with a clear error (never
+ *     silently overwrite a committed file).
+ *
+ * Pure ESM, no new deps — uses `js-yaml` already present in
+ * `packages/manual`.
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs'
+import { resolve, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+// Resolve js-yaml from the manual package where it is declared.
+const yaml = require(
+  require.resolve('js-yaml', {
+    paths: [resolve(fileURLToPath(import.meta.url), '../../packages/manual')],
+  })
+)
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..')
+const PRACTICE_YAML = resolve(REPO_ROOT, 'packages/manual/data/practice.yaml')
+const DAILY_DIR = resolve(REPO_ROOT, 'packages/manual/data/daily')
+
+// ---------- CLI parsing ----------
+function parseArgs(argv) {
+  const args = { from: null, days: null }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--from') args.from = argv[++i]
+    else if (a === '--days') args.days = Number(argv[++i])
+    else if (a.startsWith('--from=')) args.from = a.slice('--from='.length)
+    else if (a.startsWith('--days=')) args.days = Number(a.slice('--days='.length))
+  }
+  return args
+}
+
+function usage(exitCode = 1) {
+  process.stderr.write(
+    'Usage: node scripts/generate-daily-from-practice.mjs --from YYYY-MM-DD --days N\n'
+  )
+  process.exit(exitCode)
+}
+
+// ---------- Deterministic RNG ----------
+/**
+ * 32-bit FNV-1a hash of a string. Used as the seed for the per-date RNG.
+ */
+export function fnv1a32(input) {
+  let h = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  // Force unsigned 32-bit
+  return h >>> 0
+}
+
+/**
+ * mulberry32 — small, fast, well-distributed 32-bit PRNG.
+ * Same seed → same sequence on every platform.
+ */
+export function mulberry32(seed) {
+  let a = seed >>> 0
+  return function () {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/**
+ * Fisher-Yates shuffle on a fresh copy of `arr`, driven by `rng`.
+ */
+export function seededShuffle(arr, rng) {
+  const out = arr.slice()
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out
+}
+
+// ---------- Date helpers ----------
+function isValidDateString(s) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false
+  const d = new Date(`${s}T00:00:00Z`)
+  if (Number.isNaN(d.getTime())) return false
+  // Round-trip check to catch e.g. 2026-02-30
+  return d.toISOString().slice(0, 10) === s
+}
+
+function* iterateDates(fromDateString, days) {
+  const start = new Date(`${fromDateString}T00:00:00Z`)
+  for (let i = 0; i < days; i++) {
+    const d = new Date(start.getTime() + i * 86400000)
+    yield d.toISOString().slice(0, 10)
+  }
+}
+
+// ---------- Rule-precedence-preserving permutation ----------
+/**
+ * A wire rule's condition can have:
+ *   - no `wire_count` AND no other keys → absolute `{}` catch-all (must stay last)
+ *   - `wire_count: N` only → "general" fallthrough for that wire count
+ *   - `wire_count: N` plus other keys → "specific" rule for that wire count
+ *
+ * To preserve solvability we:
+ *   1. Group rules by `wire_count` (4, 5, ...) plus a "catchall" bucket.
+ *   2. Within each wire_count group, shuffle the specific rules; keep the
+ *      general rule (if any) at the tail of its group.
+ *   3. Concatenate groups in ascending wire_count order, then append the
+ *      catchall bucket (always last).
+ */
+function isCatchAllCondition(cond) {
+  return cond && typeof cond === 'object' && Object.keys(cond).length === 0
+}
+
+function permuteWireRules(rules, rng) {
+  const byWireCount = new Map() // wire_count → { specific: [], general: rule | null }
+  const catchAll = []
+
+  for (const rule of rules) {
+    const cond = rule.condition ?? {}
+    if (isCatchAllCondition(cond)) {
+      catchAll.push(rule)
+      continue
+    }
+    const wireCount = cond.wire_count
+    if (wireCount === undefined) {
+      // No wire_count key but non-empty condition: treat as catch-all-adjacent
+      // (defensive — practice.yaml does not currently produce this shape).
+      catchAll.push(rule)
+      continue
+    }
+    if (!byWireCount.has(wireCount)) {
+      byWireCount.set(wireCount, { specific: [], general: null })
+    }
+    const bucket = byWireCount.get(wireCount)
+    const otherKeyCount = Object.keys(cond).filter((k) => k !== 'wire_count').length
+    if (otherKeyCount === 0) {
+      // condition has only wire_count → general fallthrough for that wire count
+      bucket.general = rule
+    } else {
+      bucket.specific.push(rule)
+    }
+  }
+
+  const sortedWireCounts = [...byWireCount.keys()].sort((a, b) => a - b)
+  const out = []
+  for (const wc of sortedWireCounts) {
+    const { specific, general } = byWireCount.get(wc)
+    const shuffled = seededShuffle(specific, rng)
+    out.push(...shuffled)
+    if (general !== null) out.push(general)
+  }
+  out.push(...catchAll)
+  return out
+}
+
+/**
+ * Button rules: the only invariant in practice.yaml is the trailing
+ * `condition: {}` catch-all. Shuffle everything except trailing catch-alls
+ * (which stay at the end in their original order).
+ */
+function permuteButtonRules(rules, rng) {
+  const head = []
+  const tail = []
+  for (const rule of rules) {
+    if (isCatchAllCondition(rule.condition ?? {})) {
+      tail.push(rule)
+    } else {
+      head.push(rule)
+    }
+  }
+  return [...seededShuffle(head, rng), ...tail]
+}
+
+/**
+ * Symbol dial / keypad rows: shuffle the 6 symbols inside each row, then
+ * shuffle row order. Game engine semantics treat columns / sequences
+ * commutatively for purposes of "which row contains all referenced symbols",
+ * so permutation within and across rows preserves solvability.
+ */
+function permuteRowsOfSymbols(rows, rng) {
+  const innerPermuted = rows.map((row) => seededShuffle(row, rng))
+  return seededShuffle(innerPermuted, rng)
+}
+
+// ---------- Manual derivation ----------
+export function deriveDailyManual(practiceManual, dateString) {
+  const seed = fnv1a32(dateString)
+  const rng = mulberry32(seed)
+
+  // structuredClone is available on Node 17+.
+  const out = structuredClone(practiceManual)
+  out.meta = { version: dateString, type: 'daily' }
+
+  // wire_routing
+  out.modules.wire_routing.rules = permuteWireRules(out.modules.wire_routing.rules, rng)
+
+  // symbol_dial — preserve `rule` string verbatim, permute columns
+  out.modules.symbol_dial.columns = permuteRowsOfSymbols(out.modules.symbol_dial.columns, rng)
+
+  // button
+  out.modules.button.rules = permuteButtonRules(out.modules.button.rules, rng)
+
+  // keypad — preserve `rule` string verbatim, permute sequences
+  out.modules.keypad.sequences = permuteRowsOfSymbols(out.modules.keypad.sequences, rng)
+
+  // decoy_modules: opaque carry-over (kept by structuredClone above)
+
+  return out
+}
+
+// ---------- File I/O ----------
+function loadPractice() {
+  const text = readFileSync(PRACTICE_YAML, 'utf8')
+  return yaml.load(text)
+}
+
+function dumpYaml(obj) {
+  // Use default block style for readability + git diffability; lineWidth -1
+  // avoids YAML's 80-col line wrapping (matches build.ts conventions).
+  return yaml.dump(obj, { lineWidth: -1 })
+}
+
+function writeDailyIfChanged(date, content) {
+  if (!existsSync(DAILY_DIR)) mkdirSync(DAILY_DIR, { recursive: true })
+  const target = join(DAILY_DIR, `${date}.yaml`)
+  if (existsSync(target)) {
+    const existing = readFileSync(target, 'utf8')
+    if (existing === content) return 'skip'
+    throw new Error(
+      `Refusing to overwrite ${target}: content differs from regenerated output. ` +
+        `Either delete the existing file (and regenerate) or investigate the divergence.`
+    )
+  }
+  writeFileSync(target, content)
+  return 'write'
+}
+
+// ---------- Main ----------
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (!args.from || !args.days || !Number.isFinite(args.days) || args.days <= 0) usage()
+  if (!isValidDateString(args.from)) {
+    process.stderr.write(`Invalid --from date: ${args.from} (expected YYYY-MM-DD)\n`)
+    process.exit(1)
+  }
+
+  const practice = loadPractice()
+  let wrote = 0
+  let skipped = 0
+  for (const date of iterateDates(args.from, args.days)) {
+    const derived = deriveDailyManual(practice, date)
+    const text = dumpYaml(derived)
+    const result = writeDailyIfChanged(date, text)
+    if (result === 'write') wrote++
+    else skipped++
+  }
+
+  process.stdout.write(
+    `Generated ${wrote} new daily YAML(s); skipped ${skipped} unchanged. ` +
+      `Total daily files now in ${DAILY_DIR}: ${
+        readdirSync(DAILY_DIR).filter((f) => f.endsWith('.yaml')).length
+      }\n`
+  )
+}
+
+// Only run when invoked directly, not when imported by tests.
+const invokedDirectly = fileURLToPath(import.meta.url) === resolve(process.argv[1])
+if (invokedDirectly) {
+  main()
+}


### PR DESCRIPTION
## Summary

- **BUG-001 Link 1 (data supply)**: pre-generate 365 daily manual YAMLs (2026-05-12 → 2027-05-11) derived from `practice.yaml` via deterministic seed-permutation (FNV-1a 32-bit hash of `YYYY-MM-DD` → mulberry32 RNG). `practice.yaml` becomes the single hand-authored SSOT; daily files are reproducible artifacts.
- **BUG-001 Link 2 (routing)**: add `packages/game/public/_routes.json` to pin `/manual/*` and `/api/*` to the Pages Functions runtime, preventing the SPA `_redirects` catch-all from intercepting missing-date requests and returning a 200 HTML shell.
- **BUG-002 (UX)**: friendly "今天的手册还没发布" + 去练习 UI branch now reachable for any future missing-date request (was unreachable before because SPA fallback returned 200 instead of 404).

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor or cleanup (new derive-from-practice authoring model)
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (`pnpm -r run test:run` → 119/119; data-validation now iterates all 366 daily YAMLs)
- [x] New tests added (12 cases in `packages/manual/generate-daily.test.ts`):
  - RNG determinism (same date → byte-equal output)
  - Cross-date divergence
  - Rule-engine precedence invariants (trailing `condition: {}` catch-all stays last in `button.rules`; `wire_count` general fallthrough stays after specific siblings)
  - FNV-1a hash pinning across 3 dates (catches silent RNG family swaps + endian/constant tweaks)
  - `writeDailyIfChanged` idempotency: write-new / skip-on-match / abort-on-mismatch
- [ ] Tested manually post-deploy:
  - `curl -H "Accept: application/yaml, text/plain" https://bombsquad.amio.fans/manual/<future-date>` returns valid YAML
  - `curl -H "Accept: application/yaml, text/plain" https://bombsquad.amio.fans/manual/2026-03-16` still returns 10215-byte YAML (regression)
  - Click "每日挑战" on desktop Chrome → game loads
  - Mobile Safari + Chrome real-device end-to-end (practice + daily + leaderboard)

## Checklist

- [x] Code follows the project style (English-only, `pnpm lint` + `pnpm format:check` clean)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [ ] Documentation updated if needed (CHANGELOG `Unreleased` updated; design doc lives in task record)
- [x] Breaking changes documented if any (none — purely additive)

## Design rationale

User chose **Option C-commit** in the Design phase (`pages/projects/amiclaw/tasks/fix-daily-challenge-blocking-bugs.md`) over A (separate `templates/daily-template.yaml` + RNG) and B (runtime Worker generation), privileging reversibility + minimal new infrastructure over runtime autonomy. Trade-off: site degrades to friendly 404 if pipeline lapses after 2027-05-11, which is acceptable for a one-person side project with no SLA. Cron top-up workflow deferred until manual top-up tempo proves friction-causing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>