### PR TITLE
feat(manual): widen symbol reverse-alias coverage for AI partner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,18 @@ straight from the homepage CTAs.
 
 ### Improvements
 
+- **AI partner gains wider symbol-misread vocabulary** The shared symbol
+  dictionary (`shared/symbols.ts`) now anchors more of the visual gestalts a
+  real player might say when describing a symbol under time pressure. `spiral`
+  picks up `'咖啡豆 / 实心椭圆带竖中线'` alongside the existing `'圆圈'` (a
+  2026-05-27 playtest produced the coffee-bean misread that the previous
+  description could not map back); `omega` gains `'拱门'`; and the three most
+  canonical shapes (`delta` / `star` / `diamond`) carry an explicit
+  `,无常见误读模式 — 略` slot so future audits see the coverage is deliberate.
+  Six other ids already carried adequate explicit or implicit reverse-alias
+  coverage and are unchanged. The five unreferenced placeholder symbols and
+  `trident`'s PR #101 geometric description are untouched. Source task
+  `reconcile-bombsquad-symbol-pool-and-aliases`.
 - **Bomb detonation sound** Failing a daily challenge now fires a dedicated
   explosion sound effect under the full-screen detonation overlay — a sharp,
   prominent boom — replacing the muffled module-failure thud reused as a

--- a/shared/symbols.ts
+++ b/shared/symbols.ts
@@ -30,7 +30,7 @@ export const SYMBOLS: readonly Symbol[] = [
   {
     id: 'omega',
     name: 'Omega',
-    description: '马蹄铁形 / 倒 U 形,底部两个向外的小脚,中间无竖线穿过',
+    description: "马蹄铁形 / 倒 U 形,底部两个向外的小脚,中间无竖线穿过,容易被误描述为'拱门'",
     path: 'M50 15 C25 15 10 30 10 50 C10 70 25 82 38 85 L38 90 L30 90 L30 95 L70 95 L70 90 L62 90 L62 85 C75 82 90 70 90 50 C90 30 75 15 50 15 Z M50 25 C68 25 80 36 80 50 C80 64 68 76 54 78 L54 90 L46 90 L46 78 C32 76 20 64 20 50 C20 36 32 25 50 25 Z',
   },
   {
@@ -42,13 +42,13 @@ export const SYMBOLS: readonly Symbol[] = [
   {
     id: 'delta',
     name: 'Delta',
-    description: '等边三角形 △,三条直边围成封闭三角',
+    description: '等边三角形 △,三条直边围成封闭三角,无常见误读模式 — 略',
     path: 'M50 10 L90 85 L10 85 Z',
   },
   {
     id: 'star',
     name: 'Star',
-    description: '标准五角星 ☆,五个等长尖角向外',
+    description: '标准五角星 ☆,五个等长尖角向外,无常见误读模式 — 略',
     path: 'M50 5 L61 35 L95 35 L68 57 L79 91 L50 70 L21 91 L32 57 L5 35 L39 35 Z',
   },
   {
@@ -60,7 +60,7 @@ export const SYMBOLS: readonly Symbol[] = [
   {
     id: 'diamond',
     name: 'Diamond',
-    description: '正方形旋转 45 度后的菱形 ◇,四条等长边对角对称',
+    description: '正方形旋转 45 度后的菱形 ◇,四条等长边对角对称,无常见误读模式 — 略',
     path: 'M50 5 L95 50 L50 95 L5 50 Z',
   },
   {
@@ -80,7 +80,7 @@ export const SYMBOLS: readonly Symbol[] = [
     id: 'spiral',
     name: 'Spiral',
     description:
-      "从中心向外一圈圈盘旋的螺旋线 / 漩涡形,线条绕中心展开、首尾不闭合,容易被误描述为'圆圈'",
+      "从中心向外一圈圈盘旋的螺旋线 / 漩涡形,线条绕中心展开、首尾不闭合,容易被误描述为'圆圈' / '咖啡豆 / 实心椭圆带竖中线'",
     path: 'M50 50 C50 30 65 20 75 25 C90 32 90 55 75 65 C60 75 35 70 25 55 C12 37 20 15 38 10 C58 4 80 15 85 38',
   },
   {


### PR DESCRIPTION
## Summary

- Extend reverse-alias prose in `shared/symbols.ts` so the BombSquad AI partner can map more non-canonical player descriptions back to the correct symbol id.
- `spiral` gains `'咖啡豆 / 实心椭圆带竖中线'` (a 2026-05-27 playtest misread) alongside the existing `'圆圈'`; `omega` gains `'拱门'`; `delta` / `star` / `diamond` carry an explicit `,无常见误读模式 — 略` slot so future audits see the zero-alias coverage is deliberate.
- Six already-covered ids stay unchanged; the five unreferenced placeholder ids and `trident`'s PR #101 geometric description are untouched.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed — N/A, this extends existing strings that are already guarded by `manual-referenced symbols have Chinese descriptions` (CJK guard) and `manual-schema.test.ts` byte-equality
- [ ] Tested manually and documented below

Pre-commit hook ran all three workspace test suites: `packages/api` 29/29, `packages/game` 261/261, `packages/manual` 29/29. prettier + eslint + markdownlint clean.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed — `CHANGELOG.md` Unreleased / Improvements section
- [x] Breaking changes documented if any — none; description field is consumed by both the shipped manual HTML and the game's `getSymbol()` helper, and the CJK + byte-equality guards confirm no downstream desync

## Notes for reviewer

- The audit that established **this is an alias gap, not a manual-coverage or puzzle-engine bug** is at `tmp/amiclaw/reconcile-symbol-pool-audit.md` in the source vault (not in this repo). It enumerates all 366 daily YAMLs and confirms `dial/generator.ts:24` + `dial/solver.ts` + `keypad` parallel files all pull symbols only from `section.columns` / `section.sequences` — no SYMBOLS-pool fallback.
- `,无常见误读模式 — 略` is a producer-invented sentinel. If you prefer a different convention (`无典型误读`, `无常见误读`, blank), a single-character edit before merge is fine.
- `omega → 拱门` is LLM-gestalt, not playtest data. The 2026-05-27 playtest only produced the spiral misread. If future BombSquad sessions surface a different omega misread phrase, follow-up edit.

Source task: `reconcile-bombsquad-symbol-pool-and-aliases`

🤖 Generated with [Claude Code](https://claude.com/claude-code)