### PR TITLE
feat(game,manual): internal-beta UX polish batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Versions follow [Semantic Versioning](https://semver.org).
 - `replay_intent` console.info event emitted when the result-page "再来一局" button is clicked — enables manual estimation of replay-willingness (roadmap §Strategic Objectives Validation Criteria #3, 复玩意愿 ≥50%) from console logs
 - Backend event ingestion via Pages Function `/api/events` — five existing event types (game_start, module_solve, game_complete, game_abandon, manual_load_failed) plus replay_intent now POST to a Cloudflare Pages Function that writes per-event-name counters and unique-device sets to the LEADERBOARD KV namespace under `events:{date}:*` keys. Frontend `console.info` channel is replaced by fire-and-forget fetch; events include device_id (sourced from the same localStorage UUID used by leaderboard submissions) so both session-level and unique-player completion-rate can be computed.
 - Beta data dashboard at `/api/dashboard?token=xxx` showing daily game_start/complete/replay counts and completion rates against the 70%/50% north-star thresholds. Requires `DASHBOARD_TOKEN` Pages secret (set via `wrangler secret put DASHBOARD_TOKEN`).
+- **Mute toggle** The game's top bar now has a mute button that silences every
+  sound effect. The setting is saved to localStorage, so the game stays muted —
+  or un-muted — across page reloads and later sessions.
 
 ### Improvements
 
@@ -52,8 +55,9 @@ Versions follow [Semantic Versioning](https://semver.org).
 - **Landing first impression** The home page now leads with the four-step
   "怎么开始" guide above the practice / daily CTAs, so visitors arriving from
   a cold-shared link see the voice-AI partner is a prerequisite before they
-  tap a button. Step 1 carries a neon-cyan side accent and a "必备：" prefix
-  to highlight the AI-must-be-running requirement, and a new `≤480px` mobile
+  tap a button. The four how-to lines are concise and follow the order
+  players actually work in — copy the manual link on the page first, then
+  open the voice AI and send it the link. A new `≤480px` mobile
   breakpoint stacks the CTAs vertically with full-width buttons, tightens the
   BOMBSQUAD title letter-spacing, and aligns home-page padding so 320 / 375 /
   414 viewports no longer overflow.
@@ -165,6 +169,19 @@ Versions follow [Semantic Versioning](https://semver.org).
   recorded in `wrangler.toml` and the binding is attached to the Pages project,
   so the daily leaderboard endpoints persist scores in production instead of
   returning a Workers runtime error.
+- **Spark-highlight wire cut** Cutting the correct wire now plays a reworked
+  success animation — a quick spark flash at the cut point, a brief glow on
+  the two severed ends, and the halves snapping apart fast. It is pure CSS,
+  and the reduced-motion fallback keeps both halves visible without motion.
+- **Clearer Scene Info bar** The indicator lights now have their own
+  "指示灯：" label, and a divider separates them from the battery count.
+  Previously the indicator chips sat flush against "电池：N" with no label of
+  their own and were easy to misread as battery symbols.
+- **Sharper AI partner guidance** The bomb manual now explicitly tells the AI
+  what it must not say to the player — no raw rule text or condition tables,
+  no hints that decoy modules exist, no manual structure — and to reply with
+  the conclusive action only, never its reasoning. The same two guardrails
+  are added to the standard AI prompt.
 
 ### Fixed
 
@@ -261,6 +278,11 @@ Versions follow [Semantic Versioning](https://semver.org).
 - **Automation** Added the missing Dependabot labels and removed the repo-wide CODEOWNERS assignment so dependency PRs no longer auto-request `@byheaven` for review
 
 - **Docs** Removed the duplicate AI changelog guide and kept `docs/changelog-style-guide.md` as the single source of truth
+- **Indicator lights no longer repeat** Indicator lights could appear twice in
+  the same bomb (for example two "SND" chips), which also corrupted the
+  rule-engine state for that indicator since same-named lights overwrote each
+  other. Indicators are now sampled without replacement, so every indicator in
+  a bomb is unique.
 
 <!-- Add every change that will land on main directly below this header. -->
 <!-- Entries below are maintained manually -->

--- a/packages/game/src/audio/audio-context.test.ts
+++ b/packages/game/src/audio/audio-context.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// jsdom has no Web Audio API, so the master-gain tests run against a minimal
+// AudioContext stub that records the one behaviour they assert on: the gain
+// value of the node `getMasterGain` creates and `setMasterMuted` drives.
+class FakeGainNode {
+  gain = { value: 1 }
+  connect = vi.fn()
+}
+
+class FakeAudioContext {
+  state = 'running'
+  destination = {}
+  resume = vi.fn()
+  createGain = vi.fn(() => new FakeGainNode())
+}
+
+describe('audio-context master gain', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubGlobal('AudioContext', FakeAudioContext)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('getMasterGain returns one shared, connected node', async () => {
+    const { getMasterGain } = await import('./audio-context')
+    const first = getMasterGain()
+    const second = getMasterGain()
+    expect(first).not.toBeNull()
+    expect(first).toBe(second)
+    expect((first as unknown as FakeGainNode).connect).toHaveBeenCalledOnce()
+  })
+
+  it('master gain starts unmuted (gain 1) by default', async () => {
+    const { getMasterGain } = await import('./audio-context')
+    const gain = getMasterGain() as unknown as FakeGainNode
+    expect(gain.gain.value).toBe(1)
+  })
+
+  it('setMasterMuted drives the live master gain node', async () => {
+    const { getMasterGain, setMasterMuted } = await import('./audio-context')
+    const gain = getMasterGain() as unknown as FakeGainNode
+    setMasterMuted(true)
+    expect(gain.gain.value).toBe(0)
+    setMasterMuted(false)
+    expect(gain.gain.value).toBe(1)
+  })
+
+  it('a master gain created after setMasterMuted(true) starts silenced', async () => {
+    const { getMasterGain, setMasterMuted } = await import('./audio-context')
+    setMasterMuted(true)
+    const gain = getMasterGain() as unknown as FakeGainNode
+    expect(gain.gain.value).toBe(0)
+  })
+
+  it('getMasterGain returns null when Web Audio is unavailable', async () => {
+    vi.resetModules()
+    vi.stubGlobal('AudioContext', undefined)
+    vi.stubGlobal('webkitAudioContext', undefined)
+    const { getMasterGain } = await import('./audio-context')
+    expect(getMasterGain()).toBeNull()
+  })
+})

--- a/packages/game/src/audio/audio-context.ts
+++ b/packages/game/src/audio/audio-context.ts
@@ -83,3 +83,44 @@ export function getBuffer(name: SampleName): Promise<AudioBuffer | null> {
   inflight.set(name, promise)
   return promise
 }
+
+let masterGain: GainNode | null = null
+let masterMuted = false
+
+/**
+ * Returns the shared master GainNode — the single node every SFX is routed
+ * through before reaching `ctx.destination`. Created lazily on first call and
+ * connected straight to the destination. Its gain encodes the mute state
+ * (0 when muted, 1 otherwise), so routing every sound through it means mute
+ * is enforced in exactly one place. Returns null when Web Audio is
+ * unavailable — callers fall back to connecting directly to the destination.
+ */
+export function getMasterGain(): GainNode | null {
+  const context = getAudioContext()
+  if (!context) return null
+  if (masterGain) return masterGain
+  try {
+    const gain = context.createGain()
+    gain.gain.value = masterMuted ? 0 : 1
+    gain.connect(context.destination)
+    masterGain = gain
+  } catch {
+    // createGain / connect can throw if the context was closed; silent-fail.
+    masterGain = null
+    return null
+  }
+  return masterGain
+}
+
+/**
+ * Sets whether the master GainNode silences all output. Updates the live node
+ * immediately when it exists, and records the value so a master gain created
+ * later (lazily, on first SFX) starts in the correct state. The mute feature's
+ * persistence + React layer (`mute.ts`) is the sole caller.
+ */
+export function setMasterMuted(muted: boolean): void {
+  masterMuted = muted
+  if (masterGain) {
+    masterGain.gain.value = muted ? 0 : 1
+  }
+}

--- a/packages/game/src/audio/mute.test.ts
+++ b/packages/game/src/audio/mute.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the audio mute store.
+ *
+ * Note on the localStorage fake: jsdom's `localStorage` in this workspace is
+ * stubbed to a method-less object (see `src/utils/nickname.test.ts` for the
+ * precedent). We install a small Map-backed fake via `vi.stubGlobal` so the
+ * real store can exercise its real read/persist branches. The store reads
+ * localStorage once at import time, so each test resets the module registry
+ * and re-imports against a freshly-installed fake.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+const STORAGE_KEY = 'bombsquad:audio-muted'
+
+function installFakeLocalStorage() {
+  const store = new Map<string, string>()
+  const fake = {
+    getItem: (key: string) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  }
+  vi.stubGlobal('localStorage', fake)
+  return store
+}
+
+describe('audio mute store', () => {
+  let store: Map<string, string>
+
+  beforeEach(() => {
+    vi.resetModules()
+    store = installFakeLocalStorage()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('defaults to unmuted when nothing is persisted', async () => {
+    const { isMuted } = await import('./mute')
+    expect(isMuted()).toBe(false)
+  })
+
+  it('initializes from a persisted muted=true preference', async () => {
+    store.set(STORAGE_KEY, 'true')
+    const { isMuted } = await import('./mute')
+    expect(isMuted()).toBe(true)
+  })
+
+  it('setMuted flips state and persists to localStorage', async () => {
+    const { setMuted, isMuted } = await import('./mute')
+    setMuted(true)
+    expect(isMuted()).toBe(true)
+    expect(store.get(STORAGE_KEY)).toBe('true')
+    setMuted(false)
+    expect(isMuted()).toBe(false)
+    expect(store.get(STORAGE_KEY)).toBe('false')
+  })
+
+  it('toggleMuted alternates the state', async () => {
+    const { toggleMuted, isMuted } = await import('./mute')
+    expect(isMuted()).toBe(false)
+    toggleMuted()
+    expect(isMuted()).toBe(true)
+    toggleMuted()
+    expect(isMuted()).toBe(false)
+  })
+
+  it('setMuted is a no-op when the value is unchanged', async () => {
+    const { setMuted } = await import('./mute')
+    setMuted(false)
+    expect(store.has(STORAGE_KEY)).toBe(false)
+  })
+
+  it('persisted preference survives a simulated refresh (re-import)', async () => {
+    const first = await import('./mute')
+    first.setMuted(true)
+    expect(store.get(STORAGE_KEY)).toBe('true')
+    vi.resetModules()
+    const second = await import('./mute')
+    expect(second.isMuted()).toBe(true)
+  })
+})

--- a/packages/game/src/audio/mute.ts
+++ b/packages/game/src/audio/mute.ts
@@ -1,0 +1,75 @@
+/**
+ * Global SFX mute — state, persistence, and React binding.
+ *
+ * The mute preference is a single module-level boolean, mirrored to
+ * `localStorage` so it survives refresh / re-entry. The audio graph's master
+ * GainNode (owned by `audio-context.ts`) is the enforcement point; this
+ * module pushes every change down via `setMasterMuted` and syncs the audio
+ * layer with the persisted value once at import time.
+ *
+ * React components read the state with `useMuted()` (built on
+ * `useSyncExternalStore`) and flip it with `toggleMuted()`.
+ */
+
+import { useSyncExternalStore } from 'react'
+import { setMasterMuted } from './audio-context'
+
+const STORAGE_KEY = 'bombsquad:audio-muted'
+
+/**
+ * Reads the persisted preference. Defaults to false (audio on) when storage
+ * is unavailable or unset — sound-on is the intended first-run experience.
+ */
+function readPersisted(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+let muted = readPersisted()
+const listeners = new Set<() => void>()
+
+// Sync the audio layer with the persisted preference at import time so a
+// master gain created later (lazily, on first SFX) starts in the right state.
+setMasterMuted(muted)
+
+/** Current mute state. */
+export function isMuted(): boolean {
+  return muted
+}
+
+/**
+ * Sets the mute state: updates the audio graph, persists to localStorage, and
+ * notifies React subscribers. No-op when the value is unchanged.
+ */
+export function setMuted(next: boolean): void {
+  if (next === muted) return
+  muted = next
+  setMasterMuted(muted)
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(muted))
+  } catch {
+    // Storage full / unavailable — in-memory state still applies this session.
+  }
+  for (const listener of listeners) listener()
+}
+
+/** Flips the current mute state. */
+export function toggleMuted(): void {
+  setMuted(!muted)
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** React binding — re-renders the caller whenever the mute state flips. */
+export function useMuted(): boolean {
+  return useSyncExternalStore(subscribe, isMuted, isMuted)
+}

--- a/packages/game/src/audio/useSfx.ts
+++ b/packages/game/src/audio/useSfx.ts
@@ -16,7 +16,7 @@
  * design doc.
  */
 
-import { getAudioContext, getBuffer } from './audio-context'
+import { getAudioContext, getBuffer, getMasterGain } from './audio-context'
 import { SFX_PRESETS, type SfxType } from './presets'
 
 export function playSfx(type: SfxType): void {
@@ -37,7 +37,9 @@ export function playSfx(type: SfxType): void {
       const gain = ctx.createGain()
       gain.gain.value = preset.gain
       src.connect(gain)
-      gain.connect(ctx.destination)
+      // Route through the shared master gain so a single node enforces mute
+      // for every SFX; fall back to the raw destination if it can't be made.
+      gain.connect(getMasterGain() ?? ctx.destination)
       src.start(0)
     } catch {
       // Source node creation can throw if ctx was closed; safe to ignore.

--- a/packages/game/src/components/MuteButton.test.tsx
+++ b/packages/game/src/components/MuteButton.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Component tests for MuteButton.
+ *
+ * jsdom's `localStorage` is method-less in this workspace, so a Map-backed
+ * fake is installed per test (see `src/utils/nickname.test.ts` for the
+ * precedent). The mute store is a module singleton; `setMuted(false)` in
+ * `beforeEach` resets it to a known state between tests.
+ */
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import MuteButton from './MuteButton'
+import { setMuted, isMuted } from '@/audio/mute'
+
+const STORAGE_KEY = 'bombsquad:audio-muted'
+
+function installFakeLocalStorage() {
+  const store = new Map<string, string>()
+  const fake = {
+    getItem: (key: string) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  }
+  vi.stubGlobal('localStorage', fake)
+  return store
+}
+
+describe('MuteButton', () => {
+  let store: Map<string, string>
+
+  beforeEach(() => {
+    store = installFakeLocalStorage()
+    setMuted(false)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders unmuted by default with audible-state aria', () => {
+    render(<MuteButton />)
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveAttribute('aria-pressed', 'false')
+    expect(btn).toHaveAttribute('aria-label', '静音')
+  })
+
+  it('toggles to muted on click and persists the preference', () => {
+    render(<MuteButton />)
+    const btn = screen.getByRole('button')
+    fireEvent.click(btn)
+    expect(btn).toHaveAttribute('aria-pressed', 'true')
+    expect(btn).toHaveAttribute('aria-label', '取消静音')
+    expect(isMuted()).toBe(true)
+    expect(store.get(STORAGE_KEY)).toBe('true')
+  })
+
+  it('toggles back to unmuted on a second click', () => {
+    render(<MuteButton />)
+    const btn = screen.getByRole('button')
+    fireEvent.click(btn)
+    fireEvent.click(btn)
+    expect(btn).toHaveAttribute('aria-pressed', 'false')
+    expect(isMuted()).toBe(false)
+  })
+
+  it('reflects mute changes made outside the component', () => {
+    render(<MuteButton />)
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveAttribute('aria-pressed', 'false')
+    act(() => setMuted(true))
+    expect(btn).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('applies the className supplied by the host page', () => {
+    render(<MuteButton className="host-class" />)
+    expect(screen.getByRole('button')).toHaveClass('host-class')
+  })
+})

--- a/packages/game/src/components/MuteButton.tsx
+++ b/packages/game/src/components/MuteButton.tsx
@@ -1,0 +1,53 @@
+import { useMuted, toggleMuted } from '@/audio/mute'
+
+interface MuteButtonProps {
+  /** Style class supplied by the host page (see GamePage.module.css `.muteBtn`). */
+  className?: string
+}
+
+/**
+ * Icon-only toggle for the global SFX mute. Reflects and drives the shared
+ * mute store, so its state stays correct across refresh / re-entry. Renders a
+ * speaker glyph — with sound waves when audible, with a cross when muted —
+ * and exposes the state to assistive tech via `aria-pressed`.
+ */
+export default function MuteButton({ className }: MuteButtonProps) {
+  const muted = useMuted()
+  const label = muted ? '取消静音' : '静音'
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={() => toggleMuted()}
+      aria-label={label}
+      aria-pressed={muted}
+      title={label}
+    >
+      <svg
+        viewBox="0 0 24 24"
+        width="20"
+        height="20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path d="M4 9v6h4l5 4V5L8 9H4z" fill="currentColor" stroke="none" />
+        {muted ? (
+          <>
+            <path d="M17 9l5 6" />
+            <path d="M22 9l-5 6" />
+          </>
+        ) : (
+          <>
+            <path d="M16.5 8.5a5 5 0 0 1 0 7" />
+            <path d="M19.5 6a9 9 0 0 1 0 12" />
+          </>
+        )}
+      </svg>
+    </button>
+  )
+}

--- a/packages/game/src/components/SceneInfoBar.module.css
+++ b/packages/game/src/components/SceneInfoBar.module.css
@@ -20,6 +20,21 @@
   min-width: 0;
 }
 
+/* Vertical divider + extra padding between adjacent HUD fields. Without it
+   the battery value sits flush against the indicator chips and players read
+   the chips as part of the battery count ("电池：2" then 3 chips). The rule
+   draws each field as a visibly separate, separately-labelled segment. */
+.field + .field {
+  padding-left: 12px;
+  border-left: 1px solid var(--color-border);
+}
+
+/* Indicator chips wrap as a group beneath their shared "指示灯：" label so a
+   narrow viewport never splits a chip onto its own line away from the label. */
+.indicators {
+  flex-wrap: wrap;
+}
+
 .label {
   color: var(--color-text-muted);
   /* Keep the label glued to its value on one line — only the phrase wraps. */

--- a/packages/game/src/components/SceneInfoBar.test.tsx
+++ b/packages/game/src/components/SceneInfoBar.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import type { SceneInfo } from '@shared/manual-schema'
+import SceneInfoBar from './SceneInfoBar'
+
+const sceneWithIndicators: SceneInfo = {
+  sceneTongueTwister: '四是四十是十',
+  batteryCount: 2,
+  indicators: [
+    { label: 'CLR', lit: true },
+    { label: 'SND', lit: false },
+    { label: 'FRK', lit: true },
+  ],
+}
+
+describe('SceneInfoBar', () => {
+  it('renders the battery count under its own 电池 label', () => {
+    render(<SceneInfoBar sceneInfo={sceneWithIndicators} />)
+    expect(screen.getByText('电池：')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('renders indicators under a dedicated 指示灯 label, separate from the battery field', () => {
+    render(<SceneInfoBar sceneInfo={sceneWithIndicators} />)
+
+    const indicatorField = screen.getByText('指示灯：').parentElement as HTMLElement
+    const batteryField = screen.getByText('电池：').parentElement as HTMLElement
+
+    // The indicator chips live inside their own labelled group, a different
+    // element from the 电池 field — so the chips can no longer be misread as
+    // part of the battery count (the original "shows 2, see 3 symbols" bug).
+    expect(indicatorField).not.toBe(batteryField)
+    for (const label of ['CLR', 'SND', 'FRK']) {
+      const chip = screen.getByText(label)
+      expect(indicatorField).toContainElement(chip)
+      expect(batteryField).not.toContainElement(chip)
+    }
+  })
+
+  it('shows 无 under the 指示灯 label when a scene has no indicators', () => {
+    render(
+      <SceneInfoBar
+        sceneInfo={{ sceneTongueTwister: '四是四十是十', batteryCount: 1, indicators: [] }}
+      />
+    )
+    expect(screen.getByText('指示灯：')).toBeInTheDocument()
+    expect(screen.getByText('无')).toBeInTheDocument()
+  })
+})

--- a/packages/game/src/components/SceneInfoBar.tsx
+++ b/packages/game/src/components/SceneInfoBar.tsx
@@ -23,15 +23,22 @@ export default function SceneInfoBar({ sceneInfo }: SceneInfoBarProps) {
         <span className={styles.label}>电池：</span>
         <span className={styles.value}>{sceneInfo.batteryCount}</span>
       </span>
-      {sceneInfo.indicators.map((ind, i) => (
-        <span
-          key={`${ind.label}-${i}`}
-          className={`${styles.indicator} ${ind.lit ? styles.lit : styles.unlit}`}
-          title={ind.lit ? `${ind.label}（亮）` : `${ind.label}（灭）`}
-        >
-          {ind.label}
-        </span>
-      ))}
+      <span className={`${styles.field} ${styles.indicators}`}>
+        <span className={styles.label}>指示灯：</span>
+        {sceneInfo.indicators.length > 0 ? (
+          sceneInfo.indicators.map((ind, i) => (
+            <span
+              key={`${ind.label}-${i}`}
+              className={`${styles.indicator} ${ind.lit ? styles.lit : styles.unlit}`}
+              title={ind.lit ? `${ind.label}（亮）` : `${ind.label}（灭）`}
+            >
+              {ind.label}
+            </span>
+          ))
+        ) : (
+          <span className={styles.value}>无</span>
+        )}
+      </span>
     </div>
   )
 }

--- a/packages/game/src/engine/scene-info.test.ts
+++ b/packages/game/src/engine/scene-info.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { createRng } from './rng'
+import { generateSceneInfo, INDICATOR_LABELS } from './scene-info'
+
+describe('generateSceneInfo', () => {
+  it('never produces duplicate indicator labels within a scene', () => {
+    // Regression: indicators were once sampled WITH replacement (rng.pick per
+    // slot), so a scene could show e.g. two "SND" chips. They are now sampled
+    // without replacement, so every generated scene must have unique labels.
+    for (let seed = 0; seed < 500; seed++) {
+      const { indicators } = generateSceneInfo(createRng(seed))
+      const labels = indicators.map((ind) => ind.label)
+      expect(new Set(labels).size).toBe(labels.length)
+    }
+  })
+
+  it('only emits labels from the known indicator pool', () => {
+    for (let seed = 0; seed < 200; seed++) {
+      const { indicators } = generateSceneInfo(createRng(seed))
+      for (const ind of indicators) {
+        expect(INDICATOR_LABELS).toContain(ind.label)
+      }
+    }
+  })
+
+  it('produces 0–3 indicators and a battery count of 1–4', () => {
+    for (let seed = 0; seed < 200; seed++) {
+      const { indicators, batteryCount } = generateSceneInfo(createRng(seed))
+      expect(indicators.length).toBeGreaterThanOrEqual(0)
+      expect(indicators.length).toBeLessThanOrEqual(3)
+      expect(batteryCount).toBeGreaterThanOrEqual(1)
+      expect(batteryCount).toBeLessThanOrEqual(4)
+    }
+  })
+
+  it('is deterministic for a given seed', () => {
+    expect(generateSceneInfo(createRng(42))).toEqual(generateSceneInfo(createRng(42)))
+  })
+})

--- a/packages/game/src/engine/scene-info.ts
+++ b/packages/game/src/engine/scene-info.ts
@@ -1,0 +1,32 @@
+import type { SceneInfo } from '@shared/manual-schema'
+import type { Rng } from './rng'
+import { TONGUE_TWISTERS } from '@/data/tongue-twisters'
+
+/**
+ * Indicator labels a scene can display. Sampled WITHOUT replacement per run
+ * (see `generateSceneInfo`) — a bomb never carries two indicators with the
+ * same label, and a duplicate would also silently overwrite itself in the
+ * rule engine's `indicator_<label>_lit` context lookup.
+ */
+export const INDICATOR_LABELS = ['FRK', 'CAR', 'NSA', 'MSA', 'SND', 'CLR', 'BOB', 'TRN']
+
+/**
+ * Generate the puzzle-global scene info — the tongue-twister phrase, battery
+ * count, and indicators — that every module's rules read against.
+ *
+ * Indicators are produced by shuffling the label pool and slicing the first
+ * N, guaranteeing every indicator in a single scene has a unique label.
+ */
+export function generateSceneInfo(rng: Rng): SceneInfo {
+  const sceneTongueTwister = rng.pick(TONGUE_TWISTERS)
+  const batteryCount = rng.intBetween(1, 4)
+  const indicatorCount = rng.intBetween(0, 3)
+  const indicators = rng
+    .shuffle(INDICATOR_LABELS)
+    .slice(0, indicatorCount)
+    .map((label) => ({
+      label,
+      lit: rng.float() < 0.5,
+    }))
+  return { sceneTongueTwister, batteryCount, indicators }
+}

--- a/packages/game/src/modules/wire/WireModule.module.css
+++ b/packages/game/src/modules/wire/WireModule.module.css
@@ -40,12 +40,43 @@
   transition: opacity 100ms;
 }
 
+.wire-cut-top,
+.wire-cut-bottom {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
 .wire-cut-top {
-  animation: wire-cut-top 400ms ease-out forwards;
+  animation:
+    wire-cut-top 220ms cubic-bezier(0.22, 0.9, 0.3, 1) forwards,
+    wire-cut-glow 520ms ease-out forwards;
 }
 
 .wire-cut-bottom {
-  animation: wire-cut-bottom 400ms ease-out forwards;
+  animation:
+    wire-cut-bottom 220ms cubic-bezier(0.22, 0.9, 0.3, 1) forwards,
+    wire-cut-glow 520ms ease-out forwards;
+}
+
+/* Spark highlight — bright core flash at the cut point */
+.wire-cut-spark-core {
+  fill: var(--color-neon-cyan);
+  filter: drop-shadow(0 0 6px var(--color-neon-cyan));
+  transform-box: fill-box;
+  transform-origin: center;
+  pointer-events: none;
+  animation: wire-cut-spark 280ms ease-out forwards;
+}
+
+/* Spark highlight — shockwave ring radiating from the cut point */
+.wire-cut-spark-ring {
+  fill: none;
+  stroke: var(--color-neon-cyan);
+  stroke-width: 2;
+  transform-box: fill-box;
+  transform-origin: center;
+  pointer-events: none;
+  animation: wire-cut-ring 320ms ease-out forwards;
 }
 
 .wire-hit-target.clicking {

--- a/packages/game/src/modules/wire/WireModule.tsx
+++ b/packages/game/src/modules/wire/WireModule.tsx
@@ -95,6 +95,9 @@ export default function WireModule({
                     fill="none"
                     strokeLinecap="round"
                   />
+                  {/* Spark highlight at the cut point */}
+                  <circle cx={midX} cy={startY} r={5} className={styles['wire-cut-spark-ring']} />
+                  <circle cx={midX} cy={startY} r={4} className={styles['wire-cut-spark-core']} />
                 </>
               ) : (
                 <path

--- a/packages/game/src/pages/GamePage.module.css
+++ b/packages/game/src/pages/GamePage.module.css
@@ -23,6 +23,15 @@
   line-height: 1.5;
 }
 
+/* Right-side topBar control cluster — mute toggle + exit. Grouped so the
+   topBar keeps three flex children (timer / meta / actions) and the existing
+   space-between layout is preserved. The exit button's own `margin-left`
+   spaces the two controls, so no gap is set here. */
+.topBarActions {
+  display: flex;
+  align-items: center;
+}
+
 .exitBtn {
   font-family: var(--font-mono);
   font-size: 0.7rem;
@@ -42,6 +51,47 @@
 
 .exitBtn:hover,
 .exitBtn:focus-visible {
+  color: var(--color-neon-red);
+  border-color: var(--color-neon-red);
+  outline: 2px solid var(--color-neon-red);
+  outline-offset: 2px;
+}
+
+/* Mute toggle — icon-only, so it carries an `aria-label`. Neutral muted-grey
+   when audio is on; flips to neon-red when muted so "sound is off" reads at a
+   glance, not only from the speaker glyph. */
+.muteBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--touch-target);
+  min-height: var(--touch-target);
+  padding: 6px;
+  background: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.muteBtn:hover,
+.muteBtn:focus-visible {
+  color: var(--color-neon-cyan);
+  border-color: var(--color-neon-cyan);
+  outline: 2px solid var(--color-neon-cyan);
+  outline-offset: 2px;
+}
+
+.muteBtn[aria-pressed='true'] {
+  color: var(--color-neon-red);
+  border-color: var(--color-neon-red);
+}
+
+.muteBtn[aria-pressed='true']:hover,
+.muteBtn[aria-pressed='true']:focus-visible {
   color: var(--color-neon-red);
   border-color: var(--color-neon-red);
   outline: 2px solid var(--color-neon-red);

--- a/packages/game/src/pages/GamePage.tsx
+++ b/packages/game/src/pages/GamePage.tsx
@@ -19,12 +19,13 @@ import { generateKeypad } from '@/modules/keypad/generator'
 import Timer from '@/components/Timer'
 import ProgressBar from '@/components/ProgressBar'
 import SceneInfoBar from '@/components/SceneInfoBar'
+import MuteButton from '@/components/MuteButton'
 import WireModule from '@/modules/wire/WireModule'
 import DialModule from '@/modules/dial/DialModule'
 import ButtonModule from '@/modules/button/ButtonModule'
 import KeypadModule from '@/modules/keypad/KeypadModule'
 import practiceYamlRaw from '../../../manual/data/practice.yaml?raw'
-import { TONGUE_TWISTERS } from '@/data/tongue-twisters'
+import { generateSceneInfo } from '@/engine/scene-info'
 import { getAttemptNumberForMode, getRunSeed } from '@/utils/session'
 import { getAudioContext } from '@/audio/audio-context'
 import styles from './GamePage.module.css'
@@ -72,19 +73,6 @@ function detectRefresh(): boolean {
 /** Mark the refresh banner as consumed for the rest of this document's life. */
 function consumeRefreshBanner(): void {
   refreshBannerConsumed = true
-}
-
-const INDICATOR_LABELS = ['FRK', 'CAR', 'NSA', 'MSA', 'SND', 'CLR', 'BOB', 'TRN']
-
-function generateSceneInfo(rng: Rng): SceneInfo {
-  const sceneTongueTwister = rng.pick(TONGUE_TWISTERS)
-  const batteryCount = rng.intBetween(1, 4)
-  const indicatorCount = rng.intBetween(0, 3)
-  const indicators = Array.from({ length: indicatorCount }, () => ({
-    label: rng.pick(INDICATOR_LABELS),
-    lit: rng.float() < 0.5,
-  }))
-  return { sceneTongueTwister, batteryCount, indicators }
 }
 
 function generateAllModules(
@@ -498,14 +486,17 @@ export default function GamePage() {
           <div>{mode === 'daily' ? '每日' : '练习'}</div>
           <div>{mode === 'daily' ? `第 ${state.attemptNumber} 次` : '本地练习'}</div>
         </div>
-        <button
-          type="button"
-          className={styles.exitBtn}
-          onClick={handleExitRun}
-          aria-label="退出当前关卡"
-        >
-          退出
-        </button>
+        <div className={styles.topBarActions}>
+          <MuteButton className={styles.muteBtn} />
+          <button
+            type="button"
+            className={styles.exitBtn}
+            onClick={handleExitRun}
+            aria-label="退出当前关卡"
+          >
+            退出
+          </button>
+        </div>
       </div>
 
       <div className={styles.moduleArea}>

--- a/packages/game/src/pages/HomePage.module.css
+++ b/packages/game/src/pages/HomePage.module.css
@@ -145,14 +145,6 @@
   min-width: 20px;
 }
 
-/* Pre-flight requirement callout — used on step 1 only.
-   Neon-cyan side accent flags the "voice AI must be open before you start"
-   requirement without bleeding the accent across the rest of the list. */
-.howToList li.stepRequired {
-  border-left: 2px solid var(--color-neon-cyan);
-  padding-left: 8px;
-}
-
 .footer {
   font-family: var(--font-sans);
   font-size: 0.75rem;

--- a/packages/game/src/pages/HomePage.tsx
+++ b/packages/game/src/pages/HomePage.tsx
@@ -5,10 +5,10 @@ import PromptModal, { type PromptMode } from '@/components/PromptModal'
 import styles from './HomePage.module.css'
 
 const HOW_TO_STEPS = [
-  '必备：在另一个窗口/设备打开你的 AI（Claude、ChatGPT、Gemini…）并切到语音模式。',
-  '点「练习」或「每日挑战」，把弹窗里的手册地址复制发给 AI。等它说读完手册了。',
-  '回到游戏页，按「确认开始游戏」。',
-  '描述你看到的场景，AI 会告诉你怎么操作。用时越短，排名越高。',
+  '点「练习」或「每日挑战」，复制弹窗里的手册链接。',
+  '打开 AI 并切到语音模式，把链接发给它，等它读完手册。',
+  '回游戏页，按「确认开始游戏」。',
+  '描述你看到的场景，照 AI 指引操作 —— 用时越短，排名越高。',
 ]
 
 interface ModalState {
@@ -53,7 +53,7 @@ export default function HomePage() {
         <h2 className={styles.howToTitle}>怎么开始</h2>
         <ol className={styles.howToList}>
           {HOW_TO_STEPS.map((step, i) => (
-            <li key={i} className={i === 0 ? styles.stepRequired : undefined}>
+            <li key={i}>
               <span className={styles.stepNum}>{i + 1}.</span>
               <span>{step}</span>
             </li>

--- a/packages/game/src/styles/animations.css
+++ b/packages/game/src/styles/animations.css
@@ -64,27 +64,74 @@
   }
 }
 
-/* Wire cut — top half falls up */
+/* Wire cut — top half snaps upward and stays visible */
 @keyframes wire-cut-top {
-  from {
-    transform: translateY(0) rotate(0);
-    opacity: 1;
+  0% {
+    transform: translate(0, 0) rotate(0);
   }
-  to {
-    transform: translateY(-20px) rotate(-5deg);
-    opacity: 0;
+  55% {
+    transform: translate(-1px, -10px) rotate(-4deg);
+  }
+  100% {
+    transform: translate(0, -7px) rotate(-3deg);
   }
 }
 
-/* Wire cut — bottom half falls down */
+/* Wire cut — bottom half snaps downward and stays visible */
 @keyframes wire-cut-bottom {
-  from {
-    transform: translateY(0) rotate(0);
-    opacity: 1;
+  0% {
+    transform: translate(0, 0) rotate(0);
   }
-  to {
-    transform: translateY(20px) rotate(5deg);
+  55% {
+    transform: translate(1px, 10px) rotate(4deg);
+  }
+  100% {
+    transform: translate(0, 7px) rotate(3deg);
+  }
+}
+
+/* Wire cut — severed ends glow, then decay */
+@keyframes wire-cut-glow {
+  0% {
+    filter: drop-shadow(0 0 3px var(--color-neon-cyan));
+  }
+  25% {
+    filter: drop-shadow(0 0 9px var(--color-neon-cyan));
+  }
+  100% {
+    filter: none;
+  }
+}
+
+/* Wire cut — spark core flash at the cut point */
+@keyframes wire-cut-spark {
+  0% {
     opacity: 0;
+    transform: scale(0.2);
+  }
+  18% {
+    opacity: 1;
+    transform: scale(1.35);
+  }
+  45% {
+    opacity: 0.85;
+    transform: scale(0.95);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.55);
+  }
+}
+
+/* Wire cut — spark shockwave ring expanding outward */
+@keyframes wire-cut-ring {
+  0% {
+    opacity: 0.85;
+    transform: scale(0.3);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(2.6);
   }
 }
 
@@ -183,19 +230,33 @@
     }
   }
   @keyframes wire-cut-top {
-    from {
-      opacity: 1;
-    }
-    to {
-      opacity: 1;
+    0%,
+    100% {
+      transform: none;
     }
   }
   @keyframes wire-cut-bottom {
-    from {
-      opacity: 1;
+    0%,
+    100% {
+      transform: none;
     }
-    to {
-      opacity: 1;
+  }
+  @keyframes wire-cut-glow {
+    0%,
+    100% {
+      filter: none;
+    }
+  }
+  @keyframes wire-cut-spark {
+    0%,
+    100% {
+      opacity: 0;
+    }
+  }
+  @keyframes wire-cut-ring {
+    0%,
+    100% {
+      opacity: 0;
     }
   }
   @keyframes dial-slide-up {

--- a/packages/manual/build.ts
+++ b/packages/manual/build.ts
@@ -32,6 +32,30 @@ interface MinimalManual {
   meta?: { version?: string }
   modules: MinimalModules
   symbols?: Record<string, { description?: string }>
+  ai_instructions?: Record<string, string[]>
+}
+
+/**
+ * Hard output constraints for the AI partner, injected at build time into
+ * every rendered manual (practice + every daily). The manual is the only
+ * surface the AI is actually given — players never read it — so the rules
+ * governing what the AI may say to the player belong here, as data the AI
+ * reads before any puzzle rule.
+ *
+ * Injected (like `symbols`) rather than authored into each source yaml:
+ * one SSOT covers all 360+ committed daily files plus every future one,
+ * and survives the daily generator's wholesale `meta` rewrite.
+ */
+const AI_INSTRUCTIONS: Record<string, string[]> = {
+  do_not_reveal_to_player: [
+    'The player never sees this manual and acts only on what you say aloud. Never read out, paste, quote, or summarize raw manual content to the player: rule text, condition tables, YAML or data structure, rule ids, or rule counts. Convert every lookup into one concrete action the player performs right now, e.g. "cut the second wire from the top".',
+    'Never reveal or hint at the decoy modules (morse_code, maze, memory), and never tell the player that decoy or irrelevant rules exist. Only ever discuss the module the player is currently describing.',
+    'Never expose manual meta-information or structure: how the manual is organized, how many rules it holds, or that most rules do not apply. Tell the player only the next action to perform.',
+  ],
+  give_conclusions_not_reasoning: [
+    'When you look up a table, match conditions, or work out which rule applies, never narrate that process aloud. Do not tell the player which rule matched, which conditions you checked, or how you searched the manual.',
+    'Reply with only the final, conclusive, executable instruction, e.g. "Cut the second wire from the top." Add a release or stop condition only when the action needs one, e.g. "hold the button and release when the strip turns red." Never say why.',
+  ],
 }
 
 function collectReferencedSymbolIds(modules: MinimalModules): Set<string> {
@@ -86,12 +110,18 @@ function buildPage(yamlPath: string, slug: string) {
   // SYMBOLS registry. Caught here before anything ships.
   validateReferencedSymbolsAgainstSSOT(parsed)
 
-  // Build the injected variant: a deep-clone of `parsed` augmented with a
-  // `symbols` block derived from SYMBOLS. Only this variant is embedded in
-  // the rendered HTML; the source yaml and the dist raw yaml never carry
-  // descriptions (Option C: hybrid HTML-only inline).
+  // Prepend the AI output constraints so they render before any rule
+  // content. This variant feeds both the HTML page and the dist raw yaml,
+  // so the constraints reach the AI on every read path (browser HTML and
+  // `?format=yaml`).
+  const withInstructions: MinimalManual = { ai_instructions: AI_INSTRUCTIONS, ...parsed }
+
+  // Build the injected variant: a deep-clone of `withInstructions`
+  // augmented with a `symbols` block derived from SYMBOLS. Only this
+  // variant is embedded in the rendered HTML; the source yaml and the dist
+  // raw yaml never carry descriptions (Option C: hybrid HTML-only inline).
   const referenced = collectReferencedSymbolIds(parsed.modules)
-  const injected = structuredClone(parsed)
+  const injected = structuredClone(withInstructions)
   injected.symbols = Object.fromEntries(
     [...referenced].map((id) => {
       const sym = SYMBOLS.find((s) => s.id === id)
@@ -120,10 +150,10 @@ function buildPage(yamlPath: string, slug: string) {
   mkdirSync(pageDir, { recursive: true })
   writeFileSync(join(pageDir, 'index.html'), html)
 
-  // Dist raw yaml: serialise the un-injected `parsed` object (no symbols
-  // block) so the `?format=yaml` AI path and any downstream consumer of
-  // the raw asset stays consistent with the source-yaml shape.
-  writeFileSync(join(dataOutDir, `${slug}.yaml`), yaml.dump(parsed))
+  // Dist raw yaml: serialise `withInstructions` — carries the AI output
+  // constraints (so the `?format=yaml` AI path is also governed) but never
+  // the `symbols` block (Option C: descriptions stay HTML-only).
+  writeFileSync(join(dataOutDir, `${slug}.yaml`), yaml.dump(withInstructions))
   console.log(`Built manual route: /manual/${slug}`)
 }
 

--- a/prompts/standard-prompt.md
+++ b/prompts/standard-prompt.md
@@ -22,6 +22,8 @@ Please read the complete manual first, then tell your partner you are ready.
 5. The manual contains many decoy modules (morse code, maze, etc.) — ignore anything they don't describe
 6. When multiple conditions appear in a rule, ALL must match
 7. They may describe imprecisely under pressure — ask follow-up questions about key details
+8. Never relay the manual itself — do not read out, quote, paste, or summarize rule text, condition tables, the manual's structure, or rule counts; never mention the decoy modules or that decoy/irrelevant rules exist; turn every lookup into one concrete action they perform now (e.g. "cut the second wire from the top")
+9. Never narrate your reasoning — do not tell them which rule matched, which conditions you checked, or how you searched the manual; match the rules silently and reply with only the conclusive, executable instruction (the action, plus a release/stop condition when one is needed)
 
 ## Module Types
 
@@ -33,6 +35,7 @@ Please read the complete manual first, then tell your partner you are ready.
 ## Symbol Names
 
 Use these agreed-upon names when discussing dial/keypad symbols:
+
 - omega = horseshoe shape
 - psi = three-pronged fork
 - delta = triangle


### PR DESCRIPTION
## Summary

- Internal-beta UX polish batch for AmiClaw — 6 items. Source task: `polish-amiclaw-internal-beta-ux`.
- **Homepage** — trimmed the "怎么开始" copy, corrected the step order (copy the manual link first, then open the AI), removed the stray accent bar on step 1.
- **Mute toggle** — new mute button in the game top bar; master GainNode + localStorage-persisted mute state.
- **Wire-cut animation** — reworked into a spark-highlight cut (spark flash + glowing severed ends + fast snap-apart; pure CSS, reduced-motion fallback preserved).
- **Scene Info bar** — indicator lights now have a "指示灯：" label and a divider from the battery count, so the chips are no longer misread as battery symbols.
- **Indicator de-duplication** — indicator lights are sampled without replacement; fixes duplicate indicators that also corrupted rule-engine state for the repeated label.
- **AI manual** — added explicit output constraints (no raw rule text, no decoy hints, no reasoning narration) to the manual content and the standard prompt.

The daily-challenge difficulty + countdown rework that grew out of the original item 3 during intent anchoring is tracked separately as task `rework-amiclaw-game-modes`.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass — 205 tests green (api 14 / manual 25 / game 166)
- [x] New tests added if behavior changed — 23 new tests (mute, audio-context, MuteButton, scene-info de-dup, SceneInfoBar)
- [x] Tested manually and documented below

Each of the 6 items was independently verified by a separate reviewer. The Scene Info bar fix and the indicator de-dup were reproduced and confirmed in a running browser. The wire-cut animation is verified as spec-correct, CSS-only, and reduced-motion-safe — its visual feel still benefits from a human eyeball (see note).

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed — CHANGELOG.md updated
- [x] Breaking changes documented if any — none

> Note: the wire-cut animation's aesthetic (timing / brightness / feel) is best confirmed by running the game. Functionally it is pure-CSS, reduced-motion-safe, and uses design tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
