### PR TITLE
feat(game-bombsquad): wave-2 feel polish (module-pass juice, honest copy, scene nudge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,22 @@ run; a later release adds a real AI partner, voice I/O, and the full
 
 ### Improvements
 
+- **Clearing a module finally feels good** Solving a module now lands with a
+  bright two-note rising chime and a quick green bloom on the panel and the
+  just-filled progress segment, instead of the near-silent thunk it used to
+  share with a wrong answer. Finishing a run celebrates a win with a glyph
+  burst and a short rising sting, visibly and audibly distinct from the calm
+  failure screen, and a correct answer mid-run flashes a confident green panel
+  pulse mirroring the existing red error pulse. All restrained, dark-only,
+  CSS-only, and gated behind `prefers-reduced-motion`. Source task
+  `fix-bombsquad-to-invitable-quality`.
+- **Honest setup copy, and a first-run scene-bar nudge** The BombSquad landing
+  page no longer claims "AI 已就位" before you have connected one — it now says
+  you bring your own voice AI (Claude / ChatGPT / Gemini); the connect flow's
+  "switch to voice mode" step is a passive reminder instead of a fake button;
+  and the AI-avatar label reads "你的 AI" rather than a hardcoded "Claude". On
+  your first run, a one-time dismissible hint points you at the scene-info bar
+  to read out to your AI. Source task `fix-bombsquad-to-invitable-quality`.
 - **One-tap voice-AI setup, and a practice mode that onboards you** Connecting
   your AI partner is now a single tap to copy the manual link and send it —
   modern voice AIs open and read the link on their own, and the manual now

--- a/e2e/steps/common.steps.ts
+++ b/e2e/steps/common.steps.ts
@@ -1,6 +1,10 @@
 /** Shared navigation, viewport, URL and generic locator steps. */
-import { expect, type Page } from '@playwright/test'
+import { expect, type Locator, type Page } from '@playwright/test'
 import { Given, When, Then } from './fixtures'
+
+/** How long the wait fallback lets a late-rendering control appear before
+ * giving up. Bounded so a genuinely-absent target still fails promptly. */
+const TAP_TARGET_TIMEOUT_MS = 8000
 
 /** Click a button or link by its visible label, tolerant of ← / → affixes. */
 export async function tapByLabel(page: Page, raw: string): Promise<void> {
@@ -9,29 +13,53 @@ export async function tapByLabel(page: Page, raw: string): Promise<void> {
   const noArrow = text.replaceAll('←', '').replaceAll('→', '').trim()
   if (noArrow && noArrow !== text) variants.push(noArrow)
 
+  // Candidate locators in priority order: exact accessible-name, then inexact
+  // accessible-name, then visible-text content (covers buttons whose aria-label
+  // differs from their label text). Each candidate matches button OR link.
+  // Built once and reused for both the fast path and the wait fallback.
+  const candidates: Locator[] = []
   for (const exact of [true, false]) {
     for (const name of variants) {
-      const locator = page
-        .getByRole('button', { name, exact })
-        .or(page.getByRole('link', { name, exact }))
+      candidates.push(
+        page.getByRole('button', { name, exact }).or(page.getByRole('link', { name, exact }))
+      )
+    }
+  }
+  for (const name of variants) {
+    candidates.push(
+      page
+        .getByRole('button')
+        .filter({ hasText: name })
+        .or(page.getByRole('link').filter({ hasText: name }))
+    )
+  }
+
+  const clickFirstPresent = async (): Promise<boolean> => {
+    for (const locator of candidates) {
+      // `count()` is instantaneous and non-auto-waiting, so this is the fast
+      // path: click immediately when a match is already in the DOM.
       if ((await locator.count()) > 0) {
         await locator.first().click()
-        return
+        return true
       }
     }
+    return false
   }
-  // Fallback: match by visible text content rather than accessible name —
-  // covers buttons whose aria-label differs from their label text.
-  for (const name of variants) {
-    const byText = page
-      .getByRole('button')
-      .filter({ hasText: name })
-      .or(page.getByRole('link').filter({ hasText: name }))
-    if ((await byText.count()) > 0) {
-      await byText.first().click()
-      return
-    }
+
+  if (await clickFirstPresent()) return
+
+  // Slow path: the control may render a beat late (e.g. the GamePage READY
+  // "开始" button only paints after the LOADING→READY transition), so the
+  // instantaneous count-check above can miss it. Wait — bounded — for any
+  // candidate to become visible, then re-run the selection.
+  let combined = candidates[0]
+  for (const locator of candidates.slice(1)) combined = combined.or(locator)
+  try {
+    await combined.first().waitFor({ state: 'visible', timeout: TAP_TARGET_TIMEOUT_MS })
+  } catch {
+    throw new Error(`tap/click target not found: ${raw}`)
   }
+  if (await clickFirstPresent()) return
   throw new Error(`tap/click target not found: ${raw}`)
 }
 

--- a/packages/game-bombsquad/src/audio/presets.test.ts
+++ b/packages/game-bombsquad/src/audio/presets.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { SFX_PRESETS } from './presets'
+
+describe('SFX presets', () => {
+  it('module-success is a distinct tonal chime, not the percussive error sample', () => {
+    const success = SFX_PRESETS['module-success']
+    const error = SFX_PRESETS['module-error']
+
+    // The whole point of the cue rework: success no longer shares the error's
+    // `thunk` sample at a different pitch — it is synthesised as a chime.
+    expect(success.kind).toBe('chime')
+    expect(error.kind ?? 'sample').toBe('sample')
+    if (error.kind === undefined || error.kind === 'sample') {
+      expect(error.sample).toBe('thunk')
+    }
+  })
+
+  it('module-success is a short two-note rising chime, kept restrained', () => {
+    const success = SFX_PRESETS['module-success']
+    if (success.kind !== 'chime') throw new Error('module-success must be a chime preset')
+
+    expect(success.notes).toHaveLength(2)
+    // Rising: each note higher than the last.
+    expect(success.notes[1]).toBeGreaterThan(success.notes[0])
+    // Restrained: well under the 1.0 full-scale used by percussive feedback.
+    expect(success.gain).toBeLessThanOrEqual(0.4)
+  })
+
+  it('result-success is a fuller rising chime for the run-end arrival', () => {
+    const result = SFX_PRESETS['result-success']
+    if (result.kind !== 'chime') throw new Error('result-success must be a chime preset')
+
+    expect(result.notes.length).toBeGreaterThanOrEqual(3)
+    // Strictly ascending.
+    for (let i = 1; i < result.notes.length; i++) {
+      expect(result.notes[i]).toBeGreaterThan(result.notes[i - 1])
+    }
+    expect(result.gain).toBeLessThanOrEqual(0.4)
+  })
+})

--- a/packages/game-bombsquad/src/audio/presets.ts
+++ b/packages/game-bombsquad/src/audio/presets.ts
@@ -1,16 +1,23 @@
 /**
- * Per-operation sound presets — each SFX type maps to a base sample plus a
- * `playbackRate` (couples pitch + speed via Web Audio's
- * AudioBufferSourceNode.playbackRate) and a `gain` (0..1 linear amplitude
- * on the GainNode). Three shared base samples cover nine UI operations,
- * giving distinct but family-related feedback per action; the bomb
- * detonation has its own dedicated sample.
+ * Per-operation sound presets. Two preset shapes share one table:
  *
- * Gain convention: foreground action feedback at 1.0 (full sample
+ * - **Sample presets** map an SFX to a base sample plus a `rate`
+ *   (couples pitch + speed via Web Audio's AudioBufferSourceNode.playbackRate)
+ *   and a `gain` (0..1 linear amplitude on the GainNode). Three shared base
+ *   samples cover the percussive UI operations; the bomb detonation has its
+ *   own dedicated sample.
+ * - **Chime presets** are synthesised live from oscillators — a short
+ *   sequence of rising notes. Success cues use these so a win sounds tonal and
+ *   bright, clearly apart from the percussive `thunk` an error shares with the
+ *   rest of the click family. No extra audio asset is shipped for them.
+ *
+ * Gain convention: foreground percussive feedback at 1.0 (full sample
  * amplitude, no clipping risk); ambient stopwatch tick at 0.3 so it sits
  * clearly under click feedback in the mix. The detonation also plays at
  * 1.0 — the top of the no-clip range — so it lands as the loudest, most
- * prominent cue, carried further by its intrinsically punchy sample.
+ * prominent cue, carried further by its intrinsically punchy sample. Chime
+ * cues stay deliberately low (~0.3) so the success feedback reads as a clean,
+ * restrained beat rather than a fanfare.
  */
 
 import type { SampleName } from './audio-context'
@@ -24,14 +31,35 @@ export type SfxType =
   | 'button-up'
   | 'module-success'
   | 'module-error'
+  | 'result-success'
   | 'stopwatch-tick'
   | 'explosion'
 
-export interface SfxPreset {
+/** A one-shot sound built from a decoded audio sample. */
+export interface SamplePreset {
+  /** Discriminator. Sample playback is the default and may be omitted. */
+  kind?: 'sample'
   sample: SampleName
   rate: number
   gain: number
 }
+
+/** A one-shot cue synthesised from a short rising oscillator sequence. */
+export interface ChimePreset {
+  kind: 'chime'
+  /** Ascending note frequencies in Hz, played in order. */
+  notes: readonly number[]
+  /** Oscillator waveform — 'triangle' reads as a soft chime, not a test tone. */
+  waveform: OscillatorType
+  /** Per-note ring-out duration in seconds. */
+  noteDuration: number
+  /** Seconds between successive note onsets — below noteDuration for legato. */
+  noteStride: number
+  /** Peak per-note gain (0..1). Kept low so the cue stays restrained. */
+  gain: number
+}
+
+export type SfxPreset = SamplePreset | ChimePreset
 
 export const SFX_PRESETS: Record<SfxType, SfxPreset> = {
   confirm: { sample: 'click', rate: 1.0, gain: 1.0 },
@@ -40,8 +68,29 @@ export const SFX_PRESETS: Record<SfxType, SfxPreset> = {
   'keypad-press': { sample: 'click', rate: 1.5, gain: 1.0 },
   'button-down': { sample: 'click', rate: 0.85, gain: 1.0 },
   'button-up': { sample: 'click', rate: 1.0, gain: 1.0 },
-  'module-success': { sample: 'thunk', rate: 1.3, gain: 1.0 },
+  // Clearing a module: a short two-note rising chime (E5 → B5, a clean
+  // perfect fifth). Tonal and bright, so it never reads as the percussive
+  // `thunk` the error cue uses.
+  'module-success': {
+    kind: 'chime',
+    notes: [659.25, 987.77],
+    waveform: 'triangle',
+    noteDuration: 0.16,
+    noteStride: 0.085,
+    gain: 0.3,
+  },
   'module-error': { sample: 'thunk', rate: 0.65, gain: 1.0 },
+  // Finishing the whole run: a three-note rising major triad (E5 → G#5 → B5).
+  // A touch fuller than the per-module chime so the result screen feels like
+  // an arrival, still short and restrained — not a fanfare.
+  'result-success': {
+    kind: 'chime',
+    notes: [659.25, 830.61, 987.77],
+    waveform: 'triangle',
+    noteDuration: 0.22,
+    noteStride: 0.11,
+    gain: 0.28,
+  },
   'stopwatch-tick': { sample: 'tick', rate: 1.0, gain: 0.3 },
   explosion: { sample: 'explosion', rate: 1.0, gain: 1.0 },
 }

--- a/packages/game-bombsquad/src/audio/useSfx.ts
+++ b/packages/game-bombsquad/src/audio/useSfx.ts
@@ -1,10 +1,15 @@
 /**
  * `playSfx(type)` — fire-and-forget one-shot sound effect.
  *
- * Pulls preset (base sample + rate) from SFX_PRESETS, asks the buffer cache
- * for the decoded sample (decoding lazily on first call), and dispatches a
- * fresh AudioBufferSourceNode. Each call is independent — rapid retriggers
- * are natural since AudioBufferSourceNode is one-shot.
+ * Two playback paths, chosen by the preset shape:
+ * - **Sample presets**: pull the preset (base sample + rate) from
+ *   SFX_PRESETS, ask the buffer cache for the decoded sample (decoding lazily
+ *   on first call), and dispatch a fresh AudioBufferSourceNode.
+ * - **Chime presets**: synthesise a short rising note sequence with
+ *   oscillators on the fly — no asset to decode.
+ *
+ * Each call is independent — rapid retriggers are natural since both
+ * AudioBufferSourceNode and OscillatorNode are one-shot.
  *
  * Silent-fail by design: if the browser has no Web Audio, the buffer isn't
  * decoded yet, or anything else fails, the call is a no-op. Audio is
@@ -17,13 +22,50 @@
  */
 
 import { getAudioContext, getBuffer, getMasterGain } from './audio-context'
-import { SFX_PRESETS, type SfxType } from './presets'
+import { SFX_PRESETS, type ChimePreset, type SfxType } from './presets'
+
+/**
+ * Synthesise a chime preset: each note is an oscillator with a quick attack
+ * and exponential decay, scheduled in sequence off the context clock. Routed
+ * through the shared master gain so mute applies, falling back to the raw
+ * destination. Wrapped per-note so one failed node never aborts the rest.
+ */
+function playChime(preset: ChimePreset, ctx: AudioContext): void {
+  const destination = getMasterGain() ?? ctx.destination
+  const start = ctx.currentTime
+  const attack = 0.012
+  preset.notes.forEach((freq, i) => {
+    try {
+      const osc = ctx.createOscillator()
+      osc.type = preset.waveform
+      osc.frequency.value = freq
+      const env = ctx.createGain()
+      const noteStart = start + i * preset.noteStride
+      // exponentialRamp can't target 0, so floor the envelope at a near-zero
+      // value and ramp between that and the peak gain.
+      env.gain.setValueAtTime(0.0001, noteStart)
+      env.gain.exponentialRampToValueAtTime(preset.gain, noteStart + attack)
+      env.gain.exponentialRampToValueAtTime(0.0001, noteStart + preset.noteDuration)
+      osc.connect(env)
+      env.connect(destination)
+      osc.start(noteStart)
+      osc.stop(noteStart + preset.noteDuration + 0.02)
+    } catch {
+      // createOscillator / connect can throw if the context was closed; ignore.
+    }
+  })
+}
 
 export function playSfx(type: SfxType): void {
   const preset = SFX_PRESETS[type]
   if (!preset) return
   const ctx = getAudioContext()
   if (!ctx) return
+
+  if (preset.kind === 'chime') {
+    playChime(preset, ctx)
+    return
+  }
 
   void getBuffer(preset.sample).then((buf) => {
     if (!buf) return

--- a/packages/game-bombsquad/src/components/ProgressBar.module.css
+++ b/packages/game-bombsquad/src/components/ProgressBar.module.css
@@ -20,6 +20,12 @@
 .filled {
   background: var(--green);
   box-shadow: 0 0 6px var(--green);
+  /* One-shot surge the moment a segment turns green — fires as the
+     just-cleared module's segment gains `.filled` (overlay gone, next module
+     in), the visible tail of the module-pass payoff. Settles back to the
+     steady fill so a re-render never replays it. */
+  animation: segment-surge 0.5s ease-out;
+  transform-origin: center;
 }
 
 .active {
@@ -28,8 +34,29 @@
   animation: pulse 2s ease-in-out infinite;
 }
 
+/* A vertical pop + glow swell, ending exactly on the steady `.filled` look. */
+@keyframes segment-surge {
+  0% {
+    transform: scaleY(1);
+    box-shadow: 0 0 6px var(--green);
+  }
+  35% {
+    transform: scaleY(2.4);
+    box-shadow: 0 0 16px 2px var(--green);
+  }
+  100% {
+    transform: scaleY(1);
+    box-shadow: 0 0 6px var(--green);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .active {
+    animation: none;
+  }
+
+  /* Keep the 0.3s colour cross-fade (a non-motion transition); drop the pop. */
+  .filled {
     animation: none;
   }
 }

--- a/packages/game-bombsquad/src/components/SceneInfoBar.module.css
+++ b/packages/game-bombsquad/src/components/SceneInfoBar.module.css
@@ -1,6 +1,83 @@
 /* Scene info HUD row — Atlas star-chart visual language: a glass
    bar carrying the puzzle-global variables the player reads to
    their AI partner. */
+.wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* First-run hint above the bar. The container is click-through so it never
+   blocks the controls beneath it; only the dismiss button re-enables pointer
+   events. Yellow-tinted glass to match the refresh banner's idiom. */
+.nudge {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  align-self: flex-start;
+  max-width: 100%;
+  padding: 8px 8px 8px 14px;
+  pointer-events: none;
+  background: var(--glass);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 229, 62, 0.3);
+  border-radius: var(--radius-lg);
+  animation: scene-nudge-in 0.3s ease;
+}
+
+.nudgeText {
+  font: 500 0.82rem var(--font-body);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+/* A small downward caret tying the hint to the bar below it. */
+.nudgeText::after {
+  content: ' ↓';
+  color: var(--y);
+}
+
+.nudgeDismiss {
+  flex: none;
+  pointer-events: auto;
+  min-width: var(--touch-target);
+  min-height: var(--touch-target);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--soft);
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s ease;
+}
+
+.nudgeDismiss:hover,
+.nudgeDismiss:focus-visible {
+  color: #fff;
+  outline: none;
+}
+
+.nudgeDismiss:focus-visible {
+  outline: 2px solid var(--y);
+  outline-offset: 2px;
+}
+
+@keyframes scene-nudge-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .bar {
   display: flex;
   flex-wrap: wrap;
@@ -77,4 +154,32 @@
   background: rgba(255, 255, 255, 0.06);
   color: var(--soft);
   border: 1px solid var(--hairline);
+}
+
+/* While the first-run nudge is up, the bar carries a steady brighter border
+   and pulses its yellow glow a couple of times to draw the eye, then settles. */
+.barNudged {
+  border-color: rgba(255, 229, 62, 0.4);
+  animation: scene-bar-pulse 1.6s ease-in-out 2;
+}
+
+@keyframes scene-bar-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 rgba(255, 229, 62, 0);
+  }
+  50% {
+    box-shadow: 0 0 16px var(--y-glow-25);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nudge {
+    animation: none;
+  }
+
+  /* Drop the pulse but keep the steady brighter border as a static cue. */
+  .barNudged {
+    animation: none;
+  }
 }

--- a/packages/game-bombsquad/src/components/SceneInfoBar.test.tsx
+++ b/packages/game-bombsquad/src/components/SceneInfoBar.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
 import type { SceneInfo } from '@shared/manual-schema'
 import SceneInfoBar from './SceneInfoBar'
 
@@ -45,5 +45,29 @@ describe('SceneInfoBar', () => {
     )
     expect(screen.getByText('指示灯：')).toBeInTheDocument()
     expect(screen.getByText('无')).toBeInTheDocument()
+  })
+})
+
+describe('SceneInfoBar first-run nudge', () => {
+  it('does not render the nudge by default', () => {
+    render(<SceneInfoBar sceneInfo={sceneWithIndicators} />)
+    expect(screen.queryByText(/读给 AI/)).not.toBeInTheDocument()
+  })
+
+  it('renders the dismissible hint when showNudge is set', () => {
+    render(<SceneInfoBar sceneInfo={sceneWithIndicators} showNudge />)
+    expect(screen.getByText(/读给 AI/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '关闭提示' })).toBeInTheDocument()
+    // The scene fields stay rendered alongside the hint.
+    expect(screen.getByText('暗号：')).toBeInTheDocument()
+  })
+
+  it('calls onDismissNudge when the hint is dismissed', () => {
+    const onDismissNudge = vi.fn()
+    render(
+      <SceneInfoBar sceneInfo={sceneWithIndicators} showNudge onDismissNudge={onDismissNudge} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: '关闭提示' }))
+    expect(onDismissNudge).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/game-bombsquad/src/components/SceneInfoBar.tsx
+++ b/packages/game-bombsquad/src/components/SceneInfoBar.tsx
@@ -3,6 +3,10 @@ import styles from './SceneInfoBar.module.css'
 
 interface SceneInfoBarProps {
   sceneInfo: SceneInfo
+  /** First-run only: highlight the bar and show a one-time "read this to your AI" hint. */
+  showNudge?: boolean
+  /** Called when the player taps the hint's dismiss control. */
+  onDismissNudge?: () => void
 }
 
 /**
@@ -11,34 +15,58 @@ interface SceneInfoBarProps {
  * lit/unlit state). Always visible — the earlier mobile collapse hid the
  * single most important piece of onboarding information behind an unlabelled
  * chevron.
+ *
+ * On a first-timer's first module, `showNudge` adds a dismissible hint above
+ * the bar and a brief highlight pulse, prompting them to read this row to the
+ * AI before diving into the puzzle. The hint never blocks interaction — its
+ * container is click-through and only the dismiss control is interactive.
  */
-export default function SceneInfoBar({ sceneInfo }: SceneInfoBarProps) {
+export default function SceneInfoBar({
+  sceneInfo,
+  showNudge = false,
+  onDismissNudge,
+}: SceneInfoBarProps) {
   return (
-    <div className={styles.bar} aria-label="场景信息栏">
-      <span className={styles.field}>
-        <span className={styles.label}>暗号：</span>
-        <span className={styles.value}>{sceneInfo.sceneTongueTwister}</span>
-      </span>
-      <span className={styles.field}>
-        <span className={styles.label}>电池：</span>
-        <span className={styles.value}>{sceneInfo.batteryCount}</span>
-      </span>
-      <span className={`${styles.field} ${styles.indicators}`}>
-        <span className={styles.label}>指示灯：</span>
-        {sceneInfo.indicators.length > 0 ? (
-          sceneInfo.indicators.map((ind, i) => (
-            <span
-              key={`${ind.label}-${i}`}
-              className={`${styles.indicator} ${ind.lit ? styles.lit : styles.unlit}`}
-              title={ind.lit ? `${ind.label}（亮）` : `${ind.label}（灭）`}
-            >
-              {ind.label}
-            </span>
-          ))
-        ) : (
-          <span className={styles.value}>无</span>
-        )}
-      </span>
+    <div className={styles.wrap}>
+      {showNudge && (
+        <div className={styles.nudge} role="status">
+          <span className={styles.nudgeText}>开局先把这一行读给 AI</span>
+          <button
+            type="button"
+            className={styles.nudgeDismiss}
+            onClick={onDismissNudge}
+            aria-label="关闭提示"
+          >
+            ×
+          </button>
+        </div>
+      )}
+      <div className={`${styles.bar} ${showNudge ? styles.barNudged : ''}`} aria-label="场景信息栏">
+        <span className={styles.field}>
+          <span className={styles.label}>暗号：</span>
+          <span className={styles.value}>{sceneInfo.sceneTongueTwister}</span>
+        </span>
+        <span className={styles.field}>
+          <span className={styles.label}>电池：</span>
+          <span className={styles.value}>{sceneInfo.batteryCount}</span>
+        </span>
+        <span className={`${styles.field} ${styles.indicators}`}>
+          <span className={styles.label}>指示灯：</span>
+          {sceneInfo.indicators.length > 0 ? (
+            sceneInfo.indicators.map((ind, i) => (
+              <span
+                key={`${ind.label}-${i}`}
+                className={`${styles.indicator} ${ind.lit ? styles.lit : styles.unlit}`}
+                title={ind.lit ? `${ind.label}（亮）` : `${ind.label}（灭）`}
+              >
+                {ind.label}
+              </span>
+            ))
+          ) : (
+            <span className={styles.value}>无</span>
+          )}
+        </span>
+      </div>
     </div>
   )
 }

--- a/packages/game-bombsquad/src/modules/wire/WireModule.module.css
+++ b/packages/game-bombsquad/src/modules/wire/WireModule.module.css
@@ -60,6 +60,42 @@
   transition: opacity 100ms;
 }
 
+/* Wrong cut: the clicked strand flashes red and recoils (a quick horizontal
+   jitter — the snip bounces off), then settles back to its own color. The
+   strand stays INTACT; severing is reserved for the correct cut. `--wire-color`
+   is set inline per strand so the red decays back to that exact hue. */
+.strandError {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: wire-strand-error 600ms ease-out;
+}
+
+@keyframes wire-strand-error {
+  0% {
+    stroke: #ff073a;
+    filter: drop-shadow(0 0 7px #ff073a);
+    transform: translateX(0);
+  }
+  12% {
+    transform: translateX(-3px);
+  }
+  28% {
+    transform: translateX(3px);
+  }
+  44% {
+    transform: translateX(-2px);
+  }
+  60% {
+    stroke: #ff073a;
+    transform: translateX(1px);
+  }
+  100% {
+    stroke: var(--wire-color, #ff073a);
+    filter: none;
+    transform: translateX(0);
+  }
+}
+
 .halo {
   pointer-events: none;
 }
@@ -164,5 +200,11 @@
   .sparkRing {
     animation: none;
     opacity: 0;
+  }
+  /* No motion — keep the wrong-wire cue as a static red stroke (held for the
+     ~600ms error window, then cleared when the panel returns to idle). */
+  .strandError {
+    animation: none;
+    stroke: #ff073a;
   }
 }

--- a/packages/game-bombsquad/src/modules/wire/WireModule.module.css
+++ b/packages/game-bombsquad/src/modules/wire/WireModule.module.css
@@ -85,12 +85,17 @@
   stroke: rgba(255, 255, 255, 0.08);
 }
 
-/* The hit target is an SVG path; a box outline would frame the whole
-   curve's bounding rect, so focus is shown as a yellow band tracing the
-   strand instead. */
+/* The hit target is an SVG path; the browser's default box outline would
+   frame the whole curve's bounding rect (reads as two stray lines above and
+   below the strand). Suppress it on ALL focus — including pointer/tap focus,
+   where :focus-visible does NOT match — and show keyboard focus as a yellow
+   band tracing the strand instead. */
+.hitTarget:focus {
+  outline: none;
+}
+
 .hitTarget:focus-visible {
   stroke: var(--y-glow-50);
-  outline: none;
 }
 
 /* Severed strand halves — transform keyframes are global; the glow

--- a/packages/game-bombsquad/src/modules/wire/WireModule.test.tsx
+++ b/packages/game-bombsquad/src/modules/wire/WireModule.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import WireModule from './WireModule'
+import styles from './WireModule.module.css'
 
 const config = {
   wires: [
@@ -49,6 +50,52 @@ describe('WireModule', () => {
     fireEvent.click(screen.getByTestId('wire-0'))
     expect(onError).toHaveBeenCalledOnce()
     expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('flashes the clicked strand red and keeps it intact on a wrong cut', () => {
+    vi.useFakeTimers()
+    render(
+      <WireModule
+        config={config}
+        answer={answer}
+        onComplete={vi.fn()}
+        onError={vi.fn()}
+        sceneInfo={sceneInfo}
+      />
+    )
+    // answer.cutPosition is 2 — cutting wire 0 is wrong.
+    fireEvent.click(screen.getByTestId('wire-0'))
+    const wrong = screen.getByTestId('strand-0')
+    // Error treatment is applied to the clicked strand...
+    expect(wrong).toHaveClass(styles.strandError)
+    // ...and it stays INTACT (still a strand, not severed into cut halves).
+    expect(wrong).toBeInTheDocument()
+    // A different strand is untouched.
+    expect(screen.getByTestId('strand-1')).not.toHaveClass(styles.strandError)
+    // The error treatment clears when the panel resets to idle (~600ms).
+    act(() => {
+      vi.advanceTimersByTime(600)
+    })
+    expect(screen.getByTestId('strand-0')).not.toHaveClass(styles.strandError)
+    vi.useRealTimers()
+  })
+
+  it('severs the strand and applies no error treatment on a correct cut', () => {
+    render(
+      <WireModule
+        config={config}
+        answer={answer}
+        onComplete={vi.fn()}
+        onError={vi.fn()}
+        sceneInfo={sceneInfo}
+      />
+    )
+    fireEvent.click(screen.getByTestId('wire-2'))
+    // Correct cut severs strand 2 — the intact strand path is gone.
+    expect(screen.queryByTestId('strand-2')).not.toBeInTheDocument()
+    // No strand carries the wrong-cut error treatment.
+    expect(screen.getByTestId('strand-0')).not.toHaveClass(styles.strandError)
+    expect(screen.getByTestId('strand-1')).not.toHaveClass(styles.strandError)
   })
 
   it('renders correct number of wire hit targets', () => {

--- a/packages/game-bombsquad/src/modules/wire/WireModule.tsx
+++ b/packages/game-bombsquad/src/modules/wire/WireModule.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, type CSSProperties } from 'react'
 import type { WireConfig, WireAnswer } from '@shared/manual-schema'
 import type { ModuleProps } from '../types'
 import { playSfx } from '@/audio/useSfx'
@@ -29,6 +29,10 @@ export default function WireModule({
 }: ModuleProps<WireConfig, WireAnswer>) {
   const [state, setState] = useState<WireState>('idle')
   const [cutIndex, setCutIndex] = useState<number | null>(null)
+  // Index of the strand the player cut WRONG — drives a red flash + recoil on
+  // that one strand (the wire stays intact). Cleared on the same ~600ms reset
+  // that returns the panel to 'idle'. Severing is reserved for the correct cut.
+  const [errorIndex, setErrorIndex] = useState<number | null>(null)
 
   const handleClick = useCallback(
     (index: number) => {
@@ -41,11 +45,15 @@ export default function WireModule({
         navigator.vibrate?.(100)
         setTimeout(onComplete, 800)
       } else {
+        setErrorIndex(index)
         setState('error')
         playSfx('module-error')
         navigator.vibrate?.(200)
         onError()
-        setTimeout(() => setState('idle'), 600)
+        setTimeout(() => {
+          setState('idle')
+          setErrorIndex(null)
+        }, 600)
       }
     },
     [state, answer.cutPosition, onComplete, onError]
@@ -77,6 +85,7 @@ export default function WireModule({
             const d = `M 20 ${startY} Q ${midX} ${midY} 280 ${startY}`
             const color = COLOR_MAP[wire.color] ?? '#888'
             const isCut = cutIndex === i
+            const isError = errorIndex === i
 
             return (
               <g key={i}>
@@ -117,10 +126,12 @@ export default function WireModule({
                   <path
                     d={d}
                     stroke={color}
-                    className={styles.strand}
+                    className={`${styles.strand} ${isError ? styles.strandError : ''}`}
+                    style={isError ? ({ '--wire-color': color } as CSSProperties) : undefined}
                     strokeWidth={3}
                     fill="none"
                     strokeLinecap="round"
+                    data-testid={`strand-${i}`}
                   />
                 )}
                 {/* Anchor pins at both ends. */}

--- a/packages/game-bombsquad/src/pages/BombSquadLandingPage.test.tsx
+++ b/packages/game-bombsquad/src/pages/BombSquadLandingPage.test.tsx
@@ -3,8 +3,8 @@
  *
  * Covers the BombSquad game landing page (/bombsquad) — the Atlas
  * star-chart redesign (design_handoff_bombsquad README §6.1):
- *   1. render smoke — planet hero, BOMBSQUAD title, the AI-status eyebrow,
- *      and the daily-countdown card.
+ *   1. render smoke — planet hero, BOMBSQUAD title, the bring-your-own-AI
+ *      eyebrow, and the daily-countdown card.
  *   2. both the 练习 and 每日挑战 CTAs render.
  *   3. the 每日挑战 CTA enters the connect flow as mode=daily.
  *   4. the 练习 CTA enters the connect flow as mode=practice.
@@ -52,8 +52,8 @@ describe('BombSquadLandingPage', () => {
     // Hero copy markers.
     expect(screen.getByText('拆弹小队')).toBeInTheDocument()
     expect(screen.getByText(/人机协作 · 语音拆弹挑战/)).toBeInTheDocument()
-    // AI-status eyebrow.
-    expect(screen.getByText(/AI 已就位 · Claude · 语音模式/)).toBeInTheDocument()
+    // Bring-your-own-AI premise eyebrow (not a status claim).
+    expect(screen.getByText(/自带语音 AI · 支持 Claude/)).toBeInTheDocument()
     // Daily-countdown card — its label plus the mocked countdown digits.
     // The countdown splits the `:` separators into <span> elements, so the
     // digits are loose text nodes — match on the element's full textContent.

--- a/packages/game-bombsquad/src/pages/BombSquadLandingPage.tsx
+++ b/packages/game-bombsquad/src/pages/BombSquadLandingPage.tsx
@@ -24,10 +24,14 @@ export default function BombSquadLandingPage() {
       <Scenery accent="yellow" />
       <div className={styles.stage}>
         <div className={styles.home}>
-          {/* Top strip — AI-status chip + exit-to-platform control. */}
+          {/* Top strip — bring-your-own-AI premise label + exit-to-platform
+              control. This is not a status: the player supplies their own
+              voice AI, so the label invites rather than asserting any AI is
+              connected. Brand-yellow (not green) keeps it a label, not a
+              "ready/online" signal. */}
           <div className={styles.top}>
-            <Eyebrow dot color="var(--green)">
-              AI 已就位 · Claude · 语音模式
+            <Eyebrow dot color="var(--y)">
+              自带语音 AI · 支持 Claude / ChatGPT / Gemini
             </Eyebrow>
             <button
               type="button"

--- a/packages/game-bombsquad/src/pages/ConnectPage.module.css
+++ b/packages/game-bombsquad/src/pages/ConnectPage.module.css
@@ -252,6 +252,53 @@
   color: var(--green);
 }
 
+/* ----------  step-2 voice-mode reminder (passive)  ----------
+   A non-interactive instruction, visually distinct from the actionable
+   copyCard: flat fill, dashed hairline, muted (not yellow) icon, no hover
+   and no pointer. The player performs "切到语音模式" on their own AI; this
+   only reminds — it must not look tappable. */
+.voiceStep {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 16px 20px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px dashed var(--hairline);
+  text-align: left;
+}
+
+.voiceStepIcon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.voiceStepText {
+  flex: 1;
+  min-width: 0;
+}
+
+.voiceStepLabel {
+  font: 500 11px var(--amio-font-mono);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.voiceStepSub {
+  margin-top: 4px;
+  font: 500 15px var(--amio-font-mono);
+  color: rgba(255, 255, 255, 0.5);
+}
+
 .hint {
   margin: 12px 0 0;
   font: 400 13px/1.55 var(--font-body);

--- a/packages/game-bombsquad/src/pages/ConnectPage.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.tsx
@@ -142,7 +142,10 @@ export default function ConnectPage() {
                 <ConicAvatar size={64} letter="AI" ariaHidden />
                 <span className={styles.aiPulse} />
               </div>
-              <div className={styles.visLabel}>Claude</div>
+              {/* BYO-neutral: the player supplies their own voice AI (Claude /
+                  ChatGPT / Gemini / …), so this mirrors "你" rather than naming
+                  one tool. */}
+              <div className={styles.visLabel}>你的 AI</div>
             </div>
           </div>
 
@@ -200,15 +203,15 @@ export default function ConnectPage() {
             </div>
           )}
 
-          {/* Step 2 — switch the AI partner into voice mode, then hand off. */}
+          {/* Step 2 — a passive reminder of the one thing to do on the AI
+              side: switch it to voice mode. Deliberately NOT a button — the
+              UI cannot flip the player's AI into voice mode, so a tappable
+              card here would fake an action the app does not perform. The
+              only real action on this step is the 进入游戏 handoff below. */}
           {step === 2 && (
             <div className={styles.action}>
-              <button type="button" className={styles.copyCard} onClick={confirmStart}>
-                <div className={styles.copyCardText}>
-                  <div className={styles.copyCardLabel}>切到语音模式</div>
-                  <div className={styles.copyCardUrl}>AI 端 → 麦克风</div>
-                </div>
-                <div className={styles.copyCardIcon}>
+              <div className={styles.voiceStep}>
+                <div className={styles.voiceStepIcon} aria-hidden="true">
                   <svg
                     viewBox="0 0 24 24"
                     width="22"
@@ -221,7 +224,11 @@ export default function ConnectPage() {
                     <path d="M5 11 a7 7 0 0 0 14 0 M12 18 V21 M9 21 H15" />
                   </svg>
                 </div>
-              </button>
+                <div className={styles.voiceStepText}>
+                  <div className={styles.voiceStepLabel}>切到语音模式</div>
+                  <div className={styles.voiceStepSub}>AI 端 → 麦克风</div>
+                </div>
+              </div>
               <p className={styles.hint}>这样你描述、AI 回应，全程不用手离开屏幕。</p>
             </div>
           )}

--- a/packages/game-bombsquad/src/pages/GamePage.module.css
+++ b/packages/game-bombsquad/src/pages/GamePage.module.css
@@ -224,12 +224,55 @@
   }
 }
 
+/* Correct-answer feedback — the positive counterpart to .errorPulse. Same
+   panel-framed border + glow, green instead of rose, and a single confident
+   bloom rather than the error's anxious double-pulse. Sits over the module
+   area; the completion overlay blooms in just behind it. */
+.successPulse {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border: 2px solid var(--green);
+  border-radius: var(--radius-2xl);
+  box-shadow:
+    0 0 24px 4px rgba(75, 210, 102, 0.4),
+    inset 0 0 32px 4px rgba(75, 210, 102, 0.24);
+  background: radial-gradient(circle at center, rgba(75, 210, 102, 0.1), transparent 70%);
+  opacity: 0;
+  animation: module-success-pulse 0.55s ease-out;
+}
+
+@keyframes module-success-pulse {
+  0% {
+    opacity: 0;
+  }
+  18% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .errorPulse {
     animation: module-error-pulse-reduced 0.6s ease-out;
   }
 
+  .successPulse {
+    animation: module-success-pulse-reduced 0.55s ease-out;
+  }
+
   .defusedText {
+    animation: none;
+  }
+
+  .defusedBurst {
+    animation: none;
+    opacity: 0;
+  }
+
+  .overlayComplete {
     animation: none;
   }
 
@@ -244,9 +287,39 @@
       opacity: 0;
     }
   }
+
+  @keyframes module-success-pulse-reduced {
+    0% {
+      opacity: 0;
+    }
+    25% {
+      opacity: 0.8;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+}
+
+/* The completion overlay blooms in over ~0.18s instead of snapping, so the
+   green .successPulse on the panel behind it is visible for a beat before the
+   dark layer settles — the win reads as one continuous bloom. */
+.overlayComplete {
+  animation: overlay-bloom 0.18s ease-out;
+}
+
+@keyframes overlay-bloom {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .defusedText {
+  position: relative;
+  z-index: 1;
   font: 400 clamp(2.6rem, 11vw, 4.4rem) var(--font-display);
   font-style: italic;
   color: var(--green);
@@ -264,6 +337,38 @@
   to {
     opacity: 1;
     transform: scale(1);
+  }
+}
+
+/* One-shot radiating ring behind the 拆除成功 text — a soft green pop that
+   reinforces the module-pass payoff without tipping into fanfare. Centred over
+   the overlay (inset:0 + margin:auto). */
+.defusedBurst {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  border: 2px solid var(--green);
+  background: radial-gradient(circle, rgba(75, 210, 102, 0.22), transparent 62%);
+  box-shadow: 0 0 32px rgba(75, 210, 102, 0.35);
+  opacity: 0;
+  pointer-events: none;
+  animation: defused-burst 0.62s cubic-bezier(0.19, 1, 0.22, 1);
+}
+
+@keyframes defused-burst {
+  0% {
+    opacity: 0;
+    transform: scale(0.4);
+  }
+  30% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.5);
   }
 }
 

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -96,6 +96,29 @@ function consumeRefreshBanner(): void {
   refreshBannerConsumed = true
 }
 
+// First-run nudge pointing the player at the scene-info bar. A first-timer
+// often skips reading 暗号/电池/指示灯 to the AI and stalls, so on the first
+// module we surface a one-time, dismissible hint. Persisted in localStorage so
+// it shows once ever, never nagging on later runs. Read defensively — a denied
+// or full localStorage simply means the hint is treated as already seen.
+const SCENE_NUDGE_SEEN_KEY = 'bombsquad:scene-nudge-seen'
+
+function sceneNudgeAlreadySeen(): boolean {
+  try {
+    return localStorage.getItem(SCENE_NUDGE_SEEN_KEY) === '1'
+  } catch {
+    return true
+  }
+}
+
+function markSceneNudgeSeen(): void {
+  try {
+    localStorage.setItem(SCENE_NUDGE_SEEN_KEY, '1')
+  } catch {
+    /* storage unavailable — the in-memory `everSeen` flag still hides it after this run */
+  }
+}
+
 /** Generate a single module's `{ config, answer }` pair by its kind. */
 function generateModuleByKind(
   kind: ModuleKind,
@@ -179,12 +202,35 @@ export default function GamePage() {
   // remounts the pulse element, restarting the CSS animation on every error.
   const [errorPulseKey, setErrorPulseKey] = useState(0)
 
+  // A correct answer gets the positive counterpart: a single green border
+  // bloom over the same module panel, so a win reads at panel level rather
+  // than as the old small text alone. Keyed like the error pulse so it
+  // restarts on each module solved.
+  const [successPulseKey, setSuccessPulseKey] = useState(0)
+
   // Captured once on mount so it stays stable across re-renders. The player
   // can dismiss it; once dismissed it does not reappear for the lifetime of
   // this page (state lives in component memory, intentionally not persisted).
   const [wasRefreshed] = useState<boolean>(detectRefresh)
   const [refreshBannerDismissed, setRefreshBannerDismissed] = useState(false)
   const showRefreshBanner = wasRefreshed && !refreshBannerDismissed
+
+  // First-run scene-info nudge. Captured once on mount so a player who has
+  // seen it before never gets it again; dismissible mid-run. Only shown on the
+  // first module while actively playing, and only until the player advances.
+  const [sceneNudgeEverSeen] = useState<boolean>(sceneNudgeAlreadySeen)
+  const [sceneNudgeDismissed, setSceneNudgeDismissed] = useState(false)
+  const showSceneNudge =
+    !sceneNudgeEverSeen &&
+    !sceneNudgeDismissed &&
+    state.status === 'PLAYING' &&
+    state.currentModuleIndex === 0
+
+  // Mark the nudge seen the moment it first appears, so a future run never
+  // shows it — independent of whether the player dismisses it this run.
+  useEffect(() => {
+    if (showSceneNudge) markSceneNudgeSeen()
+  }, [showSceneNudge])
 
   // Consume the one-shot refresh flag from a commit-phase effect rather than
   // from inside `detectRefresh`. This keeps the detector pure so StrictMode's
@@ -387,6 +433,10 @@ export default function GamePage() {
     // based), and reads state.currentModuleErrorCount. Keeping those in
     // state, not refs, is what makes refresh-resilience possible.
     dispatch({ type: 'MODULE_COMPLETE', moduleType })
+    // Positive panel bloom, mirroring the error pulse. Fires under the
+    // completion overlay's brief fade-in so it reads as the leading edge of
+    // the green payoff.
+    setSuccessPulseKey((key) => key + 1)
   }, [dispatch, state.moduleSequence, state.currentModuleIndex])
 
   const handleExitRun = useCallback(() => {
@@ -561,12 +611,21 @@ export default function GamePage() {
           {renderModule()}
         </div>
         {errorPulseKey > 0 && (
-          <div key={errorPulseKey} className={styles.errorPulse} aria-hidden="true" />
+          <div key={`err-${errorPulseKey}`} className={styles.errorPulse} aria-hidden="true" />
+        )}
+        {successPulseKey > 0 && (
+          <div key={`ok-${successPulseKey}`} className={styles.successPulse} aria-hidden="true" />
         )}
       </div>
 
       <div className={styles.bottomArea}>
-        {state.sceneInfo && <SceneInfoBar sceneInfo={state.sceneInfo} />}
+        {state.sceneInfo && (
+          <SceneInfoBar
+            sceneInfo={state.sceneInfo}
+            showNudge={showSceneNudge}
+            onDismissNudge={() => setSceneNudgeDismissed(true)}
+          />
+        )}
         <ProgressBar
           total={state.moduleSequence.length}
           completed={state.currentModuleIndex}
@@ -575,7 +634,8 @@ export default function GamePage() {
       </div>
 
       {state.status === 'MODULE_COMPLETE' && (
-        <div className={styles.overlay}>
+        <div className={`${styles.overlay} ${styles.overlayComplete}`}>
+          <div className={styles.defusedBurst} aria-hidden="true" />
           <p className={styles.defusedText}>拆除成功</p>
         </div>
       )}

--- a/packages/game-bombsquad/src/pages/ResultPage.feedback.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.feedback.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * ResultPage success-payoff tests — the success screen plays a short rising
+ * sting on entry, the audible half of the success-only celebration. Failure
+ * stays silent (the detonation already played during EXPLODING).
+ *
+ * Setup mirrors ResultPage.outcome.test.tsx: pre-seed sessionStorage with a
+ * finished-game state so GameProvider hydrates straight into a renderable page.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('@/utils/device-fingerprint', () => ({
+  getDeviceId: () => 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee',
+}))
+vi.mock('@shared/leaderboard-api', () => ({
+  submitScore: vi.fn(),
+}))
+vi.mock('@/utils/event-log', () => ({ logEvent: vi.fn() }))
+vi.mock('@/utils/survey', () => ({
+  hasAnsweredSurvey: () => true,
+  markSurveyAnswered: vi.fn(),
+}))
+vi.mock('@/utils/nickname', () => ({
+  NICKNAME_MAX_LENGTH: 20,
+  getStoredNickname: () => '测试玩家',
+  isValidNickname: () => true,
+  setStoredNickname: () => true,
+}))
+vi.mock('@/audio/useSfx', () => ({ playSfx: vi.fn() }))
+
+import ResultPage from './ResultPage'
+import { GameProvider, type GameState, type GameOutcome } from '@/store/game-context'
+import { playSfx } from '@/audio/useSfx'
+
+const PERSISTENCE_KEY = 'bombsquad:game-state:v2'
+
+function finishedState(mode: GameState['mode'], outcome: GameOutcome): GameState {
+  const sequence: GameState['moduleSequence'] =
+    mode === 'daily' ? ['wire', 'dial', 'button', 'keypad'] : ['wire', 'keypad']
+  return {
+    status: 'RESULT',
+    mode,
+    manual: null,
+    manualUrl: null,
+    sceneInfo: null,
+    moduleSequence: sequence,
+    moduleConfigs: sequence.map(() => null),
+    moduleAnswers: sequence.map(() => null),
+    currentModuleIndex: 2,
+    moduleStats: [
+      { moduleType: 'wire', timeMs: 30_000, errorCount: 0 },
+      { moduleType: 'keypad', timeMs: 40_000, errorCount: 0 },
+    ],
+    totalStartTime: 1_700_000_000_000,
+    totalEndTime: 1_700_000_120_000,
+    currentModuleStartTime: null,
+    currentModuleErrorCount: 0,
+    strikeCount: 0,
+    timeBudgetMs: mode === 'daily' ? 600_000 : 300_000,
+    outcome,
+    errorMessage: null,
+    errorKind: null,
+    attemptNumber: 1,
+    rngSeed: 42,
+  }
+}
+
+function renderResult(state: GameState) {
+  sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(state))
+  return render(
+    <MemoryRouter initialEntries={['/bombsquad/result']}>
+      <GameProvider>
+        <ResultPage />
+      </GameProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('ResultPage success payoff', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.mocked(playSfx).mockReset()
+  })
+
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('plays the success sting on a cleared run', () => {
+    renderResult(finishedState('practice', 'practice-cleared'))
+    expect(playSfx).toHaveBeenCalledWith('result-success')
+    expect(playSfx).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays silent on a failed run', () => {
+    renderResult(finishedState('practice', 'practice-timeout'))
+    expect(playSfx).not.toHaveBeenCalled()
+  })
+})

--- a/packages/game-bombsquad/src/pages/ResultPage.module.css
+++ b/packages/game-bombsquad/src/pages/ResultPage.module.css
@@ -75,6 +75,55 @@
   filter: drop-shadow(0 0 28px rgba(255, 107, 157, 0.55));
 }
 
+/* Success-only entry payoff. A one-shot radiating ring + a spring scale-pop on
+   the glyph give the win an arrival beat the (still, calm) failure screen
+   never gets — so success reads as distinct by motion + sound, not just color.
+   Both play once on mount; the breathing halo on .burst::before continues
+   underneath. */
+.successRing {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  border: 2px solid var(--green);
+  box-shadow: 0 0 28px rgba(75, 210, 102, 0.4);
+  opacity: 0;
+  pointer-events: none;
+  animation: result-ring 0.9s cubic-bezier(0.19, 1, 0.22, 1);
+}
+
+@keyframes result-ring {
+  0% {
+    opacity: 0.8;
+    transform: scale(0.45);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.7);
+  }
+}
+
+.result[data-variant='success'] .burstGlyphEnter {
+  animation: result-glyph-pop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes result-glyph-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.12);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 /* ----------  heading + time  ---------- */
 .heading {
   margin: 0;
@@ -340,6 +389,15 @@
 
 @media (prefers-reduced-motion: reduce) {
   .burst::before {
+    animation: none;
+  }
+
+  .successRing {
+    animation: none;
+    opacity: 0;
+  }
+
+  .burstGlyphEnter {
     animation: none;
   }
 }

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -15,6 +15,7 @@ import { saveOptimisticEntry } from '@shared/leaderboard-optimistic'
 import { getStoredNickname } from '@/utils/nickname'
 import { buildRetroQuestions } from '@/utils/retro-questions'
 import { hasAnsweredSurvey, markSurveyAnswered } from '@/utils/survey'
+import { playSfx } from '@/audio/useSfx'
 import type { ScoreSubmission, ScoreSubmissionResponse } from '@shared/leaderboard-types'
 import styles from './ResultPage.module.css'
 
@@ -91,6 +92,21 @@ export default function ResultPage() {
   // game-modes rework added the `outcome` field.
   const outcome: GameOutcome = state.outcome ?? 'defused'
   const variant = resultVariant(outcome)
+
+  // True only when ResultPage was opened with no run in memory at all (distinct
+  // from a finished run that solved zero modules — that still carries an
+  // outcome). Gates both the "暂无数据" fallback and the success payoff below.
+  const noRunData = state.moduleStats.length === 0 && state.outcome === null
+
+  // Success sting on entry — a short, restrained rising chime that marks the
+  // arrival, the audible half of the success-only payoff. Failure stays silent
+  // (the detonation already played during the EXPLODING animation). Silent-fail
+  // when audio is unavailable or muted. Mount-once; StrictMode double-fires it
+  // in dev only, like the reducer's logEvent calls.
+  useEffect(() => {
+    if (variant === 'success' && !noRunData) playSfx('result-success')
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const totalMs =
     state.totalStartTime !== null && state.totalEndTime !== null
@@ -317,7 +333,7 @@ ${retroQuestions}`
 
   // No game in memory at all — distinct from a finished run that solved zero
   // modules (an exploded run, which still carries an `outcome`).
-  if (state.moduleStats.length === 0 && state.outcome === null) {
+  if (noRunData) {
     return (
       <main className={styles.page}>
         <Scenery accent="yellow" />
@@ -356,12 +372,15 @@ ${retroQuestions}`
       <div className={styles.stage}>
         <div className={styles.result} data-variant={variant}>
           <div className={styles.burst}>
+            {variant === 'success' && <span className={styles.successRing} aria-hidden="true" />}
             <Glyph
               name={burstGlyph}
               size={variant === 'success' ? 88 : 92}
               glow={false}
               color={accentColor}
-              className={styles.burstGlyph}
+              className={`${styles.burstGlyph} ${
+                variant === 'success' ? styles.burstGlyphEnter : ''
+              }`}
             />
           </div>
 


### PR DESCRIPTION
## Summary

- **Clearing a module / finishing a run finally feels rewarding.** module-success is a distinct two-note rising chime (was a near-twin of the error thunk) + a green bloom on the panel and the just-filled progress segment; the result screen celebrates a win with a glyph burst + rising sting, distinct from the calm failure screen; a correct in-run answer flashes a green panel pulse at parity with the red error pulse. All restrained, dark-only, CSS-only, `prefers-reduced-motion`-gated.
- **Honest setup copy + a first-run nudge.** Landing chip "AI 已就位 · Claude" → "自带语音 AI · 支持 Claude / ChatGPT / Gemini"; the fake "switch to voice" step is now a passive reminder; the AI-avatar label is "你的 AI" not a hardcoded "Claude"; and a one-time dismissible hint points first-timers at the scene-info bar to read out to their AI.
- **Test harness:** `tapByLabel` keeps its fast path but waits (bounded 8s) for a late-rendering target before throwing — fixes a pre-existing race on the READY "开始" button.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing + new tests pass: game-bombsquad 260, manual 45, platform 9, api 41, yijing 21; full e2e 23/23 (flaky practice scenario re-run 8/8); e2e:audit 14↔14; typecheck + build + format + lint clean
- [x] New tests added (audio preset shape, result-page success sting, scene-nudge behavior)
- [ ] **Final acceptance is a real play-test on this PR's preview** — the *feel* (chime pleasantness, restraint, pulse visibility) is subjective and not unit-testable; merge is gated on that play-test.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated (CHANGELOG)
- [x] Breaking changes documented if any — none (presentation-only + honest copy + test-harness robustness)

## Notes

- This is wave-2 of `fix-bombsquad-to-invitable-quality` (wave-1 = the AI-manual rebuild, merged in #110). The timer low-time tick escalation (B-P1-5) was deliberately held out of this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)