### PR TITLE
ci: gate the api package typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Format check
         run: pnpm format:check
 
+      - name: Typecheck
+        run: pnpm typecheck
+
       - name: Test
         run: pnpm test:run
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ Versions follow [Semantic Versioning](https://semver.org).
 - **Mute toggle** The game's top bar now has a mute button that silences every
   sound effect. The setting is saved to localStorage, so the game stays muted —
   or un-muted — across page reloads and later sessions.
+- **CI** Added a `typecheck` step that runs the `api` package's `tsc --noEmit`
+  via a new root `pnpm typecheck` aggregate script, so type errors in the
+  leaderboard API now fail CI instead of merging silently.
 
 ### Improvements
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gen:daily": "node scripts/generate-daily-from-practice.mjs",
     "test": "pnpm -r run test",
     "test:run": "pnpm -r run test:run",
+    "typecheck": "pnpm -r run typecheck",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/packages/api/src/handlers/get-dashboard.test.ts
+++ b/packages/api/src/handlers/get-dashboard.test.ts
@@ -260,7 +260,7 @@ describe('handleGetDashboard', () => {
 
     const totalsRowMatches = html.match(/<tr class="totals">[\s\S]*?<\/tr>/g) ?? []
     expect(totalsRowMatches).toHaveLength(1)
-    const totalsRow = totalsRowMatches[0]
+    const totalsRow = totalsRowMatches[0]!
     expect(totalsRow).toContain('合计')
 
     // No numeric percentage anywhere in the totals row — every percent cell


### PR DESCRIPTION
## Summary

- Add a `Typecheck` CI step that runs the `api` package's `tsc --noEmit` via a new
  root `pnpm typecheck` aggregate script, so type errors in the leaderboard API
  fail CI instead of merging silently. `api` is a Cloudflare Worker deployed via
  wrangler and was never type-checked by the pipeline (it ran lint, format, test,
  and build — and build does not include `api`).
- Fix a pre-existing `TS18048` in `get-dashboard.test.ts` by narrowing
  `totalsRowMatches[0]` with a non-null assertion (the test already asserts the
  array has length 1).
- Sync `CHANGELOG.md` and the architecture doc's CI-pipeline description.

The root `typecheck` script uses `pnpm -r run typecheck`, mirroring the existing
`test` / `test:run` aggregate scripts — it currently only matches `api`, and
`game` / `manual` will join automatically if they add a `typecheck` script later.
(`game` is already type-checked via its `build` step; `manual` builds with `tsx`
and has no `tsc` dependency.)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [x] CI or configuration

## Testing

- [x] Existing tests pass
- [ ] New tests added if behavior changed — N/A (CI infra + a type-narrowing fix; no behavior change)
- [x] Tested manually and documented below

Verified locally on the rebased branch:

- `pnpm --filter api run typecheck` → exit 0
- `pnpm typecheck` (new root script) → exit 0, visibly runs `packages/api typecheck$ tsc --noEmit`
- `pnpm -r run typecheck` → exit 0, gracefully skips `game` / `manual` (no script)
- Negative-gate test — a deliberate api type error makes `pnpm typecheck` exit non-zero, confirming the gate actually gates
- `pnpm lint`, `pnpm format:check`, `pnpm --filter api run test:run` (25 passed) → all green

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
