### PR TITLE
fix(game): widen wire-cut tap target so mobile cuts are more forgiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,13 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- **Wires are easier to cut on a phone** Tapping a wire in the first game
+  module used to demand near-pixel accuracy on a narrow screen — the
+  clickable strip along each wire was under half the recommended touch
+  size, so a slightly-off tap cut the wrong wire and reset the module. Each
+  wire's tap area is now widened as far as it can go without overlapping the
+  next wire's, so cutting the wire you aimed at is far more forgiving on
+  mobile. The wires themselves look exactly the same.
 - **Leaderboard stays readable with long nicknames** A daily player can
   legally pick a 20-character nickname with no spaces — an unbroken English
   handle, for example. Such a nickname used to stretch the leaderboard's

--- a/packages/game/src/modules/wire/WireModule.module.css
+++ b/packages/game/src/modules/wire/WireModule.module.css
@@ -15,7 +15,17 @@
 .wire-hit-target {
   cursor: crosshair;
   stroke: transparent;
-  stroke-width: 20;
+  /*
+   * Transparent click proxy layered over the visible wire (stroke-width 4).
+   * Widened from 20 to 28 to enlarge the mobile tap target (audit L3-1).
+   * Hard cap: wires sit 45 viewBox units apart, but adjacent curves bow
+   * toward each other, closing to a 30-unit minimum centerline gap at the
+   * curve midpoint. A stroke-width-W band reaches +/-W/2 around the wire,
+   * so W must stay <= 30 for zero overlap between neighbouring hit bands;
+   * 28 keeps a 2-unit safety margin. At a ~320px viewport (scale ~0.96)
+   * this renders an ~27px tap band, up from the previous ~19px.
+   */
+  stroke-width: 28;
   fill: none;
 }
 


### PR DESCRIPTION
## Summary

- The first game module's wire-cutting hit area (`.wire-hit-target`) was a clickable strip under half the 44px touch-target guideline — ~19px effective at a 320px viewport — so a slightly-off tap on a phone cut the wrong wire and reset the module.
- The transparent hit-target proxy's `stroke-width` is widened 20 → 28 viewBox units (~19px → ~27px effective). 28 is the maximum that guarantees zero overlap with adjacent wires, which bow toward a 30-unit minimum centerline gap at the curve midpoint. Visible wire thickness is unchanged.
- Found by the `verify-mobile-beta-flow` internal-beta path verification — audit + adversarial review rated this HIGH-severity. Note: full 44px compliance is geometrically infeasible without redesigning the wire layout; 28 is the in-scope maximum, and real-device cutting feel is to be sanity-checked separately.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass — 182 tests (api 14 / manual 25 / game 143), lint + build clean
- [ ] New tests added if behavior changed — SVG hit-area geometry is not unit-testable under jsdom; a regression scenario spec is recorded at `pages/projects/amiclaw/e2e/regression/verify-mobile-beta-flow.gherkin` (vault)
- [ ] Tested manually and documented below — pending real-device wire-cutting feel check (item M4 of the mobile verification checklist)

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed — `CHANGELOG.md` `### Fixed` entry added
- [x] Breaking changes documented if any — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
