### PR TITLE
fix(platform): wire dead auth-shell CTAs to honest anonymous entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**The top-right button does something now, and no button lies about signing up**
+— The yellow「登录 / 开始」button in the top-right corner used to do nothing when
+tapped, which made you wonder what else on the page was just for show. There's
+never been a login or a sign-up here — you just play — so that button now reads
+「开始玩」and takes you straight into a game. For the same reason, the footer
+button that said「注册 · 30 秒」now reads「免注册，直接开始玩」: no account, no
+form, you start playing right away.
+
 **When two star-panel symbols look alike, your AI can point you by grid cell** —
 A few of the star-panel symbols are easy to mix up by name — the three-prong
 trident and the bowl-and-stem beside it, or the hourglass and the triangle. If

--- a/e2e/steps/homepage.steps.ts
+++ b/e2e/steps/homepage.steps.ts
@@ -89,7 +89,7 @@ Then('I see the community-feed section', async ({ page }) => {
 })
 
 Then('I see the registration footer pitch', async ({ page }) => {
-  await expect(page.getByRole('button', { name: '注册 · 30 秒' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '免注册，直接开始玩' })).toBeVisible()
 })
 
 Then('the page is dark-only with no light-mode variant', async ({ page }) => {
@@ -196,7 +196,7 @@ Then('the anonymous hero is not shown', async ({ page }) => {
 
 Then('the "什么是 Amiclaw" section and the footer pitch are not shown', async ({ page }) => {
   await expect(page.getByText('关于 · WHAT IS AMICLAW')).toHaveCount(0)
-  await expect(page.getByRole('button', { name: '注册 · 30 秒' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: '免注册，直接开始玩' })).toHaveCount(0)
 })
 
 Then(

--- a/packages/platform/src/components/home/FooterPitch.test.tsx
+++ b/packages/platform/src/components/home/FooterPitch.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * FooterPitch CTA tests.
+ *
+ * The product is anonymous-by-design (roadmap: nickname + device fingerprint,
+ * no login or registration), so the footer pitch CTA must read honestly — no
+ * label that implies a registration step that does not exist:
+ *   1. the CTA reads as an honest "no signup, just play" entry
+ *   2. clicking it fires onRegister (the existing /bombsquad/ routing)
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import FooterPitch from './FooterPitch'
+
+describe('FooterPitch', () => {
+  it('renders an honest no-signup play CTA', () => {
+    render(<FooterPitch onRegister={() => {}} />)
+
+    expect(screen.getByRole('button', { name: '免注册，直接开始玩' })).toBeInTheDocument()
+    // The old dishonest registration label must be gone.
+    expect(screen.queryByText('注册 · 30 秒')).not.toBeInTheDocument()
+  })
+
+  it('fires onRegister when the CTA is clicked', () => {
+    const onRegister = vi.fn()
+    render(<FooterPitch onRegister={onRegister} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '免注册，直接开始玩' }))
+
+    expect(onRegister).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/platform/src/components/home/FooterPitch.tsx
+++ b/packages/platform/src/components/home/FooterPitch.tsx
@@ -3,8 +3,10 @@ import styles from './FooterPitch.module.css'
 
 interface FooterPitchProps {
   /* Routes to the BombSquad landing page (window.location.assign('/bombsquad/'))
-     — the「注册 · 30 秒」CTA. There is no real auth yet, so registration routes
-     into BombSquad, consistent with the other anonymous-homepage CTAs. */
+     — the play CTA. Anonymous-by-design: there is no registration (roadmap:
+     nickname + device fingerprint, no login or registration), so the CTA is an
+     honest entry straight into play, consistent with the other anonymous-
+     homepage CTAs. The prop name is kept for call-site stability. */
   onRegister: () => void
 }
 
@@ -20,7 +22,7 @@ export default function FooterPitch({ onRegister }: FooterPitchProps) {
         Amiclaw 一周一次新游戏 · 永久免费 · 不卖你的对话也不存档你的对话。
       </p>
       <Button variant="primary" onClick={onRegister}>
-        注册 · 30 秒
+        免注册，直接开始玩
       </Button>
     </section>
   )

--- a/packages/platform/src/components/platform/TopNav.module.css
+++ b/packages/platform/src/components/platform/TopNav.module.css
@@ -106,7 +106,7 @@
     font-size: 19px;
   }
 
-  /* the 登录 / 开始 button — atlas .signin-btn mobile size. .right button
+  /* the 开始玩 entry button — atlas .signin-btn mobile size. .right button
      (0,1,1) outranks Button's .sm / .primary (0,1,0). */
   .right button {
     padding: 8px 14px;

--- a/packages/platform/src/components/platform/TopNav.test.tsx
+++ b/packages/platform/src/components/platform/TopNav.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * TopNav right-slot tests.
+ *
+ * The product is anonymous-by-design (roadmap: nickname + device fingerprint,
+ * no login or registration), so the anonymous right-slot CTA must be a REAL
+ * entry into play, not a dead auth placeholder:
+ *   1. signed-out → the right slot shows an honest play-entry CTA with no
+ *      login/registration wording
+ *   2. clicking it enters the BombSquad SPA via
+ *      window.location.assign('/bombsquad/') — the same cross-app entry every
+ *      other play CTA uses (a client-side Link to "/" would no-op on the homepage)
+ *   3. signed-in (?auth=in) → the avatar link to /me replaces the CTA
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import TopNav from './TopNav'
+
+// BombSquad lives in its own SPA at /bombsquad/, so the play CTA crosses the
+// app boundary via window.location.assign. Spy on it to assert the target.
+const assignSpy = vi.fn()
+
+function renderNav(entry = '/leaderboard') {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <TopNav />
+    </MemoryRouter>
+  )
+}
+
+describe('TopNav right slot', () => {
+  beforeEach(() => {
+    assignSpy.mockClear()
+    vi.stubGlobal('location', { ...window.location, assign: assignSpy })
+  })
+
+  it('shows an honest play-entry CTA for a signed-out visitor', () => {
+    renderNav('/leaderboard')
+
+    expect(screen.getByRole('button', { name: '开始玩' })).toBeInTheDocument()
+    // The dead auth placeholder must be gone — no login/registration wording.
+    expect(screen.queryByText('登录 / 开始')).not.toBeInTheDocument()
+    expect(screen.queryByText(/登录|注册/)).not.toBeInTheDocument()
+  })
+
+  it('enters the BombSquad SPA when the play CTA is clicked', () => {
+    renderNav('/leaderboard')
+
+    fireEvent.click(screen.getByRole('button', { name: '开始玩' }))
+
+    expect(assignSpy).toHaveBeenCalledWith('/bombsquad/')
+  })
+
+  it('shows the /me avatar link instead of the CTA for a signed-in visitor', () => {
+    renderNav('/leaderboard?auth=in')
+
+    expect(screen.getByLabelText('我的')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '开始玩' })).not.toBeInTheDocument()
+  })
+})

--- a/packages/platform/src/components/platform/TopNav.tsx
+++ b/packages/platform/src/components/platform/TopNav.tsx
@@ -39,8 +39,19 @@ export default function TopNav() {
               <ConicAvatar size={36} spin letter={user?.avatarLetter} ariaHidden />
             </Link>
           ) : (
-            <Button variant="primary" size="sm">
-              登录 / 开始
+            /* Anonymous-by-design: there is no login/registration (roadmap:
+               nickname + device fingerprint, no login or registration). The
+               right slot is a real entry straight into play — into the
+               BombSquad SPA via window.location.assign('/bombsquad/'), the
+               same cross-app entry every other play CTA uses (a client-side
+               Link to "/" would no-op on the homepage). Not a dead auth
+               placeholder. */
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => window.location.assign('/bombsquad/')}
+            >
+              开始玩
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Summary

- The top-right `登录 / 开始` button was dead (no `onClick`/`Link`) — the single most prominent CTA on every page did nothing when tapped, a clear distrust signal during beta. It now reads `开始玩` and is a router `<Link to="/">` into the games home.
- The footer `注册 · 30 秒` button promised a registration that does not exist. The product is anonymous-by-design (roadmap: `账号系统 —— 排行榜用昵称 + 设备指纹，不做登录注册`), so it now reads `免注册，直接开始玩` (honest label; routing into BombSquad unchanged).
- Honest framing is **anonymous-by-design / no-account**, deliberately NOT "coming soon" — there is no login/registration on the roadmap, so implying one is coming would be a new dishonesty. `useAuth` mock + the signed-in avatar branch are untouched.
- Part of a full-site wired-vs-placeholder audit; sibling-owned surfaces (footer privacy/terms/about/Discord, `/me` account page) are intentionally left to their in-progress tasks and were not touched here.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (full monorepo `pnpm -r test:run` green: api 76 / manual 57 / yijing 21 / platform 15 / bombsquad 263)
- [x] New tests added if behavior changed (`TopNav.test.tsx`, `FooterPitch.test.tsx` — assert new label, navigation target, and absence of 登录/注册 wording)
- [ ] Tested manually and documented below

## Checklist

- [x] Code follows the project style (dark-only, CSS-only animation, Chinese copy with no embedded English)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (CHANGELOG Unreleased entry)
- [x] Breaking changes documented if any (none)