### PR TITLE
docs: refresh AGENTS.md doc references to current doc set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,9 @@ human player and an AI expert communicate only through voice.
 
 Key docs:
 
-- Game design and mechanics: `docs/AmiClaw_GameDesign.md`
-- MVP scope and requirements: `docs/AmiClaw_MVP.md`
+- System architecture (C4 model): `docs/architecture/architecture.md`
+- BombSquad gameplay, player guide: `docs/bombsquad-player-guide.md`
+- AmiClaw platform overview, player guide: `docs/amiclaw-platform-guide.md`
 - Design system: `docs/DesignSystem.md`
 - Changelog authoring guide: `docs/changelog-style-guide.md`
 


### PR DESCRIPTION
## Summary

- The AGENTS.md "Key docs" list pointed at `docs/AmiClaw_GameDesign.md` and `docs/AmiClaw_MVP.md`, both now archived (`stage: archived`) and superseded.
- Repoint to the current documentation set: the unified C4 architecture entry (`docs/architecture/architecture.md`) and two new player guides (`docs/bombsquad-player-guide.md`, `docs/amiclaw-platform-guide.md`). Design system and changelog-guide entries unchanged.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] CI or configuration

## Testing

- [ ] Existing tests pass
- [ ] New tests added if behavior changed
- [x] Tested manually and documented below

Docs-only change to `AGENTS.md` (the AI-assistant instructions file; `CLAUDE.md` is a symlink to it). Verified with `markdownlint-cli2` and `prettier --check` — both clean. No code paths touched, so no test impact; CI runs the full suite.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

🤖 Generated with [Claude Code](https://claude.com/claude-code)