### PR TITLE
feat(leaderboard): collect AI metadata with daily scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ It's now a clean three-prong trident: three separate spikes on a crossbar with
 a handle running down. Describe what you see and your AI lands on the right
 symbol the first time.
 
+**Leaderboard rows now remember who you played with** — When you clear the
+daily challenge, the result screen now asks which AI assistant helped you and
+lets you add an optional model name. Your leaderboard row shows that AI context
+next to your time, so friends can compare Claude / ChatGPT / Gemini + model
+runs instead of just names. Chinese nicknames also survive the save path now,
+so names like 小明 stay visible instead of turning into Anonymous.
+
 **Your AI partner now calls the modules by the names you see** — The manual
 used to name the puzzles by old internal labels, so when you said "光弦" or
 "星符" your AI had never heard of them and stalled on your very first sentence.

--- a/e2e/add-leaderboard-ai-metadata.gherkin
+++ b/e2e/add-leaderboard-ai-metadata.gherkin
@@ -1,0 +1,34 @@
+# Leaderboard AI metadata — the score row keeps the player-facing context that
+# matters for comparing daily runs: who played, which AI assistant helped, and
+# which model was used when the player knows it.
+
+Feature: Leaderboard AI metadata
+  As a BombSquad daily player
+  I want my leaderboard score to carry the AI assistant and model I used
+  So that leaderboard rows compare runs with their AI context intact
+
+  Background:
+    Given my viewport width is 375 pixels
+    And I open /
+
+  # Source: leaderboard-ai-metadata
+  @playwright
+  Scenario: A first daily win submits and displays Chinese nickname AI metadata
+    Given I have just defused the bomb in a daily run and the result page is open
+    And no nickname is stored on this device
+    And no leaderboard AI metadata is stored on this device
+    Then the NicknameModal is open and covers the screen
+    And the NicknameModal has no close button and cannot be dismissed by tapping the backdrop
+
+    When I type the Chinese nickname "小明" into the NicknameModal input
+    And I choose AI assistant "Claude"
+    And I type AI model "Claude Sonnet 4.5"
+    And I tap "确认"
+    Then the NicknameModal closes
+    And the leaderboard submission carries nickname "小明", AI assistant "claude", and model "Claude Sonnet 4.5"
+
+    When I tap "回主页"
+    Then I am back on the BombSquad landing page
+    When I tap "排行榜"
+    Then the URL path is /leaderboard
+    And the leaderboard table shows a row with nickname "小明" and AI metadata "Claude · Claude Sonnet 4.5"

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -21,9 +21,9 @@
 #
 # --- Regression size budget --------------------------------------------------
 # Per the governance model (rule 3): the e2e regression suite is capped at
-# 2 x the journey-scenario count. With 13 active flows <-> 13 journey
-# scenarios, the regression size budget is 26 (2026-06-03, after the
-# result-to-recap flow was deprecated by the endgame-settlement rework).
+# 2 x the journey-scenario count. With 14 active flows <-> 14 journey
+# scenarios, the regression size budget is 28 (2026-06-06, after the
+# leaderboard AI metadata flow was added).
 # Crossing it triggers a forced prune audit. Current regression count: 2.
 #
 # --- Retired scenario --------------------------------------------------------
@@ -61,6 +61,15 @@ flows:
       first submission, posts the score, and the player navigates to the
       leaderboard to find their own row.
     steps: [result-win, nickname-modal, score-submit, global-rank, leaderboard]
+    status: active
+
+  - id: leaderboard-ai-metadata
+    name: Leaderboard AI metadata
+    description: >-
+      After a first daily win the result page collects the player nickname,
+      required AI assistant, and optional model, submits them with the score,
+      and the leaderboard row displays the Chinese nickname and AI metadata.
+    steps: [result-win, nickname-modal, ai-metadata, score-submit, leaderboard]
     status: active
 
   - id: daily-fail-strikeout

--- a/e2e/mobile-beta-flow.gherkin
+++ b/e2e/mobile-beta-flow.gherkin
@@ -1,7 +1,8 @@
 # Mobile internal-beta — the daily win-to-leaderboard path a friend follows on
-# their phone: a defused daily run -> /bombsquad/result recap -> NicknameModal -> score
-# submission -> /leaderboard ranking. Daily mode is used deliberately so the
-# NicknameModal and the leaderboard segment are exercised.
+# their phone: a defused daily run -> /bombsquad/result recap -> PostGameModal
+# nickname + AI metadata gate -> score submission -> /leaderboard ranking.
+# Daily mode is used deliberately so the modal and the leaderboard segment are
+# exercised.
 #
 # Restructured for the e2e harness: each scenario carries a per-scenario
 # flow-source comment tracing to e2e/flow-inventory.yaml plus a consumption-layer
@@ -39,6 +40,7 @@ Feature: Mobile internal-beta daily win to leaderboard
     And the NicknameModal has no close button and cannot be dismissed by tapping the backdrop
 
     When I type a nickname into the NicknameModal input
+    And I choose AI assistant "Claude"
     And I tap "确认"
     Then the NicknameModal closes
     And the result page shows my global rank

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -75,6 +75,7 @@ interface LeaderboardEntry {
   time_ms: number
   attempt_number: number
   ai_tool?: string
+  ai_model?: string
 }
 interface LeaderboardGetResponse {
   date: string

--- a/e2e/steps/result.steps.ts
+++ b/e2e/steps/result.steps.ts
@@ -5,6 +5,9 @@ import { Given, When, Then } from './fixtures'
 /** Stable test nickname — no '你' so it is not flagged as the "you" row. */
 const E2E_NICKNAME = 'E2ERunner'
 
+/** Stable test AI assistant for leaderboard-gated e2e submissions. */
+const E2E_AI_ASSISTANT_LABEL = 'Claude'
+
 /** Nickname injected by the regression leaderboard scenario. */
 let regressionNickname = ''
 
@@ -44,6 +47,15 @@ Given('no nickname is stored on this device', async ({ page }) => {
   expect(stored).toBeNull()
 })
 
+Given('no leaderboard AI metadata is stored on this device', async ({ page }) => {
+  const stored = await page.evaluate(() => ({
+    tool: localStorage.getItem('bombsquad-leaderboard-ai-tool'),
+    model: localStorage.getItem('bombsquad-leaderboard-ai-model'),
+  }))
+  expect(stored.tool).toBeNull()
+  expect(stored.model).toBeNull()
+})
+
 Then('I see the total run time', async ({ page }) => {
   const total = page.locator('[class*="totalTime"]').first()
   await expect(total).toBeVisible()
@@ -78,7 +90,25 @@ Then(
 )
 
 When('I type a nickname into the NicknameModal input', async ({ page }) => {
-  await page.getByRole('dialog').getByRole('textbox').fill(E2E_NICKNAME)
+  await page.getByRole('dialog').getByRole('textbox', { name: '昵称' }).fill(E2E_NICKNAME)
+})
+
+When(
+  'I type the Chinese nickname {string} into the NicknameModal input',
+  async ({ page }, nickname: string) => {
+    await page.getByRole('dialog').getByRole('textbox', { name: '昵称' }).fill(nickname)
+  }
+)
+
+When('I choose AI assistant {string}', async ({ page }, assistant: string) => {
+  await page.getByRole('dialog').getByRole('button', { name: assistant, exact: true }).click()
+})
+
+When('I type AI model {string}', async ({ page }, model: string) => {
+  await page
+    .getByRole('dialog')
+    .getByRole('textbox', { name: /具体模型/ })
+    .fill(model)
 })
 
 Then('the NicknameModal closes', async ({ page }) => {
@@ -119,13 +149,39 @@ Then('the leaderboard submission carries a plausible time', async ({ world, page
   if (world.leaderboard.submissions.length === 0) {
     const dialog = page.getByRole('dialog')
     if ((await dialog.count()) > 0 && (await dialog.getByRole('textbox').count()) > 0) {
-      await dialog.getByRole('textbox').fill(E2E_NICKNAME)
+      await dialog.getByRole('textbox', { name: '昵称' }).fill(E2E_NICKNAME)
+      const assistant = dialog.getByRole('button', { name: E2E_AI_ASSISTANT_LABEL, exact: true })
+      if ((await assistant.count()) > 0) {
+        await assistant.click()
+      }
       await dialog.getByRole('button', { name: '确认' }).click()
     }
     await expect.poll(() => world.leaderboard.submissions.length).toBeGreaterThan(0)
   }
   assertPlausibleSubmission(world.leaderboard.submissions.at(-1))
 })
+
+Then(
+  'the leaderboard submission carries nickname {string}, AI assistant {string}, and model {string}',
+  async ({ world }, nickname: string, aiTool: string, aiModel: string) => {
+    const submission = world.leaderboard.submissions.at(-1)
+    assertPlausibleSubmission(submission)
+    expect(submission).toMatchObject({
+      nickname,
+      ai_tool: aiTool,
+      ai_model: aiModel,
+    })
+  }
+)
+
+Then(
+  'the leaderboard table shows a row with nickname {string} and AI metadata {string}',
+  async ({ page }, nickname: string, metadata: string) => {
+    const row = page.getByRole('row').filter({ hasText: nickname })
+    await expect(row).toHaveCount(1)
+    await expect(row).toContainText(metadata)
+  }
+)
 
 // --- Voice-AI compatibility page ---------------------------------------------
 

--- a/packages/api/src/handlers/post-score.test.ts
+++ b/packages/api/src/handlers/post-score.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import type { LeaderboardEntry, ScoreSubmission } from '../../../../shared/leaderboard-types'
+import { handlePostScore } from './post-score'
+
+const VALID_DEVICE_ID = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee'
+
+class FakeKV {
+  private readonly store = new Map<string, string>()
+
+  async get(key: string, type?: 'json'): Promise<unknown> {
+    const value = this.store.get(key)
+    if (value === undefined) return null
+    return type === 'json' ? JSON.parse(value) : value
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    this.store.set(key, value)
+  }
+}
+
+function submission(overrides: Partial<ScoreSubmission> = {}): ScoreSubmission {
+  const moduleTimes = [40_000, 35_000, 30_000, 25_000]
+  return {
+    date: new Date().toISOString().slice(0, 10),
+    nickname: '小明',
+    time_ms: moduleTimes.reduce((a, b) => a + b, 0),
+    attempt_number: 1,
+    module_times: moduleTimes,
+    operations_hash: 'mvp-placeholder',
+    ai_tool: 'claude',
+    device_id: VALID_DEVICE_ID,
+    ...overrides,
+  }
+}
+
+function request(body: unknown): Request {
+  return new Request('https://claw.amio.fans/api/leaderboard', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('handlePostScore — leaderboard AI metadata', () => {
+  it('stores Chinese nicknames and sanitized AI metadata', async () => {
+    const kv = new FakeKV()
+    const response = await handlePostScore(
+      request(
+        submission({
+          nickname: '<b>小明✨</b>',
+          ai_tool: 'Claude✨',
+          ai_model: '  Claude Sonnet 4.5✨  ',
+        })
+      ),
+      kv as unknown as KVNamespace
+    )
+
+    expect(response.status).toBe(200)
+    const entries = (await kv.get(
+      `leaderboard:${new Date().toISOString().slice(0, 10)}`,
+      'json'
+    )) as LeaderboardEntry[] | null
+    expect(entries?.[0]).toMatchObject({
+      nickname: '小明',
+      ai_tool: 'Claude',
+      ai_model: 'Claude Sonnet 4.5',
+    })
+  })
+
+  it('omits blank optional model text instead of storing an empty string', async () => {
+    const kv = new FakeKV()
+    const response = await handlePostScore(
+      request(submission({ ai_tool: 'Gemini', ai_model: '   ' })),
+      kv as unknown as KVNamespace
+    )
+
+    expect(response.status).toBe(200)
+    const entries = (await kv.get(
+      `leaderboard:${new Date().toISOString().slice(0, 10)}`,
+      'json'
+    )) as LeaderboardEntry[] | null
+    expect(entries?.[0]).toMatchObject({ ai_tool: 'Gemini' })
+    expect(entries?.[0]).not.toHaveProperty('ai_model')
+  })
+
+  it('keeps legacy rows readable while adding new metadata rows', async () => {
+    const kv = new FakeKV()
+    const date = new Date().toISOString().slice(0, 10)
+    await kv.put(
+      `leaderboard:${date}`,
+      JSON.stringify([{ rank: 1, nickname: 'Legacy', time_ms: 150_000, attempt_number: 1 }])
+    )
+
+    const response = await handlePostScore(
+      request(submission({ time_ms: 130_000, ai_tool: 'chatgpt' })),
+      kv as unknown as KVNamespace
+    )
+
+    expect(response.status).toBe(200)
+    const entries = (await kv.get(`leaderboard:${date}`, 'json')) as LeaderboardEntry[] | null
+    expect(entries).toEqual([
+      expect.objectContaining({ rank: 1, nickname: '小明', ai_tool: 'chatgpt' }),
+      expect.objectContaining({ rank: 2, nickname: 'Legacy' }),
+    ])
+  })
+})

--- a/packages/api/src/handlers/post-score.ts
+++ b/packages/api/src/handlers/post-score.ts
@@ -4,7 +4,13 @@ import type {
   ScoreSubmissionResponse,
 } from '../../../../shared/leaderboard-types'
 import { computeBestRecord, type BestRecord } from '../../../../shared/personal-best'
-import { validateSubmission, sanitizeNickname } from '../validation'
+import {
+  MAX_AI_MODEL_LEN,
+  MAX_AI_TOOL_LEN,
+  sanitizeLeaderboardText,
+  sanitizeNickname,
+  validateSubmission,
+} from '../validation'
 
 const RATE_LIMIT_MS = 10_000
 const MAX_ENTRIES = 100
@@ -53,8 +59,12 @@ export async function handlePostScore(request: Request, kv: KVNamespace): Promis
     nickname: sanitizeNickname(body.nickname),
     time_ms: body.time_ms,
     attempt_number: body.attempt_number,
-    ai_tool: body.ai_tool,
+    ai_tool: sanitizeLeaderboardText(body.ai_tool, MAX_AI_TOOL_LEN),
   }
+  const aiModel = body.ai_model
+    ? sanitizeLeaderboardText(body.ai_model, MAX_AI_MODEL_LEN)
+    : undefined
+  if (aiModel) newEntry.ai_model = aiModel
 
   const updated = [...existing, newEntry]
     .sort((a, b) => a.time_ms - b.time_ms)

--- a/packages/api/src/validation.test.ts
+++ b/packages/api/src/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { validateEvent, validateSubmission } from './validation'
+import { sanitizeNickname, validateEvent, validateSubmission } from './validation'
 import type { ScoreSubmission } from '../../../shared/leaderboard-types'
 
 // A valid UUID v4 — `validateEvent` checks the canonical 36-char shape.
@@ -57,6 +57,7 @@ function dailySubmission(offsetMs: number): ScoreSubmission {
     attempt_number: 1,
     module_times: moduleTimes,
     operations_hash: 'mvp-placeholder',
+    ai_tool: 'claude',
     device_id: VALID_DEVICE_ID,
   }
 }
@@ -112,5 +113,40 @@ describe('validateSubmission — module-sum tolerance', () => {
     const result = validateSubmission(dailySubmission(-2_001))
     expect(result.ok).toBe(false)
     expect(result.error).toBe('Module times do not match total time')
+  })
+})
+
+describe('validateSubmission — leaderboard AI metadata', () => {
+  it('requires ai_tool on new score submissions', () => {
+    const { ai_tool: _aiTool, ...submission } = dailySubmission(0)
+    const result = validateSubmission(submission as ScoreSubmission)
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('Invalid ai_tool')
+  })
+
+  it('rejects a blank ai_tool after sanitization', () => {
+    const result = validateSubmission({ ...dailySubmission(0), ai_tool: '  <b></b>  ' })
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('Invalid ai_tool')
+  })
+
+  it('accepts an omitted optional ai_model', () => {
+    expect(validateSubmission(dailySubmission(0))).toEqual({ ok: true })
+  })
+
+  it('accepts a blank optional ai_model so the write path can omit it', () => {
+    expect(validateSubmission({ ...dailySubmission(0), ai_model: '  <b></b>  ' })).toEqual({
+      ok: true,
+    })
+  })
+})
+
+describe('sanitizeNickname', () => {
+  it('preserves Chinese letters while stripping markup and emoji', () => {
+    expect(sanitizeNickname('<b>小明_42✨</b>')).toBe('小明_42')
+  })
+
+  it('falls back to Anonymous when no display-safe characters remain', () => {
+    expect(sanitizeNickname('✨🔥')).toBe('Anonymous')
   })
 })

--- a/packages/api/src/validation.ts
+++ b/packages/api/src/validation.ts
@@ -5,6 +5,8 @@ import { MODULE_ADVANCE_DELAY_MS } from '../../../shared/game-timing'
 const MIN_GAME_TIME_MS = 15_000 // 15 seconds minimum — reject obvious cheats
 const MAX_GAME_TIME_MS = 3_600_000 // 1 hour max
 const MAX_NICKNAME_LEN = 20
+export const MAX_AI_TOOL_LEN = 40
+export const MAX_AI_MODEL_LEN = 80
 
 // Module-sum tolerance. The wall-clock `time_ms` is always ≥ the sum of the
 // per-module times because each MODULE_COMPLETE → NEXT_MODULE transition adds a
@@ -46,6 +48,13 @@ export function validateSubmission(submission: ScoreSubmission): ValidationResul
   if (typeof submission.date !== 'string') return fail('Invalid date')
   if (typeof submission.device_id !== 'string') return fail('Invalid device_id')
   if (typeof submission.nickname !== 'string') return fail('Invalid nickname')
+  if (typeof submission.ai_tool !== 'string') return fail('Invalid ai_tool')
+  if (sanitizeLeaderboardText(submission.ai_tool, MAX_AI_TOOL_LEN).length === 0) {
+    return fail('Invalid ai_tool')
+  }
+  if (submission.ai_model !== undefined && typeof submission.ai_model !== 'string') {
+    return fail('Invalid ai_model')
+  }
 
   if (submission.time_ms < MIN_GAME_TIME_MS) return fail('Time too short — minimum 15 seconds')
   if (submission.time_ms > MAX_GAME_TIME_MS) return fail('Time exceeds maximum')
@@ -102,12 +111,23 @@ export function sanitizeNickname(raw: string): string {
     stripped = stripped.replace(/<[^>]*>/g, '')
   } while (stripped !== prev)
 
-  return (
-    stripped
-      .replace(/[^\w\s\-_.!?]/g, '') // allow alphanumeric + safe punctuation
-      .trim()
-      .slice(0, MAX_NICKNAME_LEN) || 'Anonymous'
-  )
+  return sanitizeLeaderboardText(stripped, MAX_NICKNAME_LEN) || 'Anonymous'
+}
+
+export function sanitizeLeaderboardText(raw: string, maxLength: number): string {
+  // Strip HTML tags iteratively. Keep Unicode letters/numbers (including CJK)
+  // plus a small punctuation set that is safe in plain text leaderboard rows.
+  let stripped = raw
+  let prev: string
+  do {
+    prev = stripped
+    stripped = stripped.replace(/<[^>]*>/g, '')
+  } while (stripped !== prev)
+
+  return stripped
+    .replace(/[^\p{L}\p{N}\s\-_.!?]/gu, '')
+    .trim()
+    .slice(0, maxLength)
 }
 
 function fail(error: string): ValidationResult {

--- a/packages/game-bombsquad/src/components/PostGameModal.tsx
+++ b/packages/game-bombsquad/src/components/PostGameModal.tsx
@@ -1,11 +1,18 @@
 import { useEffect, useId, useState, type FormEvent } from 'react'
 import type { SurveyAnswers } from '@shared/event-types'
 import { NICKNAME_MAX_LENGTH, isValidNickname, setStoredNickname } from '@/utils/nickname'
+import {
+  LEADERBOARD_AI_MODEL_MAX_LENGTH,
+  LEADERBOARD_AI_TOOL_MAX_LENGTH,
+  type LeaderboardPlayerMetadata,
+  isValidLeaderboardAiTool,
+  normalizeLeaderboardAiModel,
+  setStoredLeaderboardPlayerMetadata,
+} from '@/utils/leaderboard-player-metadata'
 import Button from '@/components/bombsquad/Button'
 import styles from './PostGameModal.module.css'
 
 /** Hard caps mirroring the `survey_submit` wire contract (data payload ≤ 1KB). */
-const AI_TOOL_MAX_LENGTH = 40
 const AI_ISSUE_MAX_LENGTH = 200
 
 /** Q1 — single-select AI tool. `other` reveals a free-text input. */
@@ -34,6 +41,7 @@ type DifficultyValue = SurveyAnswers['difficulty']
  */
 export interface PostGameModalResult {
   nickname?: string
+  leaderboardMetadata?: LeaderboardPlayerMetadata
   survey?: SurveyAnswers
 }
 
@@ -45,6 +53,11 @@ interface PostGameModalProps {
    * because a daily score cannot post without a nickname.
    */
   showNickname: boolean
+  /**
+   * Render the leaderboard AI metadata section. When true, AI tool is required
+   * and gates confirm; model is optional and omitted when blank.
+   */
+  showLeaderboardMetadata?: boolean
   /** Render the 4-question survey section. */
   showSurvey: boolean
   /**
@@ -75,6 +88,7 @@ interface PostGameModalProps {
 export default function PostGameModal({
   open,
   showNickname,
+  showLeaderboardMetadata = false,
   showSurvey,
   onConfirm,
   onSkip,
@@ -86,6 +100,8 @@ export default function PostGameModal({
   // Survey section state. Empty string / 0 / null mean "not yet answered".
   const [aiTool, setAiTool] = useState<string>('')
   const [aiToolOther, setAiToolOther] = useState('')
+  const [aiModel, setAiModel] = useState('')
+  const [leaderboardMetadataError, setLeaderboardMetadataError] = useState<string | null>(null)
   const [fun, setFun] = useState(0)
   const [difficulty, setDifficulty] = useState<DifficultyValue | null>(null)
   const [aiIssue, setAiIssue] = useState('')
@@ -93,13 +109,14 @@ export default function PostGameModal({
   const baseId = useId()
   const titleId = `${baseId}-title`
   const nicknameTipId = `${baseId}-nickname-tip`
+  const leaderboardMetadataTipId = `${baseId}-leaderboard-metadata-tip`
   const q1Id = `${baseId}-q1`
   const q2Id = `${baseId}-q2`
   const q3Id = `${baseId}-q3`
   const q4Id = `${baseId}-q4`
 
-  // Non-dismissable whenever the nickname gate is present.
-  const dismissable = showSurvey && !showNickname
+  // Non-dismissable whenever a leaderboard submission gate is present.
+  const dismissable = showSurvey && !showNickname && !showLeaderboardMetadata
 
   // Esc closes a survey-only modal. Registered before the early return so the
   // hook order stays stable across renders.
@@ -117,7 +134,12 @@ export default function PostGameModal({
   const trimmedNickname = nickname.trim()
   const nicknameOk = !showNickname || isValidNickname(nickname)
 
-  const aiToolOk = aiTool !== '' && (aiTool !== 'other' || aiToolOther.trim().length > 0)
+  const resolvedAiTool = (aiTool === 'other' ? aiToolOther.trim() : aiTool).slice(
+    0,
+    LEADERBOARD_AI_TOOL_MAX_LENGTH
+  )
+  const aiToolOk = isValidLeaderboardAiTool(resolvedAiTool)
+  const leaderboardMetadataOk = !showLeaderboardMetadata || aiToolOk
   // The survey is "complete" only when all three required questions (Q1/Q2/Q3)
   // are answered; Q4 is always optional.
   const surveyComplete = aiToolOk && fun >= 1 && difficulty !== null
@@ -126,7 +148,7 @@ export default function PostGameModal({
   // the survey-only modal — which always offers a separate skip affordance
   // anyway. Whenever the nickname section is present, confirm needs only a
   // valid nickname; a partially-filled survey is dropped silently on confirm.
-  const canConfirm = nicknameOk && (dismissable ? surveyComplete : true)
+  const canConfirm = nicknameOk && leaderboardMetadataOk && (dismissable ? surveyComplete : true)
 
   const handleConfirm = () => {
     if (!canConfirm) return
@@ -142,14 +164,24 @@ export default function PostGameModal({
       result.nickname = trimmedNickname
     }
 
+    if (showLeaderboardMetadata) {
+      const metadata: LeaderboardPlayerMetadata = {
+        aiTool: resolvedAiTool,
+      }
+      const resolvedAiModel = normalizeLeaderboardAiModel(aiModel)
+      if (resolvedAiModel) metadata.aiModel = resolvedAiModel
+      const ok = setStoredLeaderboardPlayerMetadata(metadata)
+      if (!ok) {
+        setLeaderboardMetadataError('保存失败，请重试。')
+        return
+      }
+      result.leaderboardMetadata = metadata
+    }
+
     // Emit survey answers only when the survey section was shown AND fully
     // answered. Confirming a merged modal with an untouched/partial survey
     // simply omits `result.survey` — no `survey_submit` fires for it.
     if (showSurvey && surveyComplete) {
-      const resolvedAiTool = (aiTool === 'other' ? aiToolOther.trim() : aiTool).slice(
-        0,
-        AI_TOOL_MAX_LENGTH
-      )
       const survey: SurveyAnswers = {
         ai_tool: resolvedAiTool,
         fun,
@@ -161,6 +193,7 @@ export default function PostGameModal({
     }
 
     setNicknameError(null)
+    setLeaderboardMetadataError(null)
     onConfirm(result)
   }
 
@@ -186,7 +219,11 @@ export default function PostGameModal({
         )}
 
         <h2 id={titleId} className={styles.title}>
-          {showNickname ? '给自己起个名字' : '聊聊这一局'}
+          {showNickname
+            ? '给自己起个名字'
+            : showLeaderboardMetadata
+              ? '记录你的 AI 搭档'
+              : '聊聊这一局'}
         </h2>
 
         <form className={styles.form} onSubmit={handleSubmit}>
@@ -222,17 +259,15 @@ export default function PostGameModal({
             </section>
           )}
 
-          {showNickname && showSurvey && <hr className={styles.divider} />}
+          {showNickname && (showLeaderboardMetadata || showSurvey) && (
+            <hr className={styles.divider} />
+          )}
 
-          {showSurvey && (
+          {showLeaderboardMetadata && (
             <section className={styles.section}>
-              {showNickname && (
-                <p className={styles.surveyIntro}>
-                  顺便聊聊这一局 —— 以下问卷选填，想跳过直接点「确认」即可。
-                </p>
-              )}
-
-              {/* Q1 — AI tool */}
+              <p id={leaderboardMetadataTipId} className={styles.tip}>
+                排行榜需要记录你这局使用的 AI 助手；具体模型选填。
+              </p>
               <fieldset className={styles.question}>
                 <legend id={q1Id} className={styles.questionLabel}>
                   你这局用的是哪个 AI 工具？
@@ -246,7 +281,10 @@ export default function PostGameModal({
                         aiTool === opt.value ? styles.optionSelected : ''
                       }`}
                       aria-pressed={aiTool === opt.value}
-                      onClick={() => setAiTool(opt.value)}
+                      onClick={() => {
+                        setAiTool(opt.value)
+                        if (leaderboardMetadataError) setLeaderboardMetadataError(null)
+                      }}
                     >
                       {opt.label}
                     </button>
@@ -257,13 +295,83 @@ export default function PostGameModal({
                     className={styles.input}
                     type="text"
                     value={aiToolOther}
-                    onChange={(e) => setAiToolOther(e.target.value)}
-                    maxLength={AI_TOOL_MAX_LENGTH}
+                    onChange={(e) => {
+                      setAiToolOther(e.target.value)
+                      if (leaderboardMetadataError) setLeaderboardMetadataError(null)
+                    }}
+                    maxLength={LEADERBOARD_AI_TOOL_MAX_LENGTH}
                     placeholder="请填写工具名称"
                     aria-label="其他 AI 工具名称"
                   />
                 )}
               </fieldset>
+              <label className={styles.label}>
+                <span className={styles.labelText}>具体模型（选填）</span>
+                <input
+                  className={styles.input}
+                  type="text"
+                  value={aiModel}
+                  onChange={(e) => setAiModel(e.target.value)}
+                  maxLength={LEADERBOARD_AI_MODEL_MAX_LENGTH}
+                  placeholder="例如：Claude Sonnet 4.5"
+                />
+              </label>
+              <div className={styles.meta}>
+                <span className={styles.counter} aria-live="polite">
+                  {aiModel.trim().length} / {LEADERBOARD_AI_MODEL_MAX_LENGTH}
+                </span>
+                {leaderboardMetadataError && (
+                  <span className={styles.error} role="alert">
+                    {leaderboardMetadataError}
+                  </span>
+                )}
+              </div>
+            </section>
+          )}
+
+          {showLeaderboardMetadata && showSurvey && <hr className={styles.divider} />}
+
+          {showSurvey && (
+            <section className={styles.section}>
+              {showNickname && (
+                <p className={styles.surveyIntro}>
+                  顺便聊聊这一局 —— 以下问卷选填，想跳过直接点「确认」即可。
+                </p>
+              )}
+
+              {!showLeaderboardMetadata && (
+                <fieldset className={styles.question}>
+                  <legend id={q1Id} className={styles.questionLabel}>
+                    你这局用的是哪个 AI 工具？
+                  </legend>
+                  <div className={styles.options}>
+                    {AI_TOOL_OPTIONS.map((opt) => (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        className={`${styles.optionBtn} ${
+                          aiTool === opt.value ? styles.optionSelected : ''
+                        }`}
+                        aria-pressed={aiTool === opt.value}
+                        onClick={() => setAiTool(opt.value)}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                  {aiTool === 'other' && (
+                    <input
+                      className={styles.input}
+                      type="text"
+                      value={aiToolOther}
+                      onChange={(e) => setAiToolOther(e.target.value)}
+                      maxLength={LEADERBOARD_AI_TOOL_MAX_LENGTH}
+                      placeholder="请填写工具名称"
+                      aria-label="其他 AI 工具名称"
+                    />
+                  )}
+                </fieldset>
+              )}
 
               {/* Q2 — fun rating */}
               <fieldset className={styles.question}>

--- a/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
@@ -4,9 +4,10 @@
  * Covers the three branches of the daily-mode submission flow:
  *   1. First-visit daily run, localStorage empty → PostGameModal renders the
  *      nickname section, the score is NOT submitted, and submission only fires
- *      after the player types a valid nickname and confirms.
- *   2. Returning daily run, localStorage already has a nickname → no modal,
- *      the score is submitted immediately with the cached nickname.
+ *      after the player types a valid nickname, chooses an AI tool, and
+ *      confirms.
+ *   2. Returning daily run, localStorage already has nickname + AI metadata
+ *      → no modal, the score is submitted immediately with cached values.
  *   3. Practice mode → no modal, no submit (practice never posts a score).
  *
  * Setup mirrors `ResultPage.test.tsx`: pre-seed sessionStorage with a finished
@@ -52,6 +53,7 @@ import { GameProvider, type GameState } from '@/store/game-context'
 
 const PERSISTENCE_KEY = 'bombsquad:game-state:v3'
 const NICKNAME_KEY = 'bombsquad-nickname'
+const AI_TOOL_KEY = 'bombsquad-leaderboard-ai-tool'
 
 const mockedSubmit = vi.mocked(submitScore)
 
@@ -147,7 +149,7 @@ describe('ResultPage nickname gate', () => {
     expect(screen.getByRole('dialog', { name: /给自己起个名字/ })).toBeInTheDocument()
     expect(mockedSubmit).not.toHaveBeenCalled()
 
-    // The confirm button is disabled until a valid nickname is typed.
+    // The confirm button is disabled until a valid nickname and AI tool are set.
     const confirmBtn = screen.getByRole('button', { name: /^确认$/ })
     expect(confirmBtn).toBeDisabled()
 
@@ -156,6 +158,9 @@ describe('ResultPage nickname gate', () => {
     expect(confirmBtn).toBeDisabled() // whitespace-only stays disabled
 
     fireEvent.change(input, { target: { value: '小明' } })
+    expect(confirmBtn).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Claude' }))
     expect(confirmBtn).toBeEnabled()
     fireEvent.click(confirmBtn)
 
@@ -163,6 +168,7 @@ describe('ResultPage nickname gate', () => {
     await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(1))
     expect(mockedSubmit.mock.calls[0][0]).toMatchObject({
       nickname: '小明',
+      ai_tool: 'claude',
       device_id: STUB_DEVICE_ID,
     })
 
@@ -171,8 +177,9 @@ describe('ResultPage nickname gate', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  it('returning daily run: cached nickname → modal does not render, submit fires immediately', async () => {
+  it('returning daily run: cached nickname and AI metadata → submit fires immediately', async () => {
     localStorage.setItem(NICKNAME_KEY, '小红')
+    localStorage.setItem(AI_TOOL_KEY, 'chatgpt')
     sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedDailyState()))
 
     renderResultPage()
@@ -181,6 +188,7 @@ describe('ResultPage nickname gate', () => {
     await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(1))
     expect(mockedSubmit.mock.calls[0][0]).toMatchObject({
       nickname: '小红',
+      ai_tool: 'chatgpt',
       device_id: STUB_DEVICE_ID,
     })
   })

--- a/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
@@ -47,6 +47,25 @@ vi.mock('@/utils/nickname', () => ({
     typeof value === 'string' && value.trim().length > 0 && value.trim().length <= 20,
 }))
 
+vi.mock('@/utils/leaderboard-player-metadata', () => ({
+  LEADERBOARD_AI_MODEL_MAX_LENGTH: 80,
+  LEADERBOARD_AI_TOOL_MAX_LENGTH: 40,
+  getStoredLeaderboardPlayerMetadata: () => null,
+  isValidLeaderboardAiTool: (value: unknown): boolean =>
+    typeof value === 'string' && value.trim().length > 0 && value.trim().length <= 40,
+  normalizeLeaderboardAiModel: (value: unknown): string | undefined => {
+    if (typeof value !== 'string') return undefined
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed.slice(0, 80) : undefined
+  },
+  setStoredLeaderboardPlayerMetadata: (value: unknown): boolean =>
+    typeof value === 'object' &&
+    value !== null &&
+    'aiTool' in value &&
+    typeof (value as { aiTool?: unknown }).aiTool === 'string' &&
+    (value as { aiTool: string }).aiTool.trim().length > 0,
+}))
+
 import ResultPage from './ResultPage'
 import { GameProvider, type GameState, type GameOutcome } from '@/store/game-context'
 import { submitScore } from '@shared/leaderboard-api'
@@ -188,7 +207,7 @@ describe('ResultPage endgame survey', () => {
     expect(screen.getAllByRole('dialog')).toHaveLength(1)
     expect(screen.getByLabelText(/昵称/)).toBeInTheDocument()
     expect(screen.getByText('你这局用的是哪个 AI 工具？')).toBeInTheDocument()
-    // Score is gated behind the nickname while the modal is open.
+    // Score is gated behind the nickname and AI metadata while the modal is open.
     expect(submitScore).not.toHaveBeenCalled()
 
     fireEvent.change(screen.getByLabelText(/昵称/), { target: { value: '小测' } })
@@ -197,7 +216,10 @@ describe('ResultPage endgame survey', () => {
 
     // Nickname path fires the score submission; survey path emits telemetry.
     await waitFor(() => expect(submitScore).toHaveBeenCalledTimes(1))
-    expect(vi.mocked(submitScore).mock.calls[0][0]).toMatchObject({ nickname: '小测' })
+    expect(vi.mocked(submitScore).mock.calls[0][0]).toMatchObject({
+      nickname: '小测',
+      ai_tool: 'claude',
+    })
     expect(logEvent).toHaveBeenCalledWith('survey_submit', {
       ai_tool: 'claude',
       fun: 4,
@@ -207,20 +229,24 @@ describe('ResultPage endgame survey', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  it('merged modal is confirmable with the nickname alone — survey skipped, no survey_submit', async () => {
+  it('merged modal is confirmable with nickname and AI tool — survey skipped, no survey_submit', async () => {
     surveyMock.hasAnsweredSurvey.mockReturnValue(false)
     renderResult(finishedState({ mode: 'daily', outcome: 'defused' }))
 
     expect(screen.getAllByRole('dialog')).toHaveLength(1)
 
-    // Fill only the nickname; leave the whole survey untouched.
+    // Fill only the leaderboard gate; leave the survey-only questions untouched.
     fireEvent.change(screen.getByLabelText(/昵称/), { target: { value: '小测' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Claude' }))
     fireEvent.click(screen.getByRole('button', { name: '确认' }))
 
     // Score still submits, the device is marked answered, but a skipped
     // survey fires no `survey_submit`.
     await waitFor(() => expect(submitScore).toHaveBeenCalledTimes(1))
-    expect(vi.mocked(submitScore).mock.calls[0][0]).toMatchObject({ nickname: '小测' })
+    expect(vi.mocked(submitScore).mock.calls[0][0]).toMatchObject({
+      nickname: '小测',
+      ai_tool: 'claude',
+    })
     expect(logEvent).not.toHaveBeenCalledWith('survey_submit', expect.anything())
     expect(surveyMock.markSurveyAnswered).toHaveBeenCalledTimes(1)
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -12,6 +12,10 @@ import { formatMs } from '@shared/format-time'
 import { submitScore, type SubmitScoreResult } from '@shared/leaderboard-api'
 import { saveOptimisticEntry } from '@shared/leaderboard-optimistic'
 import { getStoredNickname } from '@/utils/nickname'
+import {
+  getStoredLeaderboardPlayerMetadata,
+  type LeaderboardPlayerMetadata,
+} from '@/utils/leaderboard-player-metadata'
 import { hasAnsweredSurvey, markSurveyAnswered } from '@/utils/survey'
 import { playSfx } from '@/audio/useSfx'
 import type { ScoreSubmission, ScoreSubmissionResponse } from '@shared/leaderboard-types'
@@ -112,30 +116,41 @@ export default function ResultPage() {
     state.moduleStats.length > 0
 
   // Lazy initializers: read the stored nickname once on mount. Subsequent
-  // useState calls reuse the captured value so the three pieces of mount
+  // useState calls reuse the captured value so the pieces of mount
   // state stay consistent without triple-reading localStorage.
   const [nickname, setNickname] = useState<string | null>(() => getStoredNickname())
+  const [leaderboardMetadata, setLeaderboardMetadata] = useState<LeaderboardPlayerMetadata | null>(
+    () => getStoredLeaderboardPlayerMetadata()
+  )
 
   // The unified post-game modal composes two optional sections. The nickname
-  // section is the existing daily-leaderboard gate; the survey section is
-  // shown once per device after any outcome. The modal opens when either is
-  // needed — never as two stacked dialogs. Both `need*` flags are captured
-  // once on mount; the modal closes on confirm/skip rather than re-deriving.
+  // and AI metadata sections are the daily-leaderboard gates; the survey
+  // section is shown once per device after any outcome. The modal opens when
+  // any section is needed — never as two stacked dialogs. Both `need*` flags
+  // are captured once on mount; the modal closes on confirm/skip rather than
+  // re-deriving.
   const [needNickname] = useState(() => hasFinishedDailyRun && nickname === null)
+  const [needLeaderboardMetadata] = useState(
+    () => hasFinishedDailyRun && leaderboardMetadata === null
+  )
   const [needSurvey] = useState(() => !hasAnsweredSurvey())
-  const [modalOpen, setModalOpen] = useState(() => needNickname || needSurvey)
+  const [modalOpen, setModalOpen] = useState(
+    () => needNickname || needLeaderboardMetadata || needSurvey
+  )
   // Initialize submitting=true only when the effect below will actually fire a
   // request, so we avoid a synchronous setState in the effect body
   // (react-hooks/set-state-in-effect). First-visit daily runs wait for the
   // modal confirmation before flipping submitting=true.
-  const [submitting, setSubmitting] = useState(() => hasFinishedDailyRun && nickname !== null)
+  const [submitting, setSubmitting] = useState(
+    () => hasFinishedDailyRun && nickname !== null && leaderboardMetadata !== null
+  )
 
-  // The daily score is still gated on the nickname while the modal is open
-  // with the nickname section present.
-  const nicknamePending = needNickname && modalOpen
+  // The daily score is still gated while the modal is open with a leaderboard
+  // submission section present.
+  const leaderboardGatePending = (needNickname || needLeaderboardMetadata) && modalOpen
 
   const buildSubmission = useCallback(
-    (nicknameValue: string): ScoreSubmission | null => {
+    (nicknameValue: string, metadataValue: LeaderboardPlayerMetadata): ScoreSubmission | null => {
       if (totalMs === null) return null
       return {
         date: getTodayString(),
@@ -144,6 +159,8 @@ export default function ResultPage() {
         attempt_number: state.attemptNumber,
         module_times: state.moduleStats.map((s) => Math.round(s.timeMs)),
         operations_hash: 'mvp-placeholder', // temporary placeholder until real run hashing is implemented
+        ai_tool: metadataValue.aiTool,
+        ...(metadataValue.aiModel ? { ai_model: metadataValue.aiModel } : {}),
         device_id: getDeviceId(),
       }
     },
@@ -158,6 +175,7 @@ export default function ResultPage() {
         time_ms: submission.time_ms,
         attempt_number: submission.attempt_number,
         ai_tool: submission.ai_tool,
+        ...(submission.ai_model ? { ai_model: submission.ai_model } : {}),
       })
     },
     []
@@ -195,8 +213,8 @@ export default function ResultPage() {
   // Keeping `setSubmitting(true)` out of this function lets us call it from
   // inside `useEffect` without tripping react-hooks/set-state-in-effect.
   const performSubmission = useCallback(
-    (nicknameValue: string) => {
-      const submission = buildSubmission(nicknameValue)
+    (nicknameValue: string, metadataValue: LeaderboardPlayerMetadata) => {
+      const submission = buildSubmission(nicknameValue, metadataValue)
       if (!submission) return
 
       // Persist locally so a retry can succeed even if user navigates back
@@ -216,7 +234,8 @@ export default function ResultPage() {
   useEffect(() => {
     if (!hasFinishedDailyRun) return
     if (nickname === null) return
-    performSubmission(nickname)
+    if (leaderboardMetadata === null) return
+    performSubmission(nickname, leaderboardMetadata)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -229,8 +248,15 @@ export default function ResultPage() {
     (result: PostGameModalResult) => {
       if (result.nickname !== undefined) {
         setNickname(result.nickname)
+      }
+      if (result.leaderboardMetadata !== undefined) {
+        setLeaderboardMetadata(result.leaderboardMetadata)
+      }
+      const confirmedNickname = result.nickname ?? nickname
+      const confirmedMetadata = result.leaderboardMetadata ?? leaderboardMetadata
+      if (confirmedNickname !== null && confirmedMetadata !== null && hasFinishedDailyRun) {
         setSubmitting(true)
-        performSubmission(result.nickname)
+        performSubmission(confirmedNickname, confirmedMetadata)
       }
       if (result.survey !== undefined) {
         logEvent('survey_submit', { ...result.survey })
@@ -240,7 +266,7 @@ export default function ResultPage() {
       }
       setModalOpen(false)
     },
-    [performSubmission, needSurvey]
+    [performSubmission, needSurvey, nickname, leaderboardMetadata, hasFinishedDailyRun]
   )
 
   // Survey-only dismissal. The device is marked answered so the survey does
@@ -253,18 +279,19 @@ export default function ResultPage() {
 
   const handleRetrySubmit = useCallback(() => {
     if (nickname === null) return
+    if (leaderboardMetadata === null) return
     setRetried(true)
     setSubmitFailed(false)
     setSubmitFailKind(null)
     setSubmitFailMessage(null)
     setSubmitting(true)
-    const submission = buildSubmission(nickname)
+    const submission = buildSubmission(nickname, leaderboardMetadata)
     if (!submission) {
       setSubmitting(false)
       return
     }
     submitScore(submission).then((result) => applySubmitResult(submission, result))
-  }, [buildSubmission, applySubmitResult, nickname])
+  }, [buildSubmission, applySubmitResult, nickname, leaderboardMetadata])
 
   const handlePlayAgain = () => {
     // Emit BEFORE the RESET so we still capture the just-finished run's mode
@@ -360,9 +387,9 @@ export default function ResultPage() {
               ) : (
                 <div className={styles.rankCell}>
                   <div className={styles.rankPending}>
-                    {nicknamePending && '提交前请填写昵称'}
-                    {!nicknamePending && submitting && '提交成绩中…'}
-                    {!nicknamePending &&
+                    {leaderboardGatePending && '提交前请填写昵称和 AI 搭档'}
+                    {!leaderboardGatePending && submitting && '提交成绩中…'}
+                    {!leaderboardGatePending &&
                       !submitting &&
                       submitFailed &&
                       (submitFailKind === 'rejected' ? (
@@ -472,6 +499,7 @@ export default function ResultPage() {
       <PostGameModal
         open={modalOpen}
         showNickname={needNickname}
+        showLeaderboardMetadata={needLeaderboardMetadata}
         showSurvey={needSurvey}
         onConfirm={handleModalConfirm}
         onSkip={handleModalSkip}

--- a/packages/game-bombsquad/src/utils/leaderboard-optimistic.test.ts
+++ b/packages/game-bombsquad/src/utils/leaderboard-optimistic.test.ts
@@ -16,6 +16,7 @@ const baseEntry: LeaderboardEntry = {
   time_ms: 91234,
   attempt_number: 3,
   ai_tool: 'claude',
+  ai_model: 'Sonnet 4.5',
 }
 
 describe('leaderboard-optimistic', () => {

--- a/packages/game-bombsquad/src/utils/leaderboard-player-metadata.test.ts
+++ b/packages/game-bombsquad/src/utils/leaderboard-player-metadata.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  LEADERBOARD_AI_MODEL_MAX_LENGTH,
+  LEADERBOARD_AI_TOOL_MAX_LENGTH,
+  getStoredLeaderboardPlayerMetadata,
+  isValidLeaderboardAiTool,
+  normalizeLeaderboardAiModel,
+  setStoredLeaderboardPlayerMetadata,
+} from './leaderboard-player-metadata'
+
+const AI_TOOL_KEY = 'bombsquad-leaderboard-ai-tool'
+const AI_MODEL_KEY = 'bombsquad-leaderboard-ai-model'
+
+interface FakeLocalStorageOverrides {
+  getItem?: (key: string) => string | null
+  setItem?: (key: string, value: string) => void
+  removeItem?: (key: string) => void
+}
+
+function installFakeLocalStorage(overrides: FakeLocalStorageOverrides = {}) {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem:
+      overrides.getItem ?? ((key: string) => (store.has(key) ? (store.get(key) as string) : null)),
+    setItem:
+      overrides.setItem ??
+      ((key: string, value: string) => {
+        store.set(key, String(value))
+      }),
+    removeItem:
+      overrides.removeItem ??
+      ((key: string) => {
+        store.delete(key)
+      }),
+    clear: () => {
+      store.clear()
+    },
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  })
+  return store
+}
+
+describe('leaderboard player metadata', () => {
+  beforeEach(() => {
+    installFakeLocalStorage()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('requires a non-empty AI tool within the cap', () => {
+    expect(isValidLeaderboardAiTool('Claude')).toBe(true)
+    expect(isValidLeaderboardAiTool('  ChatGPT  ')).toBe(true)
+    expect(isValidLeaderboardAiTool('')).toBe(false)
+    expect(isValidLeaderboardAiTool('   ')).toBe(false)
+    expect(isValidLeaderboardAiTool('a'.repeat(LEADERBOARD_AI_TOOL_MAX_LENGTH + 1))).toBe(false)
+  })
+
+  it('normalizes optional model text and omits blank values', () => {
+    expect(normalizeLeaderboardAiModel('  Claude Sonnet 4.5  ')).toBe('Claude Sonnet 4.5')
+    expect(normalizeLeaderboardAiModel('   ')).toBeUndefined()
+    expect(normalizeLeaderboardAiModel(undefined)).toBeUndefined()
+    expect(
+      normalizeLeaderboardAiModel('a'.repeat(LEADERBOARD_AI_MODEL_MAX_LENGTH + 5))
+    ).toHaveLength(LEADERBOARD_AI_MODEL_MAX_LENGTH)
+  })
+
+  it('stores and reads AI tool plus model', () => {
+    expect(
+      setStoredLeaderboardPlayerMetadata({ aiTool: '  claude  ', aiModel: '  Sonnet 4.5  ' })
+    ).toBe(true)
+    expect(localStorage.getItem(AI_TOOL_KEY)).toBe('claude')
+    expect(localStorage.getItem(AI_MODEL_KEY)).toBe('Sonnet 4.5')
+    expect(getStoredLeaderboardPlayerMetadata()).toEqual({
+      aiTool: 'claude',
+      aiModel: 'Sonnet 4.5',
+    })
+  })
+
+  it('omits the model when it is blank', () => {
+    localStorage.setItem(AI_MODEL_KEY, 'old model')
+    expect(setStoredLeaderboardPlayerMetadata({ aiTool: 'gemini', aiModel: '   ' })).toBe(true)
+    expect(localStorage.getItem(AI_MODEL_KEY)).toBeNull()
+    expect(getStoredLeaderboardPlayerMetadata()).toEqual({ aiTool: 'gemini' })
+  })
+
+  it('returns null when the required AI tool is missing or corrupted', () => {
+    expect(getStoredLeaderboardPlayerMetadata()).toBeNull()
+    localStorage.setItem(AI_TOOL_KEY, 'a'.repeat(LEADERBOARD_AI_TOOL_MAX_LENGTH + 1))
+    expect(getStoredLeaderboardPlayerMetadata()).toBeNull()
+  })
+
+  it('returns false when storage writes fail', () => {
+    installFakeLocalStorage({
+      setItem: () => {
+        throw new Error('QuotaExceededError')
+      },
+    })
+    expect(setStoredLeaderboardPlayerMetadata({ aiTool: 'claude' })).toBe(false)
+  })
+})

--- a/packages/game-bombsquad/src/utils/leaderboard-player-metadata.ts
+++ b/packages/game-bombsquad/src/utils/leaderboard-player-metadata.ts
@@ -1,0 +1,52 @@
+export interface LeaderboardPlayerMetadata {
+  aiTool: string
+  aiModel?: string
+}
+
+const AI_TOOL_KEY = 'bombsquad-leaderboard-ai-tool'
+const AI_MODEL_KEY = 'bombsquad-leaderboard-ai-model'
+
+export const LEADERBOARD_AI_TOOL_MAX_LENGTH = 40
+export const LEADERBOARD_AI_MODEL_MAX_LENGTH = 80
+
+export function isValidLeaderboardAiTool(value: unknown): boolean {
+  if (typeof value !== 'string') return false
+  const trimmed = value.trim()
+  return trimmed.length > 0 && trimmed.length <= LEADERBOARD_AI_TOOL_MAX_LENGTH
+}
+
+export function normalizeLeaderboardAiModel(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return undefined
+  return trimmed.slice(0, LEADERBOARD_AI_MODEL_MAX_LENGTH)
+}
+
+export function getStoredLeaderboardPlayerMetadata(): LeaderboardPlayerMetadata | null {
+  try {
+    const rawAiTool = localStorage.getItem(AI_TOOL_KEY)
+    if (!isValidLeaderboardAiTool(rawAiTool)) return null
+    const aiTool = (rawAiTool as string).trim()
+    const aiModel = normalizeLeaderboardAiModel(localStorage.getItem(AI_MODEL_KEY))
+    return aiModel ? { aiTool, aiModel } : { aiTool }
+  } catch {
+    return null
+  }
+}
+
+export function setStoredLeaderboardPlayerMetadata(metadata: LeaderboardPlayerMetadata): boolean {
+  if (!isValidLeaderboardAiTool(metadata.aiTool)) return false
+  const aiTool = metadata.aiTool.trim()
+  const aiModel = normalizeLeaderboardAiModel(metadata.aiModel)
+  try {
+    localStorage.setItem(AI_TOOL_KEY, aiTool)
+    if (aiModel) {
+      localStorage.setItem(AI_MODEL_KEY, aiModel)
+    } else {
+      localStorage.removeItem(AI_MODEL_KEY)
+    }
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/platform/src/components/leaderboard/DailyLeaderboardList.module.css
+++ b/packages/platform/src/components/leaderboard/DailyLeaderboardList.module.css
@@ -55,10 +55,24 @@
   color: var(--amio-yellow);
 }
 
+.nameCell {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
 .name {
   color: var(--text-1);
   /* Wrap a long no-space nickname instead of widening the track and
      pushing the score column off a narrow viewport. */
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.aiMeta {
+  color: var(--text-3);
+  font: 400 11px var(--font-body);
   overflow-wrap: anywhere;
   word-break: break-word;
 }

--- a/packages/platform/src/components/leaderboard/DailyLeaderboardList.tsx
+++ b/packages/platform/src/components/leaderboard/DailyLeaderboardList.tsx
@@ -17,6 +17,17 @@ function isOptimistic(entry: LeaderboardEntry): entry is OptimisticLeaderboardEn
   return (entry as OptimisticLeaderboardEntry)._justSubmitted === true
 }
 
+function formatAiMetadata(entry: LeaderboardEntry): string | null {
+  if (!entry.ai_tool) return null
+  const toolLabels: Record<string, string> = {
+    claude: 'Claude',
+    chatgpt: 'ChatGPT',
+    gemini: 'Gemini',
+  }
+  const tool = toolLabels[entry.ai_tool] ?? entry.ai_tool
+  return entry.ai_model ? `${tool} · ${entry.ai_model}` : tool
+}
+
 /* The Atlas grid-row list — a CSS-grid table (not a <table>) carrying ARIA
    roles so the structure stays test-queryable: container role="table", a
    header role="row" with role="columnheader" cells, each entry role="row"
@@ -34,6 +45,7 @@ export function LeaderboardRows({ entries }: { entries: LeaderboardEntry[] }) {
       </div>
       {entries.map((row) => {
         const isYou = row.nickname.includes('你')
+        const aiMetadata = formatAiMetadata(row)
         const rowClass = [
           styles.row,
           row.rank <= 3 ? styles.rowTop : '',
@@ -51,8 +63,9 @@ export function LeaderboardRows({ entries }: { entries: LeaderboardEntry[] }) {
             <span className={styles.rank} role="cell">
               #{String(row.rank).padStart(3, '0')}
             </span>
-            <span className={styles.name} role="cell">
-              {row.nickname}
+            <span className={styles.nameCell} role="cell">
+              <span className={styles.name}>{row.nickname}</span>
+              {aiMetadata && <span className={styles.aiMeta}>{aiMetadata}</span>}
             </span>
             <span className={styles.score} role="cell">
               {formatMs(row.time_ms)} · {row.attempt_number} 次

--- a/packages/platform/src/pages/LeaderboardPage.test.tsx
+++ b/packages/platform/src/pages/LeaderboardPage.test.tsx
@@ -57,6 +57,7 @@ describe('LeaderboardPage optimistic flow', () => {
       time_ms: 91234,
       attempt_number: 3,
       ai_tool: 'claude',
+      ai_model: 'Sonnet 4.5',
     })
 
     // GET returns the cached (pre-submission) leaderboard — optimistic entry
@@ -80,6 +81,7 @@ describe('LeaderboardPage optimistic flow', () => {
     const bodyRows = screen.getAllByRole('row').slice(1)
     expect(bodyRows[0]).toHaveTextContent('Alpha')
     expect(bodyRows[1]).toHaveTextContent('Anonymous')
+    expect(bodyRows[1]).toHaveTextContent('Claude · Sonnet 4.5')
     expect(bodyRows[1]).toHaveAttribute('data-just-submitted', 'true')
     expect(bodyRows[2]).toHaveTextContent('Beta')
 
@@ -140,5 +142,26 @@ describe('LeaderboardPage optimistic flow', () => {
     bodyRows.forEach((row) => {
       expect(row).not.toHaveAttribute('data-just-submitted')
     })
+  })
+
+  it('renders AI metadata when present and keeps legacy rows readable', async () => {
+    const today = getTodayString()
+    mockedFetch.mockResolvedValueOnce({
+      date: today,
+      entries: [
+        { rank: 1, nickname: '小明', time_ms: 80000, attempt_number: 1, ai_tool: 'chatgpt' },
+        { rank: 2, nickname: 'Legacy', time_ms: 110000, attempt_number: 1 },
+      ],
+    })
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('小明')).toBeInTheDocument()
+    })
+    const bodyRows = screen.getAllByRole('row').slice(1)
+    expect(bodyRows[0]).toHaveTextContent('ChatGPT')
+    expect(bodyRows[1]).toHaveTextContent('Legacy')
+    expect(bodyRows[1]).not.toHaveTextContent('ChatGPT')
   })
 })

--- a/shared/leaderboard-types.ts
+++ b/shared/leaderboard-types.ts
@@ -5,7 +5,8 @@ export interface ScoreSubmission {
   attempt_number: number // which attempt this was today
   module_times: number[] // time per module in ms (length 4)
   operations_hash: string // SHA-256 of operation log for post-hoc verification
-  ai_tool?: string // optional: 'claude' | 'chatgpt' | 'gemini' | string
+  ai_tool: string // required: 'claude' | 'chatgpt' | 'gemini' | string
+  ai_model?: string // optional concrete model/version, omitted when blank
   device_id: string // UUID from localStorage
 }
 
@@ -25,6 +26,7 @@ export interface LeaderboardEntry {
   time_ms: number
   attempt_number: number
   ai_tool?: string
+  ai_model?: string
 }
 
 export interface LeaderboardResponse {


### PR DESCRIPTION
## Summary
- Require a self-reported AI assistant for new daily leaderboard submissions, with an optional model field that is omitted when blank.
- Preserve Chinese nicknames through server validation/storage and render AI assistant/model metadata on leaderboard rows and optimistic entries.
- Add API, game, platform, and Playwright journey coverage, including the new leaderboard AI metadata flow inventory entry.

## Test plan
- [x] pnpm e2e:audit
- [x] pnpm --filter api test:run -- validation.test.ts post-score.test.ts
- [x] pnpm --filter @amiclaw/platform test:run -- LeaderboardPage.test.tsx
- [x] pnpm --filter @amiclaw/game-bombsquad test:run -- leaderboard-player-metadata.test.ts leaderboard-optimistic.test.ts ResultPage.nickname.test.tsx ResultPage.survey.test.tsx PostGameModal.test.tsx
- [x] pnpm build
- [x] pnpm exec bddgen && pnpm exec playwright test -g "A first daily win submits and displays Chinese nickname AI metadata|A first daily win collects a nickname|The endgame survey shows once"
- [x] pre-commit hook: pnpm -r run test:run

## Task
- Source TaskNote: pages/projects/amiclaw/tasks/add-leaderboard-ai-metadata

Generated with Codex.