### PR TITLE
feat(game): add voice AI compatibility reference page + PromptModal link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Versions follow [Semantic Versioning](https://semver.org).
   names instead of a wall of "Anonymous". The prompt is required — submission
   is blocked until a valid nickname is entered — and there is no edit-later
   entry point in this release. Source task `add-leaderboard-anonymous-handle`.
+- **Voice AI compatibility reference** A new `/compatibility` page lists the
+  voice AIs that have been verified against the bomb (Claude today, with
+  ChatGPT and Gemini placeholders inviting player feedback) and surfaces a
+  ready-to-copy opening prompt the player can read to their AI partner before
+  handing over the manual URL. The prompt modal now carries a small "不确定用
+  哪个 AI？查看支持工具" link directly under its send-to-AI tip so the
+  reference is one click away from the moment the question typically arises.
 - **Audio + animation feedback** Every in-module click now gives a short
   pulse animation and a sound effect (confirm, wire-cut, dial-rotate,
   keypad-press, button-down/up). Solving or failing a module plays a soft

--- a/packages/game/src/App.tsx
+++ b/packages/game/src/App.tsx
@@ -4,6 +4,7 @@ import HomePage from './pages/HomePage'
 import GamePage from './pages/GamePage'
 import ResultPage from './pages/ResultPage'
 import LeaderboardPage from './pages/LeaderboardPage'
+import CompatibilityPage from './pages/CompatibilityPage'
 
 export default function App() {
   return (
@@ -13,6 +14,7 @@ export default function App() {
         <Route path="/game" element={<GamePage />} />
         <Route path="/result" element={<ResultPage />} />
         <Route path="/leaderboard" element={<LeaderboardPage />} />
+        <Route path="/compatibility" element={<CompatibilityPage />} />
       </Routes>
     </GameProvider>
   )

--- a/packages/game/src/components/PromptModal.module.css
+++ b/packages/game/src/components/PromptModal.module.css
@@ -66,6 +66,27 @@
   margin: 0;
 }
 
+/* Discovery link to /compatibility — sits directly under the "send to AI"
+   tip so the cross-reference reads as a natural follow-up question without
+   competing with the primary 确认开始游戏 CTA. Small font keeps it from
+   pulling visual weight away from the URL box. */
+.compatLink {
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  color: var(--color-neon-cyan);
+  text-decoration: none;
+  align-self: flex-start;
+  padding: 4px 0;
+  letter-spacing: 0.02em;
+}
+
+.compatLink:hover,
+.compatLink:focus-visible {
+  text-decoration: underline;
+  outline: 2px solid var(--color-neon-cyan);
+  outline-offset: 2px;
+}
+
 .urlBox {
   display: flex;
   align-items: center;

--- a/packages/game/src/components/PromptModal.tsx
+++ b/packages/game/src/components/PromptModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useState, type MouseEvent } from 'react'
+import { Link } from 'react-router-dom'
 import { copyToClipboard } from '@/utils/clipboard'
 import styles from './PromptModal.module.css'
 
@@ -69,6 +70,9 @@ export default function PromptModal({
           {title}
         </h2>
         <p className={styles.tip}>复制后发给你的 AI 助手</p>
+        <Link to="/compatibility" className={styles.compatLink}>
+          不确定用哪个 AI？查看支持工具
+        </Link>
 
         <div className={styles.urlBox}>
           <a className={styles.urlLink} href={manualUrl} target="_blank" rel="noopener noreferrer">

--- a/packages/game/src/pages/CompatibilityPage.module.css
+++ b/packages/game/src/pages/CompatibilityPage.module.css
@@ -1,0 +1,239 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 48px 16px;
+  gap: 32px;
+}
+
+.header {
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-align: left;
+}
+
+.title {
+  font-family: var(--font-mono);
+  font-size: clamp(1.6rem, 5vw, 2.2rem);
+  font-weight: bold;
+  color: var(--color-neon-cyan);
+  letter-spacing: 0.08em;
+  text-shadow:
+    0 0 8px rgba(0, 255, 255, 0.45),
+    0 0 24px rgba(0, 255, 255, 0.2);
+}
+
+.subtitle {
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  color: var(--color-text-primary);
+  line-height: 1.55;
+}
+
+.toolsSection {
+  width: 100%;
+  max-width: 640px;
+}
+
+.toolList {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.toolCard {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-left: 2px solid var(--color-border);
+  border-radius: 4px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Verified row earns the neon — only the AI we have actually validated gets
+   the cyan border accent, per DesignSystem "Earn the neon" principle. */
+.toolCard.toolCardVerified {
+  border-left: 2px solid var(--color-neon-cyan);
+  box-shadow: 0 0 12px rgba(0, 255, 255, 0.08);
+}
+
+.toolHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.toolName {
+  font-family: var(--font-mono);
+  font-size: 1.05rem;
+  font-weight: bold;
+  color: var(--color-text-primary);
+  letter-spacing: 0.05em;
+}
+
+.statusBadge {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  padding: 3px 8px;
+  border-radius: 3px;
+  border: 1px solid currentColor;
+  white-space: nowrap;
+  letter-spacing: 0.05em;
+}
+
+.statusBadge.statusVerified {
+  color: var(--color-neon-cyan);
+  background: rgba(0, 255, 255, 0.08);
+}
+
+.statusBadge.statusUntested {
+  color: var(--color-text-muted);
+  background: transparent;
+}
+
+.toolTip {
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.promptSection {
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.promptTitle {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.promptIntro {
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  color: var(--color-text-primary);
+}
+
+.promptBox {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-left: 2px solid var(--color-neon-cyan);
+  border-radius: 4px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.promptText {
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  color: var(--color-text-primary);
+  line-height: 1.65;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+
+.copyBtn {
+  align-self: flex-end;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  padding: 8px 16px;
+  background: transparent;
+  color: var(--color-neon-cyan);
+  border: 1px solid var(--color-neon-cyan);
+  border-radius: 3px;
+  cursor: pointer;
+  letter-spacing: 0.05em;
+  min-height: var(--touch-target);
+  transition: background 0.15s ease;
+}
+
+.copyBtn:hover,
+.copyBtn:focus-visible {
+  background: rgba(0, 255, 255, 0.08);
+  outline: 2px solid var(--color-neon-cyan);
+  outline-offset: 2px;
+}
+
+.copied {
+  color: var(--color-neon-green);
+  border-color: var(--color-neon-green);
+}
+
+.homeLink {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  letter-spacing: 0.05em;
+  margin-top: 8px;
+  padding: 10px 4px;
+  min-height: var(--touch-target);
+  display: inline-flex;
+  align-items: center;
+}
+
+.homeLink:hover,
+.homeLink:focus-visible {
+  color: var(--color-neon-cyan);
+  text-decoration: underline;
+}
+
+/* Mobile breakpoint — phones in cold-shared link flow.
+   Tightens padding and floors text at 14px so Chinese stays legible on
+   320 / 375 / 414 viewports without horizontal overflow. */
+@media (max-width: 480px) {
+  .page {
+    padding: 32px 12px;
+    gap: 24px;
+  }
+
+  .header,
+  .toolsSection,
+  .promptSection {
+    max-width: 100%;
+  }
+
+  .subtitle,
+  .toolTip,
+  .promptIntro,
+  .promptText {
+    font-size: 0.875rem;
+  }
+
+  .toolHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .copyBtn {
+    align-self: stretch;
+    font-size: 0.875rem;
+  }
+
+  /* Floor secondary text at 14px on mobile so Chinese stays legible at 375px;
+     primary text already meets the floor via base rules. */
+  .statusBadge,
+  .promptTitle,
+  .homeLink {
+    font-size: 0.875rem;
+  }
+}

--- a/packages/game/src/pages/CompatibilityPage.test.tsx
+++ b/packages/game/src/pages/CompatibilityPage.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * CompatibilityPage unit tests.
+ *
+ * Covers the four IA acceptance points for the discovery-side rendering:
+ *   1. Title + subtitle render.
+ *   2. Exactly the three AI rows (Claude / ChatGPT / Gemini) appear, with
+ *      Claude flagged as 已验证.
+ *   3. Recommended opening-prompt block renders multi-line Chinese text.
+ *   4. Copy button click triggers success feedback ("已复制！").
+ *   5. Return-home link points to `/`.
+ *
+ * Clipboard helper is stubbed so the test doesn't depend on jsdom's
+ * Clipboard API surface and the success branch is exercised deterministically.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('@/utils/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+}))
+
+import CompatibilityPage from './CompatibilityPage'
+import { copyToClipboard } from '@/utils/clipboard'
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/compatibility']}>
+      <CompatibilityPage />
+    </MemoryRouter>
+  )
+}
+
+describe('CompatibilityPage', () => {
+  beforeEach(() => {
+    vi.mocked(copyToClipboard).mockClear()
+    vi.mocked(copyToClipboard).mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+  })
+
+  it('renders the H1 title and subtitle', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { level: 1, name: '支持的 AI 工具' })).toBeInTheDocument()
+    expect(screen.getByText(/BombSquad 不集成任何 AI 接口/)).toBeInTheDocument()
+  })
+
+  it('renders exactly three AI rows: Claude / ChatGPT / Gemini', () => {
+    renderPage()
+    const rows = screen.getAllByRole('listitem')
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toHaveTextContent('Claude')
+    expect(rows[1]).toHaveTextContent('ChatGPT')
+    expect(rows[2]).toHaveTextContent('Gemini')
+  })
+
+  it('marks the Claude row as 已验证', () => {
+    renderPage()
+    const claudeRow = screen.getAllByRole('listitem')[0]
+    expect(claudeRow).toHaveTextContent('已验证')
+  })
+
+  it('renders the recommended opening-prompt block with multi-line Chinese text', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { level: 2, name: '告诉 AI 该怎么做' })).toBeInTheDocument()
+    // Prompt must include the signature lines from the recommended template.
+    expect(screen.getByText(/等会儿我会发你一个 URL/)).toBeInTheDocument()
+    expect(screen.getByText(/每次只回复一步指令/)).toBeInTheDocument()
+  })
+
+  it('shows "已复制！" feedback after clicking the copy button', async () => {
+    renderPage()
+    const button = screen.getByRole('button', { name: /复制推荐开场白到剪贴板/ })
+    expect(button).toHaveTextContent('复制开场白')
+
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(button).toHaveTextContent('已复制！')
+    })
+    expect(copyToClipboard).toHaveBeenCalledTimes(1)
+    const copiedArg = vi.mocked(copyToClipboard).mock.calls[0][0]
+    expect(copiedArg).toMatch(/等会儿我会发你一个 URL/)
+  })
+
+  it('renders a return-home link pointing to /', () => {
+    renderPage()
+    const link = screen.getByRole('link', { name: /返回 BombSquad 首页/ })
+    expect(link).toHaveAttribute('href', '/')
+  })
+})

--- a/packages/game/src/pages/CompatibilityPage.tsx
+++ b/packages/game/src/pages/CompatibilityPage.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { copyToClipboard } from '@/utils/clipboard'
+import styles from './CompatibilityPage.module.css'
+
+/**
+ * Recommended opening prompt the player can paste into their AI partner
+ * after handing over the manual URL. Kept as a multi-line template literal
+ * so it stays copy-pastable verbatim (no smart-quote / formatting drift).
+ */
+const OPENING_PROMPT = `等会儿我会发你一个 URL，里面是 YAML 拆弹手册。请打开它读完整本手册，告诉我"读完了"。
+然后我开始描述拆弹面板的画面，你根据手册告诉我下一步该怎么做。
+每次只回复一步指令，不要一口气说完，等我执行完再继续。
+如果我念出一个奇怪的中文短句（暗号），请准确听写下来并念回给我确认。`
+
+type Verification = 'verified' | 'untested'
+
+interface AiTool {
+  name: string
+  verification: Verification
+  statusLabel: string
+  tip: string
+}
+
+const AI_TOOLS: AiTool[] = [
+  {
+    name: 'Claude',
+    verification: 'verified',
+    statusLabel: '已验证 ✓',
+    tip: '目前唯一通过完整 acceptance 验证的 voice AI（练习 + 每日挑战 4 模块均通关）。',
+  },
+  {
+    name: 'ChatGPT',
+    verification: 'untested',
+    statusLabel: '未测试 · 邀请反馈',
+    tip: 'advanced voice mode 应可工作；玩通后请把成绩发给作者帮忙打勾。',
+  },
+  {
+    name: 'Gemini',
+    verification: 'untested',
+    statusLabel: '未测试 · 邀请反馈',
+    tip: 'Live API / 实时语音应可工作；玩通后请把成绩发给作者帮忙打勾。',
+  },
+]
+
+export default function CompatibilityPage() {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    const ok = await copyToClipboard(OPENING_PROMPT)
+    if (ok) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  return (
+    <main className={styles.page}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>支持的 AI 工具</h1>
+        <p className={styles.subtitle}>
+          BombSquad 不集成任何 AI 接口，你可以选择任意支持语音对话的 AI 与你协作。
+        </p>
+      </header>
+
+      <section className={styles.toolsSection} aria-label="已验证的 AI 工具">
+        <ul className={styles.toolList}>
+          {AI_TOOLS.map((tool) => (
+            <li
+              key={tool.name}
+              className={
+                tool.verification === 'verified'
+                  ? `${styles.toolCard} ${styles.toolCardVerified}`
+                  : styles.toolCard
+              }
+            >
+              <div className={styles.toolHeader}>
+                <span className={styles.toolName}>{tool.name}</span>
+                <span
+                  className={
+                    tool.verification === 'verified'
+                      ? `${styles.statusBadge} ${styles.statusVerified}`
+                      : `${styles.statusBadge} ${styles.statusUntested}`
+                  }
+                >
+                  {tool.statusLabel}
+                </span>
+              </div>
+              <p className={styles.toolTip}>{tool.tip}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className={styles.promptSection} aria-label="推荐开场白">
+        <h2 className={styles.promptTitle}>告诉 AI 该怎么做</h2>
+        <p className={styles.promptIntro}>把下面这段话先念给你的 AI 听，再把手册地址发过去。</p>
+        <div className={styles.promptBox}>
+          <pre className={styles.promptText}>{OPENING_PROMPT}</pre>
+          <button
+            type="button"
+            className={`${styles.copyBtn} ${copied ? styles.copied : ''}`}
+            onClick={handleCopy}
+            aria-label="复制推荐开场白到剪贴板"
+          >
+            {copied ? '已复制！' : '复制开场白'}
+          </button>
+        </div>
+      </section>
+
+      <Link to="/" className={styles.homeLink}>
+        ← 返回 BombSquad 首页
+      </Link>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- Add a new `/compatibility` reference page listing supported voice AI tools (Claude marked verified; ChatGPT and Gemini marked untested with an open invitation for player feedback) plus a recommended opening-prompt the player can copy and paste to their AI.
- Place a small discovery link in `PromptModal` (`不确定用哪个 AI？查看支持工具`) so players who pause at the "send URL to your AI" step have a one-click path to the reference page; existing copy / Esc / 确认开始游戏 flow is untouched.
- Deliberately omit browser-requirement copy — BombSquad's only hard browser dependency is the Clipboard API (which already has a fallback) and the voice AI runs on a separate device, so listing browser requirements would add cold-click friction without protecting against any real failure. This is consistent with the `polish-landing-first-impression` decision in #73.

## Type of change

- [x] New feature
- [x] Documentation (CHANGELOG)

## Testing

- [x] Existing tests pass (96 game-package tests still green)
- [x] New tests added — 6 RTL test cases in `CompatibilityPage.test.tsx` covering title, AI row count, Claude verified status, copy-button success feedback, recommended-prompt text, and home link
- [ ] Tested manually in browser — pending visual review of mobile breakpoint

`pnpm install && pnpm run lint && pnpm run test && pnpm run build` all pass on this branch. 141 tests pass total (14 api + 25 manual + 102 game).

## Checklist

- [x] Code follows the project style (English code/comments; Chinese only in user-facing strings; dark-only; CSS-only animation; no new dependencies)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated — `CHANGELOG.md` `[Unreleased]` entry added under `### Added`
- [x] Breaking changes documented if any — none

## Internal source

Task: [add-voice-ai-compatibility-page](pages/projects/amiclaw/tasks/add-voice-ai-compatibility-page.md) (Tier 1 internal-beta queue, source idea: `voice-ai-compatibility-matrix`).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>