### PR TITLE
refactor(game): retire residual CRT palette tokens, unify on Atlas

### DIFF
--- a/packages/game/src/components/ExplosionOverlay.module.css
+++ b/packages/game/src/components/ExplosionOverlay.module.css
@@ -27,7 +27,7 @@
     circle at center,
     #ffee00 0%,
     #ff7b00 28%,
-    var(--color-neon-red) 55%,
+    var(--bs-red) 55%,
     rgba(255, 7, 58, 0) 80%
   );
   opacity: 0;
@@ -47,7 +47,7 @@
 }
 
 .shockwaveDelayed {
-  border-color: var(--color-neon-red);
+  border-color: var(--bs-red);
   animation-delay: 0.18s;
 }
 
@@ -61,8 +61,8 @@
   letter-spacing: 0.12em;
   text-shadow:
     0 0 12px #ffee00,
-    0 0 36px var(--color-neon-red),
-    0 0 72px var(--color-neon-red);
+    0 0 36px var(--bs-red),
+    0 0 72px var(--bs-red);
   animation: explosion-boom 1.4s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
 }
 

--- a/packages/game/src/components/NicknameModal.module.css
+++ b/packages/game/src/components/NicknameModal.module.css
@@ -101,7 +101,7 @@
 }
 
 .error {
-  color: var(--color-neon-red);
+  color: var(--amio-danger);
   text-align: right;
 }
 

--- a/packages/game/src/pages/AccountPage.module.css
+++ b/packages/game/src/pages/AccountPage.module.css
@@ -142,7 +142,7 @@
   border-radius: 8px;
   background: rgba(0, 255, 255, 0.12);
   font: 600 11px var(--amio-font-mono);
-  color: #00ffff;
+  color: var(--bs-cyan);
 }
 
 .runGame {

--- a/packages/game/src/pages/CommunityPage.module.css
+++ b/packages/game/src/pages/CommunityPage.module.css
@@ -79,8 +79,8 @@
   background: radial-gradient(circle at 30% 30%, rgba(0, 255, 255, 0.3), transparent 55%), #0a0a1a;
   font: 700 18px var(--amio-font-mono);
   letter-spacing: 0.1em;
-  color: #00ffff;
-  text-shadow: 0 0 12px #00ffff;
+  color: var(--bs-cyan);
+  text-shadow: 0 0 12px var(--bs-cyan);
 }
 
 .foot {

--- a/packages/game/src/pages/CompatibilityPage.module.css
+++ b/packages/game/src/pages/CompatibilityPage.module.css
@@ -173,8 +173,8 @@
 }
 
 .copied {
-  color: var(--color-neon-green);
-  border-color: var(--color-neon-green);
+  color: var(--positive);
+  border-color: var(--positive);
 }
 
 .homeLink {

--- a/packages/game/src/styles/atlas-tokens.css
+++ b/packages/game/src/styles/atlas-tokens.css
@@ -157,7 +157,6 @@
   /* ----------  GLOWS  ---------- */
   --glow-yellow: 0 0 22px rgba(255, 229, 62, 0.45);
   --glow-yellow-strong: 0 0 32px rgba(255, 229, 62, 0.5);
-  --glow-cyan: 0 0 14px #00ffff, 0 0 50px rgba(0, 255, 255, 0.4);
 
   /* ----------  MOTION  ---------- */
   --transition-fast: 0.15s cubic-bezier(0.4, 0, 0.2, 1);

--- a/packages/game/src/styles/global.css
+++ b/packages/game/src/styles/global.css
@@ -2,9 +2,6 @@
 :root {
   /* Colors */
   --color-bg: #1a1a2e;
-  --color-neon-cyan: #00ffff;
-  --color-neon-green: #39ff14;
-  --color-neon-red: #ff073a;
   --color-surface: #0d0d1a;
   --color-border: #1e2a4a;
   --color-text-primary: #e0e0ff;


### PR DESCRIPTION
## Summary

- Retire the legacy CRT neon palette (`--color-neon-cyan/green/red`) left over after the Atlas redesign (#91 / #93): migrate all 7 `--color-neon-*` consumers to semantic Atlas tokens, then delete the 3 definitions from `global.css`. `NicknameModal` validation error → `--amio-danger`; `ExplosionOverlay` detonation effect (4 sites) → `--bs-red`; `CompatibilityPage` "copied" feedback → `--positive`.
- Tokenize the raw `#00ffff` in the `CommunityPage` result badge and the `AccountPage` run icon to `var(--bs-cyan)`. The cyan is intentionally retained — homepage design handoff §6.10 specifies a cyan badge for BombSquad game content — so this is a zero-visual-change token swap, not a recolor.
- `grep -rn "color-neon" packages/` now returns zero hits. The companion Atlas design-system doc rewrite (`docs/DesignSystem.md`) lands in the vault and is not part of this diff.

## Type of change

- [x] Refactor or cleanup

## Testing

- [x] Existing tests pass

`pnpm typecheck`, `lint`, `format:check`, `build`, and `test:run` (game 225 + manual 25 + api) all green locally. Pure CSS custom-property swaps with no layout, geometry, or behavior change; visual confirmation deferred to the per-PR Cloudflare Pages preview.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [ ] Breaking changes documented if any
