### PR TITLE
feat(game): leaderboard nickname prompt + localStorage gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ### Added
 
+- **Leaderboard nickname prompt** First time a player finishes a daily
+  challenge, the result page asks for a nickname (max 20 chars) before posting
+  the score. The value is stored in localStorage and reused on every later
+  daily run from the same device, so the leaderboard finally shows recognisable
+  names instead of a wall of "Anonymous". The prompt is required — submission
+  is blocked until a valid nickname is entered — and there is no edit-later
+  entry point in this release. Source task `add-leaderboard-anonymous-handle`.
 - **Audio + animation feedback** Every in-module click now gives a short
   pulse animation and a sound effect (confirm, wire-cut, dial-rotate,
   keypad-press, button-down/up). Solving or failing a module plays a soft

--- a/packages/game/src/components/NicknameModal.module.css
+++ b/packages/game/src/components/NicknameModal.module.css
@@ -1,0 +1,135 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(13, 13, 26, 0.92);
+  z-index: 1100;
+}
+
+.dialog {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-neon-cyan);
+  border-radius: 6px;
+  padding: 32px 24px 24px;
+  box-shadow: 0 0 30px rgba(0, 255, 255, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.title {
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  font-weight: bold;
+  color: var(--color-neon-cyan);
+  letter-spacing: 0.1em;
+  margin: 0;
+}
+
+.tip {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.labelText {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.input {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  color: var(--color-text-primary);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 10px 12px;
+  min-height: var(--touch-target);
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.input:focus-visible {
+  outline: none;
+  border-color: var(--color-neon-cyan);
+  box-shadow: 0 0 8px rgba(0, 255, 255, 0.3);
+}
+
+.meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  min-height: 1.2em;
+  gap: 12px;
+}
+
+.counter {
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.error {
+  color: var(--color-neon-red);
+  text-align: right;
+}
+
+.confirmBtn {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  font-weight: bold;
+  padding: 12px 24px;
+  background: transparent;
+  color: var(--color-neon-cyan);
+  border: 2px solid var(--color-neon-cyan);
+  border-radius: 4px;
+  cursor: pointer;
+  letter-spacing: 0.1em;
+  min-height: var(--touch-target);
+  box-shadow: 0 0 10px rgba(0, 255, 255, 0.2);
+  transition:
+    background 0.15s ease,
+    box-shadow 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.confirmBtn:hover:not(:disabled),
+.confirmBtn:focus-visible:not(:disabled) {
+  background: rgba(0, 255, 255, 0.08);
+  box-shadow: 0 0 20px rgba(0, 255, 255, 0.5);
+  outline: 2px solid var(--color-neon-cyan);
+  outline-offset: 2px;
+}
+
+.confirmBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}

--- a/packages/game/src/components/NicknameModal.tsx
+++ b/packages/game/src/components/NicknameModal.tsx
@@ -1,0 +1,94 @@
+import { useId, useState, type FormEvent } from 'react'
+import { NICKNAME_MAX_LENGTH, isValidNickname, setStoredNickname } from '@/utils/nickname'
+import styles from './NicknameModal.module.css'
+
+interface NicknameModalProps {
+  open: boolean
+  onConfirm: (nickname: string) => void
+}
+
+/**
+ * Required first-submission gate for the daily leaderboard.
+ *
+ * Shown when `getStoredNickname()` returns null on a daily-mode ResultPage.
+ * The modal is intentionally non-dismissable — there is no close button, Esc
+ * does nothing, and clicking the backdrop does nothing — because the player
+ * cannot post a score without a nickname. Once confirmed, the value is stored
+ * in localStorage by this component and reused on subsequent daily runs.
+ */
+export default function NicknameModal({ open, onConfirm }: NicknameModalProps) {
+  const [value, setValue] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const titleId = useId()
+  const descId = useId()
+
+  if (!open) return null
+
+  const trimmed = value.trim()
+  const canConfirm = isValidNickname(value)
+
+  const handleConfirm = () => {
+    if (!canConfirm) return
+    const ok = setStoredNickname(value)
+    if (!ok) {
+      setError('保存失败，请重试。')
+      return
+    }
+    setError(null)
+    onConfirm(trimmed)
+  }
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    handleConfirm()
+  }
+
+  return (
+    <div className={styles.overlay} role="presentation">
+      <div
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+      >
+        <h2 id={titleId} className={styles.title}>
+          给自己起个名字
+        </h2>
+        <p id={descId} className={styles.tip}>
+          排行榜上需要一个能让朋友找到你的名字。最多 {NICKNAME_MAX_LENGTH} 字。
+        </p>
+
+        <form className={styles.form} onSubmit={handleSubmit}>
+          <label className={styles.label}>
+            <span className={styles.labelText}>昵称</span>
+            <input
+              className={styles.input}
+              type="text"
+              value={value}
+              onChange={(e) => {
+                setValue(e.target.value)
+                if (error) setError(null)
+              }}
+              maxLength={NICKNAME_MAX_LENGTH}
+              autoFocus
+            />
+          </label>
+          <div className={styles.meta}>
+            <span className={styles.counter} aria-live="polite">
+              {trimmed.length} / {NICKNAME_MAX_LENGTH}
+            </span>
+            {error && (
+              <span className={styles.error} role="alert">
+                {error}
+              </span>
+            )}
+          </div>
+          <button type="submit" className={styles.confirmBtn} disabled={!canConfirm}>
+            确认
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/packages/game/src/pages/ResultPage.nickname.test.tsx
+++ b/packages/game/src/pages/ResultPage.nickname.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * ResultPage nickname-gate integration tests.
+ *
+ * Covers the three branches of the daily-mode submission flow:
+ *   1. First-visit daily run, localStorage empty → NicknameModal renders, the
+ *      score is NOT submitted, and submission only fires after the player
+ *      types a valid nickname and confirms.
+ *   2. Returning daily run, localStorage already has a nickname → no modal,
+ *      the score is submitted immediately with the cached nickname.
+ *   3. Practice mode → no modal, no submit (practice never posts a score).
+ *
+ * Setup mirrors `ResultPage.test.tsx`: pre-seed sessionStorage with a finished
+ * game state so `GameProvider`'s lazy initializer hydrates straight into a
+ * renderable ResultPage instead of driving the 4-module flow.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const { STUB_DEVICE_ID } = vi.hoisted(() => ({
+  STUB_DEVICE_ID: 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee',
+}))
+
+vi.mock('@/utils/device-fingerprint', () => ({
+  getDeviceId: () => STUB_DEVICE_ID,
+}))
+
+vi.mock('@/utils/leaderboard-api', () => ({
+  submitScore: vi.fn(),
+  fetchLeaderboard: vi.fn(),
+}))
+
+// Event-log POSTs to /api/events on RESET / mount-side effects — mock it away
+// so we don't need a global fetch stub and the tests stay focused on submit.
+vi.mock('@/utils/event-log', () => ({
+  logEvent: vi.fn(),
+}))
+
+import ResultPage from './ResultPage'
+import { submitScore } from '@/utils/leaderboard-api'
+import { GameProvider, type GameState } from '@/store/game-context'
+
+const PERSISTENCE_KEY = 'bombsquad:game-state:v1'
+const NICKNAME_KEY = 'bombsquad-nickname'
+
+const mockedSubmit = vi.mocked(submitScore)
+
+// jsdom's `localStorage` in this workspace is a method-less stub (see the
+// boot-time `--localstorage-file` warning and the precedent in
+// `ResultPage.test.tsx`). Install a Map-backed fake so `getStoredNickname` /
+// `setStoredNickname` actually round-trip.
+function installFakeLocalStorage() {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  })
+  return store
+}
+
+function finishedDailyState(): GameState {
+  return {
+    status: 'RESULT',
+    mode: 'daily',
+    manual: null,
+    manualUrl: null,
+    sceneInfo: null,
+    moduleConfigs: [null, null, null, null],
+    moduleAnswers: [null, null, null, null],
+    currentModuleIndex: 4,
+    moduleStats: [
+      { moduleType: 'wire', timeMs: 30_000, errorCount: 0 },
+      { moduleType: 'dial', timeMs: 45_000, errorCount: 1 },
+      { moduleType: 'button', timeMs: 25_000, errorCount: 0 },
+      { moduleType: 'keypad', timeMs: 50_000, errorCount: 0 },
+    ],
+    totalStartTime: 1_700_000_000_000,
+    totalEndTime: 1_700_000_150_000,
+    currentModuleStartTime: null,
+    currentModuleErrorCount: 0,
+    errorMessage: null,
+    errorKind: null,
+    attemptNumber: 3,
+    rngSeed: 12345,
+  }
+}
+
+function finishedPracticeState(): GameState {
+  return { ...finishedDailyState(), mode: 'practice' }
+}
+
+function renderResultPage() {
+  return render(
+    <MemoryRouter initialEntries={['/result']}>
+      <GameProvider>
+        <ResultPage />
+      </GameProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('ResultPage nickname gate', () => {
+  beforeEach(() => {
+    installFakeLocalStorage()
+    sessionStorage.clear()
+    mockedSubmit.mockReset()
+    mockedSubmit.mockResolvedValue({ rank: 5, total_players: 100 })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    sessionStorage.clear()
+  })
+
+  it('first-visit daily run: shows modal, blocks submit until the player confirms', async () => {
+    sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedDailyState()))
+
+    renderResultPage()
+
+    // Modal is visible and blocks submission.
+    expect(screen.getByRole('dialog', { name: /给自己起个名字/ })).toBeInTheDocument()
+    expect(mockedSubmit).not.toHaveBeenCalled()
+
+    // The confirm button is disabled until a valid nickname is typed.
+    const confirmBtn = screen.getByRole('button', { name: /^确认$/ })
+    expect(confirmBtn).toBeDisabled()
+
+    const input = screen.getByLabelText(/昵称/) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '   ' } })
+    expect(confirmBtn).toBeDisabled() // whitespace-only stays disabled
+
+    fireEvent.change(input, { target: { value: '小明' } })
+    expect(confirmBtn).toBeEnabled()
+    fireEvent.click(confirmBtn)
+
+    // Submission now fires with the typed nickname.
+    await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(1))
+    expect(mockedSubmit.mock.calls[0][0]).toMatchObject({
+      nickname: '小明',
+      device_id: STUB_DEVICE_ID,
+    })
+
+    // localStorage persisted the nickname; modal is gone.
+    expect(localStorage.getItem(NICKNAME_KEY)).toBe('小明')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('returning daily run: cached nickname → modal does not render, submit fires immediately', async () => {
+    localStorage.setItem(NICKNAME_KEY, '小红')
+    sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedDailyState()))
+
+    renderResultPage()
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(1))
+    expect(mockedSubmit.mock.calls[0][0]).toMatchObject({
+      nickname: '小红',
+      device_id: STUB_DEVICE_ID,
+    })
+  })
+
+  it('practice mode: never shows the modal and never submits', async () => {
+    sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedPracticeState()))
+
+    renderResultPage()
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    // Flush microtasks — if a stray submit was scheduled it would have fired by now.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockedSubmit).not.toHaveBeenCalled()
+    expect(localStorage.getItem(NICKNAME_KEY)).toBeNull()
+  })
+})

--- a/packages/game/src/pages/ResultPage.tsx
+++ b/packages/game/src/pages/ResultPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import NicknameModal from '@/components/NicknameModal'
 import { useGame } from '@/store/game-context'
 import { copyToClipboard } from '@/utils/clipboard'
 import { getTodayString } from '@/utils/date'
@@ -7,6 +8,7 @@ import { getDeviceId } from '@/utils/device-fingerprint'
 import { logEvent } from '@/utils/event-log'
 import { submitScore } from '@/utils/leaderboard-api'
 import { saveOptimisticEntry } from '@/utils/leaderboard-optimistic'
+import { getStoredNickname } from '@/utils/nickname'
 import type { ScoreSubmission, ScoreSubmissionResponse } from '@shared/leaderboard-types'
 import styles from './ResultPage.module.css'
 
@@ -32,24 +34,39 @@ export default function ResultPage() {
       ? state.totalEndTime - state.totalStartTime
       : null
 
-  // Initialize submitting=true when the effect below will actually fire a request,
-  // so we avoid a synchronous setState in the effect body (react-hooks/set-state-in-effect).
-  const [submitting, setSubmitting] = useState(
-    () => state.mode === 'daily' && totalMs !== null && state.moduleStats.length > 0
-  )
+  // Daily mode submits a score. Practice mode never submits and never asks
+  // for a nickname.
+  const hasFinishedDailyRun =
+    state.mode === 'daily' && totalMs !== null && state.moduleStats.length > 0
 
-  const buildSubmission = useCallback((): ScoreSubmission | null => {
-    if (totalMs === null) return null
-    return {
-      date: getTodayString(),
-      nickname: 'Anonymous',
-      time_ms: Math.round(totalMs),
-      attempt_number: state.attemptNumber,
-      module_times: state.moduleStats.map((s) => Math.round(s.timeMs)),
-      operations_hash: 'mvp-placeholder', // temporary placeholder until real run hashing is implemented
-      device_id: getDeviceId(),
-    }
-  }, [totalMs, state.attemptNumber, state.moduleStats])
+  // Lazy initializers: read the stored nickname once on mount. Subsequent
+  // useState calls reuse the captured value so the three pieces of mount
+  // state stay consistent without triple-reading localStorage.
+  const [nickname, setNickname] = useState<string | null>(() => getStoredNickname())
+  const [nicknameModalOpen, setNicknameModalOpen] = useState(
+    () => hasFinishedDailyRun && nickname === null
+  )
+  // Initialize submitting=true only when the effect below will actually fire a
+  // request, so we avoid a synchronous setState in the effect body
+  // (react-hooks/set-state-in-effect). First-visit daily runs wait for the
+  // modal confirmation before flipping submitting=true.
+  const [submitting, setSubmitting] = useState(() => hasFinishedDailyRun && nickname !== null)
+
+  const buildSubmission = useCallback(
+    (nicknameValue: string): ScoreSubmission | null => {
+      if (totalMs === null) return null
+      return {
+        date: getTodayString(),
+        nickname: nicknameValue,
+        time_ms: Math.round(totalMs),
+        attempt_number: state.attemptNumber,
+        module_times: state.moduleStats.map((s) => Math.round(s.timeMs)),
+        operations_hash: 'mvp-placeholder', // temporary placeholder until real run hashing is implemented
+        device_id: getDeviceId(),
+      }
+    },
+    [totalMs, state.attemptNumber, state.moduleStats]
+  )
 
   const recordOptimistic = useCallback(
     (submission: ScoreSubmission, result: ScoreSubmissionResponse) => {
@@ -64,42 +81,66 @@ export default function ResultPage() {
     []
   )
 
-  // Submit score on mount (daily mode only)
-  useEffect(() => {
-    if (state.mode !== 'daily' || totalMs === null || state.moduleStats.length === 0) return
+  // Fires the actual submission. Callers own `submitting` toggles — the mount
+  // path relies on the lazy `useState` initializer above to start truthy, and
+  // the modal-confirm path flips it on synchronously before calling here.
+  // Keeping `setSubmitting(true)` out of this function lets us call it from
+  // inside `useEffect` without tripping react-hooks/set-state-in-effect.
+  const performSubmission = useCallback(
+    (nicknameValue: string) => {
+      const submission = buildSubmission(nicknameValue)
+      if (!submission) return
 
-    const submission = buildSubmission()
-    if (!submission) return
-
-    // Persist locally so a retry can succeed even if user navigates back
-    try {
-      sessionStorage.setItem(`pending-score:${submission.date}`, JSON.stringify(submission))
-    } catch {
-      /* storage full */
-    }
-
-    submitScore(submission).then((result) => {
-      setSubmitting(false)
-      if (result) {
-        setRankResult(result)
-        recordOptimistic(submission, result)
-        try {
-          sessionStorage.removeItem(`pending-score:${submission.date}`)
-        } catch {
-          /* ignore */
-        }
-      } else {
-        setSubmitFailed(true)
+      // Persist locally so a retry can succeed even if user navigates back
+      try {
+        sessionStorage.setItem(`pending-score:${submission.date}`, JSON.stringify(submission))
+      } catch {
+        /* storage full */
       }
-    })
+
+      submitScore(submission).then((result) => {
+        setSubmitting(false)
+        if (result) {
+          setRankResult(result)
+          recordOptimistic(submission, result)
+          try {
+            sessionStorage.removeItem(`pending-score:${submission.date}`)
+          } catch {
+            /* ignore */
+          }
+        } else {
+          setSubmitFailed(true)
+        }
+      })
+    },
+    [buildSubmission, recordOptimistic]
+  )
+
+  // Submit score on mount when a nickname is already known (returning daily
+  // player). First-visit daily players wait for the modal handler below.
+  useEffect(() => {
+    if (!hasFinishedDailyRun) return
+    if (nickname === null) return
+    performSubmission(nickname)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const handleNicknameConfirm = useCallback(
+    (value: string) => {
+      setNickname(value)
+      setNicknameModalOpen(false)
+      setSubmitting(true)
+      performSubmission(value)
+    },
+    [performSubmission]
+  )
+
   const handleRetrySubmit = useCallback(() => {
+    if (nickname === null) return
     setRetried(true)
     setSubmitFailed(false)
     setSubmitting(true)
-    const submission = buildSubmission()
+    const submission = buildSubmission(nickname)
     if (!submission) {
       setSubmitting(false)
       return
@@ -118,7 +159,7 @@ export default function ResultPage() {
         setSubmitFailed(true)
       }
     })
-  }, [buildSubmission, recordOptimistic])
+  }, [buildSubmission, recordOptimistic, nickname])
 
   const handlePlayAgain = () => {
     // Emit BEFORE the RESET so we still capture the just-finished run's mode
@@ -192,7 +233,10 @@ ${breakdown}
 
       {state.mode === 'daily' && (
         <div className={styles.rankBlock}>
-          {submitting && <span className={styles.rankMuted}>提交成绩中…</span>}
+          {nicknameModalOpen && <span className={styles.rankMuted}>提交前请填写昵称</span>}
+          {!nicknameModalOpen && submitting && (
+            <span className={styles.rankMuted}>提交成绩中…</span>
+          )}
           {rankResult && (
             <span className={styles.rankValue}>
               全球排名：<strong>#{rankResult.rank}</strong> / {rankResult.total_players}
@@ -257,6 +301,8 @@ ${breakdown}
           </Link>
         </div>
       </div>
+
+      <NicknameModal open={nicknameModalOpen} onConfirm={handleNicknameConfirm} />
     </main>
   )
 }

--- a/packages/game/src/utils/nickname.test.ts
+++ b/packages/game/src/utils/nickname.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for the nickname utility — validation rules plus localStorage
+ * read/write semantics. The acceptance criteria from the source task records:
+ *   - empty / whitespace-only / >20 chars rejected
+ *   - unicode (multi-byte chars like 小明) accepted by character count
+ *   - trim before persist
+ *   - quota / disabled-storage failures surface as `false` without throwing
+ *   - corrupted older values (e.g. 30-char string written before this util
+ *     existed) read back as null instead of contaminating submission
+ *
+ * Note on the localStorage fake: jsdom's `localStorage` in this workspace is
+ * stubbed to a method-less object (the test runner emits a
+ * `--localstorage-file` warning at boot — see
+ * `src/pages/ResultPage.test.tsx` for the precedent). We install a small
+ * Map-backed fake via `vi.stubGlobal('localStorage', …)` so the real util can
+ * exercise its real branches. For the "storage throws" branches we install a
+ * variant whose methods throw.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  NICKNAME_MAX_LENGTH,
+  getStoredNickname,
+  isValidNickname,
+  setStoredNickname,
+} from './nickname'
+
+const KEY = 'bombsquad-nickname'
+
+interface FakeLocalStorageOverrides {
+  getItem?: (key: string) => string | null
+  setItem?: (key: string, value: string) => void
+}
+
+function installFakeLocalStorage(overrides: FakeLocalStorageOverrides = {}) {
+  const store = new Map<string, string>()
+  const fake = {
+    getItem:
+      overrides.getItem ?? ((key: string) => (store.has(key) ? (store.get(key) as string) : null)),
+    setItem:
+      overrides.setItem ??
+      ((key: string, value: string) => {
+        store.set(key, String(value))
+      }),
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  }
+  vi.stubGlobal('localStorage', fake)
+  return { store, fake }
+}
+
+describe('isValidNickname', () => {
+  it('rejects empty string', () => {
+    expect(isValidNickname('')).toBe(false)
+  })
+
+  it('rejects whitespace-only input', () => {
+    expect(isValidNickname('   ')).toBe(false)
+    expect(isValidNickname('\t\n')).toBe(false)
+  })
+
+  it('accepts a single-character name', () => {
+    expect(isValidNickname('A')).toBe(true)
+  })
+
+  it('accepts the boundary length of 20 chars', () => {
+    expect(isValidNickname('a'.repeat(NICKNAME_MAX_LENGTH))).toBe(true)
+  })
+
+  it('rejects 21 chars (over cap)', () => {
+    expect(isValidNickname('a'.repeat(NICKNAME_MAX_LENGTH + 1))).toBe(false)
+  })
+
+  it('accepts CJK chars by character count', () => {
+    // 小明 — 2 characters, well under the 20-char cap.
+    expect(isValidNickname('小明')).toBe(true)
+  })
+
+  it('accepts values whose visible portion is within the cap after trim', () => {
+    // 18 visible chars + 2 leading + 2 trailing spaces → trimmed length 18.
+    expect(isValidNickname(`  ${'a'.repeat(18)}  `)).toBe(true)
+  })
+
+  it('rejects values whose trimmed length still exceeds the cap', () => {
+    // 21 visible chars with trailing space — trim drops the space but length stays 21.
+    expect(isValidNickname(`${'a'.repeat(21)} `)).toBe(false)
+  })
+
+  it('rejects non-string inputs defensively', () => {
+    expect(isValidNickname(null)).toBe(false)
+    expect(isValidNickname(undefined)).toBe(false)
+    expect(isValidNickname(123)).toBe(false)
+  })
+})
+
+describe('getStoredNickname', () => {
+  beforeEach(() => {
+    installFakeLocalStorage()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns null when localStorage has no entry', () => {
+    expect(getStoredNickname()).toBeNull()
+  })
+
+  it('returns the trimmed stored value when valid', () => {
+    localStorage.setItem(KEY, '  小明  ')
+    expect(getStoredNickname()).toBe('小明')
+  })
+
+  it('returns null when the stored value is whitespace-only', () => {
+    localStorage.setItem(KEY, '   ')
+    expect(getStoredNickname()).toBeNull()
+  })
+
+  it('returns null when the stored value exceeds the cap (corrupted data)', () => {
+    localStorage.setItem(KEY, 'a'.repeat(30))
+    expect(getStoredNickname()).toBeNull()
+  })
+
+  it('returns null when localStorage.getItem throws', () => {
+    installFakeLocalStorage({
+      getItem: () => {
+        throw new Error('storage disabled')
+      },
+    })
+    expect(getStoredNickname()).toBeNull()
+  })
+})
+
+describe('setStoredNickname', () => {
+  beforeEach(() => {
+    installFakeLocalStorage()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('writes the trimmed value and returns true on success', () => {
+    expect(setStoredNickname('  小明  ')).toBe(true)
+    expect(localStorage.getItem(KEY)).toBe('小明')
+  })
+
+  it('returns false and does not write when the value is empty', () => {
+    expect(setStoredNickname('')).toBe(false)
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('returns false and does not write when the value is whitespace-only', () => {
+    expect(setStoredNickname('   ')).toBe(false)
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('returns false and does not write when the value exceeds the cap', () => {
+    expect(setStoredNickname('a'.repeat(NICKNAME_MAX_LENGTH + 1))).toBe(false)
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('returns false when localStorage.setItem throws (quota exceeded)', () => {
+    installFakeLocalStorage({
+      setItem: () => {
+        throw new Error('QuotaExceededError')
+      },
+    })
+    expect(setStoredNickname('小明')).toBe(false)
+  })
+
+  it('round-trips through getStoredNickname', () => {
+    setStoredNickname('小红')
+    expect(getStoredNickname()).toBe('小红')
+  })
+})

--- a/packages/game/src/utils/nickname.ts
+++ b/packages/game/src/utils/nickname.ts
@@ -1,0 +1,56 @@
+/**
+ * Player nickname collection for the daily leaderboard.
+ *
+ * The first time a player reaches ResultPage on a daily run with no stored
+ * nickname, NicknameModal is shown and submission is blocked until they enter
+ * a valid value. Subsequent daily runs on the same device reuse the stored
+ * value. Validation matches the server-side cap in `shared/leaderboard-types.ts`
+ * (max 20 chars after trim, non-empty, whitespace-only rejected).
+ */
+
+const NICKNAME_KEY = 'bombsquad-nickname'
+
+export const NICKNAME_MAX_LENGTH = 20
+
+/** Pure validator used by the modal to enable/disable the confirm button. */
+export function isValidNickname(value: unknown): boolean {
+  if (typeof value !== 'string') return false
+  const trimmed = value.trim()
+  return trimmed.length > 0 && trimmed.length <= NICKNAME_MAX_LENGTH
+}
+
+/**
+ * Returns the trimmed stored nickname, or null when:
+ *  - localStorage is empty for this key
+ *  - the stored value is whitespace-only (defensive against external edits)
+ *  - the stored value exceeds NICKNAME_MAX_LENGTH (corrupted from older code)
+ *  - localStorage access throws (private mode / disabled)
+ */
+export function getStoredNickname(): string | null {
+  try {
+    const raw = localStorage.getItem(NICKNAME_KEY)
+    if (raw === null) return null
+    const trimmed = raw.trim()
+    if (!isValidNickname(trimmed)) return null
+    return trimmed
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Validates, trims, and writes the value. Returns true on success, false on
+ * either validation failure or storage failure (quota exceeded, private mode).
+ * Caller (NicknameModal) keeps the modal open and surfaces a brief error if
+ * false is returned.
+ */
+export function setStoredNickname(value: string): boolean {
+  if (!isValidNickname(value)) return false
+  const trimmed = value.trim()
+  try {
+    localStorage.setItem(NICKNAME_KEY, trimmed)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

- First-time daily-challenge submission now requires a nickname entered via a non-dismissable modal; persisted to `localStorage` (key `bombsquad-nickname`) and reused on subsequent runs from the same device, so the leaderboard finally shows recognisable names instead of "Anonymous".
- The modal is intentionally non-dismissable — no close button, no Esc, no backdrop click. `submitScore` is blocked until a valid nickname (trim + 1–20 chars + non-whitespace) is confirmed. This was the user-locked UX decision; v1 ships without an edit-later entry point.
- Source task: `add-leaderboard-anonymous-handle` (Tier 1 internal-beta-readiness queue).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (117 game / 14 api / 25 manual)
- [x] New tests added: 13 unit specs in `packages/game/src/utils/nickname.test.ts` + 3 integration specs in `packages/game/src/pages/ResultPage.nickname.test.tsx` (first-visit blocks-submit, returning-visit immediate-submit, practice-mode unaffected)
- [ ] Tested manually and documented below
  - Manual mobile check on iOS Safari is recommended before the friend-circle beta: the input `autoFocus` pops the soft keyboard, which may shift the dialog under it. Tracked as opportunistic follow-up if internal-beta users complain.

## Checklist

- [x] Code follows the project style (eslint + prettier + markdownlint via pre-commit hook)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (`CHANGELOG.md` `Unreleased` entry)
- [x] Breaking changes documented if any — none; existing `LeaderboardEntry.nickname` schema unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)