### PR TITLE
test(e2e): add dual-agent simulation layer scenarios and CI reminder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,59 @@ jobs:
 
       - name: Check golden answers fixture is in sync
         run: git diff --exit-code e2e/fixtures/answers.json
+
+  # Non-blocking reminder: the dual-agent simulation is an LLM-agent workload
+  # that cannot run in GitHub Actions, so it is never a CI check or merge gate.
+  # This job only prints a reminder when game logic / manual data changed. Its
+  # single meaningful step always exits 0 and is also marked `continue-on-error`,
+  # so this job's conclusion is always success even if the reminder logic breaks.
+  simulation-reminder:
+    name: E2E Simulation Reminder
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the diff base (PR base SHA / push "before" SHA) is
+          # available locally for the changed-file check below.
+          fetch-depth: 0
+
+      - name: Remind about e2e dual-agent simulation on game / manual changes
+        # Insurance: even if the script below were edited into a failing state,
+        # this keeps the job green. The simulation must never gate a PR.
+        continue-on-error: true
+        # Pass workflow context through env vars (the documented injection-safe
+        # pattern) rather than interpolating ${{ }} directly into the script.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          # Resolve the diff base for both push and pull_request events.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base="$PR_BASE_SHA"
+          else
+            base="$PUSH_BEFORE_SHA"
+          fi
+
+          # Collect the changed file set. Every failure mode (missing base SHA,
+          # first push, shallow fetch, fork PR) falls back to an empty set so
+          # this step can never error out.
+          changed=""
+          if [ -n "$base" ] \
+            && [ "$base" != "0000000000000000000000000000000000000000" ] \
+            && git cat-file -e "$base^{commit}" 2>/dev/null; then
+            changed="$(git diff --name-only "$base" HEAD 2>/dev/null || true)"
+          fi
+
+          if printf '%s\n' "$changed" | grep -Eq '^(packages/game/|packages/manual/data/)'; then
+            echo "NOTE: game logic / manual data changed — consider running an e2e dual-agent simulation."
+            echo "NOTE: playbook: ~/.claude/scheduled-tasks/e2e-test"
+            echo "NOTE: this is a reminder only and never gates the build."
+            echo "::notice title=E2E dual-agent simulation::game logic / manual data changed — consider running an e2e dual-agent simulation (see ~/.claude/scheduled-tasks/e2e-test). Reminder only; not a merge gate."
+          else
+            echo "No packages/game or packages/manual/data changes detected — e2e simulation reminder not applicable."
+          fi
+
+          # Belt-and-suspenders: always succeed regardless of the above.
+          exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,17 @@ straight from the homepage CTAs.
   orphaned, duplicated, or untagged flow fails the build — and regenerates
   the golden `answers.json` fixture so a puzzle-generator change that would
   silently invalidate it is caught loudly.
+- **E2E dual-agent simulation layer** The second layer of the e2e
+  governance model. Six `@simulation` collaboration-usability scenarios
+  under `e2e/simulation/` — the four BombSquad modules in isolation plus
+  full practice and daily-challenge runs — drive an LLM-based dual-agent
+  test harness, where a player agent that only sees the screen and an
+  assistant agent that only reads the manual collaborate to defuse the
+  bomb. This layer is LLM-driven and run on demand; it is never a CI
+  check or a merge gate. A non-blocking `simulation-reminder` CI job
+  flags pushes touching `packages/game/` or `packages/manual/data/` as
+  candidates for a simulation run. Source task
+  `implement-e2e-dual-agent-simulation`.
 
 ### Improvements
 

--- a/e2e/simulation/button.gherkin
+++ b/e2e/simulation/button.gherkin
@@ -1,0 +1,59 @@
+# Button module — collaborative defusal via the player-assistant voice channel.
+#
+# The button module shows a single large button with a color and a label. The
+# assistant determines whether the player should tap or hold based on the
+# button's color, label, battery count, and indicator states. If the action is
+# hold, the player must press and hold until a cycling "side strip" light
+# reaches a specified color, then release. Failure modes this scenario can
+# surface: the hold-mode side strip is not explained in the manual (the player
+# does not know what UI element to watch), the "6" label renders too small or
+# too dim to read, tap vs hold confusion when the condition chain has multiple
+# similar-looking branches.
+#
+# Runs in practice mode for clean isolation.
+
+Feature: Button module collaboration
+  As a BombSquad player who can only see the screen
+  And an AI assistant who can only read the manual
+  I want us to defuse the button module together through a message channel
+  So that the tap-or-hold decision and the hold-release timing work correctly
+
+  Background:
+    Given the coordinator has spawned player-agent and assistant-agent
+    And three-way isolation is enforced — the player cannot read the manual and the assistant cannot see the screen
+    And the assistant has loaded the practice manual from packages/manual/data/practice.yaml
+
+  # Module: button
+  # Mode: practice
+  @simulation
+  Scenario: Player and assistant collaboratively defuse the button module in practice mode
+    Given the player has started a practice-mode game
+    And the button module is the currently displayed module
+
+    When the player describes the button module to the assistant
+    Then the player's description includes the button color
+    And the player's description includes the text label on the button
+    And the player's description includes the battery count shown in the SceneInfoBar
+    And the player's description includes which indicators are lit or unlit
+
+    When the assistant receives the button description
+    Then the assistant consults the button rules in the manual
+    And the assistant walks the condition chain top to bottom and identifies the first matching rule
+    And the assistant determines whether the action is tap or hold
+
+    When the action is tap
+    Then the assistant instructs the player to tap the button once
+    And the player taps the button
+    And the button module is defused
+
+    When the action is hold
+    Then the assistant instructs the player to press and hold the button
+    And the assistant tells the player which side-strip light color to watch for before releasing
+    And the player holds the button and watches for the specified light color
+    And the player releases when the side-strip light matches the target color
+    And the button module is defused
+
+    Then the coordinator records whether the action was tap or hold
+    And the coordinator records whether the player had difficulty identifying the side-strip light element
+    And the coordinator records the number of communication rounds
+    And the coordinator records the in-game time spent on this module

--- a/e2e/simulation/full-run.gherkin
+++ b/e2e/simulation/full-run.gherkin
@@ -1,0 +1,107 @@
+# Full-run scenarios — end-to-end collaboration across all modules in both game
+# modes.
+#
+# Practice mode runs 2 modules with a 05:00 timer; wrong answers never fail
+# the run. Daily-challenge mode runs 4 modules with a 10:00 timer; three
+# strikes detonate the bomb and the run fails. The daily-challenge scenario
+# explicitly tests the "decline submission" path: the player completes the run
+# but does NOT submit a score — the NicknameModal is left unfilled. This
+# prevents leaderboard pollution from simulation runs (per the Design proposal
+# Area 3 decision: fresh browser profile, no saved nickname, decline
+# submission).
+#
+# These scenarios exercise the full collaboration arc: game entry, module
+# sequencing, cross-module time pressure, mode-specific end conditions, and
+# the result page. They complement the per-module isolation scenarios by
+# testing how multi-module runs interact with the timer budget and strike
+# mechanic.
+
+Feature: Full game run collaboration
+  As a BombSquad player who can only see the screen
+  And an AI assistant who can only read the manual
+  I want us to defuse the entire bomb together through a message channel
+  So that a complete run succeeds under realistic time pressure
+
+  Background:
+    Given the coordinator has spawned player-agent and assistant-agent
+    And three-way isolation is enforced — the player cannot read the manual and the assistant cannot see the screen
+
+  # Mode: practice
+  @simulation
+  Scenario: Player and assistant complete a full practice run collaborating through the message channel
+    Given the assistant has loaded the practice manual from packages/manual/data/practice.yaml
+    And the player opens a practice-mode game from the homepage
+    And the player confirms the prompt modal and starts the game
+
+    When the game starts
+    Then the timer begins counting down from 05:00
+    And the module progress bar shows 2 segments
+
+    When the first module appears
+    Then the player describes the module state to the assistant
+    And the assistant identifies the module type and consults the relevant manual section
+    And the assistant gives step-by-step instructions
+    And the player executes the instructions and reports the result
+    And the first module is defused
+
+    When the second module appears
+    Then the player describes the module state to the assistant
+    And the assistant identifies the module type and consults the relevant manual section
+    And the assistant gives step-by-step instructions
+    And the player executes the instructions and reports the result
+    And the second module is defused
+
+    Then the result page shows a successful completion
+    And the coordinator records the total in-game time
+    And the coordinator records the total number of communication rounds across all modules
+    And the coordinator records per-module breakdown of time and communication rounds
+    And the coordinator records any collaboration friction points observed during the run
+
+  # Mode: daily-challenge
+  @simulation
+  Scenario: Player and assistant complete a full daily-challenge run and decline score submission
+    Given the assistant has loaded the daily manual from packages/manual/data/daily/
+    And the player uses a fresh browser profile with no saved nickname
+    And the player opens a daily-challenge game from the homepage
+    And the player confirms the prompt modal and starts the game
+
+    When the game starts
+    Then the timer begins counting down from 10:00
+    And the module progress bar shows 4 segments
+
+    When the first module appears
+    Then the player describes the module state to the assistant
+    And the assistant identifies the module type and consults the relevant manual section
+    And the assistant gives step-by-step instructions
+    And the player executes the instructions and reports the result
+    And the first module is defused
+
+    When the second module appears
+    Then the player describes the module state to the assistant
+    And the assistant consults the manual and gives instructions
+    And the player executes and reports
+    And the second module is defused
+
+    When the third module appears
+    Then the player describes the module state to the assistant
+    And the assistant consults the manual and gives instructions
+    And the player executes and reports
+    And the third module is defused
+
+    When the fourth module appears
+    Then the player describes the module state to the assistant
+    And the assistant consults the manual and gives instructions
+    And the player executes and reports
+    And the fourth module is defused
+
+    Then the result page shows the heading for a successful daily defusal
+    And the NicknameModal appears because no nickname is stored on this fresh profile
+    And the player does NOT fill in the NicknameModal — the submission is declined
+    And no score is submitted to the leaderboard
+
+    Then the coordinator records the total in-game time
+    And the coordinator records the total number of communication rounds across all modules
+    And the coordinator records per-module breakdown of time and communication rounds
+    And the coordinator records whether any wrong answers triggered the strike mechanic
+    And the coordinator records that leaderboard submission was declined
+    And the coordinator records any collaboration friction points observed during the run

--- a/e2e/simulation/keypad.gherkin
+++ b/e2e/simulation/keypad.gherkin
@@ -1,0 +1,53 @@
+# Keypad module — collaborative defusal via the player-assistant voice channel.
+#
+# The keypad module displays 4 symbols in a 2x2 grid. The player describes all
+# four symbols; the assistant finds the sequence in the manual that contains all
+# four and tells the player to press them in the sequence's order. The known
+# structural risk: the symbol pool is shared across all sequences, so a given
+# 4-symbol subset may appear in multiple sequences — the assistant must verify
+# uniqueness or flag ambiguity rather than defaulting to the first match.
+# Failure modes this scenario can surface: subset ambiguity across sequences
+# (the original BLOCKER documented in the 2026-05-13 report), symbol-naming
+# confusion between visually similar glyphs, and incorrect press order if the
+# assistant reads the sequence index wrong.
+#
+# Runs in practice mode for clean isolation.
+
+Feature: Keypad module collaboration
+  As a BombSquad player who can only see the screen
+  And an AI assistant who can only read the manual
+  I want us to defuse the keypad module together through a message channel
+  So that the correct press sequence is identified even when the symbol subset is ambiguous
+
+  Background:
+    Given the coordinator has spawned player-agent and assistant-agent
+    And three-way isolation is enforced — the player cannot read the manual and the assistant cannot see the screen
+    And the assistant has loaded the practice manual from packages/manual/data/practice.yaml
+
+  # Module: keypad
+  # Mode: practice
+  @simulation
+  Scenario: Player and assistant collaboratively defuse the keypad module in practice mode
+    Given the player has started a practice-mode game
+    And the keypad module is the currently displayed module
+
+    When the player describes the four symbols visible on the 2x2 keypad grid
+    Then the player's description uses natural visual language to name each symbol
+    And the player reports all four symbols without omission
+
+    When the assistant receives the symbol descriptions
+    Then the assistant maps the player's visual descriptions to canonical symbol names
+    And the assistant checks ALL sequences in the manual — not just the first match
+    And the assistant determines how many sequences contain the reported four-symbol subset
+    And if only one sequence matches the assistant extracts the press order from that sequence
+    And if multiple sequences match the assistant either flags the ambiguity or uses a tiebreaker strategy
+
+    When the assistant sends the press-order instruction to the player
+    Then the instruction names the four symbols in the order they should be pressed
+    And the player presses each symbol in the instructed order
+
+    Then the keypad module is defused
+    And the coordinator records whether the four-symbol subset matched multiple sequences
+    And the coordinator records the assistant's resolution strategy if ambiguity was encountered
+    And the coordinator records the number of communication rounds
+    And the coordinator records the in-game time spent on this module

--- a/e2e/simulation/symbol-dial.gherkin
+++ b/e2e/simulation/symbol-dial.gherkin
@@ -1,0 +1,59 @@
+# Symbol-dial module — collaborative defusal via the player-assistant voice
+# channel.
+#
+# The symbol-dial module is the most counter-intuitive collaboration. Three
+# dials each display a symbol at position 0. The player reports the three
+# visible symbols; the assistant finds the column in the manual that contains
+# all three, then tells the player how many times to press the right arrow on
+# each dial to reach the target index. The critical semantic trap: the symbol
+# displayed AFTER rotation is from the dial's own symbol pool and will NOT
+# match the column symbol at that index — this is correct behavior, not a bug.
+# Failure modes this scenario can surface: the player expects the rotated
+# symbol to match the column entry and second-guesses the instruction, the
+# assistant confuses "rotate to show symbol X" with "rotate to index N",
+# symbol-naming ambiguity between visually similar glyphs (psi vs trident,
+# omega vs horseshoe).
+#
+# Runs in practice mode for clean isolation.
+
+Feature: Symbol-dial module collaboration
+  As a BombSquad player who can only see the screen
+  And an AI assistant who can only read the manual
+  I want us to defuse the symbol-dial module together through a message channel
+  So that the index-based rotation logic is communicated without semantic confusion
+
+  Background:
+    Given the coordinator has spawned player-agent and assistant-agent
+    And three-way isolation is enforced — the player cannot read the manual and the assistant cannot see the screen
+    And the assistant has loaded the practice manual from packages/manual/data/practice.yaml
+
+  # Module: symbol-dial
+  # Mode: practice
+  @simulation
+  Scenario: Player and assistant collaboratively defuse the symbol-dial module in practice mode
+    Given the player has started a practice-mode game
+    And the symbol-dial module is the currently displayed module
+
+    When the player describes the three symbols currently shown on the dials
+    Then the player's description uses natural visual language to name each symbol
+    And the player reports the symbols in order from left to right
+
+    When the assistant receives the symbol descriptions
+    Then the assistant maps the player's visual descriptions to canonical symbol names
+    And the assistant searches the columns table for the column containing all three symbols
+    And the assistant determines the target index for each dial within that column
+    And the assistant formulates rotation instructions as a number of right-arrow presses per dial
+    And the assistant's instruction does not say "rotate until you see symbol X" — it says "press right N times"
+
+    When the assistant sends the rotation instructions to the player
+    Then the player executes the right-arrow presses on each dial
+
+    When the player reports what the dials now show after rotation
+    Then the displayed symbols may differ from the column entries at those indices — this is expected
+    And the assistant confirms the rotation count was correct regardless of the displayed symbols
+
+    When the player presses confirm
+    Then the symbol-dial module is defused
+    And the coordinator records whether the player questioned the mismatch between displayed and expected symbols
+    And the coordinator records the number of communication rounds
+    And the coordinator records the in-game time spent on this module

--- a/e2e/simulation/wire.gherkin
+++ b/e2e/simulation/wire.gherkin
@@ -1,0 +1,53 @@
+# Wire module — collaborative defusal via the player-assistant voice channel.
+#
+# The wire module is the simplest collaboration loop: the player describes the
+# wire count, their colors (top to bottom), the last wire's color, plus bomb
+# metadata (battery count, indicator states). The assistant matches the first
+# applicable wire_routing rule in the manual and tells the player which wire to
+# cut. Failure modes this scenario can surface: color-description ambiguity
+# (hex colors that look different from their canonical name, e.g. dark grey
+# rendered as "black"), missing metadata in the player's initial description
+# forcing an extra clarification round, and the yellow-rule fallback gap
+# (4 wires + last yellow + 0 red wires = no valid target).
+#
+# Runs in practice mode for clean isolation — no strike mechanic, no
+# leaderboard, no fail condition.
+
+Feature: Wire module collaboration
+  As a BombSquad player who can only see the screen
+  And an AI assistant who can only read the manual
+  I want us to defuse the wire module together through a message channel
+  So that the collaboration loop for wire-cutting works end to end
+
+  Background:
+    Given the coordinator has spawned player-agent and assistant-agent
+    And three-way isolation is enforced — the player cannot read the manual and the assistant cannot see the screen
+    And the assistant has loaded the practice manual from packages/manual/data/practice.yaml
+
+  # Module: wire
+  # Mode: practice
+  @simulation
+  Scenario: Player and assistant collaboratively defuse the wire module in practice mode
+    Given the player has started a practice-mode game
+    And the wire module is the currently displayed module
+
+    When the player describes the wire module to the assistant
+    Then the player's description includes the total number of wires
+    And the player's description includes the color of each wire from top to bottom
+    And the player's description includes the color of the last wire explicitly
+    And the player's description includes the battery count shown in the SceneInfoBar
+    And the player's description includes which indicators are lit or unlit
+
+    When the assistant receives the wire description
+    Then the assistant consults the wire_routing rules in the manual
+    And the assistant identifies the first rule whose condition matches the described state
+    And the assistant formulates a specific cut instruction naming the target wire by position or color
+
+    When the assistant sends the cut instruction to the player
+    Then the player locates the specified wire on screen
+    And the player cuts the wire
+
+    Then the wire module is defused
+    And the coordinator records the number of communication rounds
+    And the coordinator records whether any clarification exchanges were needed
+    And the coordinator records the in-game time spent on this module


### PR DESCRIPTION
## Summary

- Adds `e2e/simulation/` — 6 `@simulation` collaboration-usability Gherkin scenarios: the 4 BombSquad modules in isolation (practice mode) plus full practice and daily-challenge runs. This is the **second layer** of the e2e governance model — the LLM-driven dual-agent simulation that tests human-AI collaboration usability (a player who only sees the screen + an assistant who only reads the manual).
- Adds a non-blocking `simulation-reminder` CI job that flags pushes touching `packages/game/**` or `packages/manual/data/**` as candidates for a simulation run. It is a reminder only — never a CI check failure, never a merge gate.
- The `@simulation` scenarios are an **independent third population** (alongside `journey` and `regression`), traced by `# Module:` / `# Mode:` annotations rather than `flow-inventory.yaml`, and are excluded from the journey↔flow coverage audit (which is non-recursive and naturally skips `e2e/simulation/`).
- The coordinator harness (`e2e-test` skill) and the e2e-governance blueprint revision are companion deliverables that live outside this repo; this PR is the repo-resident slice.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [x] CI or configuration

## Testing

- [x] Existing tests pass — pre-commit ran the full suite (265 tests: api 25 / manual 25 / game 215), all green
- [x] New tests added if behavior changed — the 6 `@simulation` scenarios are the new test layer; the coverage audit (`pnpm e2e:audit`) remains a clean 13↔13 bijection with `e2e/simulation/` correctly excluded
- [x] Tested manually and documented below — the dual-agent simulation is an LLM-agent workload run via the coordinator skill, not in CI; the `simulation-reminder` job script was smoke-tested under the CI shell across 4 change-set cases (all exit 0)

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed — `CHANGELOG.md` Unreleased `### Added` entry
- [x] Breaking changes documented if any — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)