### PR TITLE
fix(game): wrap long leaderboard nicknames so score columns stay visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,14 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- **Leaderboard stays readable with long nicknames** A daily player can
+  legally pick a 20-character nickname with no spaces — an unbroken English
+  handle, for example. Such a nickname used to stretch the leaderboard's
+  nickname column wide enough to push the time and attempt columns off the
+  right edge on a narrow phone, where the page's overflow guard clipped them
+  with no way to scroll across. The nickname column now wraps long handles
+  onto multiple lines, so the time and attempt counts stay visible at any
+  viewport width.
 - **Daily challenge no longer crashes on missing dates** Every date for the
   next year now serves a real daily manual derived deterministically from
   the practice rulebook, so opening "每日挑战" on any date through

--- a/packages/game/src/pages/LeaderboardPage.module.css
+++ b/packages/game/src/pages/LeaderboardPage.module.css
@@ -43,6 +43,12 @@
   padding: 10px 12px;
   color: var(--color-text-primary);
   border-bottom: 1px solid var(--color-border);
+  /* Wrap a long nickname (e.g. a 20-char no-space ASCII handle) inside the
+     nickname column. Without this, table-layout:auto widens that column to
+     the unbroken word and pushes the time / attempt columns past a 320px
+     viewport, where body{overflow-x:hidden} silently clips them. */
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .rank {


### PR DESCRIPTION
## Summary

- Long no-space nicknames (a legal 20-char ASCII handle) stretched the leaderboard nickname column under `table-layout:auto`, pushing the time / attempt columns off a 320px viewport where `body{overflow-x:hidden}` silently clipped them — no scroll, no error.
- `.table td` now wraps long handles via `overflow-wrap:anywhere`, so the time and attempt columns stay visible at any viewport width.
- Found by the `verify-mobile-beta-flow` internal-beta path verification — the audit + adversarial review rated this a HIGH-severity mobile breakpoint (silent leaderboard data loss for **all** viewers, and KV is persistent).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass — 182 tests (api 14 / manual 25 / game 143), lint + build clean
- [ ] New tests added if behavior changed — CSS layout behaviour is not unit-testable under jsdom; a regression scenario spec is recorded at `pages/projects/amiclaw/e2e/regression/verify-mobile-beta-flow.gherkin` (vault)
- [ ] Tested manually and documented below — pending real-device leaderboard check (item M6 of the mobile verification checklist)

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed — `CHANGELOG.md` `### Fixed` entry added
- [x] Breaking changes documented if any — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
