### PR TITLE
feat(game,api): add game-failed telemetry events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ Versions follow [Semantic Versioning](https://semver.org).
 - `replay_intent` console.info event emitted when the result-page "再来一局" button is clicked — enables manual estimation of replay-willingness (roadmap §Strategic Objectives Validation Criteria #3, 复玩意愿 ≥50%) from console logs
 - Backend event ingestion via Pages Function `/api/events` — five existing event types (game_start, module_solve, game_complete, game_abandon, manual_load_failed) plus replay_intent now POST to a Cloudflare Pages Function that writes per-event-name counters and unique-device sets to the LEADERBOARD KV namespace under `events:{date}:*` keys. Frontend `console.info` channel is replaced by fire-and-forget fetch; events include device_id (sourced from the same localStorage UUID used by leaderboard submissions) so both session-level and unique-player completion-rate can be computed.
 - Beta data dashboard at `/api/dashboard?token=xxx` showing daily game_start/complete/replay counts and completion rates against the 70%/50% north-star thresholds. Requires `DASHBOARD_TOKEN` Pages secret (set via `wrangler secret put DASHBOARD_TOKEN`).
+- `game_failed_strikeout` / `game_failed_timeout` telemetry events — a
+  daily challenge that detonates now emits one of two failure events that
+  distinguish the loss cause: three cumulative strikes (strike-out) versus
+  the countdown reaching zero (timeout). The beta data dashboard gains two
+  raw-count columns showing the per-day failure-mode split. Telemetry-only
+  with no player-visible change; practice mode never fails and emits
+  neither event.
 - **Mute toggle** The game's top bar now has a mute button that silences every
   sound effect. The setting is saved to localStorage, so the game stays muted —
   or un-muted — across page reloads and later sessions.

--- a/packages/api/src/handlers/get-dashboard.test.ts
+++ b/packages/api/src/handlers/get-dashboard.test.ts
@@ -275,6 +275,35 @@ describe('handleGetDashboard', () => {
     }
   })
 
+  it('renders game_failed_strikeout / game_failed_timeout columns with per-day and totals values', async () => {
+    const store = {
+      'events:2026-05-18:game_start': { count: 10 },
+      'events:2026-05-18:game_failed_strikeout': { count: 3 },
+      'events:2026-05-18:game_failed_timeout': { count: 2 },
+      'events:2026-05-17:game_start': { count: 6 },
+      'events:2026-05-17:game_failed_strikeout': { count: 1 },
+      'events:2026-05-17:game_failed_timeout': { count: 4 },
+    }
+    const kv = makeKv(store)
+    const res = await handleGetDashboard(makeRequest('?token=t'), kv, 't')
+    expect(res.status).toBe(200)
+    const html = await res.text()
+
+    // Both event names appear as their own column headers.
+    expect(html).toContain('<th class="num">game_failed_strikeout</th>')
+    expect(html).toContain('<th class="num">game_failed_timeout</th>')
+
+    // The two new columns are the last two cells of every row.
+    // 2026-05-18: strikeout 3, timeout 2.
+    expect(html).toContain('<td class="num">3</td>\n<td class="num">2</td>\n</tr>')
+    // 2026-05-17: strikeout 1, timeout 4.
+    expect(html).toContain('<td class="num">1</td>\n<td class="num">4</td>\n</tr>')
+
+    // Totals row sums both columns: strikeout 3+1=4, timeout 2+4=6.
+    const totalsRow = (html.match(/<tr class="totals">[\s\S]*?<\/tr>/g) ?? [])[0]
+    expect(totalsRow).toContain('<td class="num">4</td>\n<td class="num">6</td>\n</tr>')
+  })
+
   it('uses constant-time comparison — same-length wrong token still returns 401', async () => {
     // Sanity check that the equality is not a structural shortcut: a token
     // whose length matches but content differs must still fail.

--- a/packages/api/src/handlers/get-dashboard.ts
+++ b/packages/api/src/handlers/get-dashboard.ts
@@ -27,6 +27,8 @@ type CounterEvent =
   | 'module_solve'
   | 'manual_load_failed'
   | 'replay_intent'
+  | 'game_failed_strikeout'
+  | 'game_failed_timeout'
 
 interface DailyMetrics {
   date: string
@@ -36,6 +38,8 @@ interface DailyMetrics {
   module_solve: number
   manual_load_failed: number
   replay_intent: number
+  game_failed_strikeout: number
+  game_failed_timeout: number
   unique_starts: number
   unique_completes: number
 }
@@ -153,6 +157,8 @@ function ensureDate(map: Map<string, DailyMetrics>, date: string): DailyMetrics 
       module_solve: 0,
       manual_load_failed: 0,
       replay_intent: 0,
+      game_failed_strikeout: 0,
+      game_failed_timeout: 0,
       unique_starts: 0,
       unique_completes: 0,
     }
@@ -168,7 +174,9 @@ function isCounterEvent(suffix: string): suffix is CounterEvent {
     suffix === 'game_abandon' ||
     suffix === 'module_solve' ||
     suffix === 'manual_load_failed' ||
-    suffix === 'replay_intent'
+    suffix === 'replay_intent' ||
+    suffix === 'game_failed_strikeout' ||
+    suffix === 'game_failed_timeout'
   )
 }
 
@@ -312,6 +320,8 @@ function aggregateTotals(rows: DailyMetrics[]): DailyMetrics {
     module_solve: 0,
     manual_load_failed: 0,
     replay_intent: 0,
+    game_failed_strikeout: 0,
+    game_failed_timeout: 0,
     unique_starts: 0,
     unique_completes: 0,
   }
@@ -322,6 +332,8 @@ function aggregateTotals(rows: DailyMetrics[]): DailyMetrics {
     totals.module_solve += r.module_solve
     totals.manual_load_failed += r.manual_load_failed
     totals.replay_intent += r.replay_intent
+    totals.game_failed_strikeout += r.game_failed_strikeout
+    totals.game_failed_timeout += r.game_failed_timeout
     totals.unique_starts += r.unique_starts
     totals.unique_completes += r.unique_completes
   }
@@ -346,6 +358,8 @@ ${markerCell(uniqueRate)}
 <td class="num">${r.module_solve}</td>
 <td class="num">${r.game_abandon}</td>
 <td class="num">${r.manual_load_failed}</td>
+<td class="num">${r.game_failed_strikeout}</td>
+<td class="num">${r.game_failed_timeout}</td>
 </tr>`
 }
 
@@ -363,6 +377,8 @@ function renderTable(rows: DailyMetrics[]): string {
     'module_solve',
     'game_abandon',
     'manual_load_failed',
+    'game_failed_strikeout',
+    'game_failed_timeout',
   ]
   const headerRow = headers
     .map((h, i) => `<th${i === 0 ? '' : ' class="num"'}>${escapeHtml(h)}</th>`)

--- a/packages/api/src/handlers/post-event.test.ts
+++ b/packages/api/src/handlers/post-event.test.ts
@@ -71,3 +71,34 @@ describe('handlePostEvent — KV TTL', () => {
     }
   })
 })
+
+describe('handlePostEvent — game-failed telemetry counters', () => {
+  it('writes a plain counter for the two game-failed events and creates no unique-device set', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-05-21T10:00:00.000Z'))
+      for (const event of ['game_failed_strikeout', 'game_failed_timeout'] as const) {
+        const { kv, puts } = makeKv()
+        const req = makeRequest({
+          event,
+          timestamp: '2026-05-21T09:59:00.000Z',
+          device_id: 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee',
+        })
+        const res = await handlePostEvent(req, kv)
+        expect(res.status).toBe(200)
+
+        // Ingestion is event-name-agnostic for counters — the failure events
+        // get the same `events:{date}:{name}` counter as any other event.
+        const counterPut = puts.find((p) => p.key === `events:2026-05-21:${event}`)
+        expect(counterPut).toBeDefined()
+        expect(counterPut?.value).toBe(JSON.stringify({ count: 1 }))
+
+        // Only game_start / game_complete maintain unique-device sets; the
+        // failure events must never produce a `unique_*` key.
+        expect(puts.some((p) => p.key.includes(':unique_'))).toBe(false)
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/api/src/validation.test.ts
+++ b/packages/api/src/validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { validateEvent } from './validation'
+
+// A valid UUID v4 — `validateEvent` checks the canonical 36-char shape.
+const VALID_DEVICE_ID = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee'
+
+// Build a structurally-valid event payload for a given name. The timestamp is
+// taken as "now" so it always lands inside the today-or-yesterday window the
+// validator enforces.
+function eventPayload(event: string): Record<string, unknown> {
+  return {
+    event,
+    timestamp: new Date().toISOString(),
+    device_id: VALID_DEVICE_ID,
+  }
+}
+
+describe('validateEvent — event-name whitelist', () => {
+  const validNames = [
+    'game_start',
+    'module_solve',
+    'game_complete',
+    'game_abandon',
+    'manual_load_failed',
+    'replay_intent',
+    'game_failed_strikeout',
+    'game_failed_timeout',
+  ]
+
+  for (const name of validNames) {
+    it(`accepts the known event name "${name}"`, () => {
+      expect(validateEvent(eventPayload(name))).toEqual({ ok: true })
+    })
+  }
+
+  it('rejects an unknown event name', () => {
+    const result = validateEvent(eventPayload('game_failed_meltdown'))
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('Unknown event name')
+  })
+})

--- a/packages/api/src/validation.ts
+++ b/packages/api/src/validation.ts
@@ -12,6 +12,8 @@ const VALID_EVENT_NAMES: ReadonlySet<EventName> = new Set<EventName>([
   'game_abandon',
   'manual_load_failed',
   'replay_intent',
+  'game_failed_strikeout',
+  'game_failed_timeout',
 ])
 
 // UUID v4 shape — any 36-char canonical UUID matches; we deliberately do not

--- a/packages/game/src/store/game-context.test.ts
+++ b/packages/game/src/store/game-context.test.ts
@@ -6,7 +6,7 @@
  * generalisation (practice runs fewer modules), and the last-module win lock
  * that protects an already-won daily run from a racing TIME_EXPIRED.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // The reducer fires telemetry on several transitions; stub it so tests do not
 // attempt a real /api/events POST.
@@ -19,6 +19,7 @@ import {
   MAX_STRIKES,
   type GameState,
 } from './game-context'
+import { logEvent } from '@/utils/event-log'
 
 /** A PLAYING daily-run state; override per test. */
 function baseState(overrides: Partial<GameState> = {}): GameState {
@@ -267,5 +268,78 @@ describe('gameReducer — EXPLOSION_DONE / ALL_MODULES_COMPLETE', () => {
       { type: 'ALL_MODULES_COMPLETE' }
     )
     expect(practiceDone.outcome).toBe('practice-cleared')
+  })
+})
+
+describe('gameReducer — failure telemetry', () => {
+  // Calls to the mocked logEvent for a given event name. The mock accumulates
+  // across the whole file, so each test in this block clears it first.
+  const callsFor = (name: string) => vi.mocked(logEvent).mock.calls.filter((c) => c[0] === name)
+
+  beforeEach(() => {
+    vi.mocked(logEvent).mockClear()
+  })
+
+  it('daily: the 3rd MODULE_ERROR emits game_failed_strikeout exactly once', () => {
+    let s = baseState({ mode: 'daily', status: 'PLAYING' })
+
+    s = gameReducer(s, { type: 'MODULE_ERROR' })
+    s = gameReducer(s, { type: 'MODULE_ERROR' })
+    // The first two strikes do not detonate — no failure event yet.
+    expect(callsFor('game_failed_strikeout')).toHaveLength(0)
+
+    s = gameReducer(s, { type: 'MODULE_ERROR' })
+    expect(s.status).toBe('EXPLODING')
+    expect(callsFor('game_failed_strikeout')).toHaveLength(1)
+    expect(callsFor('game_failed_strikeout')[0][1]).toMatchObject({
+      mode: 'daily',
+      attemptNumber: 1,
+      strikeCount: MAX_STRIKES,
+      moduleIndex: 0,
+      moduleStats: [],
+    })
+  })
+
+  it('daily: TIME_EXPIRED emits game_failed_timeout exactly once', () => {
+    const s = baseState({ mode: 'daily', status: 'PLAYING' })
+    const after = gameReducer(s, { type: 'TIME_EXPIRED' })
+
+    expect(after.status).toBe('EXPLODING')
+    expect(callsFor('game_failed_timeout')).toHaveLength(1)
+    expect(callsFor('game_failed_timeout')[0][1]).toMatchObject({
+      mode: 'daily',
+      attemptNumber: 1,
+      strikeCount: 0,
+      moduleIndex: 0,
+    })
+  })
+
+  it('practice: TIME_EXPIRED emits neither failure event', () => {
+    const s = baseState({
+      mode: 'practice',
+      status: 'PLAYING',
+      moduleSequence: ['wire', 'keypad'],
+    })
+    gameReducer(s, { type: 'TIME_EXPIRED' })
+
+    expect(callsFor('game_failed_strikeout')).toHaveLength(0)
+    expect(callsFor('game_failed_timeout')).toHaveLength(0)
+  })
+
+  it('does not double-emit when an already-EXPLODING run is re-entered', () => {
+    // A racing MODULE_ERROR / TIME_EXPIRED landing after detonation hits the
+    // terminal-state guards and no-ops — it must not emit a second event.
+    const exploded = baseState({
+      mode: 'daily',
+      status: 'EXPLODING',
+      outcome: 'exploded',
+      strikeCount: MAX_STRIKES,
+      totalEndTime: 1_700_000_000_123,
+    })
+    gameReducer(exploded, { type: 'MODULE_ERROR' })
+    gameReducer(exploded, { type: 'TIME_EXPIRED' })
+
+    expect(callsFor('game_failed_strikeout')).toHaveLength(0)
+    expect(callsFor('game_failed_timeout')).toHaveLength(0)
   })
 })

--- a/packages/game/src/store/game-context.tsx
+++ b/packages/game/src/store/game-context.tsx
@@ -319,12 +319,26 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       }
       const nextStrikes = state.strikeCount + 1
       if (nextStrikes >= MAX_STRIKES) {
+        // Third strike — the bomb detonates. Emit failure telemetry so the
+        // beta dashboard can tell a strike-out apart from a timeout. `now` is
+        // shared with `totalEndTime` below so the logged run duration matches
+        // the recorded run end exactly.
+        const now = Date.now()
+        const totalTimeMs = state.totalStartTime !== null ? now - state.totalStartTime : 0
+        logEvent('game_failed_strikeout', {
+          mode: state.mode,
+          totalTimeMs,
+          attemptNumber: state.attemptNumber,
+          strikeCount: nextStrikes,
+          moduleStats: state.moduleStats,
+          moduleIndex: state.currentModuleIndex,
+        })
         return {
           ...state,
           status: 'EXPLODING',
           strikeCount: nextStrikes,
           currentModuleErrorCount: state.currentModuleErrorCount + 1,
-          totalEndTime: Date.now(),
+          totalEndTime: now,
           outcome: 'exploded',
         }
       }
@@ -343,6 +357,19 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       if (state.totalEndTime !== null || state.outcome !== null) return state
       const now = Date.now()
       if (state.mode === 'daily') {
+        // Countdown hit zero on the daily challenge — the bomb detonates.
+        // This emit sits after the two terminal-state guards above, so a
+        // no-op TIME_EXPIRED never logs and a real transition logs exactly
+        // once.
+        const totalTimeMs = state.totalStartTime !== null ? now - state.totalStartTime : 0
+        logEvent('game_failed_timeout', {
+          mode: state.mode,
+          totalTimeMs,
+          attemptNumber: state.attemptNumber,
+          strikeCount: state.strikeCount,
+          moduleStats: state.moduleStats,
+          moduleIndex: state.currentModuleIndex,
+        })
         return { ...state, status: 'EXPLODING', totalEndTime: now, outcome: 'exploded' }
       }
       // Practice never fails — running out of time gently ends the run.

--- a/shared/event-types.ts
+++ b/shared/event-types.ts
@@ -17,6 +17,8 @@ export type EventName =
   | 'game_abandon'
   | 'manual_load_failed'
   | 'replay_intent'
+  | 'game_failed_strikeout'
+  | 'game_failed_timeout'
 
 export interface EventPayload {
   event: EventName


### PR DESCRIPTION
## Summary

- Add two telemetry events — `game_failed_strikeout` and `game_failed_timeout` — emitted from the game reducer's two daily-challenge explosion transitions (3rd strike via `MODULE_ERROR`, countdown-zero via `TIME_EXPIRED`), so a lost run is distinguishable by failure cause instead of only registering as "not completed".
- Wire the events through the shared `EventName` type and the backend `VALID_EVENT_NAMES` whitelist; surface them as two new columns on the beta data dashboard.
- Completion-rate semantics (`game_complete / game_start`) and the `/api/events` ingestion path are unchanged. Practice-timeout is not a failure and emits nothing.

## Type of change

- [x] New feature

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [ ] Tested manually and documented below

256 tests across 3 packages (api 25 / game 206 / manual 25), lint, and build all green. New coverage: reducer emit assertions (strikeout / timeout / practice-no-emit / no-double-emit on terminal re-entry), `validateEvent` whitelist acceptance, dashboard column rendering + totals row.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [ ] Breaking changes documented if any

C4 architecture docs (`arch-component-telemetry.md`, `arch-component-game-session.md`) were updated in the docs vault to reflect the two new events. No breaking changes — purely additive background telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
