### PR TITLE
feat(platform,api): add oracle.amio.fans vanity-subdomain 301 redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ run; a later release adds a real AI partner, voice I/O, and the full
 
 ### Changed
 
+- **Yijing Oracle gets its own vanity domain** The Yijing Oracle now has a
+  memorable own-domain entry at `oracle.amio.fans` that 301-redirects to
+  `claw.amio.fans/oracle/*` — root lands on `/oracle`, deep links are
+  prefixed onto `/oracle`, and the shared `/manual/*` and `/api/*` paths
+  pass through unchanged. This matches the BombSquad vanity pattern, so
+  every game now has its own memorable domain that funnels into the
+  platform.
 - **BombSquad landing and connect screens get the Atlas look** Entering
   BombSquad from the homepage now opens BombSquad's own landing page in the
   「星图 / Atlas」cosmic style — a floating planet hero, the BOMBSQUAD

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,26 +1,39 @@
 import {
   LEGACY_HOST,
+  ORACLE_HOST,
   mapLegacyBombsquadPath,
+  mapLegacyOraclePath,
 } from '../packages/api/src/handlers/middleware-host-redirect'
 
 /**
  * Cloudflare Pages Function catch-all middleware — `_middleware.ts` runs
  * BEFORE any matched route handler under `functions/` and ahead of the
- * static SPA assets. We use it to 301-redirect the legacy
- * `bombsquad.amio.fans` host to its `claw.amio.fans/bombsquad` canonical
- * equivalent. Any other host (the new canonical `claw.amio.fans`,
- * preview deployments on `*.amiclaw.pages.dev`, localhost) falls through
- * via `context.next()`.
+ * static SPA assets. We use it to 301-redirect each game's per-game vanity
+ * host to its `claw.amio.fans` canonical equivalent: `bombsquad.amio.fans`
+ * → `claw.amio.fans/bombsquad`, `oracle.amio.fans` → `claw.amio.fans/oracle`.
+ * Any other host (the new canonical `claw.amio.fans`, preview deployments
+ * on `*.amiclaw.pages.dev`, localhost) falls through via `context.next()`.
  *
- * The URL-mapping rules live in
- * `packages/api/src/handlers/middleware-host-redirect.ts` as a pure
- * helper, so the redirect contract is unit-testable without spinning up
- * a Workers runtime.
+ * The per-host URL-mapping rules live in
+ * `packages/api/src/handlers/middleware-host-redirect.ts` as pure helpers,
+ * so each redirect contract is unit-testable without spinning up a Workers
+ * runtime. To add another game's vanity host, register its mapper below.
  */
 
 interface Context {
   request: Request
   next: () => Promise<Response>
+}
+
+/**
+ * Vanity host → pure path-mapper dispatch table. Each mapper takes the
+ * inbound `(pathname, search)` and returns the canonical absolute URL on
+ * `claw.amio.fans`. A host absent from this table falls through to the
+ * downstream handler / static assets.
+ */
+const VANITY_HOST_MAPPERS: Record<string, (pathname: string, search: string) => string> = {
+  [LEGACY_HOST]: mapLegacyBombsquadPath,
+  [ORACLE_HOST]: mapLegacyOraclePath,
 }
 
 export async function onRequest(context: Context): Promise<Response> {
@@ -31,8 +44,9 @@ export async function onRequest(context: Context): Promise<Response> {
   // already carries the worker host instead of the inbound host.
   const inboundHost = url.host || request.headers.get('host') || ''
 
-  if (inboundHost === LEGACY_HOST) {
-    const target = mapLegacyBombsquadPath(url.pathname, url.search)
+  const mapper = VANITY_HOST_MAPPERS[inboundHost]
+  if (mapper) {
+    const target = mapper(url.pathname, url.search)
     return Response.redirect(target, 301)
   }
 

--- a/packages/api/src/handlers/middleware-host-redirect.test.ts
+++ b/packages/api/src/handlers/middleware-host-redirect.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { LEGACY_HOST, CANONICAL_HOST, mapLegacyBombsquadPath } from './middleware-host-redirect'
+import {
+  LEGACY_HOST,
+  ORACLE_HOST,
+  CANONICAL_HOST,
+  mapLegacyBombsquadPath,
+  mapLegacyOraclePath,
+} from './middleware-host-redirect'
 
 /**
  * Covers the path-mapping table the `bombsquad.amio.fans` → `claw.amio.fans`
@@ -65,12 +71,52 @@ describe('mapLegacyBombsquadPath — specific path rewrites', () => {
   })
 })
 
-describe('LEGACY_HOST / CANONICAL_HOST constants', () => {
+/**
+ * Covers the path-mapping table the `oracle.amio.fans` → `claw.amio.fans`
+ * 301 middleware is built on. Unlike BombSquad, the Yijing Oracle SPA lives
+ * entirely under `/oracle/*`, so unknown paths are prefixed with `/oracle`
+ * rather than passed through verbatim; the shared `/manual/*` and `/api/*`
+ * namespaces still pass through unchanged.
+ */
+describe('mapLegacyOraclePath — Oracle SPA path rewrites', () => {
+  it('maps root to the /oracle landing on the canonical host', () => {
+    expect(mapLegacyOraclePath('/', '')).toBe(`https://${CANONICAL_HOST}/oracle`)
+  })
+
+  it('treats an empty pathname like root (defensive — `URL` always produces "/")', () => {
+    expect(mapLegacyOraclePath('', '')).toBe(`https://${CANONICAL_HOST}/oracle`)
+  })
+
+  it('passes through /manual/* paths verbatim onto the canonical host', () => {
+    expect(mapLegacyOraclePath('/manual/2026-05-30', '')).toBe(
+      `https://${CANONICAL_HOST}/manual/2026-05-30`
+    )
+  })
+
+  it('passes through /api/* paths verbatim, preserving the query string', () => {
+    expect(mapLegacyOraclePath('/api/leaderboard', '?date=2026-05-30')).toBe(
+      `https://${CANONICAL_HOST}/api/leaderboard?date=2026-05-30`
+    )
+  })
+
+  it('prefixes unknown SPA paths with /oracle', () => {
+    expect(mapLegacyOraclePath('/casting', '')).toBe(`https://${CANONICAL_HOST}/oracle/casting`)
+  })
+
+  it('prefixes deep SPA paths with /oracle and preserves the query string', () => {
+    expect(mapLegacyOraclePath('/reading/sign', '?seed=42')).toBe(
+      `https://${CANONICAL_HOST}/oracle/reading/sign?seed=42`
+    )
+  })
+})
+
+describe('LEGACY_HOST / ORACLE_HOST / CANONICAL_HOST constants', () => {
   it('exposes the exact host strings the middleware checks against', () => {
     // These strings are the authoritative spelling. If a rename ever lands,
     // the test must change in lockstep — a typo here would silently break
     // every legacy link in the wild.
     expect(LEGACY_HOST).toBe('bombsquad.amio.fans')
+    expect(ORACLE_HOST).toBe('oracle.amio.fans')
     expect(CANONICAL_HOST).toBe('claw.amio.fans')
   })
 })

--- a/packages/api/src/handlers/middleware-host-redirect.ts
+++ b/packages/api/src/handlers/middleware-host-redirect.ts
@@ -1,14 +1,14 @@
 /**
- * Pure URL-mapping helpers for the legacy-host 301 redirect.
+ * Pure URL-mapping helpers for the per-game vanity-host 301 redirects.
  *
  * The Cloudflare Pages catch-all middleware at `functions/_middleware.ts`
- * intercepts requests whose Host header is `bombsquad.amio.fans` and
- * rewrites them to their `claw.amio.fans` canonical equivalents. The
- * mapping rules live here as pure functions so the redirect contract is
- * unit-testable in the Node vitest environment without spinning up a
- * Workers runtime.
+ * intercepts requests whose Host header is a per-game vanity domain
+ * (`bombsquad.amio.fans`, `oracle.amio.fans`) and rewrites them to their
+ * `claw.amio.fans` canonical equivalents. The mapping rules live here as
+ * pure functions so each redirect contract is unit-testable in the Node
+ * vitest environment without spinning up a Workers runtime.
  *
- * Mapping:
+ * BombSquad mapping (`bombsquad.amio.fans` → `claw.amio.fans`):
  *   `/`                          → `/bombsquad`
  *   `/game`                      → `/bombsquad`
  *   `/game/connect`              → `/bombsquad/connect`
@@ -19,10 +19,17 @@
  *   `/api/...`                   → `/api/...`     (same path on new host)
  *   anything else                → same path on new host (no rewrite)
  *
+ * Yijing Oracle mapping (`oracle.amio.fans` → `claw.amio.fans`):
+ *   `/`                          → `/oracle`
+ *   `/manual/...`                → `/manual/...`  (same path — shared platform manual)
+ *   `/api/...`                   → `/api/...`     (same path — shared platform API)
+ *   anything else `/<x>`         → `/oracle/<x>`  (prefix /oracle — the SPA lives under /oracle/*)
+ *
  * Query string is preserved verbatim on every branch.
  */
 
 export const LEGACY_HOST = 'bombsquad.amio.fans'
+export const ORACLE_HOST = 'oracle.amio.fans'
 export const CANONICAL_HOST = 'claw.amio.fans'
 
 /**
@@ -50,4 +57,32 @@ function rewritePath(pathname: string): string {
   // Same-path passthroughs — `/manual/*`, `/api/*`, and any other path
   // not in the rewrite table go to the same path on the canonical host.
   return pathname
+}
+
+/**
+ * Build the canonical absolute URL an `oracle.amio.fans` request should be
+ * redirected to. `pathname` and `search` come straight from
+ * `new URL(request.url)`; `search` already starts with `?` when present
+ * and is empty otherwise.
+ *
+ * Unlike BombSquad — which passes unknown paths through verbatim — the
+ * Yijing Oracle SPA lives entirely under `/oracle/*`, so any path outside
+ * the shared `/manual/*` and `/api/*` namespaces is prefixed with
+ * `/oracle` (e.g. a vanity deep link `/casting` → `/oracle/casting`).
+ */
+export function mapLegacyOraclePath(pathname: string, search: string): string {
+  // Root → Yijing Oracle landing on the new platform.
+  if (pathname === '/' || pathname === '') return `https://${CANONICAL_HOST}/oracle${search}`
+
+  // Shared platform namespaces — `/manual/*` and `/api/*` are not
+  // game-specific, so they pass through to the same path verbatim.
+  if (pathname === '/manual' || pathname.startsWith('/manual/')) {
+    return `https://${CANONICAL_HOST}${pathname}${search}`
+  }
+  if (pathname === '/api' || pathname.startsWith('/api/')) {
+    return `https://${CANONICAL_HOST}${pathname}${search}`
+  }
+
+  // Everything else is an Oracle SPA route — prefix with /oracle.
+  return `https://${CANONICAL_HOST}/oracle${pathname}${search}`
 }


### PR DESCRIPTION
## Summary

- Add the `oracle.amio.fans` vanity subdomain — every path 301-redirects to its `claw.amio.fans/oracle/*` canonical equivalent, mirroring the existing BombSquad vanity pattern so every game now has a memorable own-domain entry.
- Generalize `functions/_middleware.ts` from a single-host bombsquad check into an extensible `VANITY_HOST_MAPPERS` host→mapper dispatch table; registering a future game's vanity host is now a one-line entry.
- Oracle mapping: root → `/oracle`; `/manual/*` and `/api/*` pass through verbatim (shared platform namespaces); every other path is prefixed `/oracle` (the Oracle SPA lives entirely under `/oracle/*`, unlike BombSquad which passes unknown paths through). Query string preserved on every branch.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass — bombsquad host-redirect suite untouched, 6/6 green; full repo suite green via pre-commit hook
- [x] New tests added — 6 `mapLegacyOraclePath` cases (root, empty, `/manual/*`, `/api/*`+query, `/oracle`-prefix fallback, deep path+query) + `ORACLE_HOST` assertion
- [ ] Tested manually — the live 301 can only be exercised once the Cloudflare custom domain + DNS for `oracle.amio.fans` is configured (user-side, see below); the pure mapper contract is exhaustively unit-tested

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed — `docs/architecture/architecture.md` vanity-redirect descriptions (vault SSOT) + `CHANGELOG.md` Unreleased
- [x] Breaking changes documented if any — none, purely additive; bombsquad behavior byte-identical

## Remaining user action

After merge, configure `oracle.amio.fans` as a custom domain on the `amiclaw` Cloudflare Pages project + add the DNS record (same operation as the BombSquad vanity domain — can be batched). Until then the redirect code is inert.
