### PR TITLE
feat(manual): add game framing + collaboration philosophy to AI_INSTRUCTIONS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,18 @@ straight from the homepage CTAs.
 
 ### Added
 
+- **AI manual gains game framing and collaboration philosophy** The AI
+  partner now receives full game context before any rule content on every
+  manual fetch. `AI_INSTRUCTIONS` now carries two new top-level keys —
+  `game_context` (role / player role / voice-only medium / session
+  freshness: every URL fetch starts a fresh game with no cross-session
+  memory) and `collaboration_philosophy` (guide the player to describe
+  features instead of guessing dictionary names, admit uncertainty before
+  guessing, and anchor the trust loop's data source to the BombSquad
+  app-rendered recap) — alongside the existing tactical-output keys.
+  Both injection paths (HTML embedded yaml and dist raw yaml at
+  `?format=yaml`) carry all four key categories. Source task
+  `add-bombsquad-ai-framing-and-collab-philosophy`.
 - **Endgame survey** After any game ends — win, loss, timeout, practice or
   daily — the result page now shows a one-time, four-question survey: which AI
   tool you played with, how fun and how hard the run felt, and an optional

--- a/packages/manual/build.ts
+++ b/packages/manual/build.ts
@@ -11,6 +11,7 @@ import yaml from 'js-yaml'
 // description copy).
 import sharedSymbolsModule from '../../shared/symbols.ts'
 const { SYMBOLS } = sharedSymbolsModule
+import { validateNoSourceAiInstructions, validateNoSourceSymbols } from './validators.ts'
 
 /**
  * Local copy of the Manual / validator types to avoid the ESM+CJS interop
@@ -55,6 +56,17 @@ const AI_INSTRUCTIONS: Record<string, string[]> = {
   give_conclusions_not_reasoning: [
     'When you look up a table, match conditions, or work out which rule applies, never narrate that process aloud. Do not tell the player which rule matched, which conditions you checked, or how you searched the manual.',
     'Reply with only the final, conclusive, executable instruction, e.g. "Cut the second wire from the top." Add a release or stop condition only when the action needs one, e.g. "hold the button and release when the strip turns red." Never say why.',
+  ],
+  game_context: [
+    'Every fetch of this manual URL starts a fresh game. You have no memory of any previous session, and you must not assume any prior context about this player, this bomb, or any earlier conversation. Treat every player as new and every defusal as the first one.',
+    'You are the bomb-defusal manual expert. The player never sees this manual; the entire document exists only for you. Your job is to translate every rule you read into a single concrete action the player can perform right now.',
+    "The player is the defuser standing in front of the bomb. They can see the bomb's wires, buttons, displays, and symbols, but they cannot look anything up. Their entire knowledge of what to do comes from what you say aloud.",
+    'Your only channel to the player is voice. There is no text chat, no diagrams, and no shared screen. Phrase every instruction so it is unambiguous when spoken aloud and easy to act on without re-asking.',
+  ],
+  collaboration_philosophy: [
+    'When the player describes a symbol or feature and your visual vocabulary does not match, ask them to describe the shape in their own words — strokes, curves, comparisons to everyday objects — rather than asking them to pick from a list of dictionary names. Trust their description over your assumption.',
+    'When you are not confident which rule applies, say so before guessing. Tell the player what you are uncertain about and ask one targeted clarifying question. Confidence about the wrong rule causes detonations; admitted uncertainty does not.',
+    'This manual is intentionally incomplete by design, and your imperfect collaboration with the player is a feature, not a bug. After the session ends, the BombSquad app renders a recap summary that the player may choose to share with you outside the game; that app-rendered recap is the only legitimate source of information about prior play. Never claim to remember a previous session, and never act as if you can hear or recall any voice conversation that happened before this fetch.',
   ],
 }
 
@@ -110,11 +122,24 @@ function buildPage(yamlPath: string, slug: string) {
   // SYMBOLS registry. Caught here before anything ships.
   validateReferencedSymbolsAgainstSSOT(parsed)
 
+  // Fail loud if a source YAML carries its own `ai_instructions:` block —
+  // AI_INSTRUCTIONS is owned here and injected; a source-level copy would
+  // silently fight this constant if the merge order below ever regressed.
+  validateNoSourceAiInstructions(parsed)
+
+  // Fail loud if a source YAML carries its own `symbols:` block — symbol
+  // descriptions live only in SYMBOLS SSOT and are HTML-only at injection;
+  // a source-level copy would leak descriptions to the dist raw yaml path
+  // (Option C invariant).
+  validateNoSourceSymbols(parsed)
+
   // Prepend the AI output constraints so they render before any rule
   // content. This variant feeds both the HTML page and the dist raw yaml,
   // so the constraints reach the AI on every read path (browser HTML and
-  // `?format=yaml`).
-  const withInstructions: MinimalManual = { ai_instructions: AI_INSTRUCTIONS, ...parsed }
+  // `?format=yaml`). Spread order places `ai_instructions` LAST so the
+  // hard-coded AI_INSTRUCTIONS wins regardless of what `parsed` contains —
+  // defense in depth alongside `validateNoSourceAiInstructions`.
+  const withInstructions: MinimalManual = { ...parsed, ai_instructions: AI_INSTRUCTIONS }
 
   // Build the injected variant: a deep-clone of `withInstructions`
   // augmented with a `symbols` block derived from SYMBOLS. Only this
@@ -160,14 +185,23 @@ function buildPage(yamlPath: string, slug: string) {
 // Build practice manual
 buildPage(resolve(__dirname, 'data/practice.yaml'), 'practice')
 
-// Build daily manuals
+// Build daily manuals. Narrow the try/catch to ONLY `readdirSync` and ONLY
+// the ENOENT case (the directory has not been created yet — fine, no daily
+// manuals to build). Any other readdir error (EACCES, EIO, …) and any error
+// thrown from inside `buildPage` (validator throws, yaml parse errors, fs
+// write failures, etc.) MUST propagate so the build exits non-zero — a
+// broad swallow here would let a malformed daily yaml silently drop its
+// route from `dist/` while the build still reports success.
 const dailyDir = resolve(__dirname, 'data/daily')
+let dailyFiles: string[] = []
 try {
-  for (const file of readdirSync(dailyDir)) {
-    if (file.endsWith('.yaml')) {
-      buildPage(join(dailyDir, file), basename(file, '.yaml'))
-    }
-  }
-} catch {
+  dailyFiles = readdirSync(dailyDir).filter((f) => f.endsWith('.yaml'))
+} catch (err) {
+  // Only "directory does not exist yet" is acceptable here; surface every
+  // other read error (permissions, IO, …) so it fails the build loudly.
+  if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err
   // data/daily/ may not exist yet — that is fine
+}
+for (const file of dailyFiles) {
+  buildPage(join(dailyDir, file), basename(file, '.yaml'))
 }

--- a/packages/manual/data-validation.test.ts
+++ b/packages/manual/data-validation.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it, beforeAll } from 'vitest'
 import { collectReferencedSymbols, validateManualSymbols, type Manual } from '@shared/manual-schema'
 import { SYMBOLS } from '@shared/symbols'
 import yaml from 'js-yaml'
-import { readFileSync, readdirSync } from 'fs'
+import { existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'fs'
 import { resolve, join } from 'path'
 import { execFileSync } from 'child_process'
+import { validateNoSourceAiInstructions, validateNoSourceSymbols } from './validators'
 
 const PRACTICE_YAML = resolve(__dirname, 'data/practice.yaml')
 const DAILY_DIR = resolve(__dirname, 'data/daily')
@@ -247,6 +248,264 @@ describe('manual set-discrimination invariant', () => {
     expect(dailyFiles.length).toBeGreaterThan(0)
     for (const file of dailyFiles) {
       assertDiscriminating(file, loadManual(join(DAILY_DIR, file)))
+    }
+  })
+})
+
+describe('AI_INSTRUCTIONS carries game framing + collaboration philosophy', () => {
+  // build.ts injects AI_INSTRUCTIONS into the HTML-embedded yaml AND the dist
+  // raw yaml on every render. This block locks in the four-key schema (the
+  // existing tactical-output keys plus the new framing + philosophy keys) so
+  // the AI receives full game context before any rule content, on every
+  // manual fetch, in either consumption path.
+  beforeAll(() => {
+    buildManualForTests()
+  })
+
+  interface ManualWithInstructions extends Manual {
+    ai_instructions?: Record<string, string[]>
+  }
+
+  function extractEmbeddedYaml(htmlPath: string): ManualWithInstructions {
+    const html = readFileSync(htmlPath, 'utf8')
+    const m = html.match(/<pre class="anti-human">([\s\S]*?)<\/pre>/)
+    if (!m) throw new Error(`No <pre class="anti-human"> block found in ${htmlPath}`)
+    return yaml.load(m[1]) as ManualWithInstructions
+  }
+
+  const REQUIRED_KEYS = [
+    'do_not_reveal_to_player',
+    'give_conclusions_not_reasoning',
+    'game_context',
+    'collaboration_philosophy',
+  ] as const
+
+  it('practice manual HTML embedded yaml ai_instructions contains all four required keys', () => {
+    const manual = extractEmbeddedYaml(join(MANUAL_DIST, 'practice/index.html'))
+    expect(
+      manual.ai_instructions,
+      'ai_instructions block missing from HTML embedded yaml'
+    ).toBeDefined()
+    const keys = Object.keys(manual.ai_instructions ?? {})
+    for (const required of REQUIRED_KEYS) {
+      expect(keys, `practice HTML ai_instructions missing key '${required}'`).toContain(required)
+    }
+  })
+
+  it('every ai_instructions key is a non-empty string[] with each entry at least 30 characters', () => {
+    const manual = extractEmbeddedYaml(join(MANUAL_DIST, 'practice/index.html'))
+    const instructions = manual.ai_instructions ?? {}
+    for (const required of REQUIRED_KEYS) {
+      const value = instructions[required]
+      expect(Array.isArray(value), `ai_instructions['${required}'] should be a string[]`).toBe(true)
+      expect(value.length, `ai_instructions['${required}'] should be non-empty`).toBeGreaterThan(0)
+      for (let i = 0; i < value.length; i++) {
+        const entry = value[i]
+        expect(typeof entry, `ai_instructions['${required}'][${i}] should be a string`).toBe(
+          'string'
+        )
+        expect(
+          entry.length,
+          `ai_instructions['${required}'][${i}] should be at least 30 characters (got ${entry.length})`
+        ).toBeGreaterThanOrEqual(30)
+      }
+    }
+  })
+
+  it('framing and philosophy values carry the load-bearing English tokens', () => {
+    const manual = extractEmbeddedYaml(join(MANUAL_DIST, 'practice/index.html'))
+    const instructions = manual.ai_instructions ?? {}
+
+    // game_context anchors session freshness (no cross-session memory) and
+    // names the voice-only medium — both are physical anchors for the
+    // trust-building loop and the manual's role as the only AI-facing surface.
+    const gameContextText = (instructions.game_context ?? []).join('\n')
+    expect(gameContextText, 'game_context must state that each fetch is a fresh game').toMatch(
+      /fresh game/i
+    )
+    expect(gameContextText, 'game_context must name the voice-only medium').toMatch(/voice/i)
+
+    // collaboration_philosophy must (a) tell the AI to ask the player to
+    // describe shapes instead of guessing dictionary names, (b) call for
+    // admitting uncertainty before guessing, and (c) anchor trust-loop data
+    // source to the BombSquad app-rendered recap (NOT voice-conversation
+    // replay — that would violate the zero-integration principle).
+    const philosophyText = (instructions.collaboration_philosophy ?? []).join('\n')
+    expect(
+      philosophyText,
+      'collaboration_philosophy must invite the player to describe shapes'
+    ).toMatch(/describe/i)
+    expect(philosophyText, 'collaboration_philosophy must call for admitting uncertainty').toMatch(
+      /uncertain/i
+    )
+    expect(
+      philosophyText,
+      'collaboration_philosophy must anchor trust-loop data source to the app-rendered recap'
+    ).toMatch(/recap/i)
+  })
+})
+
+describe('source yaml ai_instructions block is rejected (build-time fail-loud)', () => {
+  // AI_INSTRUCTIONS is owned by `build.ts` as a single hard-coded constant and
+  // injected into every rendered manual. `validateNoSourceAiInstructions` is
+  // the gate that rejects any source YAML that tries to carry its own
+  // `ai_instructions:` block — without the gate, a malicious or careless
+  // source could silently fight the hard-coded constant if the build merge
+  // order ever regressed. This block locks the fail-loud contract.
+
+  it('throws when manual carries a source-level ai_instructions block', () => {
+    const fixture = {
+      meta: { version: 'fixture-v1' },
+      modules: {},
+      ai_instructions: { decoy_key: ['decoy attempt'] },
+    }
+    expect(() => validateNoSourceAiInstructions(fixture)).toThrow(/ai_instructions/)
+    expect(() => validateNoSourceAiInstructions(fixture)).toThrow(/source YAML/i)
+  })
+
+  it('passes silently when manual has no ai_instructions block', () => {
+    const fixture = {
+      meta: { version: 'fixture-v2' },
+      modules: {},
+    }
+    expect(() => validateNoSourceAiInstructions(fixture)).not.toThrow()
+  })
+})
+
+describe('manual build fails non-zero when a daily yaml is invalid (daily-loop catch is narrow)', () => {
+  // End-to-end guard: the daily-build loop in `build.ts` MUST surface a
+  // `buildPage` throw as a non-zero process exit. Earlier the loop was wrapped
+  // in `try { readdirSync + for buildPage } catch {}` which silently swallowed
+  // every error — a malformed daily yaml carrying `ai_instructions:` would
+  // simply drop its dist route while the build kept reporting success. We
+  // place a fixture daily yaml with an `ai_instructions:` block (which
+  // `validateNoSourceAiInstructions` rejects), run `pnpm --filter manual
+  // build`, and expect the subprocess to exit non-zero with the validator's
+  // error text in stderr.
+  //
+  // Cleanup is wrapped in `try { ... } finally { unlinkSync(...) }` so a
+  // crashed test never leaves a poisonous fixture in `data/daily/` that would
+  // break every subsequent run of the rest of this suite.
+
+  it('exits non-zero and propagates the validator throw when a daily yaml carries ai_instructions', () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    const fixturePath = join(DAILY_DIR, `_test-fixture-${stamp}.yaml`)
+    const fixtureYaml =
+      `meta:\n` +
+      `  version: test-fixture-${stamp}\n` +
+      `  type: daily\n` +
+      `modules: {}\n` +
+      `ai_instructions:\n` +
+      `  decoy_key:\n` +
+      `    - decoy attempt that should be rejected at build time\n`
+    writeFileSync(fixturePath, fixtureYaml)
+    try {
+      let exitCode: number | null = 0
+      let stderr = ''
+      let stdout = ''
+      try {
+        execFileSync('pnpm', ['--filter', 'manual', 'build'], {
+          cwd: resolve(__dirname, '../..'),
+          stdio: 'pipe',
+        })
+      } catch (err) {
+        const e = err as { status?: number | null; stderr?: Buffer; stdout?: Buffer }
+        exitCode = e.status ?? null
+        stderr = e.stderr?.toString() ?? ''
+        stdout = e.stdout?.toString() ?? ''
+      }
+      expect(
+        exitCode,
+        `build should exit non-zero when a daily yaml is invalid; got exit ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`
+      ).not.toBe(0)
+      // The validator error text mentions the offending source-level key.
+      const combined = `${stdout}\n${stderr}`
+      expect(combined, 'validator error text must surface in build output').toMatch(
+        /ai_instructions/
+      )
+    } finally {
+      if (existsSync(fixturePath)) unlinkSync(fixturePath)
+    }
+  })
+})
+
+describe('source yaml symbols block is rejected (build-time fail-loud)', () => {
+  // Symbol descriptions live only in the `shared/symbols.ts` SYMBOLS SSOT;
+  // `build.ts` injects them into the HTML-embedded yaml at build time and
+  // never into the dist raw yaml (Option C: descriptions stay HTML-only so
+  // the AI's `?format=yaml` fetch path never sees human-readable
+  // descriptions). `validateNoSourceSymbols` is the gate that rejects any
+  // source YAML that tries to carry its own `symbols:` block — without the
+  // gate, a source-level copy would both shadow the SSOT and leak through
+  // the `{ ...parsed, ai_instructions: AI_INSTRUCTIONS }` spread into the
+  // dist raw yaml. This block locks the fail-loud contract in parallel to
+  // the `ai_instructions` validator above.
+
+  it('throws when manual carries a source-level symbols block', () => {
+    const fixture = {
+      meta: { version: 'fixture-symbols-v1' },
+      modules: {},
+      symbols: { decoy_id: { description: 'decoy attempt' } },
+    }
+    expect(() => validateNoSourceSymbols(fixture)).toThrow(/symbols/)
+    expect(() => validateNoSourceSymbols(fixture)).toThrow(/source YAML/i)
+  })
+
+  it('passes silently when manual has no symbols block', () => {
+    const fixture = {
+      meta: { version: 'fixture-symbols-v2' },
+      modules: {},
+    }
+    expect(() => validateNoSourceSymbols(fixture)).not.toThrow()
+  })
+})
+
+describe('manual build fails non-zero when a daily yaml contains a source symbols block', () => {
+  // End-to-end parallel to the `ai_instructions` daily-loop test above: the
+  // daily-build loop in `build.ts` MUST surface a `validateNoSourceSymbols`
+  // throw as a non-zero process exit. We place a fixture daily yaml with a
+  // `symbols:` block, run `pnpm --filter manual build`, and expect the
+  // subprocess to exit non-zero with the validator's error text in the
+  // combined stdout+stderr. Cleanup is wrapped in `try { ... } finally
+  // { unlinkSync(...) }` so a crashed test never leaves a poisonous fixture
+  // in `data/daily/` that would break every subsequent run of this suite.
+
+  it('exits non-zero and propagates the validator throw when a daily yaml carries symbols', () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    const fixturePath = join(DAILY_DIR, `_test-fixture-symbols-${stamp}.yaml`)
+    const fixtureYaml =
+      `meta:\n` +
+      `  version: test-fixture-symbols-${stamp}\n` +
+      `  type: daily\n` +
+      `modules: {}\n` +
+      `symbols:\n` +
+      `  decoy_id:\n` +
+      `    description: decoy attempt that should be rejected at build time\n`
+    writeFileSync(fixturePath, fixtureYaml)
+    try {
+      let exitCode: number | null = 0
+      let stderr = ''
+      let stdout = ''
+      try {
+        execFileSync('pnpm', ['--filter', 'manual', 'build'], {
+          cwd: resolve(__dirname, '../..'),
+          stdio: 'pipe',
+        })
+      } catch (err) {
+        const e = err as { status?: number | null; stderr?: Buffer; stdout?: Buffer }
+        exitCode = e.status ?? null
+        stderr = e.stderr?.toString() ?? ''
+        stdout = e.stdout?.toString() ?? ''
+      }
+      expect(
+        exitCode,
+        `build should exit non-zero when a daily yaml carries a symbols block; got exit ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`
+      ).not.toBe(0)
+      // The validator error text mentions the offending source-level key.
+      const combined = `${stdout}\n${stderr}`
+      expect(combined, 'validator error text must surface in build output').toMatch(/symbols/)
+    } finally {
+      if (existsSync(fixturePath)) unlinkSync(fixturePath)
     }
   })
 })

--- a/packages/manual/validators.ts
+++ b/packages/manual/validators.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure build-time validators for the manual pipeline. This file is
+ * import-pure (no top-level side effects) so test code can import the
+ * validators without triggering `build.ts`'s top-level `buildPage(...)`
+ * loop. `build.ts` imports these validators and calls them inside
+ * `buildPage`; the regression test in `data-validation.test.ts` imports
+ * them directly to exercise the fail-loud contract.
+ */
+
+/**
+ * Minimal shape a source-YAML-derived manual must satisfy for
+ * `validateNoSourceAiInstructions` and `validateNoSourceSymbols` to inspect
+ * it. Only the fields the validators actually read are typed here so the
+ * file stays a thin pure module independent of `MinimalManual` in
+ * `build.ts`. Each validator inspects exactly one optional field.
+ */
+export interface ManualForInstructionsValidation {
+  meta?: { version?: string }
+  ai_instructions?: unknown
+  symbols?: unknown
+}
+
+/**
+ * Fail loud if a source YAML carries its own `ai_instructions:` block.
+ * `AI_INSTRUCTIONS` is owned by `build.ts` as the single source of truth
+ * and is injected at build time; any source-level `ai_instructions:` key
+ * would silently fight the hard-coded constant if the build merge ever
+ * regressed, so we reject it at the gate. Mirrors the shape of
+ * `validateReferencedSymbolsAgainstSSOT` (param: manual; return: void;
+ * throws on failure with the manual version named for traceability).
+ */
+export function validateNoSourceAiInstructions(manual: ManualForInstructionsValidation): void {
+  if (manual.ai_instructions !== undefined) {
+    throw new Error(
+      `Manual ${manual.meta?.version ?? '<unknown>'}: source YAML must not carry an \`ai_instructions\` block — that key is injected at build time from the hard-coded AI_INSTRUCTIONS constant; carrying it in source would silently override the trust-boundary and framing rules.`
+    )
+  }
+}
+
+/**
+ * Fail loud if a source YAML carries its own `symbols:` block. The
+ * `SYMBOLS` constant in `shared/symbols.ts` is the single source of truth
+ * for symbol descriptions; `build.ts` injects them into the HTML-embedded
+ * yaml only (Option C: source YAML + dist raw YAML both stay free of
+ * `symbols:` so human-readable descriptions do not leak to the AI's
+ * `?format=yaml` fetch path). A source-level `symbols:` block would both
+ * shadow the SYMBOLS SSOT at build time and leak through the dist raw yaml
+ * spread, so we reject it at the same gate where
+ * `validateNoSourceAiInstructions` rejects its parallel. Together with
+ * `validateReferencedSymbolsAgainstSSOT` (which checks every referenced
+ * id is registered) this validator provides defense in depth on both the
+ * registration check and the source-leak path.
+ */
+export function validateNoSourceSymbols(manual: ManualForInstructionsValidation): void {
+  if (manual.symbols !== undefined) {
+    throw new Error(
+      `Manual ${manual.meta?.version ?? '<unknown>'}: source YAML must not carry a \`symbols\` block — symbol descriptions live only in the shared/symbols.ts SYMBOLS SSOT and are injected into the HTML-embedded yaml at build time; carrying \`symbols\` in source would shadow the SSOT and leak human-readable descriptions to the AI-readable dist raw yaml (\`?format=yaml\` path), violating the Option C invariant.`
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Add `game_context` (4 items) and `collaboration_philosophy` (3 items) keys to `AI_INSTRUCTIONS`, so the AI partner receives full game context — session freshness, role, voice-only medium, collaboration philosophy anchored to the BombSquad app-rendered recap — before any rule content on every manual fetch
- Defense-in-depth hardening for the `AI_INSTRUCTIONS` + Option C invariants: new `validateNoSourceAiInstructions` + `validateNoSourceSymbols` fail-loud validators in import-pure `validators.ts`; reversed spread merge so the hard-coded constant always wins; narrowed `data/daily` `readdirSync` catch to ENOENT-only so `buildPage` throws propagate (previously a broad catch silently swallowed errors, dropping bad daily routes while the build still exited 0)
- Tests: 9 new (unit-level validator tests + end-to-end subprocess build regression tests + framing/philosophy describe with token assertions); manual 29 → 38; full monorepo 319 → 328

## Type of change

- [x] New feature
- [x] Bug fix (latent enforcement gaps in the build pipeline, exposed by the new trust-boundary validators)

## Testing

- [x] Existing tests pass (319 prior tests unchanged + 9 new)
- [x] New tests added if behavior changed (validators + end-to-end build regressions + token coverage)
- [x] Tested manually and documented below

Local verification:

- `pnpm --filter manual build`: exit 0 (~370 routes built)
- `pnpm --filter manual test`: exit 0 (38/38)
- `pnpm test` (full monorepo): exit 0 (api 29 + game 261 + manual 38 = 328)
- FORCE FAIL probe (transient `throw` inside `buildPage` made build exit 1 with the throw in stack trace; reverted)
- Fixture cleanup probe: `find packages/manual/data/daily -name '_test-fixture*'` returns zero after test runs

## Checklist

- [x] Code follows the project style (eslint + prettier + markdownlint via pre-commit hook all passed)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (CHANGELOG `### Added` entry; vault arch spec §Mechanism + §Invariants 必须 + §Invariants 必不 group all synced)
- [x] Breaking changes documented if any (no breaking changes — additive)

---

Source task: \`add-bombsquad-ai-framing-and-collab-philosophy\` (parent plan: \`revise-bombsquad-manual-and-ai-framing\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)