### PR TITLE
feat(game): promote how-to above CTAs + add mobile breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ### Improvements
 
+- **Landing first impression** The home page now leads with the four-step
+  "怎么开始" guide above the practice / daily CTAs, so visitors arriving from
+  a cold-shared link see the voice-AI partner is a prerequisite before they
+  tap a button. Step 1 carries a neon-cyan side accent and a "必备：" prefix
+  to highlight the AI-must-be-running requirement, and a new `≤480px` mobile
+  breakpoint stacks the CTAs vertically with full-width buttons, tightens the
+  BOMBSQUAD title letter-spacing, and aligns home-page padding so 320 / 375 /
+  414 viewports no longer overflow.
 - **Test runner self-containment** Internal refactor — `packages/manual` now
   has its own vitest setup, and the cross-SSOT character-equal guard tests
   (manual yaml symbols matching `shared/symbols.ts`) live in the manual

--- a/packages/game/src/pages/HomePage.module.css
+++ b/packages/game/src/pages/HomePage.module.css
@@ -160,7 +160,7 @@
   text-align: center;
 }
 
-/* Mobile breakpoint — phones in 朋友圈 cold-share flow.
+/* Mobile breakpoint — phones in cold-shared link flow.
    At <=480px the page switches to a top-anchored vertical stack so the
    how-to guide and CTAs both stay visible on a 320 / 375 / 414 viewport. */
 @media (max-width: 480px) {

--- a/packages/game/src/pages/HomePage.module.css
+++ b/packages/game/src/pages/HomePage.module.css
@@ -145,9 +145,55 @@
   min-width: 20px;
 }
 
+/* Pre-flight requirement callout — used on step 1 only.
+   Neon-cyan side accent flags the "voice AI must be open before you start"
+   requirement without bleeding the accent across the rest of the list. */
+.howToList li.stepRequired {
+  border-left: 2px solid var(--color-neon-cyan);
+  padding-left: 8px;
+}
+
 .footer {
   font-family: var(--font-sans);
   font-size: 0.75rem;
   color: var(--color-text-muted);
   text-align: center;
+}
+
+/* Mobile breakpoint — phones in 朋友圈 cold-share flow.
+   At <=480px the page switches to a top-anchored vertical stack so the
+   how-to guide and CTAs both stay visible on a 320 / 375 / 414 viewport. */
+@media (max-width: 480px) {
+  .page {
+    justify-content: flex-start;
+    padding: 24px 12px;
+    gap: 24px;
+  }
+
+  .title {
+    /* 0.15em letter-spacing tips BOMBSQUAD past 320px viewport width when
+       paired with the clamp() minimum font-size; tighten on small screens. */
+    letter-spacing: 0.08em;
+  }
+
+  .ctaRow {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    max-width: 320px;
+  }
+
+  .btnPrimary,
+  .btnSecondary {
+    width: 100%;
+  }
+
+  .howTo {
+    max-width: 100%;
+  }
+
+  .howToList li {
+    /* Floor at 14px so Chinese characters stay legible on phones. */
+    font-size: 0.875rem;
+  }
 }

--- a/packages/game/src/pages/HomePage.tsx
+++ b/packages/game/src/pages/HomePage.tsx
@@ -5,7 +5,7 @@ import PromptModal, { type PromptMode } from '@/components/PromptModal'
 import styles from './HomePage.module.css'
 
 const HOW_TO_STEPS = [
-  '在另一个窗口/设备打开你的 AI（Claude、ChatGPT、Gemini…）并切到语音模式。',
+  '必备：在另一个窗口/设备打开你的 AI（Claude、ChatGPT、Gemini…）并切到语音模式。',
   '点「练习」或「每日挑战」，把弹窗里的手册地址复制发给 AI。等它说读完手册了。',
   '回到游戏页，按「确认开始游戏」。',
   '描述你看到的场景，AI 会告诉你怎么操作。用时越短，排名越高。',
@@ -49,6 +49,18 @@ export default function HomePage() {
       <h1 className={styles.title}>BOMBSQUAD</h1>
       <p className={styles.subtitle}>人机协作 · 语音拆弹挑战</p>
 
+      <section className={styles.howTo} aria-label="怎么开始">
+        <h2 className={styles.howToTitle}>怎么开始</h2>
+        <ol className={styles.howToList}>
+          {HOW_TO_STEPS.map((step, i) => (
+            <li key={i} className={i === 0 ? styles.stepRequired : undefined}>
+              <span className={styles.stepNum}>{i + 1}.</span>
+              <span>{step}</span>
+            </li>
+          ))}
+        </ol>
+      </section>
+
       <div className={styles.ctaRow}>
         <button className={styles.btnSecondary} onClick={openPractice}>
           练习
@@ -61,18 +73,6 @@ export default function HomePage() {
       <Link to="/leaderboard" className={styles.leaderboardLink}>
         排行榜 →
       </Link>
-
-      <section className={styles.howTo} aria-label="怎么开始">
-        <h2 className={styles.howToTitle}>怎么开始</h2>
-        <ol className={styles.howToList}>
-          {HOW_TO_STEPS.map((step, i) => (
-            <li key={i}>
-              <span className={styles.stepNum}>{i + 1}.</span>
-              <span>{step}</span>
-            </li>
-          ))}
-        </ol>
-      </section>
 
       <p className={styles.footer}>支持 Claude · ChatGPT · Gemini 或任意语音 AI</p>
 


### PR DESCRIPTION
## Summary

- Move HOW_TO_STEPS guide above CTA buttons so cold-shared link visitors see the voice-AI prerequisite before tapping a button
- Add neon-cyan border-left accent + "必备：" prefix on step 1 (DesignSystem `--color-neon-cyan` token reuse — Cyberpunk HUD callout, no glyph duplication, no whole-row bold competing with title)
- Add `@media (max-width: 480px)` breakpoint covering 320 / 375 / 414 viewports — vertical CTA stack (capped 320px max-width), 14px font floor on `.howToList li`, tightened title letter-spacing for 320px fit
- CHANGELOG.md `[Unreleased]` > Improvements updated

## Type of change

- [x] Refactor or cleanup
- [x] New feature

(Layout refactor + new mobile breakpoint counts as both.)

## Testing

- [x] Existing tests pass — `pnpm run test`: 94/94 game-package + 25/25 manual-package tests, including `game-flow.test.tsx` integration
- [x] `pnpm run lint`: 0 errors
- [x] `pnpm run build`: 0 warnings
- [x] verifier-claude `verify-correctness` round → `passed` against 7 Acceptance Criteria + Scope-Out checks
- [ ] Manual mobile sanity check at 320 / 375 / 414 viewports recommended pre-merge (not blocking — CSS-only change)

## Checklist

- [x] Code follows the project style — DesignSystem token reuse (`--color-neon-cyan`, `--touch-target`); CSS-only animation; dark-only theme preserved
- [x] Self-reviewed the diff — JSX reorder + additive CSS only; PromptModal / App / route pages untouched
- [x] No debug logging remains
- [x] Documentation updated if needed — CHANGELOG.md `[Unreleased]` entry per `docs/changelog-style-guide.md`
- [x] Breaking changes documented if any — none; presentation-only, no behavior path change, PromptModal flow zero-regression

## Notes

- **No browser-requirements copy added** — IA AUQ user override; sibling task `add-voice-ai-compatibility-page` is the dedicated surface for AI/browser compatibility details.
- **Task record**: `pages/projects/amiclaw/tasks/polish-landing-first-impression.md`
- **Parent scope**: `pages/projects/amiclaw/tasks/scope-amiclaw-internal-beta-readiness.md` Tier 1 #1 (5/18-5/31 internal beta readiness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)