### PR TITLE
feat(game): error fallback guidance for 4 failure surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ Versions follow [Semantic Versioning](https://semver.org).
   breakpoint stacks the CTAs vertically with full-width buttons, tightens the
   BOMBSQUAD title letter-spacing, and aligns home-page padding so 320 / 375 /
   414 viewports no longer overflow.
+- **Failure-state guidance** Four failure surfaces in the daily flow now
+  point players toward a recovery path instead of dead-ending. A corrupted
+  manual is recognized as a parse error and surfaces "手册格式异常，请截图邮件
+  反馈给 <byheaven0912@gmail.com>" instead of the previous misleading
+  "check your network" prompt. Network drops show "加载失败，请检查网络或换
+  Chrome / Safari 试试。一直失败可邮件反馈" alongside a retry button. The
+  leaderboard error state, previously a static "排行榜暂不可用，稍后再试。",
+  now exposes an inline 重试 button plus the same feedback hint. And a
+  result-page repeat-submit failure no longer leaves a blank screen — it
+  shows "网络不稳定，可下次再来重新提交。或邮件反馈" so players know the
+  run isn't lost on our side.
 - **Test runner self-containment** Internal refactor — `packages/manual` now
   has its own vitest setup, and the cross-SSOT character-equal guard tests
   (manual yaml symbols matching `shared/symbols.ts`) live in the manual

--- a/packages/game/src/pages/GamePage.tsx
+++ b/packages/game/src/pages/GamePage.tsx
@@ -5,7 +5,12 @@ import type { Manual, SceneInfo, ModuleConfig, ModuleAnswer } from '@shared/manu
 import { useGame } from '@/store/game-context'
 import { useTimer } from '@/hooks/useTimer'
 import { createRng, type Rng } from '@/engine/rng'
-import { loadManual, ManualNotFoundError } from '@/utils/yaml-loader'
+import {
+  loadManual,
+  ManualNetworkError,
+  ManualNotFoundError,
+  ManualParseError,
+} from '@/utils/yaml-loader'
 import { logEvent } from '@/utils/event-log'
 import { generateWire } from '@/modules/wire/generator'
 import { generateDial } from '@/modules/dial/generator'
@@ -116,9 +121,21 @@ async function loadWithCache(manualUrl: string): Promise<Manual> {
     // 404 means the manual was never published — no point consulting the cache.
     // Re-throw so the caller can render a dedicated "not published" UI.
     if (err instanceof ManualNotFoundError) throw err
+    // Parse error means the server-side YAML is malformed — the cached copy
+    // (a successfully-loaded earlier dump) won't help the user understand the
+    // current breakage, and we want UI to surface "format" not "network".
+    if (err instanceof ManualParseError) throw err
+    // Network error (fetch reject / 5xx etc.) — try cached copy first.
     const cached = sessionStorage.getItem(cacheKey)
-    if (cached) return yaml.load(cached) as Manual
-    throw new Error('手册加载失败，请检查网络。', { cause: err })
+    if (cached) {
+      try {
+        return yaml.load(cached) as Manual
+      } catch {
+        /* cached blob unreadable — fall through to typed error */
+      }
+    }
+    if (err instanceof ManualNetworkError) throw err
+    throw new ManualNetworkError(manualUrl, undefined, err)
   }
 }
 
@@ -257,12 +274,28 @@ export default function GamePage() {
           rngSeed: seed,
         })
       } catch (err) {
-        const notPublished = err instanceof ManualNotFoundError
-        dispatch({
-          type: 'LOAD_ERROR',
-          message: err instanceof Error ? err.message : '手册加载失败',
-          kind: notPublished ? 'not_published' : 'generic',
-        })
+        if (err instanceof ManualNotFoundError) {
+          dispatch({ type: 'LOAD_ERROR', message: err.message, kind: 'not_published' })
+        } else if (err instanceof ManualParseError) {
+          dispatch({
+            type: 'LOAD_ERROR',
+            message: '手册格式异常，请截图邮件反馈给 byheaven0912@gmail.com',
+            kind: 'yaml_parse',
+          })
+        } else if (err instanceof ManualNetworkError) {
+          dispatch({
+            type: 'LOAD_ERROR',
+            message:
+              '加载失败，请检查网络或换 Chrome / Safari 试试。一直失败可邮件 byheaven0912@gmail.com',
+            kind: 'network',
+          })
+        } else {
+          dispatch({
+            type: 'LOAD_ERROR',
+            message: err instanceof Error ? err.message : '手册加载失败',
+            kind: 'generic',
+          })
+        }
       }
     }
 
@@ -399,9 +432,25 @@ export default function GamePage() {
                   ← 返回首页
                 </Link>
               </>
+            ) : state.errorKind === 'yaml_parse' ? (
+              <>
+                <p className={styles.errorText}>
+                  手册格式异常，请截图邮件反馈给 byheaven0912@gmail.com
+                </p>
+                <button className={styles.retryBtn} onClick={() => window.location.reload()}>
+                  重试
+                </button>
+                <Link to="/" className={styles.homeLink}>
+                  ← 返回首页
+                </Link>
+              </>
             ) : (
               <>
-                <p className={styles.errorText}>{state.errorMessage}</p>
+                <p className={styles.errorText}>
+                  {state.errorKind === 'network'
+                    ? '加载失败，请检查网络或换 Chrome / Safari 试试。一直失败可邮件 byheaven0912@gmail.com'
+                    : state.errorMessage}
+                </p>
                 <button className={styles.retryBtn} onClick={() => window.location.reload()}>
                   重试
                 </button>

--- a/packages/game/src/pages/LeaderboardPage.module.css
+++ b/packages/game/src/pages/LeaderboardPage.module.css
@@ -73,3 +73,38 @@
   color: var(--color-text-primary);
   text-decoration: underline;
 }
+
+.errorBlock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 0;
+}
+
+.retryBtn {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  padding: 10px 28px;
+  background: transparent;
+  color: var(--color-neon-red);
+  border: 1px solid var(--color-neon-red);
+  border-radius: 4px;
+  cursor: pointer;
+  letter-spacing: 0.1em;
+  min-height: var(--touch-target);
+}
+
+.retryBtn:hover,
+.retryBtn:focus-visible {
+  background: rgba(255, 7, 58, 0.08);
+  outline: 2px solid var(--color-neon-red);
+  outline-offset: 2px;
+}
+
+.statusMuted {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  text-align: center;
+}

--- a/packages/game/src/pages/LeaderboardPage.tsx
+++ b/packages/game/src/pages/LeaderboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { fetchLeaderboard } from '@/utils/leaderboard-api'
 import {
@@ -34,7 +34,12 @@ export default function LeaderboardPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
 
-  useEffect(() => {
+  // The fetch + merge body is shared between mount and retry. Synchronous
+  // `setLoading(true)` / `setError(false)` are deliberately kept OUT of here so
+  // calling it from `useEffect` doesn't trigger react-hooks/set-state-in-effect;
+  // the mount path relies on the initial `loading: true` / `error: false` state,
+  // and the retry handler resets both before calling this.
+  const fetchEntries = useCallback(() => {
     fetchLeaderboard(today).then((data) => {
       setLoading(false)
       if (data) {
@@ -56,13 +61,31 @@ export default function LeaderboardPage() {
     })
   }, [today])
 
+  useEffect(() => {
+    fetchEntries()
+  }, [fetchEntries])
+
+  const handleRetry = useCallback(() => {
+    setLoading(true)
+    setError(false)
+    fetchEntries()
+  }, [fetchEntries])
+
   return (
     <main className={styles.page}>
       <h1 className={styles.title}>排行榜</h1>
       <p className={styles.notice}>每日 — {today}</p>
 
       {loading && <p className={styles.status}>加载中…</p>}
-      {error && <p className={styles.status}>排行榜暂不可用，稍后再试。</p>}
+      {error && (
+        <div className={styles.errorBlock}>
+          <p className={styles.status}>排行榜暂不可用，稍后再试。</p>
+          <button type="button" className={styles.retryBtn} onClick={handleRetry}>
+            重试
+          </button>
+          <p className={styles.statusMuted}>若一直无法访问，可邮件 byheaven0912@gmail.com 反馈</p>
+        </div>
+      )}
 
       {!loading && !error && entries.length === 0 && (
         <p className={styles.status}>今日还没有成绩，来抢第一！</p>

--- a/packages/game/src/pages/ResultPage.tsx
+++ b/packages/game/src/pages/ResultPage.tsx
@@ -198,16 +198,19 @@ ${breakdown}
               全球排名：<strong>#{rankResult.rank}</strong> / {rankResult.total_players}
             </span>
           )}
-          {submitFailed && (
-            <span className={styles.rankMuted}>
-              提交失败（可能离线）
-              {!retried && (
+          {submitFailed &&
+            (retried ? (
+              <span className={styles.rankMuted}>
+                网络不稳定，可下次再来重新提交。或邮件反馈 byheaven0912@gmail.com
+              </span>
+            ) : (
+              <span className={styles.rankMuted}>
+                提交失败（可能离线）
                 <button className={styles.retryBtn} onClick={handleRetrySubmit}>
                   重试
                 </button>
-              )}
-            </span>
-          )}
+              </span>
+            ))}
         </div>
       )}
 

--- a/packages/game/src/store/game-context.tsx
+++ b/packages/game/src/store/game-context.tsx
@@ -23,7 +23,7 @@ export interface ModuleStat {
   errorCount: number // number of wrong answers before solving
 }
 
-export type LoadErrorKind = 'not_published' | 'generic'
+export type LoadErrorKind = 'not_published' | 'generic' | 'yaml_parse' | 'network'
 
 export interface GameState {
   status: GameStatus

--- a/packages/game/src/utils/yaml-loader.test.ts
+++ b/packages/game/src/utils/yaml-loader.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ManualNotFoundError, loadManual } from './yaml-loader'
+import {
+  ManualNetworkError,
+  ManualNotFoundError,
+  ManualParseError,
+  loadManual,
+} from './yaml-loader'
 
 const SAMPLE_MANUAL_YAML = `
 meta:
@@ -12,6 +17,11 @@ modules:
   button: { rules: [] }
   keypad: { sequences: [] }
 `
+
+// `*missing` references an undefined YAML anchor — js-yaml reliably throws
+// a YAMLException ("undefined alias"), which is the parse-failure path we
+// want to distinguish from network failures at the loader boundary.
+const INVALID_YAML = '*missing'
 
 describe('loadManual', () => {
   const originalFetch = globalThis.fetch
@@ -29,7 +39,7 @@ describe('loadManual', () => {
     )
   })
 
-  it('rejects with a generic Error on other non-ok responses', async () => {
+  it('rejects with ManualNetworkError on other non-ok responses', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue(new Response('server boom', { status: 500 }))
 
     let caught: unknown
@@ -38,9 +48,43 @@ describe('loadManual', () => {
     } catch (err) {
       caught = err
     }
-    expect(caught).toBeInstanceOf(Error)
+    expect(caught).toBeInstanceOf(ManualNetworkError)
     expect(caught).not.toBeInstanceOf(ManualNotFoundError)
+    expect((caught as ManualNetworkError).status).toBe(500)
     expect((caught as Error).message).toContain('500')
+  })
+
+  it('rejects with ManualNetworkError when fetch itself rejects', async () => {
+    const networkFailure = new TypeError('Failed to fetch')
+    globalThis.fetch = vi.fn().mockRejectedValue(networkFailure)
+
+    let caught: unknown
+    try {
+      await loadManual('https://example.test/manual/offline-case')
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(ManualNetworkError)
+    expect((caught as ManualNetworkError).status).toBeUndefined()
+    expect((caught as { cause?: unknown }).cause).toBe(networkFailure)
+  })
+
+  it('rejects with ManualParseError when the body is invalid YAML', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(INVALID_YAML, {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      })
+    )
+
+    let caught: unknown
+    try {
+      await loadManual('https://example.test/manual/bad-yaml-case')
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(ManualParseError)
+    expect(caught).not.toBeInstanceOf(ManualNetworkError)
   })
 
   it('returns the parsed manual on success', async () => {

--- a/packages/game/src/utils/yaml-loader.ts
+++ b/packages/game/src/utils/yaml-loader.ts
@@ -17,20 +17,66 @@ export class ManualNotFoundError extends Error {
   }
 }
 
+/**
+ * Thrown when the manual body fetched from the server cannot be parsed as
+ * YAML (js-yaml throws YAMLException). Distinct from network errors so the
+ * UI can tell the user the manual itself is malformed and a network retry
+ * won't help — they should report it instead.
+ */
+export class ManualParseError extends Error {
+  readonly kind = 'yaml_parse' as const
+
+  constructor(url: string, cause?: unknown) {
+    super(`Manual YAML parse failed at ${url}`, cause !== undefined ? { cause } : undefined)
+    this.name = 'ManualParseError'
+  }
+}
+
+/**
+ * Thrown when the manual could not be fetched due to a network-layer failure
+ * (fetch reject) or a non-ok HTTP status other than 404. Callers may fall
+ * back to a session-cached copy before surfacing this to the user.
+ */
+export class ManualNetworkError extends Error {
+  readonly kind = 'network' as const
+  readonly status?: number
+
+  constructor(url: string, status?: number, cause?: unknown) {
+    super(
+      status !== undefined
+        ? `Failed to load manual: ${status} at ${url}`
+        : `Network error loading manual at ${url}`,
+      cause !== undefined ? { cause } : undefined
+    )
+    this.name = 'ManualNetworkError'
+    if (status !== undefined) this.status = status
+  }
+}
+
 export async function loadManual(url: string): Promise<Manual> {
   if (CACHE.has(url)) return CACHE.get(url)!
 
-  const res = await fetch(url, {
-    headers: { Accept: 'application/yaml, text/plain' },
-  })
+  let res: Response
+  try {
+    res = await fetch(url, {
+      headers: { Accept: 'application/yaml, text/plain' },
+    })
+  } catch (err) {
+    throw new ManualNetworkError(url, undefined, err)
+  }
   if (res.status === 404) {
     throw new ManualNotFoundError(url)
   }
   if (!res.ok) {
-    throw new Error(`Failed to load manual: ${res.status} ${res.statusText}`)
+    throw new ManualNetworkError(url, res.status)
   }
   const text = await res.text()
-  const manual = yaml.load(text) as Manual
+  let manual: Manual
+  try {
+    manual = yaml.load(text) as Manual
+  } catch (err) {
+    throw new ManualParseError(url, err)
+  }
   CACHE.set(url, manual)
   return manual
 }


### PR DESCRIPTION
## Summary

- Discriminate YAML parse errors from network errors in the daily-manual loader so corrupt manuals no longer mislead users to "check your network".
- Add user-recoverable error UI to four failure surfaces (manual parse, network drop, leaderboard fetch, repeat score submit) with a single feedback channel (byheaven0912@gmail.com).
- Internal-beta unblocker: the 5/18-5/31 friend cohort now sees a recovery path on every failure mode instead of dead-ending.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Manual / automated coverage:

- `pnpm test` — 121 / 121 pass (96 game + 25 manual).
- `pnpm lint` — 0 errors.
- `pnpm build` — succeeds (78 modules transformed).
- yaml-loader has new unit tests covering ManualParseError (corrupt YAML) and ManualNetworkError (fetch reject + non-ok response), plus the existing ManualNotFoundError + 500 cases continue to pass.
- The four UI changes were code-reviewed against the spec:
  - GamePage `LOADING` state: `not_published` / `yaml_parse` / `network` / `generic` UI branches.
  - LeaderboardPage error state: 重试 button performs a real re-fetch via `fetchEntries`.
  - ResultPage second-failure (`submitFailed && retried`): shows consolation copy, no retry button.

## Checklist

- [x] Code follows the project style (lint-staged + prettier + markdownlint clean)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (CHANGELOG entry in the same change set)
- [x] Breaking changes documented if any (none — yaml-loader still exports `loadManual(url)` with the same signature; new exports are additive)

## TaskNote

[[pages/projects/amiclaw/tasks/add-error-fallback-messages]] — Tier 1 internal-beta-readiness queue.