### PR TITLE
fix(game-yijing): remove dead 设置 placeholder button from home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**The Yijing home no longer shows a settings button that does nothing** — The
+gear icon in the top corner of the 易经 oracle home looked tappable but had
+nothing behind it — there are no settings to open. It's gone now, so every
+control on the page does something.
+
 **The top-right button does something now, and no button lies about signing up**
 — The yellow「登录 / 开始」button in the top-right corner used to do nothing when
 tapped, which made you wonder what else on the page was just for show. There's

--- a/packages/game-yijing/src/pages/PageHome.module.css
+++ b/packages/game-yijing/src/pages/PageHome.module.css
@@ -25,25 +25,6 @@
   align-items: center;
 }
 
-.iconBtn {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--hairline);
-  color: rgba(255, 255, 255, 0.7);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-.iconBtn:hover {
-  color: #fff;
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 229, 62, 0.3);
-}
-
 /* ───── hero ───── */
 .hero {
   text-align: center;

--- a/packages/game-yijing/src/pages/PageHome.tsx
+++ b/packages/game-yijing/src/pages/PageHome.tsx
@@ -42,19 +42,6 @@ export function PageHome() {
       <div className={styles.content}>
         <div className={styles.top}>
           <EyebrowTag variant="hero-pill">语音 oracle · 已就位</EyebrowTag>
-          <button className={styles.iconBtn} type="button" aria-label="设置">
-            <svg
-              viewBox="0 0 24 24"
-              width="20"
-              height="20"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-            >
-              <circle cx="12" cy="12" r="3" />
-              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-            </svg>
-          </button>
         </div>
 
         <div className={styles.hero}>


### PR DESCRIPTION
## Summary

- The Yijing home top bar had a gear button (`aria-label="设置"`) with no `onClick` and no settings UI behind it — a dead placeholder, surfaced by the full-site wired-vs-placeholder audit.
- The product is anonymous-by-design (no account, no preferences, no audio settings), so there is nothing for the gear to open. Removed the dead affordance and its now-orphan `.iconBtn` styles rather than fake a "coming soon" settings panel.
- The `.top` flexbox keeps the lone hero pill correctly placed; the other Yijing pages' back-buttons (their own per-page `.iconBtn`) are untouched.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (game-yijing 21/21, typecheck + build clean)
- [ ] New tests added if behavior changed
- [x] Tested manually and documented below — gear removed, top bar layout intact

## Checklist

- [x] Code follows the project style (dark-only, CSS-only animation)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (n/a — no behavior contract)
- [x] Breaking changes documented if any (none)