### PR TITLE
fix(platform): /me shows a login guide to anonymous visitors, not a fake profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**「我的」no longer shows a stranger's stats before you have any of your own** —
+Opening「我的」used to greet every visitor with a complete profile — 42 games
+cleared, a 6-day streak, a wall of badges — that belonged to someone who wasn't
+you, sitting right under the line「所有数据只属于你」. Before you have a profile of
+your own, the page now shows a clean prompt and a preview of what your 星轨 will
+hold — your record, streak, and badges — instead of another player's numbers.
+
 **The Yijing home no longer shows a settings button that does nothing** — The
 gear icon in the top corner of the 易经 oracle home looked tappable but had
 nothing behind it — there are no settings to open. It's gone now, so every

--- a/packages/platform/src/pages/AccountPage.module.css
+++ b/packages/platform/src/pages/AccountPage.module.css
@@ -198,6 +198,59 @@
   text-align: center;
 }
 
+/* ----------  signed-out — login-guide empty state  ----------
+   Shown to anonymous visitors instead of a fake profile. A single
+   centered card: heading + a plain-text unlock preview + a primary CTA
+   linking to the platform homepage. Brand yellow accent, no fake data. */
+.guideCard {
+  max-width: 480px;
+  padding: 40px 36px;
+  text-align: center;
+}
+
+.guideTitle {
+  margin: 0;
+  font: 400 26px var(--font-display);
+  color: var(--text-1);
+}
+
+.unlockList {
+  margin: 22px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.unlockItem {
+  font: 500 14px var(--font-body);
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.02em;
+}
+
+/* CTA — mirrors the primary Button affordance (yellow pill, dark text,
+   glow-lift on hover). CSS-only animation; rendered as a react-router
+   Link so it navigates to the homepage / onboarding surface. */
+.guideCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 30px;
+  padding: 16px 28px;
+  border-radius: 999px;
+  background: var(--amio-yellow);
+  color: #000;
+  font: 600 15px var(--font-body);
+  text-decoration: none;
+  transition: all 0.25s;
+}
+
+.guideCta:hover {
+  box-shadow: var(--glow-yellow-strong);
+  transform: translateY(-2px);
+}
+
 /* ----------  responsive: mobile  ----------
    atlas.html ≤768px — .acct-grid collapses to one column (profile card
    stacks above the recent-runs / badges detail column). */

--- a/packages/platform/src/pages/AccountPage.test.tsx
+++ b/packages/platform/src/pages/AccountPage.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * AccountPage (/me) integration tests.
+ *
+ * Regression guard for the bug where `/me` rendered a complete fake profile
+ * to unauthenticated visitors. The page now branches on useAuth():
+ *   1. signed-out `/me` renders a login-guide empty state (heading + a
+ *      plain-text unlock preview + a functional CTA) and NONE of the fake
+ *      profile content (no 林星海 / 星海, no 42, no「所有数据只属于你」copy,
+ *      no recent-runs table, no badge grid).
+ *   2. the signed-out CTA navigates to the platform homepage `/`.
+ *   3. signed-in `/me` (?auth=in) renders the profile, 最近 5 局 and 勋章.
+ *
+ * Render the page directly inside a MemoryRouter. A sibling `/` route renders
+ * a location probe so the CTA's navigation target is assertable without
+ * mounting the real homepage. Auth is mock: `?auth=in` persists to
+ * localStorage, so each test clears it first to start signed out.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import AccountPage from './AccountPage'
+
+function renderAccount(entry = '/me') {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/me" element={<AccountPage />} />
+        <Route path="/" element={<div>HOME PROBE</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('AccountPage /me', () => {
+  beforeEach(() => {
+    // ?auth=in persists to localStorage; clear it so each test starts signed
+    // out. The jsdom localStorage in this workspace can be non-functional —
+    // ignore failures.
+    try {
+      localStorage.clear()
+    } catch {
+      // ignore storage failures (private mode, non-functional jsdom stub)
+    }
+  })
+
+  it('renders the login guide and no fake profile for a signed-out visitor', () => {
+    renderAccount('/me')
+
+    // Login-guide markers: the heading and the plain-text unlock preview.
+    expect(screen.getByText('登录后查看你的星轨')).toBeInTheDocument()
+    expect(screen.getByText('战绩与单局完成率')).toBeInTheDocument()
+    expect(screen.getByText('连胜与最快记录')).toBeInTheDocument()
+    expect(screen.getByText('勋章墙')).toBeInTheDocument()
+    // A functional CTA linking to the homepage.
+    expect(screen.getByRole('link', { name: '登录 / 开始' })).toBeInTheDocument()
+
+    // None of the fake-profile content may render for an anonymous visitor.
+    expect(screen.queryByText('星海')).not.toBeInTheDocument()
+    expect(screen.queryByText('林星海')).not.toBeInTheDocument()
+    expect(screen.queryByText('42')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('你的战绩、连胜、个人最快记录。所有数据只属于你。')
+    ).not.toBeInTheDocument()
+    // The recent-runs table and the badge grid are absent.
+    expect(screen.queryByText('最近 5 局')).not.toBeInTheDocument()
+    expect(screen.queryByText('勋章')).not.toBeInTheDocument()
+  })
+
+  it('navigates to the homepage when the signed-out CTA is clicked', () => {
+    renderAccount('/me')
+
+    fireEvent.click(screen.getByRole('link', { name: '登录 / 开始' }))
+
+    expect(screen.getByText('HOME PROBE')).toBeInTheDocument()
+  })
+
+  it('renders the profile, recent runs and badges for a signed-in visitor', () => {
+    renderAccount('/me?auth=in')
+
+    // Profile identity comes from the authenticated user (林 + 星海).
+    expect(screen.getByText('林星海')).toBeInTheDocument()
+    // Stats card surfaces the completed count.
+    expect(screen.getByText('42')).toBeInTheDocument()
+    // The 最近 5 局 table and 勋章 grid render.
+    expect(screen.getByText('最近 5 局')).toBeInTheDocument()
+    expect(screen.getByText('勋章')).toBeInTheDocument()
+    // The login-guide empty state must NOT be present.
+    expect(screen.queryByRole('link', { name: '登录 / 开始' })).not.toBeInTheDocument()
+  })
+})

--- a/packages/platform/src/pages/AccountPage.tsx
+++ b/packages/platform/src/pages/AccountPage.tsx
@@ -1,41 +1,59 @@
+import { Link } from 'react-router-dom'
 import { Button, ConicAvatar, EyebrowTag, GlassCard } from '@amiclaw/ui'
 import { badges, recentRuns } from '@/mocks/account'
-import { mockUser } from '@/mocks/auth'
+import type { MockUser } from '@/mocks/auth'
+import { useAuth } from '@/hooks/useAuth'
 import styles from './AccountPage.module.css'
 
 /* Account page — handoff §6.11. A profile card (identity + stats) beside
    a「最近 5 局」run table and a 勋章 badge grid. Platform chrome — every
-   accent is brand yellow; no BombSquad cyan on this surface. */
+   accent is brand yellow; no BombSquad cyan on this surface.
+
+   The page reads identity from useAuth(): a signed-in visitor sees the
+   profile; an anonymous visitor gets a login-guide empty state instead of
+   another user's profile (mirrors GamesPage's signed-in / anonymous split). */
 export default function AccountPage() {
-  const fullName = `${mockUser.avatarLetter}${mockUser.displayName}`
+  const { signedIn, user } = useAuth()
+
   return (
     <div className={styles.page}>
       <EyebrowTag variant="section">我的 · ACCOUNT</EyebrowTag>
+      {signedIn && user ? <SignedInProfile user={user} /> : <SignedOutGuide />}
+    </div>
+  )
+}
+
+/* The signed-in profile — identity and stats come from the authenticated
+   `user`; recentRuns / badges are the demo user's run history and badge wall. */
+function SignedInProfile({ user }: { user: MockUser }) {
+  const fullName = `${user.avatarLetter}${user.displayName}`
+  return (
+    <>
       <h2 className={styles.title}>
-        <span className={styles.accent}>{mockUser.displayName}</span> 的星轨。
+        <span className={styles.accent}>{user.displayName}</span> 的星轨。
       </h2>
       <p className={styles.lead}>你的战绩、连胜、个人最快记录。所有数据只属于你。</p>
 
       <div className={styles.grid}>
         <GlassCard radius="2xl" className={styles.profile}>
           <div className={styles.avatar}>
-            <ConicAvatar size={96} letter={mockUser.avatarLetter} ariaHidden />
+            <ConicAvatar size={96} letter={user.avatarLetter} ariaHidden />
           </div>
           <div className={styles.name}>{fullName}</div>
           <div className={styles.rank}>
-            本周 #{mockUser.weekRank} · 累计 #{mockUser.totalRank.toLocaleString('en-US')}
+            本周 #{user.weekRank} · 累计 #{user.totalRank.toLocaleString('en-US')}
           </div>
           <div className={styles.stats}>
             <div className={styles.stat}>
-              <div className={styles.statValue}>{mockUser.streakDays}</div>
+              <div className={styles.statValue}>{user.streakDays}</div>
               <div className={styles.statLabel}>连胜</div>
             </div>
             <div className={styles.stat}>
-              <div className={styles.statValue}>{mockUser.completed}</div>
+              <div className={styles.statValue}>{user.completed}</div>
               <div className={styles.statLabel}>已完成</div>
             </div>
             <div className={styles.stat}>
-              <div className={styles.statValue}>{mockUser.fastest}</div>
+              <div className={styles.statValue}>{user.fastest}</div>
               <div className={styles.statLabel}>最快</div>
             </div>
           </div>
@@ -81,6 +99,36 @@ export default function AccountPage() {
           </section>
         </div>
       </div>
-    </div>
+    </>
+  )
+}
+
+/* What signing in unlocks — plain text only. No fake numbers, names, or a
+   blurred/skeleton fake-data placeholder; the anonymous visitor must never
+   see another user's stats here. */
+const UNLOCK_PREVIEW = ['战绩与单局完成率', '连胜与最快记录', '勋章墙']
+
+/* The anonymous empty state — a single login-guide card. Routes to the
+   platform homepage (the onboarding/entry surface) via react-router. */
+function SignedOutGuide() {
+  return (
+    <>
+      <h2 className={styles.title}>登录后查看你的星轨。</h2>
+      <p className={styles.lead}>登录后，这里会显示属于你的战绩、连胜和勋章。</p>
+
+      <GlassCard radius="2xl" className={styles.guideCard}>
+        <h3 className={styles.guideTitle}>登录后查看你的星轨</h3>
+        <ul className={styles.unlockList}>
+          {UNLOCK_PREVIEW.map((item) => (
+            <li key={item} className={styles.unlockItem}>
+              {item}
+            </li>
+          ))}
+        </ul>
+        <Link to="/" className={styles.guideCta}>
+          登录 / 开始
+        </Link>
+      </GlassCard>
+    </>
   )
 }


### PR DESCRIPTION
## Summary

- The `/me` account page rendered `mockUser` + mock run/badge data unconditionally, so an **unauthenticated** visitor saw a complete fake profile (林星海: 42 completed, 6-day streak, 02:14 fastest, a 最近5局 table, a 勋章 wall) under the copy「所有数据只属于你」— while the nav showed an anonymous entry button. The data plainly wasn't "yours", and wasn't anyone's.
- `AccountPage` now reads `useAuth()` and branches like `GamesPage`: `{signedIn && user ? <SignedInProfile/> : <SignedOutGuide/>}`. Signed-in reads identity/stats from the authenticated `user` (not the imported `mockUser`). Signed-out renders one login-guide card (heading +「解锁预告」plain-text list + a functional CTA) — no fake numbers, no stranger's name, no recent-runs table or badge grid.
- Source: playtest finding R2-F10. Mock files untouched (they remain the signed-in demo data).

## ⚠️ One intentional inconsistency to confirm at merge

This branch keeps the **「登录后查看你的星轨 / 登录·开始」** framing on `/me`, chosen by the product owner after being shown that the just-merged #131 ("wire dead auth-shell CTAs to honest anonymous entry") made the rest of the auth shell **anonymous-by-design** (TopNav →「开始玩」→ `/bombsquad/`; "there's never been a login or a sign-up here"). So `/me` is the one surface that still uses login wording while the rest of the site doesn't. This is a deliberate, informed choice (the owner may intend `/me` as a future real-login surface) — flagged here for one more look before merge. The CHANGELOG entry is written to avoid claiming login exists, so release notes stay self-consistent.

## Type of change

- [x] Bug fix

## Testing

- [x] Existing tests pass (full monorepo suite green via pre-commit hook: platform 18, game-bombsquad 263, api 76, manual 60, game-yijing 21)
- [x] New tests added — `AccountPage.test.tsx` encodes both Gherkin scenarios (signed-out → login guide + absence of fake markers; signed-in → profile). Failing-first verified independently.
- [ ] Visual check on the PR's Cloudflare Pages preview (signed-out `/me` and `/me?auth=in`) — pending preview deploy.

## Checklist

- [x] Code follows the project style (dark-only, CSS-only, English code/comments)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (CHANGELOG)
- [x] Breaking changes documented if any (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)