### PR TITLE
feat(game,api): restore recap+skills data layer from 5/6 WIP

### DIFF
--- a/packages/api/src/handlers/post-score.ts
+++ b/packages/api/src/handlers/post-score.ts
@@ -3,19 +3,17 @@ import type {
   LeaderboardEntry,
   ScoreSubmissionResponse,
 } from '../../../../shared/leaderboard-types'
+import { computeBestRecord, type BestRecord } from '../../../../shared/personal-best'
 import { validateSubmission, sanitizeNickname } from '../validation'
 
 const RATE_LIMIT_MS = 10_000
 const MAX_ENTRIES = 100
-const KV_TTL_SECONDS = 48 * 60 * 60  // 48 hours
+const KV_TTL_SECONDS = 48 * 60 * 60 // 48 hours
 
-export async function handlePostScore(
-  request: Request,
-  kv: KVNamespace,
-): Promise<Response> {
+export async function handlePostScore(request: Request, kv: KVNamespace): Promise<Response> {
   let body: ScoreSubmission
   try {
-    body = await request.json() as ScoreSubmission
+    body = (await request.json()) as ScoreSubmission
   } catch {
     return jsonResponse({ error: 'Invalid JSON' }, 400)
   }
@@ -27,27 +25,31 @@ export async function handlePostScore(
 
   // Rate limiting: 1 submission per 10 seconds per device
   const rateLimitKey = `ratelimit:${body.device_id}`
-  const lastSubmit = await kv.get(rateLimitKey, 'json') as { ts: number } | null
+  const lastSubmit = (await kv.get(rateLimitKey, 'json')) as { ts: number } | null
   if (lastSubmit && Date.now() - lastSubmit.ts < RATE_LIMIT_MS) {
     return jsonResponse({ error: 'Rate limit: wait 10 seconds between submissions' }, 429)
   }
   await kv.put(rateLimitKey, JSON.stringify({ ts: Date.now() }), { expirationTtl: 60 })
 
-  // Update personal best for today
+  // Update personal best for today.
+  // KV value shape evolved from { time_ms } → { time_ms, attempt_number }.
+  // Legacy records may still be missing attempt_number; treat that as graceful
+  // and only emit personal_best_attempt in the response when it's present.
   const bestKey = `best:${body.date}:${body.device_id}`
-  const currentBest = await kv.get(bestKey, 'json') as { time_ms: number } | null
-  if (!currentBest || body.time_ms < currentBest.time_ms) {
-    await kv.put(bestKey, JSON.stringify({ time_ms: body.time_ms }), {
+  const currentBest = (await kv.get(bestKey, 'json')) as BestRecord | null
+  const { record: bestRecord, isNewBest } = computeBestRecord(currentBest, body)
+  if (isNewBest) {
+    await kv.put(bestKey, JSON.stringify(bestRecord), {
       expirationTtl: KV_TTL_SECONDS,
     })
   }
 
   // Read-modify-write leaderboard
   const leaderboardKey = `leaderboard:${body.date}`
-  const existing = (await kv.get(leaderboardKey, 'json') as LeaderboardEntry[] | null) ?? []
+  const existing = ((await kv.get(leaderboardKey, 'json')) as LeaderboardEntry[] | null) ?? []
 
   const newEntry: LeaderboardEntry = {
-    rank: 0,  // assigned below after sort
+    rank: 0, // assigned below after sort
     nickname: sanitizeNickname(body.nickname),
     time_ms: body.time_ms,
     attempt_number: body.attempt_number,
@@ -63,13 +65,16 @@ export async function handlePostScore(
     expirationTtl: KV_TTL_SECONDS,
   })
 
-  const rank = updated.findIndex(
-    e => e.nickname === newEntry.nickname && e.time_ms === newEntry.time_ms,
-  ) + 1
+  const rank =
+    updated.findIndex((e) => e.nickname === newEntry.nickname && e.time_ms === newEntry.time_ms) + 1
 
   const response: ScoreSubmissionResponse = {
     rank: rank > 0 ? rank : updated.length + 1,
     total_players: updated.length,
+    personal_best_ms: bestRecord.time_ms,
+    ...(bestRecord.attempt_number !== undefined
+      ? { personal_best_attempt: bestRecord.attempt_number }
+      : {}),
   }
   return jsonResponse(response, 200)
 }

--- a/packages/game/src/utils/personal-best.test.ts
+++ b/packages/game/src/utils/personal-best.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { computeBestRecord } from '@shared/personal-best'
+
+describe('computeBestRecord', () => {
+  it('treats fresh KV (null) as a new best and stamps attempt_number', () => {
+    const submission = { time_ms: 180_000, attempt_number: 1 }
+    const { record, isNewBest } = computeBestRecord(null, submission)
+    expect(isNewBest).toBe(true)
+    expect(record.time_ms).toBe(180_000)
+    expect(record.attempt_number).toBe(1)
+  })
+
+  it('keeps legacy record (no attempt_number) on a slower submission, omitting the field entirely', () => {
+    const legacy = { time_ms: 200_000 } // legacy KV: no attempt_number key
+    const submission = { time_ms: 250_000, attempt_number: 3 }
+    const { record, isNewBest } = computeBestRecord(legacy, submission)
+    expect(isNewBest).toBe(false)
+    expect(record.time_ms).toBe(200_000)
+    // Field must be absent (not undefined) — verifies JSON serialization omits the key.
+    expect('attempt_number' in record).toBe(false)
+    expect(JSON.stringify(record)).toBe('{"time_ms":200000}')
+  })
+
+  it('preserves the original attempt_number on a tie (older record wins)', () => {
+    const existing = { time_ms: 175_000, attempt_number: 2 }
+    const submission = { time_ms: 175_000, attempt_number: 5 }
+    const { record, isNewBest } = computeBestRecord(existing, submission)
+    expect(isNewBest).toBe(false)
+    expect(record.time_ms).toBe(175_000)
+    expect(record.attempt_number).toBe(2)
+  })
+
+  it('returns isNewBest=true only when the submission is strictly faster', () => {
+    const existing = { time_ms: 200_000, attempt_number: 1 }
+    const faster = { time_ms: 199_999, attempt_number: 4 }
+    const { record, isNewBest } = computeBestRecord(existing, faster)
+    expect(isNewBest).toBe(true)
+    expect(record.time_ms).toBe(199_999)
+    expect(record.attempt_number).toBe(4)
+  })
+})

--- a/packages/game/src/utils/retro-questions.test.ts
+++ b/packages/game/src/utils/retro-questions.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { buildRetroQuestions } from './retro-questions'
+import type { ModuleStat } from '@/store/game-context'
+
+function stat(moduleType: string, timeMs: number, errorCount = 0): ModuleStat {
+  return { moduleType, timeMs, errorCount }
+}
+
+describe('buildRetroQuestions', () => {
+  const baseStats: ModuleStat[] = [
+    stat('wire', 30_000),
+    stat('dial', 105_000), // longest
+    stat('button', 38_000),
+    stat('keypad', 48_000),
+  ]
+
+  it('returns three "- " prefixed lines', () => {
+    const out = buildRetroQuestions(baseStats, 1, 'practice')
+    const lines = out.split('\n')
+    expect(lines).toHaveLength(3)
+    for (const line of lines) {
+      expect(line.startsWith('- ')).toBe(true)
+    }
+  })
+
+  it('Q1 names the slowest module by Chinese label (single longest)', () => {
+    const out = buildRetroQuestions(baseStats, 1, 'practice')
+    const q1 = out.split('\n')[0]
+    expect(q1).toContain('密码盘模块耗时最长')
+  })
+
+  it('on time ties, Q1 picks the lower-index module (stable)', () => {
+    const tied: ModuleStat[] = [
+      stat('wire', 60_000), // index 0 — wins tie
+      stat('dial', 60_000),
+      stat('button', 30_000),
+      stat('keypad', 30_000),
+    ]
+    const out = buildRetroQuestions(tied, 1, 'practice')
+    const q1 = out.split('\n')[0]
+    expect(q1).toContain('线路模块耗时最长')
+    expect(q1).not.toContain('密码盘模块耗时最长')
+  })
+
+  it('Q1 omits reset count when errorCount is 0', () => {
+    const out = buildRetroQuestions(baseStats, 1, 'practice')
+    const q1 = out.split('\n')[0]
+    expect(q1).toContain('耗时最长')
+    expect(q1).not.toContain('重置')
+  })
+
+  it('Q1 includes reset count when errorCount >= 1', () => {
+    const withReset: ModuleStat[] = [
+      stat('wire', 30_000),
+      stat('dial', 105_000, 2), // 2 resets
+      stat('button', 38_000),
+      stat('keypad', 48_000),
+    ]
+    const out = buildRetroQuestions(withReset, 1, 'practice')
+    const q1 = out.split('\n')[0]
+    expect(q1).toContain('耗时最长且重置 2 次')
+  })
+
+  it('Q2 in daily mode with attemptNumber > 1 references the attempt number', () => {
+    const out = buildRetroQuestions(baseStats, 3, 'daily')
+    const q2 = out.split('\n')[1]
+    expect(q2).toContain('第 3 次')
+    expect(q2).toContain('跟前几次比')
+  })
+
+  it('Q2 in daily mode with attemptNumber === 1 falls back to the generic question', () => {
+    const out = buildRetroQuestions(baseStats, 1, 'daily')
+    const q2 = out.split('\n')[1]
+    expect(q2).not.toContain('第 1 次')
+    expect(q2).toContain('这一局')
+  })
+
+  it('Q2 in practice mode uses the generic question regardless of attemptNumber', () => {
+    const out = buildRetroQuestions(baseStats, 4, 'practice')
+    const q2 = out.split('\n')[1]
+    expect(q2).not.toContain('第 4 次')
+    expect(q2).toContain('这一局')
+  })
+
+  it('Q3 always asks about updating the skills file', () => {
+    for (const mode of ['practice', 'daily'] as const) {
+      const out = buildRetroQuestions(baseStats, 2, mode)
+      const q3 = out.split('\n')[2]
+      expect(q3).toContain('skills 文件')
+    }
+  })
+
+  it('returns empty string when stats is empty', () => {
+    expect(buildRetroQuestions([], 1, 'practice')).toBe('')
+    expect(buildRetroQuestions([], 3, 'daily')).toBe('')
+  })
+})

--- a/packages/game/src/utils/retro-questions.ts
+++ b/packages/game/src/utils/retro-questions.ts
@@ -1,0 +1,57 @@
+import type { GameMode, ModuleStat } from '@/store/game-context'
+
+const MODULE_LABELS = ['线路', '密码盘', '按钮', '键盘']
+
+/**
+ * Find the index of the slowest module. Stable on ties — ties break toward
+ * the earlier index so the player always hears the same name back when they
+ * re-read the recap.
+ *
+ * Returns 0 on empty input; callers must short-circuit on empty stats before
+ * trusting the result (see `buildRetroQuestions` empty-stats guard).
+ */
+function findLongestModuleIndex(stats: ModuleStat[]): number {
+  if (stats.length === 0) return 0
+  let best = 0
+  for (let i = 1; i < stats.length; i++) {
+    if (stats[i].timeMs > stats[best].timeMs) {
+      best = i
+    }
+  }
+  return best
+}
+
+/**
+ * Build the spec §5.3 three-question retrospective block:
+ *  - Q1: focuses on the slowest module (and its reset count, if any)
+ *  - Q2: contextual — daily-mode 2nd-or-later attempt invites a comparison;
+ *        otherwise asks for a smooth/sticky moment
+ *  - Q3: closes the loop on the skills file
+ *
+ * Output is three "- " bulleted lines, ready to drop straight into the recap.
+ */
+export function buildRetroQuestions(
+  stats: ModuleStat[],
+  attemptNumber: number,
+  mode: GameMode
+): string {
+  if (stats.length === 0) return ''
+  const longestIdx = findLongestModuleIndex(stats)
+  const longest = stats[longestIdx]
+  const longestName = MODULE_LABELS[longestIdx] ?? longest?.moduleType ?? '某个'
+  const resets = longest?.errorCount ?? 0
+
+  const q1 =
+    resets >= 1
+      ? `${longestName}模块耗时最长且重置 ${resets} 次，我们的沟通/操作哪里可以改进？`
+      : `${longestName}模块耗时最长，我们的沟通/操作哪里可以改进？`
+
+  const q2 =
+    mode === 'daily' && attemptNumber > 1
+      ? `这是我今天的第 ${attemptNumber} 次，跟前几次比哪里更顺、哪里更卡？`
+      : `这一局有什么时刻沟通格外顺、有什么时刻格外卡？`
+
+  const q3 = `我们的 skills 文件需要补什么，下次能再快一点？`
+
+  return `- ${q1}\n- ${q2}\n- ${q3}`
+}

--- a/prompts/example-skills.md
+++ b/prompts/example-skills.md
@@ -3,6 +3,7 @@
 ## Opening Protocol
 
 At the start of each run, I report:
+
 1. Serial number (read left to right, distinguish letters from numbers)
 2. Battery count (total batteries visible)
 3. Indicator lights (label and whether lit or unlit)
@@ -12,37 +13,47 @@ You record these — all modules may reference them.
 ## Symbol Description Convention
 
 Agreed names for dial and keypad symbols:
-- omega    = horseshoe (U-shape with serifs)
-- psi      = three-pronged fork
-- delta    = filled triangle
-- star     = six-pointed star
-- xi       = three horizontal lines
-- diamond  = rotated square
-- trident  = trident with three upward prongs
+
+- omega = horseshoe (U-shape with serifs)
+- psi = three-pronged fork
+- delta = filled triangle
+- star = six-pointed star
+- xi = three horizontal lines
+- diamond = rotated square
+- trident = trident with three upward prongs
 - crescent = crescent moon shape
+- spiral = inward-curling spiral
+- cross = plus sign / cross
+- eye = eye shape with a central dot
+- lambda = upside-down V
+- hourglass = two triangles tip-to-tip
 
 If I describe something you don't recognize, repeat it back and confirm before giving instructions.
 
 ## Module Communication Protocols
 
 ### Wire Routing
+
 - I describe wires top-to-bottom with color and stripe info
 - Format: "Red, blue striped, yellow, green, black"
 - Always mention stripes — they may matter
 - You respond: "Cut wire #X" (1-indexed from top)
 
 ### Symbol Dial
+
 - I describe the current top symbol on each of the 3 dials
 - Format: "Dial 1: omega, Dial 2: star, Dial 3: delta"
 - You respond: "Set Dial 1 to position X, Dial 2 to Y, Dial 3 to Z"
 - I confirm and click Confirm button
 
 ### Big Button
+
 - I describe: color, label text
 - You respond immediately: "TAP" or "HOLD"
 - If HOLD: I press and hold, you tell me the indicator light color to watch for, then say "RELEASE" when I describe that color
 
 ### Keypad
+
 - I describe the 4 symbols in reading order (top-left, top-right, bottom-left, bottom-right)
 - You respond: "Click in order: [symbol1], [symbol2], [symbol3], [symbol4]"
 - I click them in that order

--- a/shared/leaderboard-types.ts
+++ b/shared/leaderboard-types.ts
@@ -1,17 +1,22 @@
 export interface ScoreSubmission {
-  date: string             // YYYY-MM-DD
-  nickname: string         // max 20 chars, sanitized server-side
-  time_ms: number          // total game time in milliseconds
-  attempt_number: number   // which attempt this was today
-  module_times: number[]   // time per module in ms (length 4)
-  operations_hash: string  // SHA-256 of operation log for post-hoc verification
-  ai_tool?: string         // optional: 'claude' | 'chatgpt' | 'gemini' | string
-  device_id: string        // UUID from localStorage
+  date: string // YYYY-MM-DD
+  nickname: string // max 20 chars, sanitized server-side
+  time_ms: number // total game time in milliseconds
+  attempt_number: number // which attempt this was today
+  module_times: number[] // time per module in ms (length 4)
+  operations_hash: string // SHA-256 of operation log for post-hoc verification
+  ai_tool?: string // optional: 'claude' | 'chatgpt' | 'gemini' | string
+  device_id: string // UUID from localStorage
 }
 
 export interface ScoreSubmissionResponse {
   rank: number
   total_players: number
+  /** Player's best time today (ms) — typically the lower of currentBest and the just-submitted time. */
+  personal_best_ms?: number
+  /** Attempt number on which the personal_best was set today.
+   *  Optional because legacy KV records pre-dating this field have no attempt_number. */
+  personal_best_attempt?: number
 }
 
 export interface LeaderboardEntry {

--- a/shared/personal-best.ts
+++ b/shared/personal-best.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure decision logic for the daily personal-best record kept in KV.
+ *
+ * KV value shape evolved from `{ time_ms }` to `{ time_ms, attempt_number }`.
+ * Legacy records may be missing `attempt_number`; this helper preserves that
+ * absence so the response layer can omit `personal_best_attempt` entirely
+ * (rather than emit `undefined`) when the existing best predates the field.
+ */
+export interface BestRecord {
+  time_ms: number
+  attempt_number?: number
+}
+
+export interface BestSubmission {
+  time_ms: number
+  attempt_number: number
+}
+
+export interface ComputeBestResult {
+  record: BestRecord
+  isNewBest: boolean
+}
+
+/**
+ * Decide the canonical best record after a submission.
+ *
+ * Strict `<` on time_ms: ties keep the existing record, so the older attempt
+ * — the canonical "first to achieve this time" — wins. When `currentBest` is
+ * `null` (fresh KV), the submission becomes the new best.
+ */
+export function computeBestRecord(
+  currentBest: BestRecord | null,
+  submission: BestSubmission
+): ComputeBestResult {
+  if (!currentBest || submission.time_ms < currentBest.time_ms) {
+    return {
+      record: {
+        time_ms: submission.time_ms,
+        attempt_number: submission.attempt_number,
+      },
+      isNewBest: true,
+    }
+  }
+  return { record: currentBest, isNewBest: false }
+}


### PR DESCRIPTION
## Summary

- Rebuilds the personal-best + retro-questions data layer that 2026-05-06 task [build-amiclaw-recap-and-skills](pages/projects/amiclaw/tasks/build-amiclaw-recap-and-skills.md) produced (verifier-passed) but was never committed.
- The accompanying prompt / HomePage / ResultPage UI from that WIP was obsoleted by #65 (PromptModal refactor) and is intentionally left out of this PR; a follow-up will rewire UI against the new architecture.
- Also ports 5 missing symbol definitions (spiral / cross / eye / lambda / hourglass) from the 5/6 WIP Chinese skills.md into the English `prompts/example-skills.md`.

## What's in this PR (7 files, +292/-31)

| File | Kind | Purpose |
|---|---|---|
| `shared/personal-best.ts` | new | `computeBestRecord` pure helper (strict-less tie-keep-original + graceful legacy KV) |
| `packages/game/src/utils/personal-best.test.ts` | new | 4 vitest cases (fresh / legacy JSON-omit / tie-keep-original / strict-faster) |
| `packages/game/src/utils/retro-questions.ts` | new | \`buildRetroQuestions\` util with stable tie-break + empty-stats guard |
| `packages/game/src/utils/retro-questions.test.ts` | new | 9 vitest cases (longest-module / ties / resets wording / daily-Nth vs practice fallback / Q3-always-skills / empty stats) |
| `packages/api/src/handlers/post-score.ts` | modified | KV shape evolves to \`{time_ms, attempt_number?}\`; uses helper; returns \`personal_best_ms\` + optional \`personal_best_attempt\` |
| `shared/leaderboard-types.ts` | modified | +2 optional \`ScoreSubmissionResponse\` fields, zero break on existing callers |
| \`prompts/example-skills.md\` | modified | +5 symbol definitions ported from 5/6 WIP Chinese version |

## Test plan

- [x] \`pnpm -w test:run\` — 24 files / 133 tests pass (22 game + 2 manual)
- [x] \`pnpm -w build\` — TypeScript compile + vite 78 modules transformed pass
- [ ] Verify in deployed preview: \`POST /api/score\` with a daily-mode submission returns \`personal_best_ms\` field; second submission with slower time returns same \`personal_best_ms\` (tie-keep-original)
- [ ] Verify in deployed preview: legacy KV records (pre this PR, only \`{time_ms}\` shape) still work and the response omits \`personal_best_attempt\`

## Follow-up

UI integration (wire \`personal_best_*\` fields into the Result page and use \`buildRetroQuestions\` in the recap summary) needs separate work to rebuild on top of #65's PromptModal architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)