### PR TITLE
fix(game): polish mobile beta-flow tap targets, fonts, modal overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,20 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- **Mobile beta-flow polish** A pass over the phone experience makes the
+  daily beta path easier to use. Small text links and buttons that sat
+  below a comfortable finger size — the home page's leaderboard link, the
+  prompt dialog's close button and AI-compatibility link, the result
+  page's leaderboard / home links and its submit-retry button, and the
+  leaderboard's back-to-home link — now have full 44px tap areas, with no
+  change to how they look.
+  The in-game 暗号 code phrase you read aloud to your AI partner and the
+  result page's module-time table no longer render below 14px, so they
+  stay legible on small screens. The in-game exit button is no longer
+  narrower than it is tall, and the prompt and nickname dialogs gain a
+  scroll fallback so a short landscape viewport can no longer clip their
+  content with no way to reach the rest. The in-game error screens'
+  "← 返回首页" link also picks up the styling it was silently missing.
 - **Wires are easier to cut on a phone** Tapping a wire in the first game
   module used to demand near-pixel accuracy on a narrow screen — the
   clickable strip along each wire was under half the recommended touch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,9 +230,10 @@ Versions follow [Semantic Versioning](https://semver.org).
   page's leaderboard / home links and its submit-retry button, and the
   leaderboard's back-to-home link — now have full 44px tap areas, with no
   change to how they look.
-  The in-game 暗号 code phrase you read aloud to your AI partner and the
-  result page's module-time table no longer render below 14px, so they
-  stay legible on small screens. The in-game exit button is no longer
+  The in-game 暗号 code phrase you read aloud to your AI partner, the
+  result page's module-time table, and the in-game exit button label no
+  longer render below 14px, so they stay legible on small screens. The
+  in-game exit button is no longer
   narrower than it is tall, and the prompt and nickname dialogs gain a
   scroll fallback so a short landscape viewport can no longer clip their
   content with no way to reach the rest. The in-game error screens'

--- a/packages/game/src/components/NicknameModal.module.css
+++ b/packages/game/src/components/NicknameModal.module.css
@@ -13,6 +13,10 @@
   position: relative;
   width: 100%;
   max-width: 420px;
+  /* Scroll fallback so a short landscape viewport cannot clip the dialog
+     without an escape — leaves the 24px overlay padding top and bottom. */
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
   background: var(--color-surface);
   border: 1px solid var(--color-neon-cyan);
   border-radius: 6px;

--- a/packages/game/src/components/PromptModal.module.css
+++ b/packages/game/src/components/PromptModal.module.css
@@ -13,6 +13,10 @@
   position: relative;
   width: 100%;
   max-width: 480px;
+  /* Scroll fallback so a short landscape viewport cannot clip the dialog
+     without an escape — leaves the 24px overlay padding top and bottom. */
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
   background: var(--color-surface);
   border: 1px solid var(--color-neon-cyan);
   border-radius: 6px;
@@ -27,8 +31,13 @@
   position: absolute;
   top: 8px;
   right: 8px;
-  width: 32px;
-  height: 32px;
+  /* 44x44 tap target; the glyph keeps its 1.4rem size and is centred by
+     flex so the larger hit area is invisible to the player. */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--touch-target);
+  height: var(--touch-target);
   font-family: var(--font-mono);
   font-size: 1.4rem;
   line-height: 1;
@@ -71,12 +80,16 @@
    competing with the primary 确认开始游戏 CTA. Small font keeps it from
    pulling visual weight away from the URL box. */
 .compatLink {
+  /* Text-link tap-target pattern (shared with the home / result /
+     leaderboard nav links): inline-block + padding + --touch-target. */
+  display: inline-block;
+  min-height: var(--touch-target);
+  padding: 14px 8px;
   font-family: var(--font-sans);
   font-size: 0.8rem;
   color: var(--color-neon-cyan);
   text-decoration: none;
   align-self: flex-start;
-  padding: 4px 0;
   letter-spacing: 0.02em;
 }
 

--- a/packages/game/src/components/SceneInfoBar.module.css
+++ b/packages/game/src/components/SceneInfoBar.module.css
@@ -44,6 +44,9 @@
 .value {
   color: var(--color-text-primary);
   font-weight: bold;
+  /* 14px floor: the 暗号 phrase is read aloud to the AI partner, so it must
+     stay legible — lifted off the bar's 0.85rem inherited size. */
+  font-size: 0.875rem;
   /* Allow the Chinese phrase to wrap mid-character on narrow viewports so it
      never pushes the indicator chips off-screen. */
   overflow-wrap: anywhere;

--- a/packages/game/src/pages/GamePage.module.css
+++ b/packages/game/src/pages/GamePage.module.css
@@ -44,7 +44,7 @@
 
 .exitBtn {
   font-family: var(--font-mono);
-  font-size: 0.7rem;
+  font-size: 0.875rem;
   padding: 6px 12px;
   margin-left: 12px;
   background: transparent;

--- a/packages/game/src/pages/GamePage.module.css
+++ b/packages/game/src/pages/GamePage.module.css
@@ -53,6 +53,9 @@
   border-radius: 3px;
   cursor: pointer;
   letter-spacing: 0.05em;
+  /* "退出" is only two mono glyphs; min-height alone left the rendered
+     width ~41px. Pin both axes to the 44px touch-target floor. */
+  min-width: var(--touch-target);
   min-height: var(--touch-target);
   transition:
     color 0.15s ease,
@@ -231,6 +234,25 @@
   text-align: center;
   max-width: 400px;
   line-height: 1.5;
+}
+
+/* "← 返回首页" link shown on the in-game error states. Mirrors the shared
+   text-link visual style used on the other pages plus the mobile
+   tap-target pattern (inline-block + padding + --touch-target floor). */
+.homeLink {
+  display: inline-block;
+  min-height: var(--touch-target);
+  padding: 14px 8px;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  letter-spacing: 0.05em;
+}
+
+.homeLink:hover {
+  color: var(--color-text-primary);
+  text-decoration: underline;
 }
 
 .startBtn {

--- a/packages/game/src/pages/HomePage.module.css
+++ b/packages/game/src/pages/HomePage.module.css
@@ -96,8 +96,13 @@
 }
 
 .leaderboardLink {
+  /* Text-link tap-target pattern: inline-block + padding + the shared
+     --touch-target floor lifts a bare text link to a 44px tap area. */
+  display: inline-block;
+  min-height: var(--touch-target);
+  padding: 14px 8px;
   font-family: var(--font-mono);
-  font-size: 0.85rem;
+  font-size: 0.875rem;
   color: var(--color-text-muted);
   text-decoration: none;
   letter-spacing: 0.05em;

--- a/packages/game/src/pages/LeaderboardPage.module.css
+++ b/packages/game/src/pages/LeaderboardPage.module.css
@@ -69,6 +69,11 @@
 }
 
 .link {
+  /* Text-link tap-target pattern (shared with the home / prompt-modal /
+     result-page nav links): inline-block + padding + --touch-target. */
+  display: inline-block;
+  min-height: var(--touch-target);
+  padding: 14px 8px;
   font-family: var(--font-mono);
   font-size: 0.85rem;
   color: var(--color-text-muted);

--- a/packages/game/src/pages/ResultPage.module.css
+++ b/packages/game/src/pages/ResultPage.module.css
@@ -88,7 +88,9 @@
   width: 100%;
   border-collapse: collapse;
   font-family: var(--font-mono);
-  font-size: 0.85rem;
+  /* 14px floor: the module-time table is the recap's main content the
+     player reads — keep it legible on small screens. */
+  font-size: 0.875rem;
 }
 
 .table th {
@@ -160,6 +162,11 @@
 }
 
 .link {
+  /* Text-link tap-target pattern (shared with the home / prompt-modal /
+     leaderboard nav links): inline-block + padding + --touch-target. */
+  display: inline-block;
+  min-height: var(--touch-target);
+  padding: 14px 8px;
   font-family: var(--font-mono);
   font-size: 0.85rem;
   color: var(--color-text-muted);
@@ -219,6 +226,12 @@
 
 .retryBtn {
   margin-left: 10px;
+  /* Inline retry button on the submit-failure error state: keep the bare
+     link-like look (no background / border, inherited size) but lift the
+     tap area to the 44px touch-target floor — symmetric padding centres
+     the "重试" label within it. */
+  min-height: var(--touch-target);
+  padding: 14px 8px;
   background: none;
   border: none;
   color: var(--color-neon-cyan);
@@ -226,7 +239,6 @@
   font-size: inherit;
   cursor: pointer;
   text-decoration: underline;
-  padding: 0;
 }
 
 .retryBtn:hover {


### PR DESCRIPTION
## Summary

- Re-verified the medium/low responsive-audit findings from the 2026-05-20 mobile beta-flow review against current `main` — the audit was line-pinned to a pre-#82/#85 commit, so each finding was re-located by selector before fixing. All 13 were still present; none had been silently fixed by the intervening merges.
- Fixed all 13 mobile-polish items: text-link / inline-button tap targets (home leaderboard link, prompt-modal close button + AI-compatibility link, result-page nav links + submit-retry button, leaderboard back-to-home link) lifted to a full 44px tap area via one shared `inline-block + padding + --touch-target` pattern; the in-game code-phrase HUD value and the result-page module-time table lifted off sub-14px; the prompt and nickname dialogs gained a `max-height + overflow-y` scroll fallback; the missing `.homeLink` class was added; the exit button pinned to 44px on both axes.
- CSS-only — no logic or component-structure changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [ ] New tests added if behavior changed
- [ ] Tested manually and documented below

Responsive CSS changes (tap-target size, font-size floor, modal overflow) are not observable in the jsdom test environment, so no automated tests were added — consistent with the source audit's own conclusion. Lint is clean (0 ESLint + 0 markdownlint errors) and all 256 tests pass across the `game`, `api`, and `manual` packages. An independent verifier cross-checked each of the 13 findings against the audit's repair directions (verdict: passed). The user completed a real-device walkthrough before scope was finalized.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [ ] Breaking changes documented if any — none

## Out of scope

- WireModule wire-cut hit area (audit L3-1) — already fixed in #81; the user's real-device walkthrough confirmed the current ~27px target is adequate.
- NicknameModal iOS soft-keyboard offset + `enterKeyHint` (audit L5-3) — stays in the `add-leaderboard-anonymous-handle` followup.
- Two residual sub-14px texts the verifier noted (`.compatLink` 12.8px, `.exitBtn` label 11.2px) — left as-is: `.compatLink`'s small size is an intentional design choice (documented in CSS), and both fall outside this task's confirmed font-size scope.
