### PR TITLE
fix(game-bombsquad): make dark wires visible with a neutral casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**The dark wire is finally readable** — The darkest of the six wires used to all
+but vanish into the panel, so "cut the black one" turned into a guessing game.
+Every wire now sits on a thin light casing that lifts it off the background, so
+all six colors read at a glance and the dark wire stays clearly the dark
+one — no hue lost, just visible now.
+
 **Refreshing or sharing a game link no longer lands on a blank page** —
 Reloading mid-run, opening a bookmark, or following a link a friend sent you
 used to drop you on an empty platform screen instead of the game. Now those

--- a/packages/game-bombsquad/src/modules/wire/WireModule.module.css
+++ b/packages/game-bombsquad/src/modules/wire/WireModule.module.css
@@ -100,6 +100,13 @@
   pointer-events: none;
 }
 
+/* Neutral cable casing drawn under the colored strand. Static (no animation),
+   so it is unaffected by prefers-reduced-motion. Clicks land on .hitTarget,
+   which sits above it. */
+.casing {
+  pointer-events: none;
+}
+
 .pin {
   stroke: rgba(0, 0, 0, 0.55);
   stroke-width: 2;

--- a/packages/game-bombsquad/src/modules/wire/WireModule.test.tsx
+++ b/packages/game-bombsquad/src/modules/wire/WireModule.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
-import WireModule from './WireModule'
+import WireModule, { STRAND_CASING } from './WireModule'
 import styles from './WireModule.module.css'
 
 const config = {
@@ -13,6 +13,49 @@ const config = {
 }
 const answer = { type: 'wire' as const, cutPosition: 2 }
 const sceneInfo = { sceneTongueTwister: '四是四十是十', batteryCount: 2, indicators: [] as [] }
+
+// Full 6-color vocabulary, including the previously near-invisible `black`.
+const allColorsConfig = {
+  wires: [
+    { color: 'red' as const },
+    { color: 'blue' as const },
+    { color: 'yellow' as const },
+    { color: 'green' as const },
+    { color: 'white' as const },
+    { color: 'black' as const },
+  ],
+}
+const allColorsAnswer = { type: 'wire' as const, cutPosition: 0 }
+
+// --- WCAG contrast helpers (used by the casing contrast-floor guard) ---
+function srgbToLinear(channel: number): number {
+  const s = channel / 255
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4)
+}
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b)
+}
+function compositeOver(
+  fg: [number, number, number],
+  alpha: number,
+  bg: [number, number, number]
+): [number, number, number] {
+  return [
+    Math.round(alpha * fg[0] + (1 - alpha) * bg[0]),
+    Math.round(alpha * fg[1] + (1 - alpha) * bg[1]),
+    Math.round(alpha * fg[2] + (1 - alpha) * bg[2]),
+  ]
+}
+function contrastRatio(a: number, b: number): number {
+  const [hi, lo] = a >= b ? [a, b] : [b, a]
+  return (hi + 0.05) / (lo + 0.05)
+}
+function parseRgba(value: string): { rgb: [number, number, number]; alpha: number } {
+  const match = value.match(/rgba?\(([^)]+)\)/)
+  if (!match) throw new Error(`unparseable color: ${value}`)
+  const parts = match[1].split(',').map((p) => parseFloat(p.trim()))
+  return { rgb: [parts[0], parts[1], parts[2]], alpha: parts[3] ?? 1 }
+}
 
 describe('WireModule', () => {
   it('calls onComplete when correct wire is clicked', () => {
@@ -112,5 +155,49 @@ describe('WireModule', () => {
     expect(screen.getByTestId('wire-1')).toBeInTheDocument()
     expect(screen.getByTestId('wire-2')).toBeInTheDocument()
     expect(screen.getByTestId('wire-3')).toBeInTheDocument()
+  })
+
+  // Regression guard for the dark-wire visibility fix (playtest finding F10).
+  // Before the fix there was no casing element at all, so this FAILS pre-fix.
+  it('draws a wider neutral casing UNDER every idle strand, including the dark wire', () => {
+    render(
+      <WireModule
+        config={allColorsConfig}
+        answer={allColorsAnswer}
+        onComplete={vi.fn()}
+        onError={vi.fn()}
+        sceneInfo={sceneInfo}
+      />
+    )
+    for (let i = 0; i < allColorsConfig.wires.length; i++) {
+      const strand = screen.getByTestId(`strand-${i}`)
+      const casing = screen.getByTestId(`strand-casing-${i}`)
+      expect(casing).toBeInTheDocument()
+      // The casing must be wider than the colored strand so it shows as an edge.
+      const casingWidth = Number(casing.getAttribute('stroke-width'))
+      const strandWidth = Number(strand.getAttribute('stroke-width'))
+      expect(casingWidth).toBeGreaterThan(strandWidth)
+      // The casing must paint UNDER the strand — i.e. appear earlier in the DOM
+      // so the colored strand renders on top of it.
+      expect(casing.compareDocumentPosition(strand) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    }
+  })
+
+  it('casing color clears the WCAG 3:1 graphical-object floor over the dark stage', () => {
+    // Effective stage background: the stage paints rgba(5,5,17,0.5) over the
+    // page's #050511 bottom gradient stop, which composites back to ≈ #050511.
+    const stageBg: [number, number, number] = [5, 5, 17]
+    const { rgb, alpha } = parseRgba(STRAND_CASING)
+    const cased = compositeOver(rgb, alpha, stageBg)
+    const ratio = contrastRatio(relativeLuminance(cased), relativeLuminance(stageBg))
+    expect(ratio).toBeGreaterThanOrEqual(3)
+
+    // Sanity: the bare `black` strand value (#333344) is what fails this floor,
+    // which is exactly why the casing is needed.
+    const bareBlackRatio = contrastRatio(
+      relativeLuminance([0x33, 0x33, 0x44]),
+      relativeLuminance(stageBg)
+    )
+    expect(bareBlackRatio).toBeLessThan(3)
   })
 })

--- a/packages/game-bombsquad/src/modules/wire/WireModule.tsx
+++ b/packages/game-bombsquad/src/modules/wire/WireModule.tsx
@@ -19,6 +19,19 @@ const COLOR_MAP: Record<string, string> = {
   black: '#333344',
 }
 
+/* Neutral under-casing for every strand. A light, color-agnostic stroke drawn
+   one layer beneath the colored strand and made wider than it, so each wire
+   keeps a luminance silhouette against the dark glass stage regardless of hue.
+   Without it the dark `black` wire (#333344) has near-zero contrast on the
+   rgba(5,5,17,0.5) stage and is effectively invisible — a fairness defect,
+   since "which wire to cut" depends entirely on reading the wire's color.
+   The colored strand still sits on top and dominates naming (black stays the
+   only dark-centered wire), while the casing edge makes it readable at a glance.
+   Value mirrors the --amio-fg-3 design token (white @ 50%); exported so the
+   co-located contrast-floor test asserts the exact rendered color. */
+export const STRAND_CASING = 'rgba(255, 255, 255, 0.5)'
+const STRAND_CASING_WIDTH = 7
+
 type WireState = 'idle' | 'cut' | 'error'
 
 export default function WireModule({
@@ -99,6 +112,20 @@ export default function WireModule({
                     opacity={0.32}
                     filter="url(#wire-glow)"
                     className={styles.halo}
+                  />
+                )}
+                {/* Neutral under-casing — wider than the colored strand and
+                    drawn beneath it, so every wire (including the dark one)
+                    keeps a luminance silhouette against the dark stage. */}
+                {!isCut && (
+                  <path
+                    d={d}
+                    stroke={STRAND_CASING}
+                    strokeWidth={STRAND_CASING_WIDTH}
+                    fill="none"
+                    strokeLinecap="round"
+                    className={styles.casing}
+                    data-testid={`strand-casing-${i}`}
                   />
                 )}
                 {isCut ? (


### PR DESCRIPTION
## Summary

- The darkest wire (`#333344`) had near-zero contrast on the dark glass stage (**1.64:1**) and was effectively invisible — a fairness/solvability defect, since which wire to cut depends entirely on reading the wire's color (playtest finding F10).
- Adds a color-agnostic white@0.5 under-casing (the `--amio-fg-3` token) beneath every strand, giving each wire a luminance silhouette regardless of hue. The dark wire now clears **5.31:1**; all six colors clear the WCAG 3:1 graphical-object floor.
- Color values are unchanged, so every wire keeps its name — black stays the darkest, nameable wire (dark core + dark anchor pins), distinct from white.
- Dark-only, CSS/SVG-only, no new colors (reuses an existing token).

## Type of change

- [x] Bug fix

## Testing

- [x] Existing tests pass (262 bombsquad tests green post-rebase)
- [x] New tests added: casing presence / width(7>3) / paint-order across all 6 colors; WCAG ≥3:1 contrast-floor guard (+ proof the bare `black` value fails the floor)
- [x] Tested manually: real-browser before/after of all 6 wires on the actual stage background — the previously near-invisible black wire is now plainly readable and still reads as black (dark core + dark pins), clearly distinct from the white wire; bright wires keep their hue.

## Checklist

- [x] Code follows the project style (eslint + prettier clean)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (`CHANGELOG.md`)
- [x] Breaking changes documented if any (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
