### PR TITLE
test(manual): guard committed daily manuals against generator drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,11 @@ straight from the homepage CTAs.
   package alongside the data they test. The game-package test file is back
   to schema-unit only, and root `pnpm test:run` runs both packages via
   `-r run` (CI inherits automatically).
+- **Daily-manual drift guard** Internal refactor — a new test in
+  `packages/manual` fails CI whenever a committed `data/daily/*.yaml` no longer
+  matches what the generator derives from the current `practice.yaml`, so
+  editing the practice rulebook without regenerating the daily manuals can no
+  longer drift silently into production.
 - **Post-refresh guidance** A short banner appears at the top of the game
   page after an accidental F5 / Cmd+R, diagnosing what just happened so the
   player can decide how to re-sync with their AI partner. The copy now

--- a/packages/manual/generate-daily.test.ts
+++ b/packages/manual/generate-daily.test.ts
@@ -8,11 +8,12 @@
  */
 import { afterAll, describe, expect, it } from 'vitest'
 import yaml from 'js-yaml'
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join, resolve } from 'path'
 import {
   deriveDailyManual,
+  dumpYaml,
   fnv1a32,
   mulberry32,
   seededShuffle,
@@ -218,5 +219,43 @@ describe('daily generator — writeDailyIfChanged idempotency', () => {
     expect(() => writeDailyIfChanged(date, 'new: content\n', dir)).toThrow(/Refusing to overwrite/)
     // File on disk must remain the original — abort, do not overwrite.
     expect(readFileSync(target, 'utf8')).toBe('old: content\n')
+  })
+})
+
+describe('daily generator — committed daily manuals stay in sync (drift guard)', () => {
+  // Drift guard: every committed `data/daily/<date>.yaml` must byte-equal what
+  // the generator emits today. Without this, editing `practice.yaml` without
+  // regenerating the derived daily manuals drifts silently. The comparison
+  // uses the generator's own exported `dumpYaml`, so the guard tracks the
+  // generator's exact serialization config (`lineWidth: -1`) with zero
+  // replication — if those options ever change, the guard follows.
+  const DAILY_DIR = resolve(__dirname, 'data/daily')
+
+  it('every data/daily/*.yaml byte-equals the regenerated output', () => {
+    // Load practice once and reuse across all dates (deriveDailyManual does
+    // not mutate its input — see the test above).
+    const practice = loadPractice()
+    // Enumerate dynamically — the daily set grows over time, so a hardcoded
+    // count would rot. Sorted for a deterministic failure message.
+    const dailyFiles = readdirSync(DAILY_DIR)
+      .filter((f) => f.endsWith('.yaml'))
+      .sort()
+    // An accidental empty glob must not let the guard pass vacuously.
+    expect(dailyFiles.length).toBeGreaterThanOrEqual(1)
+
+    const drifted: string[] = []
+    for (const file of dailyFiles) {
+      const date = file.slice(0, -'.yaml'.length)
+      const committed = readFileSync(join(DAILY_DIR, file), 'utf8')
+      const regenerated = dumpYaml(deriveDailyManual(practice, date))
+      if (committed !== regenerated) drifted.push(date)
+    }
+
+    // Surface every drifted date at once, not just the first mismatch.
+    const regenCmd = 'node scripts/generate-daily-from-practice.mjs'
+    expect(
+      drifted,
+      `${drifted.length} daily manual(s) no longer match the generator — regenerate with \`${regenCmd}\`: ${drifted.join(', ')}`
+    ).toEqual([])
   })
 })

--- a/scripts/generate-daily-from-practice.mjs
+++ b/scripts/generate-daily-from-practice.mjs
@@ -242,7 +242,7 @@ function loadPractice() {
   return yaml.load(text)
 }
 
-function dumpYaml(obj) {
+export function dumpYaml(obj) {
   // Use default block style for readability + git diffability; lineWidth -1
   // avoids YAML's 80-col line wrapping (matches build.ts conventions).
   return yaml.dump(obj, { lineWidth: -1 })


### PR DESCRIPTION
## Summary

- Add a vitest drift guard so every committed `packages/manual/data/daily/*.yaml` is checked byte-for-byte against the current generator output. Editing `practice.yaml` without regenerating the 366 derived daily manuals now fails CI instead of drifting silently into production.
- `dumpYaml` is exported from `generate-daily-from-practice.mjs` so the guard compares against the generator's exact serialization (`lineWidth: -1`) instead of replicating dump options. The daily set is enumerated dynamically (no hardcoded count); every drifted date is named on failure.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Adversarial check (independent verifier): mutating one committed `daily/*.yaml` makes the guard fail and name the drifted date; `git checkout --` restores green. Suites: manual 28/28, api 29/29, game 261/261.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

🤖 Generated with [Claude Code](https://claude.com/claude-code)
