### PR TITLE
fix(game-bombsquad): connect step-1 primary CTA copies the manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**The big button on the connect screen now actually copies the manual** — On the
+first step of handing the manual to your AI, the largest, brightest button at the
+bottom used to do nothing until you found a smaller card above it — so a first tap
+felt like the screen had frozen. That button is now the real action: tap「复制手册」,
+it copies the link, turns green, and moves you straight to the next step. The link
+still shows above it so you can see exactly what gets sent.
+
 **The dark wire is finally readable** — The darkest of the six wires used to all
 but vanish into the panel, so "cut the black one" turned into a guessing game.
 Every wire now sits on a thin light casing that lifts it off the background, so

--- a/e2e/regression/fix-connect-copy-button-affordance.assert.mjs
+++ b/e2e/regression/fix-connect-copy-button-affordance.assert.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Regression assertion runner for fix-connect-copy-button-affordance.
+ *
+ * Cheap static source-read backstop over
+ *   packages/game-bombsquad/src/pages/ConnectPage.tsx
+ * guarding against re-introducing the affordance inversion: a dead
+ * (disabled) bottom CTA on step 1 while the real copy hides in a smaller card.
+ *
+ * The AUTHORITATIVE executable guard is the React Testing Library unit test in
+ * the same package (ConnectPage.test.tsx) — this script is only a no-browser
+ * source backstop, matching the gherkin documentation in
+ * e2e/regression/fix-connect-copy-button-affordance.gherkin. Exits 0 on full
+ * pass, non-zero on any failure with every failed scenario named in stderr.
+ *
+ * Usage:
+ *   node e2e/regression/fix-connect-copy-button-affordance.assert.mjs
+ */
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '../..')
+const CONNECT_PAGE = resolve(REPO_ROOT, 'packages/game-bombsquad/src/pages/ConnectPage.tsx')
+
+const failures = []
+function record(scenarioName, message) {
+  failures.push(`  ✗ ${scenarioName}\n      ${message}`)
+}
+
+const src = readFileSync(CONNECT_PAGE, 'utf8')
+
+/* Extract the step-1 branch of the bottom CTA — the JSX between `step === 1 ?`
+   and the `) : (` that opens the step-2 branch inside the `.cta` container. We
+   anchor on the `.cta` wrapper to avoid matching the step-1 content block. */
+function ctaStep1Branch() {
+  const ctaIdx = src.indexOf('className={styles.cta}')
+  if (ctaIdx === -1) return null
+  const rest = src.slice(ctaIdx)
+  // The first `) : (` after the cta wrapper closes the step-1 branch.
+  const branchMatch = rest.match(/step === 1 \?([\s\S]*?)\)\s*:\s*\(/)
+  return branchMatch ? branchMatch[1] : null
+}
+
+// ---------- Scenario 1: step-1 primary CTA is the copy action, not dead ----------
+function scenarioCta() {
+  const name = 'step-1 primary CTA is the copy action, not a dead control'
+  const branch = ctaStep1Branch()
+  if (branch === null) {
+    record(name, 'could not locate the step-1 branch of the bottom CTA in ConnectPage.tsx')
+    return
+  }
+  // The step-1 primary CTA must NOT carry a `disabled` prop. Strip block
+  // comments first so the word "disabled" inside an explanatory comment does
+  // not trip the guard — only a real JSX `disabled` attribute should.
+  const branchNoComments = branch.replace(/\/\*[\s\S]*?\*\//g, '')
+  if (/\bdisabled(\s*=|[\s/>])/.test(branchNoComments)) {
+    record(
+      name,
+      'step-1 primary CTA still carries a `disabled` prop — the dead-control affordance inversion is back'
+    )
+  }
+  // The CTA must be wired to the copy handler.
+  if (!/onClick=\{handleCopy\}/.test(branch)) {
+    record(name, 'step-1 primary CTA is not wired to handleCopy (onClick={handleCopy} missing)')
+  }
+  // The label must be the copy action「复制手册」(and the copied state「已复制」).
+  if (!/复制手册/.test(branch)) {
+    record(name, 'step-1 primary CTA label「复制手册」not found')
+  }
+  if (!/已复制/.test(branch)) {
+    record(name, 'step-1 primary CTA copied-state label「已复制」not found')
+  }
+}
+
+// ---------- Scenario 2: URL preview is passive, not a second button ----------
+function scenarioPreview() {
+  const name = 'the URL preview is a passive preview, not a second copy button'
+  // The preview must use the urlPreview class on a <div>, not a <button>.
+  const previewMatch = src.match(/<(\w+)[^>]*className=\{`\$\{styles\.urlPreview\}/)
+  if (!previewMatch) {
+    record(name, 'styles.urlPreview element not found in ConnectPage.tsx')
+    return
+  }
+  if (previewMatch[1] !== 'div') {
+    record(
+      name,
+      `the URL preview is a <${previewMatch[1]}> — it must be a non-interactive <div> (no second copy control)`
+    )
+  }
+  // The legacy clickable copyCard class must be gone.
+  if (/styles\.copyCard\b/.test(src)) {
+    record(
+      name,
+      'the legacy clickable styles.copyCard is still referenced (should be styles.urlPreview)'
+    )
+  }
+  // The manual URL must still be rendered (trust requirement).
+  if (!/\{manualUrl\}/.test(src)) {
+    record(name, 'the manual URL ({manualUrl}) is no longer rendered on step 1 (trust requirement)')
+  }
+}
+
+// ---------- Scenario 3: /compatibility link stays reachable ----------
+function scenarioCompatLink() {
+  const name = 'the /compatibility discovery link stays reachable from step 1'
+  if (!/to="\/bombsquad\/compatibility"/.test(src)) {
+    record(name, 'the /bombsquad/compatibility discovery link is missing from ConnectPage.tsx')
+  }
+}
+
+// ---------- Driver ----------
+const scenarios = [
+  ['cta', scenarioCta],
+  ['preview', scenarioPreview],
+  ['compat-link', scenarioCompatLink],
+]
+
+process.stdout.write(
+  '== fix-connect-copy-button-affordance regression run ==\n' +
+    `Repo root: ${REPO_ROOT}\n` +
+    `Scenarios: ${scenarios.length}\n\n`
+)
+
+for (const [, fn] of scenarios) {
+  fn()
+}
+
+if (failures.length === 0) {
+  process.stdout.write(`✓ all ${scenarios.length} scenarios passed\n`)
+  process.exit(0)
+}
+
+process.stderr.write(`✗ ${failures.length} failure(s):\n`)
+for (const f of failures) {
+  process.stderr.write(`${f}\n`)
+}
+process.exit(1)

--- a/e2e/regression/fix-connect-copy-button-affordance.gherkin
+++ b/e2e/regression/fix-connect-copy-button-affordance.gherkin
@@ -1,0 +1,74 @@
+# Regression guard for fix-connect-copy-button-affordance
+# (task fix-connect-copy-button-affordance, 2026-06-07).
+#
+# Bug: on /bombsquad/connect step 1 the most prominent element — the bottom
+#   full-width yellow primary CTA — was a DEAD control (disabled until copied,
+#   label「先复制手册」), while the real copy action lived on a smaller, less
+#   prominent URL card above it. Classic affordance inversion: a player taps
+#   the biggest, brightest, bottom-anchored CTA first, gets no feedback, and
+#   assumes the page is frozen.
+# Fix (Option ①): the bottom primary CTA IS the copy action now — label
+#   「复制手册」, tapping it copies the manual URL, flips to the green
+#   「已复制 ✓」 confirmed state, and the existing 0.7s effect auto-advances to
+#   step 2. The former copy card was demoted from a <button> to a passive
+#   read-only <div> preview (keeps the URL visible + turns green on copy). The
+#   redundant manual「下一步 →」step was removed (auto-advance covers it). Step 2
+#   is untouched.
+#
+# Executable home: this behavior is interaction-natured, so its authoritative
+#   executable guard is the React Testing Library unit test in
+#   packages/game-bombsquad/src/pages/ConnectPage.test.tsx — specifically the
+#   "makes the most prominent CTA the copy action with no dead control on step 1"
+#   and "copies the manual link from the primary CTA and auto-advances ..."
+#   cases. Run it via:
+#     pnpm --filter @amiclaw/game-bombsquad run test:run src/pages/ConnectPage.test.tsx
+#
+# Companion static guard: fix-connect-copy-button-affordance.assert.mjs in this
+#   directory is a cheap source-read backstop (no browser, no preview server) —
+#   it asserts the step-1 primary CTA is not rendered with `disabled` and that
+#   the URL preview is no longer a <button>. Run via:
+#     node e2e/regression/fix-connect-copy-button-affordance.assert.mjs
+#   It exits 0 on full pass and non-zero on any failure, naming the failing
+#   scenario in stderr — matching the rest of this directory's data-assertion
+#   regression scenarios.
+
+Feature: connect-page copy-button affordance regression coverage
+  As a player handing the bomb manual to my AI partner on /bombsquad/connect
+  I want the single most prominent element on step 1 to be the real copy action
+  So that my first tap on the biggest, brightest control succeeds instead of
+  hitting a dead disabled CTA while the real copy hides in a smaller card
+
+  Background:
+    Given the connect page component packages/game-bombsquad/src/pages/ConnectPage.tsx is loaded
+
+  # Behavior verified executably by ConnectPage.test.tsx
+  # ("makes the most prominent CTA the copy action with no dead control on step 1").
+  # retire-when: ConnectPage step 1 stops surfacing a copy action, or the
+  #   connect flow is redesigned away from the "copy manual → auto-advance" model.
+  Scenario: step-1 primary CTA is the copy action, not a dead control
+    Given /bombsquad/connect on step 1
+    When the player looks at the most prominent (bottom full-width primary) control
+    Then that control's label is「复制手册」
+    And tapping it copies the manual URL to the clipboard
+    And the payload is the manual URL itself
+    And the control flips to the「已复制 ✓」green confirmed state
+    And the flow auto-advances to step 2 after ~0.7s
+    And no control on step 1 is disabled
+
+  # Behavior verified executably by ConnectPage.test.tsx
+  # ("renders step 1 with the URL preview and manual URL").
+  # retire-when: the manual URL is no longer shown on the connect page (it is a
+  #   trust requirement that the link stays visible before the player copies it).
+  Scenario: the URL preview is a passive preview, not a second copy button
+    Given /bombsquad/connect on step 1
+    When inspecting the manual-URL card above the CTA
+    Then it renders the manual URL (still visible for trust)
+    And it is NOT a <button> (no second/competing copy control)
+
+  # Behavior verified executably by ConnectPage.test.tsx
+  # ("surfaces the /bombsquad/compatibility discovery link on step 1").
+  # retire-when: the /bombsquad/compatibility page is removed.
+  Scenario: the /compatibility discovery link stays reachable from step 1
+    Given /bombsquad/connect on step 1
+    When inspecting the discovery link under the hint
+    Then a link「查看支持工具 →」points at /bombsquad/compatibility

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -202,22 +202,33 @@ export class World {
     await this.openConnect(mode)
   }
 
-  /** Connect step 1 — click the copy card and wait for its copied state. */
+  /**
+   * Connect step 1 — click the primary copy CTA and wait for its copied state.
+   * The copy action now lives on the most prominent element (the bottom
+   * 复制手册 CTA); the URL above is a passive preview, not a button.
+   */
   async copyManualLink(): Promise<void> {
-    await this.page.locator('button[class*="copyCard"]').first().click()
+    await this.page.getByRole('button', { name: '复制手册' }).click()
     await this.page.getByText('已复制到剪贴板').first().waitFor()
   }
 
   /**
-   * Connect steps 1→2→run. The controlled clock is paused, so the post-copy
-   * 700ms auto-advance to step 2 never fires — the step is advanced by an
-   * explicit 下一步 click instead. The single readiness confirm was removed
-   * (it now lives once on GamePage's 开始), so step 2 ends with a plain
-   * 进入游戏 navigation. Assumes the manual link is already copied.
+   * Connect steps 1→2→run. The primary CTA itself performs the copy, so step 1
+   * is already in its copied state. The redundant manual 下一步 control was
+   * removed — step 2 is now reached only via the post-copy 700ms auto-advance
+   * effect. The controlled clock is paused, so fire that timer explicitly with
+   * advance(700); that also pushes Date.now() to seedT+700, so re-pin the clock
+   * back to seedT with setSystemTime (which fires no timers and keeps the clock
+   * paused) before the run navigation — otherwise GamePage's getRunSeed reads a
+   * shifted Date.now() and generates a daily puzzle that no longer matches
+   * answers.json. The single readiness confirm was removed (it now lives once on
+   * GamePage's 开始), so step 2 ends with a plain 进入游戏 navigation. Assumes
+   * the manual link is already copied.
    */
   async finishConnectFlow(): Promise<void> {
-    await this.page.getByRole('button', { name: '下一步 →' }).click()
+    await this.advance(700)
     await this.page.getByText('第 2/2 步').first().waitFor()
+    await this.page.clock.setSystemTime(this.seedT)
     await this.page.getByRole('button', { name: '进入游戏 →' }).click()
     await this.page.waitForURL((url) => new URL(url).pathname === '/bombsquad/run', {
       timeout: 12_000,

--- a/packages/game-bombsquad/src/pages/ConnectPage.module.css
+++ b/packages/game-bombsquad/src/pages/ConnectPage.module.css
@@ -176,8 +176,12 @@
   flex-direction: column;
 }
 
-/* ----------  copy / voice-mode card  ---------- */
-.copyCard {
+/* ----------  manual-URL preview (passive)  ----------
+   A non-interactive preview of the manual link. The copy action lives on the
+   bottom primary CTA, so this card has no pointer, no hover, and no focus
+   ring — it only shows the URL (trust requirement) and turns green once the
+   CTA has copied it. */
+.urlPreview {
   display: flex;
   align-items: center;
   gap: 14px;
@@ -191,23 +195,11 @@
   font-family: var(--font-body);
   color: #fff;
   text-align: left;
-  cursor: pointer;
   transition: all 0.2s;
 }
 
-.copyCard:hover {
-  background: var(--glass-strong);
-  border-color: rgba(255, 229, 62, 0.3);
-}
-
-.copyCard:focus-visible {
-  outline: 2px solid var(--y);
-  outline-offset: 2px;
-}
-
 /* done — the card turns green the moment the link is copied. */
-.copyCardDone,
-.copyCardDone:hover {
+.urlPreviewDone {
   background: rgba(20, 30, 22, 0.6);
   border-color: rgba(75, 210, 102, 0.4);
 }
@@ -224,7 +216,7 @@
   color: var(--y);
 }
 
-.copyCardDone .copyCardLabel {
+.urlPreviewDone .copyCardLabel {
   color: var(--green);
 }
 
@@ -247,14 +239,14 @@
   color: var(--y);
 }
 
-.copyCardDone .copyCardIcon {
+.urlPreviewDone .copyCardIcon {
   background: rgba(75, 210, 102, 0.15);
   color: var(--green);
 }
 
 /* ----------  step-2 voice-mode reminder (passive)  ----------
-   A non-interactive instruction, visually distinct from the actionable
-   copyCard: flat fill, dashed hairline, muted (not yellow) icon, no hover
+   A non-interactive instruction, visually distinct from the step-1 copy
+   CTA: flat fill, dashed hairline, muted (not yellow) icon, no hover
    and no pointer. The player performs "切到语音模式" on their own AI; this
    only reminds — it must not look tappable. */
 .voiceStep {
@@ -428,7 +420,7 @@
     font-size: 28px;
   }
 
-  .copyCard {
+  .urlPreview {
     padding: 22px 26px;
   }
 

--- a/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
@@ -3,13 +3,16 @@
  *
  * Covers the connect-AI flow at /bombsquad/connect — the Atlas redesign's
  * 2-step handoff (design_handoff_bombsquad README §6.2):
- *   1. step 1 renders the copy card with the manual URL.
- *   2. copying the manual link shows the copied feedback and auto-advances
- *      to step 2 after ~0.7s; the clipboard payload is the manual URL.
- *   3. the 2-step state machine reaches the voice-mode step and hands off.
- *   4. daily mode hands off to the run carrying the manual URL as ?url=.
- *   5. practice mode hands off without a ?url= param.
- *   6. step 1 surfaces the /bombsquad/compatibility discovery link
+ *   1. step 1 renders the URL preview with the manual URL.
+ *   2. the most prominent element (the bottom primary CTA「复制手册」) IS the
+ *      copy action: tapping it copies the manual link, shows the copied
+ *      feedback, and auto-advances to step 2 after ~0.7s; the clipboard
+ *      payload is the manual URL.
+ *   3. step 1 has no disabled / dead control — the affordance-inversion guard.
+ *   4. the 2-step state machine reaches the voice-mode step and hands off.
+ *   5. daily mode hands off to the run carrying the manual URL as ?url=.
+ *   6. practice mode hands off without a ?url= param.
+ *   7. step 1 surfaces the /bombsquad/compatibility discovery link
  *      (re-homed from the retired PromptModal).
  *
  * The readiness gate now lives once on GamePage's "开始" button, so this flow
@@ -61,12 +64,12 @@ function renderConnect(mode: 'daily' | 'practice') {
   )
 }
 
-/* Drive the flow from step 1 to step 2 by copying the handoff message and
+/* Drive the flow from step 1 to step 2 by tapping the primary copy CTA and
    waiting for the ~0.7s auto-advance to settle. Waiting for step 2 to actually
    render means the auto-advance timer has already fired, so it can never
    race a later manual step change. */
 async function copyAndReachStep2() {
-  fireEvent.click(screen.getByRole('button', { name: /手册链接/ }))
+  fireEvent.click(screen.getByRole('button', { name: '复制手册' }))
   await waitFor(() => {
     expect(screen.getByText('切到语音模式')).toBeInTheDocument()
   })
@@ -78,14 +81,34 @@ describe('ConnectPage', () => {
     vi.mocked(copyToClipboard).mockResolvedValue(true)
   })
 
-  it('renders step 1 with the copy card and manual URL', () => {
+  it('renders step 1 with the URL preview and manual URL', () => {
     renderConnect('daily')
 
     expect(screen.getByText('第 1/2 步')).toBeInTheDocument()
     expect(screen.getByRole('heading', { level: 2, name: /发给 AI/ })).toBeInTheDocument()
-    // The copy card surfaces the manual link only — no opening prompt.
+    // The preview surfaces the manual link only — no opening prompt.
     expect(screen.getByText('手册链接')).toBeInTheDocument()
     expect(screen.getByText(DAILY_URL)).toBeInTheDocument()
+  })
+
+  it('makes the most prominent CTA the copy action with no dead control on step 1', () => {
+    renderConnect('daily')
+
+    // The affordance-inversion guard: the bottom primary CTA is the real copy
+    // action ("复制手册"), and step 1 has no disabled / dead control — the old
+    // "biggest button does nothing until you find the smaller card" trap.
+    const copyCta = screen.getByRole('button', { name: '复制手册' })
+    expect(copyCta).toBeInTheDocument()
+    expect(copyCta).not.toBeDisabled()
+
+    // No button on step 1 is disabled (the back-arrow icon button is enabled
+    // too, so the assertion covers every button rendered here).
+    for (const btn of screen.getAllByRole('button')) {
+      expect(btn).not.toBeDisabled()
+    }
+
+    // The URL preview is no longer a button — the only copy control is the CTA.
+    expect(screen.queryByRole('button', { name: /手册链接/ })).not.toBeInTheDocument()
   })
 
   it('surfaces the /bombsquad/compatibility discovery link on step 1', () => {
@@ -99,15 +122,17 @@ describe('ConnectPage', () => {
     expect(compatLink).toHaveAttribute('href', '/bombsquad/compatibility')
   })
 
-  it('copies the manual link and auto-advances to step 2 after ~0.7s', async () => {
+  it('copies the manual link from the primary CTA and auto-advances to step 2 after ~0.7s', async () => {
     renderConnect('practice')
 
-    fireEvent.click(screen.getByRole('button', { name: /手册链接/ }))
+    fireEvent.click(screen.getByRole('button', { name: '复制手册' }))
 
-    // Copy action — the card flips to its copied state.
+    // Copy action — the CTA flips to its copied state and the preview turns
+    // green ("已复制到剪贴板").
     await waitFor(() => {
-      expect(screen.getByText('已复制到剪贴板')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: '已复制 ✓' })).toBeInTheDocument()
     })
+    expect(screen.getByText('已复制到剪贴板')).toBeInTheDocument()
     expect(copyToClipboard).toHaveBeenCalledTimes(1)
     // The clipboard payload is the manual URL alone.
     expect(copyToClipboard).toHaveBeenCalledWith(PRACTICE_URL)

--- a/packages/game-bombsquad/src/pages/ConnectPage.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.tsx
@@ -149,21 +149,21 @@ export default function ConnectPage() {
             </div>
           </div>
 
-          {/* Step 1 — copy the manual link. */}
+          {/* Step 1 — copy the manual link. The copy action lives on the
+              bottom primary CTA (the most prominent element); this card is a
+              passive read-only preview of the URL so the link stays visible
+              and trustworthy. It is deliberately NOT a button — the only copy
+              control on this step is the CTA below. */}
           {step === 1 && (
             <div className={styles.action}>
-              <button
-                type="button"
-                className={`${styles.copyCard} ${copied ? styles.copyCardDone : ''}`}
-                onClick={handleCopy}
-              >
+              <div className={`${styles.urlPreview} ${copied ? styles.urlPreviewDone : ''}`}>
                 <div className={styles.copyCardText}>
                   <div className={styles.copyCardLabel}>
                     {copied ? '已复制到剪贴板' : '手册链接'}
                   </div>
                   <div className={styles.copyCardUrl}>{manualUrl}</div>
                 </div>
-                <div className={styles.copyCardIcon}>
+                <div className={styles.copyCardIcon} aria-hidden="true">
                   {copied ? (
                     <svg
                       viewBox="0 0 24 24"
@@ -191,7 +191,7 @@ export default function ConnectPage() {
                     </svg>
                   )}
                 </div>
-              </button>
+              </div>
 
               <p className={styles.hint}>粘贴到你常用的 AI，让它读完手册后说「好了」。</p>
               {/* /compatibility discovery link — re-homed here from the
@@ -235,8 +235,17 @@ export default function ConnectPage() {
 
           <div className={styles.cta}>
             {step === 1 ? (
-              <Button variant="primary" full disabled={!copied} onClick={() => setStep(2)}>
-                {copied ? '下一步 →' : '先复制手册'}
+              /* The most prominent element IS the copy action: tap copies the
+                 manual URL, flips to the green confirmed state, and the 0.7s
+                 effect above auto-advances to step 2. No disabled / dead
+                 control on this step. */
+              <Button
+                variant="primary"
+                full
+                accent={copied ? 'green' : 'yellow'}
+                onClick={handleCopy}
+              >
+                {copied ? '已复制 ✓' : '复制手册'}
               </Button>
             ) : (
               <Button variant="primary" full onClick={confirmStart}>


### PR DESCRIPTION
## Summary

- Fixes the connect-page step-1 affordance reversal (playtest **F5**, major): the largest, brightest bottom CTA was the disabled `先复制手册` control while the real copy action lived on a smaller card above — a first tap on the dominant control did nothing and read as a frozen screen.
- The bottom full-width primary CTA is now the real action: tap copies the manual URL, flips to green `已复制 ✓`, and the existing 0.7s effect auto-advances to step 2. The URL card is demoted from a button to a passive read-only preview (link stays visible, exactly one copy control), and the redundant manual `下一步 →` state is removed. Step 2 is unchanged.
- Adds a regression guard (`e2e/regression/fix-connect-copy-button-affordance.{gherkin,assert.mjs}`) committed red-before-fix; verified it catches a reintroduced `disabled`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (`pnpm test:run` — bombsquad 256, all packages green)
- [x] New tests added if behavior changed (ConnectPage RTL affordance-inversion test + regression assert)
- [x] Tested manually and documented below

`pnpm e2e:audit` clean 14↔14 bijection; `pnpm test:regression` all asserts pass; typecheck / eslint / prettier clean on touched files.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (CHANGELOG under Unreleased)
- [x] Breaking changes documented if any (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)