### PR TITLE
fix(api,game-bombsquad): accept legit daily inter-module gaps; surface real submit errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Your daily-challenge time now makes it onto the leaderboard** — Finishing
+the daily challenge and entering your name used to fail for many players with
+a misleading "submission failed (you may be offline)" message, even on a
+solid connection — so a clean run never showed a rank. Submissions now go
+through, and you see where your time lands. When a submission really is
+refused for another reason, the result screen tells you that plainly instead
+of blaming your network, and keeps the retry button handy.
+
 **Your AI partner stops inventing a dial it can't see** — On the symbol
 dial, your AI used to talk about a pointer or a clock face and ask you to
 turn every dial to "12 o'clock" — a mechanic the game never had — then

--- a/packages/api/src/validation.test.ts
+++ b/packages/api/src/validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { validateEvent } from './validation'
+import { validateEvent, validateSubmission } from './validation'
+import type { ScoreSubmission } from '../../../shared/leaderboard-types'
 
 // A valid UUID v4 — `validateEvent` checks the canonical 36-char shape.
 const VALID_DEVICE_ID = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee'
@@ -37,5 +38,79 @@ describe('validateEvent — event-name whitelist', () => {
     const result = validateEvent(eventPayload('game_failed_meltdown'))
     expect(result.ok).toBe(false)
     expect(result.error).toBe('Unknown event name')
+  })
+})
+
+// Build a structurally-valid daily submission whose wall-clock `time_ms` is
+// offset from the module-time sum by `offsetMs`. Four module times sum to a
+// fixed S; `time_ms = S + offsetMs`. A positive offset over-reports (the honest
+// direction — transitions); a negative offset under-reports (the cheat
+// direction). The date is "today" so it lands inside the today-or-yesterday
+// window the validator enforces.
+function dailySubmission(offsetMs: number): ScoreSubmission {
+  const moduleTimes = [40_000, 35_000, 30_000, 25_000] // sum S = 130_000 ms
+  const moduleSum = moduleTimes.reduce((a, b) => a + b, 0)
+  return {
+    date: new Date().toISOString().slice(0, 10),
+    nickname: 'tester',
+    time_ms: moduleSum + offsetMs,
+    attempt_number: 1,
+    module_times: moduleTimes,
+    operations_hash: 'mvp-placeholder',
+    device_id: VALID_DEVICE_ID,
+  }
+}
+
+describe('validateSubmission — module-sum tolerance', () => {
+  // Regression for the daily-submit-422 bug: a real daily run's wall-clock
+  // `time_ms` exceeds the module-time sum by ~2400ms (three ~800ms inter-module
+  // transitions counted in wall-clock but in no module). Under the old fixed
+  // 2000ms tolerance this legitimate submission was rejected with
+  // "Module times do not match total time"; the scaling tolerance accepts it.
+  it('accepts a legitimate daily run with ~2400ms of inter-module transitions', () => {
+    expect(validateSubmission(dailySubmission(2_400))).toEqual({ ok: true })
+  })
+
+  // Anti-cheat is preserved: an overshoot far beyond the legitimate transition
+  // budget (here +30s) is still rejected.
+  it('rejects a tampered run whose total far exceeds the legitimate overshoot', () => {
+    const result = validateSubmission(dailySubmission(30_000))
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('Module times do not match total time')
+  })
+
+  // The high-side boundary is strict: an overshoot exactly at the upper bound
+  // passes. upperBound = BASE_MARGIN (2000) + PER_TRANSITION_SLACK (800) × 3 = 4400ms.
+  it('accepts an overshoot exactly at the high-side boundary', () => {
+    expect(validateSubmission(dailySubmission(4_400))).toEqual({ ok: true })
+  })
+
+  it('rejects an overshoot one millisecond past the high-side boundary', () => {
+    const result = validateSubmission(dailySubmission(4_401))
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('Module times do not match total time')
+  })
+
+  // Anti-cheat on the LOW side. The leaderboard ranks by ascending time_ms, so a
+  // cheater under-reports time_ms relative to their module sum to climb. The
+  // low-side window is kept tight at BASE_MARGIN (2000ms) — it is NOT widened by
+  // the transition slack, because under-reporting has no legitimate cause. This
+  // is the case that the old symmetric `Math.abs(...) > tolerance` check let
+  // through once the high-side budget grew to 4400ms.
+  it('rejects an under-reported time_ms that the symmetric tolerance would have allowed', () => {
+    // -4400 is inside the old symmetric ±4400 band but outside the -2000 low bound.
+    const result = validateSubmission(dailySubmission(-4_400))
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('Module times do not match total time')
+  })
+
+  it('accepts an under-report exactly at the low-side boundary', () => {
+    expect(validateSubmission(dailySubmission(-2_000))).toEqual({ ok: true })
+  })
+
+  it('rejects an under-report one millisecond past the low-side boundary', () => {
+    const result = validateSubmission(dailySubmission(-2_001))
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('Module times do not match total time')
   })
 })

--- a/packages/api/src/validation.ts
+++ b/packages/api/src/validation.ts
@@ -1,9 +1,21 @@
 import type { ScoreSubmission } from '../../../shared/leaderboard-types'
 import type { EventName, EventPayload } from '../../../shared/event-types'
+import { MODULE_ADVANCE_DELAY_MS } from '../../../shared/game-timing'
 
 const MIN_GAME_TIME_MS = 15_000 // 15 seconds minimum — reject obvious cheats
 const MAX_GAME_TIME_MS = 3_600_000 // 1 hour max
 const MAX_NICKNAME_LEN = 20
+
+// Module-sum tolerance. The wall-clock `time_ms` is always ≥ the sum of the
+// per-module times because each MODULE_COMPLETE → NEXT_MODULE transition adds a
+// wall-clock gap (MODULE_ADVANCE_DELAY_MS) that is not attributed to any module.
+// A run with N modules has (N − 1) such gaps, so the legitimate overshoot scales
+// with the module count rather than being a fixed budget. BASE_MARGIN absorbs
+// timing jitter (clock resolution, the brief render/dispatch latency around each
+// stamp). PER_TRANSITION_SLACK_MS is the per-gap allowance — pinned to the real
+// frontend auto-advance delay via the shared constant so the two never drift.
+const MODULE_SUM_BASE_MARGIN_MS = 2_000
+const PER_TRANSITION_SLACK_MS = MODULE_ADVANCE_DELAY_MS
 
 const VALID_EVENT_NAMES: ReadonlySet<EventName> = new Set<EventName>([
   'game_start',
@@ -45,10 +57,29 @@ export function validateSubmission(submission: ScoreSubmission): ValidationResul
     return fail('Invalid date — must be today or yesterday')
   }
 
-  // Module times must sum to ≈ total time (within 2 seconds)
+  // Module times must sum to ≈ total time, but the allowed window is ASYMMETRIC.
+  // Honest play always has wall-clock `time_ms` ≥ sum(module_times): the only
+  // wall-clock not attributed to a module is the inter-module transition gap,
+  // and that is strictly positive. So `diff = time_ms − moduleSum` is normally
+  // ≥ 0, growing by PER_TRANSITION_SLACK_MS per transition.
+  //
+  //   - High side (positive diff): the legitimate overshoot. Allow up to
+  //     BASE_MARGIN jitter + PER_TRANSITION_SLACK_MS × (n − 1) transitions.
+  //   - Low side (negative diff): a player UNDER-reporting time_ms relative to
+  //     their module sum has no legitimate cause — and since the leaderboard
+  //     ranks by ascending time_ms, under-reporting is exactly how one would
+  //     cheat for a better rank. Keep this side tight at BASE_MARGIN (the same
+  //     2000ms the original symmetric check enforced), so widening the high
+  //     side to cover transitions does not open a low-side cheat window.
+  //
+  // Boundaries stay strict (`diff` exactly at either bound still passes) and the
+  // check still only runs for a length-4 module_times array.
   if (Array.isArray(submission.module_times) && submission.module_times.length === 4) {
     const moduleSum = submission.module_times.reduce((a, b) => a + b, 0)
-    if (Math.abs(moduleSum - submission.time_ms) > 2_000) {
+    const diff = submission.time_ms - moduleSum
+    const upperBound =
+      MODULE_SUM_BASE_MARGIN_MS + PER_TRANSITION_SLACK_MS * (submission.module_times.length - 1)
+    if (diff < -MODULE_SUM_BASE_MARGIN_MS || diff > upperBound) {
       return fail('Module times do not match total time')
     }
   }

--- a/packages/game-bombsquad/src/game-flow.test.tsx
+++ b/packages/game-bombsquad/src/game-flow.test.tsx
@@ -51,7 +51,7 @@ vi.mock('./modules/keypad/KeypadModule', () => ({
 }))
 
 vi.mock('@shared/leaderboard-api', () => ({
-  submitScore: vi.fn().mockResolvedValue({ rank: 5, total_players: 100 }),
+  submitScore: vi.fn().mockResolvedValue({ ok: true, data: { rank: 5, total_players: 100 } }),
   fetchLeaderboard: vi.fn().mockResolvedValue({ date: '2026-03-16', entries: [] }),
 }))
 

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/utils/yaml-loader'
 import { logEvent } from '@/utils/event-log'
 import { formatMs } from '@shared/format-time'
+import { MODULE_ADVANCE_DELAY_MS } from '@shared/game-timing'
 import { generateWire } from '@/modules/wire/generator'
 import { generateDial } from '@/modules/dial/generator'
 import { generateButton } from '@/modules/button/generator'
@@ -397,12 +398,14 @@ export default function GamePage() {
     }
   }, [state.status, navigate])
 
-  // Auto-advance from MODULE_COMPLETE after 800ms
+  // Auto-advance from MODULE_COMPLETE after the inter-module transition delay.
+  // The constant is shared with the score validator (@shared/game-timing) so
+  // the server-side module-sum tolerance stays in step with this wall-clock gap.
   useEffect(() => {
     if (state.status !== 'MODULE_COMPLETE') return
     const timeout = setTimeout(() => {
       dispatch({ type: 'NEXT_MODULE' })
-    }, 800)
+    }, MODULE_ADVANCE_DELAY_MS)
     return () => clearTimeout(timeout)
   }, [state.status, dispatch])
 

--- a/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
@@ -130,7 +130,7 @@ describe('ResultPage nickname gate', () => {
     installFakeLocalStorage()
     sessionStorage.clear()
     mockedSubmit.mockReset()
-    mockedSubmit.mockResolvedValue({ rank: 5, total_players: 100 })
+    mockedSubmit.mockResolvedValue({ ok: true, data: { rank: 5, total_players: 100 } })
   })
 
   afterEach(() => {

--- a/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
@@ -118,7 +118,7 @@ describe('ResultPage endgame survey', () => {
     surveyMock.hasAnsweredSurvey.mockReset()
     surveyMock.markSurveyAnswered.mockReset()
     vi.mocked(submitScore).mockReset()
-    vi.mocked(submitScore).mockResolvedValue({ rank: 5, total_players: 100 })
+    vi.mocked(submitScore).mockResolvedValue({ ok: true, data: { rank: 5, total_players: 100 } })
   })
 
   afterEach(() => {

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -9,7 +9,7 @@ import { getTodayString } from '@shared/date'
 import { getDeviceId } from '@/utils/device-fingerprint'
 import { logEvent } from '@/utils/event-log'
 import { formatMs } from '@shared/format-time'
-import { submitScore } from '@shared/leaderboard-api'
+import { submitScore, type SubmitScoreResult } from '@shared/leaderboard-api'
 import { saveOptimisticEntry } from '@shared/leaderboard-optimistic'
 import { getStoredNickname } from '@/utils/nickname'
 import { hasAnsweredSurvey, markSurveyAnswered } from '@/utils/survey'
@@ -69,6 +69,10 @@ export default function ResultPage() {
   const [rankResult, setRankResult] = useState<ScoreSubmissionResponse | null>(null)
   const [submitFailed, setSubmitFailed] = useState(false)
   const [retried, setRetried] = useState(false)
+  // Distinguishes a server-side validation rejection from a network failure so
+  // the failure copy can be honest. `null` while no failure is showing.
+  const [submitFailKind, setSubmitFailKind] = useState<'network' | 'rejected' | null>(null)
+  const [submitFailMessage, setSubmitFailMessage] = useState<string | null>(null)
 
   // Fall back to `defused` for any legacy RESULT state persisted before the
   // game-modes rework added the `outcome` field.
@@ -156,6 +160,32 @@ export default function ResultPage() {
     []
   )
 
+  // Applies a submission outcome to UI state. Centralizes the three-way mapping
+  // (success / network failure / server rejection) so the mount, modal-confirm,
+  // and retry paths stay in lockstep.
+  const applySubmitResult = useCallback(
+    (submission: ScoreSubmission, result: SubmitScoreResult) => {
+      setSubmitting(false)
+      if (result.ok) {
+        setSubmitFailed(false)
+        setSubmitFailKind(null)
+        setSubmitFailMessage(null)
+        setRankResult(result.data)
+        recordOptimistic(submission, result.data)
+        try {
+          sessionStorage.removeItem(`pending-score:${submission.date}`)
+        } catch {
+          /* ignore */
+        }
+      } else {
+        setSubmitFailed(true)
+        setSubmitFailKind(result.kind)
+        setSubmitFailMessage(result.kind === 'rejected' ? (result.error ?? null) : null)
+      }
+    },
+    [recordOptimistic]
+  )
+
   // Fires the actual submission. Callers own `submitting` toggles — the mount
   // path relies on the lazy `useState` initializer above to start truthy, and
   // the modal-confirm path flips it on synchronously before calling here.
@@ -173,22 +203,9 @@ export default function ResultPage() {
         /* storage full */
       }
 
-      submitScore(submission).then((result) => {
-        setSubmitting(false)
-        if (result) {
-          setRankResult(result)
-          recordOptimistic(submission, result)
-          try {
-            sessionStorage.removeItem(`pending-score:${submission.date}`)
-          } catch {
-            /* ignore */
-          }
-        } else {
-          setSubmitFailed(true)
-        }
-      })
+      submitScore(submission).then((result) => applySubmitResult(submission, result))
     },
-    [buildSubmission, recordOptimistic]
+    [buildSubmission, applySubmitResult]
   )
 
   // Submit score on mount when a nickname is already known (returning daily
@@ -235,27 +252,16 @@ export default function ResultPage() {
     if (nickname === null) return
     setRetried(true)
     setSubmitFailed(false)
+    setSubmitFailKind(null)
+    setSubmitFailMessage(null)
     setSubmitting(true)
     const submission = buildSubmission(nickname)
     if (!submission) {
       setSubmitting(false)
       return
     }
-    submitScore(submission).then((result) => {
-      setSubmitting(false)
-      if (result) {
-        setRankResult(result)
-        recordOptimistic(submission, result)
-        try {
-          sessionStorage.removeItem(`pending-score:${submission.date}`)
-        } catch {
-          /* ignore */
-        }
-      } else {
-        setSubmitFailed(true)
-      }
-    })
-  }, [buildSubmission, recordOptimistic, nickname])
+    submitScore(submission).then((result) => applySubmitResult(submission, result))
+  }, [buildSubmission, applySubmitResult, nickname])
 
   const handlePlayAgain = () => {
     // Emit BEFORE the RESET so we still capture the just-finished run's mode
@@ -356,7 +362,26 @@ export default function ResultPage() {
                     {!nicknamePending &&
                       !submitting &&
                       submitFailed &&
-                      (retried ? (
+                      (submitFailKind === 'rejected' ? (
+                        // Server reached and refused — not an offline state.
+                        // Retry once for transient refusals (e.g. rate limit);
+                        // a persistent rejection points the player at feedback.
+                        retried ? (
+                          <>
+                            成绩未能通过校验，暂时无法上榜。
+                            {submitFailMessage ? `（${submitFailMessage}）` : ''}
+                            可邮件反馈 byheaven0912@gmail.com
+                          </>
+                        ) : (
+                          <>
+                            成绩校验未通过
+                            {submitFailMessage ? `（${submitFailMessage}）` : ''}
+                            <button className={styles.retryBtn} onClick={handleRetrySubmit}>
+                              重试
+                            </button>
+                          </>
+                        )
+                      ) : retried ? (
                         '网络不稳定，可下次再来重新提交。或邮件反馈 byheaven0912@gmail.com'
                       ) : (
                         <>

--- a/shared/game-timing.ts
+++ b/shared/game-timing.ts
@@ -1,0 +1,20 @@
+// Timing constants shared between the game frontend and the server-side score
+// validator. Keeping them here as a single source of truth prevents the two
+// sides from drifting: the frontend uses MODULE_ADVANCE_DELAY_MS to pace the
+// inter-module transition, and the validator uses the same value to size its
+// module-sum tolerance.
+
+/**
+ * Delay between solving one module and the next module becoming playable.
+ *
+ * During this window the run sits in MODULE_COMPLETE before NEXT_MODULE fires.
+ * The time is wall-clock — it counts toward `time_ms` (totalEndTime −
+ * totalStartTime) but is NOT attributed to any module's `timeMs`. With N
+ * modules there are (N − 1) such transitions, so a clean run's wall-clock total
+ * exceeds the sum of module times by roughly (N − 1) × MODULE_ADVANCE_DELAY_MS.
+ *
+ * Consumed by:
+ * - packages/game-bombsquad/src/pages/GamePage.tsx (MODULE_COMPLETE → NEXT_MODULE auto-advance)
+ * - packages/api/src/validation.ts (module-sum tolerance derivation)
+ */
+export const MODULE_ADVANCE_DELAY_MS = 800

--- a/shared/leaderboard-api.ts
+++ b/shared/leaderboard-api.ts
@@ -6,19 +6,51 @@ import type {
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? 'https://claw.amio.fans'
 
-export async function submitScore(
-  submission: ScoreSubmission
-): Promise<ScoreSubmissionResponse | null> {
+/**
+ * Outcome of a score submission, discriminated on `ok` so callers can tell a
+ * server-side validation rejection apart from a network failure. A `rejected`
+ * result means the request reached the server and was refused (e.g. 422 from
+ * `validateSubmission`, 429 rate limit); the player's run is fine and the copy
+ * should NOT imply they are offline. A `network` result means the request never
+ * completed (fetch threw) or its body could not be parsed — that is the only
+ * case where "可能离线" is accurate.
+ */
+export type SubmitScoreResult =
+  | { ok: true; data: ScoreSubmissionResponse }
+  | { ok: false; kind: 'network' }
+  | { ok: false; kind: 'rejected'; status: number; error?: string }
+
+export async function submitScore(submission: ScoreSubmission): Promise<SubmitScoreResult> {
+  let res: Response
   try {
-    const res = await fetch(`${API_BASE}/api/leaderboard`, {
+    res = await fetch(`${API_BASE}/api/leaderboard`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(submission),
     })
-    if (!res.ok) return null
-    return res.json() as Promise<ScoreSubmissionResponse>
   } catch {
-    return null // network failure — result page shows without rank
+    return { ok: false, kind: 'network' } // request never completed
+  }
+
+  if (!res.ok) {
+    // Server reached and refused. Surface its error message when present so the
+    // UI can show a real reason instead of an "offline" guess.
+    let error: string | undefined
+    try {
+      const body = (await res.json()) as { error?: string }
+      error = typeof body.error === 'string' ? body.error : undefined
+    } catch {
+      /* body absent or not JSON — leave error undefined */
+    }
+    return { ok: false, kind: 'rejected', status: res.status, error }
+  }
+
+  try {
+    const data = (await res.json()) as ScoreSubmissionResponse
+    return { ok: true, data }
+  } catch {
+    // 2xx but the success body did not parse — treat as a network-class failure.
+    return { ok: false, kind: 'network' }
   }
 }
 


### PR DESCRIPTION
## Summary

- **Fixes daily leaderboard "提交失败（可能离线）"** — the real cause was a backend validation false-positive, **not CORS**. The deployed game already POSTs same-origin to `claw.amio.fans` (verified: live bundle has 0 references to `bombsquad.amio.fans`, same-origin preflight returns 204 + CORS, backend POST is healthy).
- A daily run's wall-clock `time_ms` exceeds `sum(module_times)` by ~2400ms (three fixed ~800ms `MODULE_COMPLETE → NEXT_MODULE` auto-advance gaps, counted in wall-clock but not in any module timer), exceeding the fixed **2000ms** module-sum tolerance → 422 "Module times do not match total time". `submitScore` collapsed every non-2xx into `null`, which `ResultPage` rendered as an offline error. Practice (2 modules = 1 gap) stays under tolerance and never submits, so only the daily challenge failed.
- **Module-sum tolerance is now an asymmetric band**: the legitimate (high) side scales as `BASE_MARGIN + PER_TRANSITION_SLACK × (n−1)` (= 4400ms for 4 modules) to cover transitions; the cheat (low / under-report) side stays tight at `BASE_MARGIN` (2000ms), so anti-cheat is not weakened.
- `MODULE_ADVANCE_DELAY_MS` (800ms) hoisted to `shared/game-timing.ts` as a single source of truth, consumed by both `GamePage` and the validator to prevent drift.
- `submitScore` now returns a discriminated result; `ResultPage` shows a real "成绩校验未通过" message on rejection and reserves the offline copy for true network failures.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

`pnpm -r test:run` → 374 passed (api 48, game-bombsquad 245, others). `pnpm typecheck` → 0 errors. `pnpm lint` → 0 errors. `pnpm build` → all packages built + Pages assets assembled. Regression proven fail→pass on both directions (legit +2400/+4400 accepted; under-report −4400/−2001 and +30s tamper rejected). Final real-play verification (user completes the daily challenge and submits) happens after deploy.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

🤖 Generated with [Claude Code](https://claude.com/claude-code)
