### PR TITLE
feat(platform): add privacy policy and terms pages, wire from footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**There's now a real privacy policy and terms page** — The 隐私 and 条款 links
+in the footer used to be dead text. They now open proper pages that spell out
+exactly what we collect (your nickname and chosen AI tool go on the public
+leaderboard; an anonymous device id and game events; an optional survey), how
+long we keep it, and how to ask us to delete it — so you can see what happens to
+your data before you play.
+
 **「我的」no longer shows a stranger's stats before you have any of your own** —
 Opening「我的」used to greet every visitor with a complete profile — 42 games
 cleared, a 6-day streak, a wall of badges — that belonged to someone who wasn't

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -21,9 +21,9 @@
 #
 # --- Regression size budget --------------------------------------------------
 # Per the governance model (rule 3): the e2e regression suite is capped at
-# 2 x the journey-scenario count. With 14 active flows <-> 14 journey
-# scenarios, the regression size budget is 28 (2026-06-06, after the
-# leaderboard AI metadata flow was added).
+# 2 x the journey-scenario count. With 16 active flows <-> 16 journey
+# scenarios, the regression size budget is 32 (2026-06-07, after the
+# footer privacy / terms page flows were added).
 # Crossing it triggers a forced prune audit. Current regression count: 2.
 #
 # --- Retired scenario --------------------------------------------------------
@@ -181,4 +181,22 @@ flows:
       The BombSquad cyan accent stays confined to the featured BombSquad art
       panel and never leaks into the platform chrome.
     steps: [landing, featured-bombsquad-zone, chrome-no-cyan]
+    status: active
+
+  - id: footer-to-privacy-policy
+    name: Footer privacy policy navigation
+    description: >-
+      A visitor clicks the 隐私 link in the platform footer and lands on the
+      /privacy route, where the full privacy policy renders inside the platform
+      shell.
+    steps: [landing, footer-privacy-link, privacy-page]
+    status: active
+
+  - id: footer-to-terms
+    name: Footer terms-of-service navigation
+    description: >-
+      A visitor clicks the 条款 link in the platform footer and lands on the
+      /terms route, where the full user agreement renders inside the platform
+      shell.
+    steps: [landing, footer-terms-link, terms-page]
     status: active

--- a/e2e/privacy-terms-pages.gherkin
+++ b/e2e/privacy-terms-pages.gherkin
@@ -1,0 +1,33 @@
+# Privacy & Terms pages — the platform footer 隐私 / 条款 links route to the
+# /privacy and /terms routes, which render the full legal documents inside the
+# platform shell.
+#
+# Each scenario carries a per-scenario flow-source comment tracing to
+# e2e/flow-inventory.yaml plus the @playwright consumption-layer tag. Every
+# step reuses an existing common step definition (I open / I click {string} /
+# the URL path is {path} / I see the heading {string} / I see the subtitle
+# {string}), so this file adds no new step bindings.
+
+Feature: Platform privacy and terms pages
+  As a visitor to claw.amio.fans
+  I want the footer 隐私 and 条款 links to open the real legal pages
+  So that I can read how my data is handled and the rules of the service
+
+  Background:
+    Given I open /
+
+  # Source: footer-to-privacy-policy
+  @playwright
+  Scenario: The footer 隐私 link opens the privacy policy
+    When I click "隐私"
+    Then the URL path is /privacy
+    And I see the heading "隐私政策 · PRIVACY"
+    And I see the subtitle "本政策说明 AmiClaw 收集哪些信息、为什么收集、如何使用与保存，以及你对这些信息拥有的权利。"
+
+  # Source: footer-to-terms
+  @playwright
+  Scenario: The footer 条款 link opens the user agreement
+    When I click "条款"
+    Then the URL path is /terms
+    And I see the heading "用户条款 · TERMS"
+    And I see the subtitle "本条款是你与运营方就使用 AmiClaw 平台达成的协议。请在使用本服务前阅读并接受。"

--- a/packages/platform/src/App.tsx
+++ b/packages/platform/src/App.tsx
@@ -4,6 +4,8 @@ import GamesPage from './pages/GamesPage'
 import LeaderboardPage from './pages/LeaderboardPage'
 import CommunityPage from './pages/CommunityPage'
 import AccountPage from './pages/AccountPage'
+import PrivacyPage from './pages/PrivacyPage'
+import TermsPage from './pages/TermsPage'
 
 export default function App() {
   return (
@@ -14,6 +16,8 @@ export default function App() {
         <Route path="/leaderboard" element={<LeaderboardPage />} />
         <Route path="/community" element={<CommunityPage />} />
         <Route path="/me" element={<AccountPage />} />
+        <Route path="/privacy" element={<PrivacyPage />} />
+        <Route path="/terms" element={<TermsPage />} />
       </Route>
     </Routes>
   )

--- a/packages/platform/src/components/platform/PlatformFooter.module.css
+++ b/packages/platform/src/components/platform/PlatformFooter.module.css
@@ -29,6 +29,13 @@
 
 .link {
   color: rgba(255, 255, 255, 0.55);
+  text-decoration: none;
+}
+
+/* Only the real <a> links (隐私 / 条款) are interactive; the dead <span>s
+   (关于 / Discord) keep the default cursor and never brighten on hover. */
+a.link:hover {
+  color: rgba(255, 255, 255, 0.85);
 }
 
 /* ----------  responsive: mobile  ----------

--- a/packages/platform/src/components/platform/PlatformFooter.test.tsx
+++ b/packages/platform/src/components/platform/PlatformFooter.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * PlatformFooter link-wiring test.
+ *
+ * 隐私 and 条款 must be real react-router links to /privacy and /terms; 关于
+ * and Discord are owned by a sibling task and must stay non-link dead text
+ * until their destinations land. This test pins both halves of that contract.
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import PlatformFooter from './PlatformFooter'
+
+function renderFooter() {
+  return render(
+    <MemoryRouter>
+      <PlatformFooter />
+    </MemoryRouter>
+  )
+}
+
+describe('PlatformFooter', () => {
+  it('renders 隐私 as a link to /privacy', () => {
+    renderFooter()
+    const link = screen.getByRole('link', { name: '隐私' })
+    expect(link).toHaveAttribute('href', '/privacy')
+  })
+
+  it('renders 条款 as a link to /terms', () => {
+    renderFooter()
+    const link = screen.getByRole('link', { name: '条款' })
+    expect(link).toHaveAttribute('href', '/terms')
+  })
+
+  it('keeps 关于 and Discord as non-link dead text (owned by a sibling task)', () => {
+    renderFooter()
+    expect(screen.queryByRole('link', { name: '关于' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Discord' })).not.toBeInTheDocument()
+    // They still render as text.
+    expect(screen.getByText('关于')).toBeInTheDocument()
+    expect(screen.getByText('Discord')).toBeInTheDocument()
+  })
+})

--- a/packages/platform/src/components/platform/PlatformFooter.tsx
+++ b/packages/platform/src/components/platform/PlatformFooter.tsx
@@ -1,8 +1,15 @@
+import { Link } from 'react-router-dom'
 import styles from './PlatformFooter.module.css'
 
-/* The secondary links have no destinations yet — the corresponding pages
-   land in later phases, so they render as plain text for now. */
-const FOOTER_LINKS = ['关于', '隐私', '条款', 'Discord']
+/* Secondary footer links. 隐私 / 条款 route to their platform pages; 关于 and
+   Discord have no destination yet (owned by a sibling task) and render as
+   plain text until those pages land. */
+const FOOTER_LINKS: { label: string; to?: string }[] = [
+  { label: '关于' },
+  { label: '隐私', to: '/privacy' },
+  { label: '条款', to: '/terms' },
+  { label: 'Discord' },
+]
 
 /* Platform footer — copyright line + secondary link row. */
 export default function PlatformFooter() {
@@ -11,11 +18,17 @@ export default function PlatformFooter() {
       <div className={styles.inner}>
         <span>© 2026 AMIO · amio.love</span>
         <div className={styles.links}>
-          {FOOTER_LINKS.map((label) => (
-            <span key={label} className={styles.link}>
-              {label}
-            </span>
-          ))}
+          {FOOTER_LINKS.map(({ label, to }) =>
+            to ? (
+              <Link key={label} to={to} className={styles.link}>
+                {label}
+              </Link>
+            ) : (
+              <span key={label} className={styles.link}>
+                {label}
+              </span>
+            )
+          )}
         </div>
       </div>
     </footer>

--- a/packages/platform/src/pages/PrivacyPage.module.css
+++ b/packages/platform/src/pages/PrivacyPage.module.css
@@ -1,0 +1,118 @@
+/* Privacy policy page — a long-form legal document on one glass card.
+   Header mirrors the other platform pages (.page / .title / .accent /
+   .lead); the card carries readable prose with a constrained measure for
+   legibility. Dark-only, brand-yellow accents, no BombSquad cyan. */
+
+.page {
+  padding: 60px 0;
+}
+
+.title {
+  margin: 0;
+  font: 400 44px var(--font-display);
+  color: var(--text-1);
+}
+
+.accent {
+  color: var(--amio-yellow);
+  font-style: italic;
+}
+
+.lead {
+  margin: 10px 0 36px;
+  max-width: 640px;
+  font: 400 16px/1.6 var(--font-body);
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.card {
+  padding: 36px 40px;
+}
+
+.prose {
+  max-width: 720px;
+}
+
+.section {
+  margin-top: 32px;
+}
+
+.section:first-child {
+  margin-top: 0;
+}
+
+.heading {
+  margin: 0 0 12px;
+  font: 600 20px/1.4 var(--font-display);
+  color: var(--text-1);
+}
+
+.subheading {
+  margin: 20px 0 8px;
+  font: 600 15px/1.5 var(--font-body);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.prose p {
+  margin: 0 0 12px;
+  font: 400 15px/1.7 var(--font-body);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.prose p:last-child {
+  margin-bottom: 0;
+}
+
+.list {
+  margin: 0 0 12px;
+  padding-left: 22px;
+}
+
+.list li {
+  margin-bottom: 8px;
+  font: 400 15px/1.7 var(--font-body);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.list li:last-child {
+  margin-bottom: 0;
+}
+
+.list strong,
+.prose strong {
+  font-weight: 600;
+  color: var(--text-1);
+}
+
+.note {
+  padding: 12px 16px;
+  border-left: 2px solid var(--border-yellow-soft);
+  border-radius: var(--radius-md);
+  background: var(--amio-yellow-glow-10);
+}
+
+.link {
+  color: var(--amio-yellow);
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.effective {
+  margin-top: 20px;
+  font: 400 13px var(--font-body);
+  color: var(--text-4);
+}
+
+/* ----------  responsive: mobile  ---------- */
+@media (max-width: 768px) {
+  .title {
+    font-size: 32px;
+  }
+
+  .card {
+    padding: 24px 20px;
+  }
+}

--- a/packages/platform/src/pages/PrivacyPage.test.tsx
+++ b/packages/platform/src/pages/PrivacyPage.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * PrivacyPage rendering test.
+ *
+ * Asserts the production privacy policy renders and that the faithfulness-
+ * critical facts are present: the retention windows (48h leaderboard / 30d
+ * telemetry), the contact address, the "we do not collect email / phone /
+ * real name" disclaimer, and the public-leaderboard disclosure. These are the
+ * legal-compliance load-bearing claims, so the test guards them against an
+ * accidental edit that would make the page misstate the real data practice.
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import PrivacyPage from './PrivacyPage'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PrivacyPage />
+    </MemoryRouter>
+  )
+}
+
+describe('PrivacyPage', () => {
+  it('renders the policy with its title and lead', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { name: /我们如何对待你的数据/ })).toBeInTheDocument()
+    expect(screen.getByText(/本政策说明 AmiClaw 收集哪些信息/)).toBeInTheDocument()
+  })
+
+  it('states the 48-hour leaderboard and 30-day telemetry retention windows', () => {
+    renderPage()
+    expect(screen.getByText(/保留 48\s*小时后自动过期/)).toBeInTheDocument()
+    expect(screen.getByText(/保留 30 天后自动过期/)).toBeInTheDocument()
+  })
+
+  it('discloses the public leaderboard and what it shows', () => {
+    renderPage()
+    expect(
+      screen.getByText(/你的昵称、通关用时、当日尝试次数，以及你所填的[\s\S]*AI 工具与模型/)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/在每日排行榜上公开展示/)).toBeInTheDocument()
+  })
+
+  it('carries the faithful "we do not collect email / phone / real name" disclaimer', () => {
+    renderPage()
+    expect(
+      screen.getByText(/我们不收集邮箱、手机号、真实姓名、精确地理位置或任何支付信息/)
+    ).toBeInTheDocument()
+  })
+
+  it('names Cloudflare as the hosting and storage processor', () => {
+    renderPage()
+    expect(screen.getByText(/Cloudflare Pages/)).toBeInTheDocument()
+    expect(screen.getByText(/Cloudflare KV/)).toBeInTheDocument()
+  })
+
+  it('provides the deletion / contact email and an effective date', () => {
+    renderPage()
+    const mailtoLinks = screen.getAllByRole('link', { name: 'hi@amio.love' })
+    expect(mailtoLinks.length).toBeGreaterThan(0)
+    expect(mailtoLinks[0]).toHaveAttribute('href', 'mailto:hi@amio.love')
+    expect(screen.getByText(/生效日期：2026-06-07/)).toBeInTheDocument()
+  })
+})

--- a/packages/platform/src/pages/PrivacyPage.tsx
+++ b/packages/platform/src/pages/PrivacyPage.tsx
@@ -1,0 +1,200 @@
+import { EyebrowTag, GlassCard } from '@amiclaw/ui'
+import styles from './PrivacyPage.module.css'
+
+const CONTACT_EMAIL = 'hi@amio.love'
+const EFFECTIVE_DATE = '2026-06-07'
+
+/* Privacy policy page — a production-grade Chinese privacy policy for the
+   AmiClaw platform (claw.amio.fans). The collected-data inventory is kept
+   faithful to the real submission and telemetry contracts (validation.ts /
+   post-event.ts / leaderboard-types.ts / event-types.ts) and the real KV
+   retention windows (leaderboard 48h, telemetry 30d). Platform chrome —
+   every accent is brand yellow; no BombSquad cyan on this surface. */
+export default function PrivacyPage() {
+  return (
+    <div className={styles.page}>
+      <EyebrowTag variant="section">隐私政策 · PRIVACY</EyebrowTag>
+      <h2 className={styles.title}>
+        我们如何对待<span className={styles.accent}>你的数据</span>。
+      </h2>
+      <p className={styles.lead}>
+        本政策说明 AmiClaw 收集哪些信息、为什么收集、如何使用与保存，以及你对这些信息拥有的权利。
+        请在使用本服务前阅读。
+      </p>
+
+      <GlassCard radius="2xl" className={styles.card}>
+        <article className={styles.prose}>
+          <section className={styles.section}>
+            <h3 className={styles.heading}>一、适用范围与运营方</h3>
+            <p>
+              本政策适用于你访问与使用 AmiClaw 平台（claw.amio.fans，含 BombSquad
+              等其上的游戏）时，运营方对你个人信息的处理。本服务的运营方为 AMIO 团队。
+            </p>
+            <p>
+              本服务不设账号体系，无须注册，也无须提供邮箱、手机号或真实姓名即可游玩。
+              下文逐项说明我们实际收集的信息。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>二、我们收集哪些信息</h3>
+            <p>我们只收集运行游戏与维护排行榜所必需的信息，逐项列举如下，并说明每项的收集原因。</p>
+
+            <h4 className={styles.subheading}>1. 你主动提交的信息</h4>
+            <ul className={styles.list}>
+              <li>
+                <strong>昵称</strong>（最长 20
+                个字符）：在你首次提交每日挑战成绩时由你自行填写，用于在排行榜上标识你的成绩。
+              </li>
+              <li>
+                <strong>所用 AI 工具</strong>（最长 40 个字符，必填）：你这一局协作所用的语音 AI（如
+                Claude、ChatGPT、Gemini 或你填写的其他名称），用于在排行榜上展示成绩的协作背景。
+              </li>
+              <li>
+                <strong>AI 模型</strong>（最长 80
+                个字符，选填）：你可补充具体模型或版本；不填则不收集。
+              </li>
+              <li>
+                <strong>问卷回答</strong>（选填）：你可在结算页选择填写一份简短问卷，内容包括所用 AI
+                工具、好玩程度评分、难度感受，以及一段不超过 200 字的可选文字反馈。问卷可随时跳过。
+              </li>
+            </ul>
+
+            <h4 className={styles.subheading}>2. 游戏运行中自动产生的信息</h4>
+            <ul className={styles.list}>
+              <li>
+                <strong>设备标识符</strong>
+                （device_id）：首次访问时在你的浏览器本地生成的一个随机标识，
+                用于区分不同设备、防止重复计数与刷榜，不包含你的真实身份。
+              </li>
+              <li>
+                <strong>成绩相关数据</strong>
+                ：通关用时、每个模块的用时、当日第几次尝试，以及一段用于事后校验的操作记录摘要（哈希值）。这些用于排名、个人最佳计算与反作弊校验。
+              </li>
+              <li>
+                <strong>匿名行为事件</strong>
+                ：游戏开始、模块通关、通关、放弃、手册加载失败、再玩意向、三振出局、到达时间上限、问卷提交等事件的计数，附带发生时间与上述设备标识符。这些用于了解整体游玩与完成情况，均为聚合统计，不针对个人画像。
+              </li>
+            </ul>
+
+            <p className={styles.note}>
+              我们不收集邮箱、手机号、真实姓名、精确地理位置或任何支付信息。本服务目前不涉及付费，也不接入支付渠道。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>三、我们如何使用这些信息</h3>
+            <ul className={styles.list}>
+              <li>生成并展示每日排行榜，计算你的排名与当日个人最佳成绩。</li>
+              <li>进行成绩的服务端校验与基础反作弊，识别异常或刷榜的提交。</li>
+              <li>以聚合方式统计游玩与完成情况，评估游戏体验并据此改进。</li>
+              <li>根据问卷反馈了解协作中的问题，改进游戏设计。</li>
+            </ul>
+            <p>我们不会将上述信息用于与本服务无关的目的，也不会用于自动化决策对你产生重大影响。</p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>四、公开展示与第三方共享</h3>
+            <p>
+              <strong>公开排行榜</strong>
+              ：你提交成绩后，你的昵称、通关用时、当日尝试次数，以及你所填的 AI
+              工具与模型，将在每日排行榜上公开展示，访问本服务的任何人都可看到。
+              请勿在昵称中填写你不愿公开的个人信息。
+            </p>
+            <p>
+              <strong>托管与存储服务商</strong>：本服务托管于 Cloudflare。页面由 Cloudflare Pages
+              提供，服务端逻辑运行于 Cloudflare Workers，成绩与事件数据存储于 Cloudflare KV。
+              这意味着上述数据会经由 Cloudflare 的基础设施传输与存储，受其作为处理方的安全措施约束。
+            </p>
+            <p>
+              <strong>你自带的 AI 工具</strong>：你与之语音协作的 AI
+              由你自行选择并独立使用，属于不受我们控制的第三方服务。你与该 AI
+              的对话不经过本服务，也不由我们收集；该 AI 如何处理你的数据，由其各自的隐私政策约束。
+            </p>
+            <p>
+              除上述托管与存储服务商外，我们不向任何第三方出售、出租你的个人信息，也不会在法律要求之外对外共享。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>五、Cookie 与本地存储</h3>
+            <p>
+              本服务不使用用于广告追踪的
+              Cookie。我们使用浏览器的本地存储（localStorage）保存上述设备标识符，以及你填过的昵称与
+              AI
+              工具信息，便于你下次游玩时无须重填；并使用会话存储（sessionStorage）在你提交成绩后临时保留你的排行榜成绩，用于即时展示。清除浏览器的本地存储即可移除这些数据。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>六、数据保留期限</h3>
+            <p>我们仅在实现上述目的所必需的期限内保留数据，到期后由存储服务自动删除。</p>
+            <ul className={styles.list}>
+              <li>
+                <strong>排行榜成绩数据</strong>：自写入起保留 48
+                小时后自动过期，对应每日榜的展示周期。
+              </li>
+              <li>
+                <strong>匿名行为事件与问卷回答</strong>：自写入起保留 30 天后自动过期。
+              </li>
+              <li>
+                <strong>本地存储中的设备标识符与昵称等</strong>：保存在你的设备上，由你随时清除。
+              </li>
+            </ul>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>七、你的权利</h3>
+            <p>
+              在适用法律允许的范围内，你对自己的个人信息享有访问、更正、删除以及撤回同意的权利。
+            </p>
+            <p>
+              由于本服务不设账号，我们通过你提交时的昵称与提交日期来定位你的成绩记录。
+              如需行使上述权利，请发送邮件至{' '}
+              <a className={styles.link} href={`mailto:${CONTACT_EMAIL}`}>
+                {CONTACT_EMAIL}
+              </a>
+              ，并在邮件中附上你的昵称与成绩提交日期，以便我们核实并处理。
+              请注意，排行榜成绩与行为事件均会在前述保留期限到期后自动删除。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>八、信息安全</h3>
+            <p>
+              我们依托 Cloudflare
+              的基础设施，对数据的传输采用加密连接（HTTPS），并将数据访问限制在实现服务目的所必需的范围内。请注意，任何通过互联网传输或存储的方式都无法保证绝对安全；我们会持续采取合理措施保护你的信息。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>九、未成年人</h3>
+            <p>
+              本服务面向成年人设计。我们不有意收集未满 14
+              周岁未成年人的个人信息。若你是未成年人，请在监护人同意并指导下使用本服务。如我们发现在未取得监护人同意的情况下收集了未成年人信息，将及时删除。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>十、政策更新</h3>
+            <p>
+              我们可能会不时更新本政策。更新后将在本页面公布并更新下方的生效日期。涉及重大变更时，我们会以适当方式提示。你在更新生效后继续使用本服务，即表示你接受更新后的政策。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>十一、联系我们</h3>
+            <p>
+              如对本政策或你的个人信息有任何疑问，请联系{' '}
+              <a className={styles.link} href={`mailto:${CONTACT_EMAIL}`}>
+                {CONTACT_EMAIL}
+              </a>
+              。
+            </p>
+            <p className={styles.effective}>生效日期：{EFFECTIVE_DATE}</p>
+          </section>
+        </article>
+      </GlassCard>
+    </div>
+  )
+}

--- a/packages/platform/src/pages/TermsPage.module.css
+++ b/packages/platform/src/pages/TermsPage.module.css
@@ -1,0 +1,120 @@
+/* Terms-of-service page — a long-form legal document on one glass card.
+   Header mirrors the other platform pages (.page / .title / .accent /
+   .lead); the card carries readable prose with a constrained measure for
+   legibility. Kept structurally identical to PrivacyPage.module.css so the
+   two legal pages render with the same styling. Dark-only, brand-yellow
+   accents, no BombSquad cyan. */
+
+.page {
+  padding: 60px 0;
+}
+
+.title {
+  margin: 0;
+  font: 400 44px var(--font-display);
+  color: var(--text-1);
+}
+
+.accent {
+  color: var(--amio-yellow);
+  font-style: italic;
+}
+
+.lead {
+  margin: 10px 0 36px;
+  max-width: 640px;
+  font: 400 16px/1.6 var(--font-body);
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.card {
+  padding: 36px 40px;
+}
+
+.prose {
+  max-width: 720px;
+}
+
+.section {
+  margin-top: 32px;
+}
+
+.section:first-child {
+  margin-top: 0;
+}
+
+.heading {
+  margin: 0 0 12px;
+  font: 600 20px/1.4 var(--font-display);
+  color: var(--text-1);
+}
+
+.subheading {
+  margin: 20px 0 8px;
+  font: 600 15px/1.5 var(--font-body);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.prose p {
+  margin: 0 0 12px;
+  font: 400 15px/1.7 var(--font-body);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.prose p:last-child {
+  margin-bottom: 0;
+}
+
+.list {
+  margin: 0 0 12px;
+  padding-left: 22px;
+}
+
+.list li {
+  margin-bottom: 8px;
+  font: 400 15px/1.7 var(--font-body);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.list li:last-child {
+  margin-bottom: 0;
+}
+
+.list strong,
+.prose strong {
+  font-weight: 600;
+  color: var(--text-1);
+}
+
+.note {
+  padding: 12px 16px;
+  border-left: 2px solid var(--border-yellow-soft);
+  border-radius: var(--radius-md);
+  background: var(--amio-yellow-glow-10);
+}
+
+.link {
+  color: var(--amio-yellow);
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.effective {
+  margin-top: 20px;
+  font: 400 13px var(--font-body);
+  color: var(--text-4);
+}
+
+/* ----------  responsive: mobile  ---------- */
+@media (max-width: 768px) {
+  .title {
+    font-size: 32px;
+  }
+
+  .card {
+    padding: 24px 20px;
+  }
+}

--- a/packages/platform/src/pages/TermsPage.test.tsx
+++ b/packages/platform/src/pages/TermsPage.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * TermsPage rendering test.
+ *
+ * Asserts the production user agreement renders and that its mandatory
+ * sections are present: the applicable-law / dispute clause, the disclaimer,
+ * and the public-display-of-user-content clause. Also guards the contact
+ * address and effective date.
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import TermsPage from './TermsPage'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <TermsPage />
+    </MemoryRouter>
+  )
+}
+
+describe('TermsPage', () => {
+  it('renders the agreement with its title and lead', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { name: /使用本服务的约定/ })).toBeInTheDocument()
+    expect(screen.getByText(/本条款是你与运营方就使用 AmiClaw 平台达成的协议/)).toBeInTheDocument()
+  })
+
+  it('covers the applicable-law and dispute-resolution section', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { name: /适用法律与争议解决/ })).toBeInTheDocument()
+    expect(screen.getByText(/适用中华人民共和国法律/)).toBeInTheDocument()
+  })
+
+  it('covers the disclaimer section', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { name: /免责声明/ })).toBeInTheDocument()
+    expect(screen.getByText(/按「现状」与「现有可用」基础提供/)).toBeInTheDocument()
+  })
+
+  it('discloses that submitted content is publicly displayed', () => {
+    renderPage()
+    expect(screen.getByText(/将在每日排行榜上公开展示/)).toBeInTheDocument()
+  })
+
+  it('provides the contact email and an effective date', () => {
+    renderPage()
+    const mailtoLinks = screen.getAllByRole('link', { name: 'hi@amio.love' })
+    expect(mailtoLinks.length).toBeGreaterThan(0)
+    expect(mailtoLinks[0]).toHaveAttribute('href', 'mailto:hi@amio.love')
+    expect(screen.getByText(/生效日期：2026-06-07/)).toBeInTheDocument()
+  })
+})

--- a/packages/platform/src/pages/TermsPage.tsx
+++ b/packages/platform/src/pages/TermsPage.tsx
@@ -1,0 +1,140 @@
+import { EyebrowTag, GlassCard } from '@amiclaw/ui'
+import styles from './TermsPage.module.css'
+
+const CONTACT_EMAIL = 'hi@amio.love'
+const EFFECTIVE_DATE = '2026-06-07'
+
+/* Terms-of-service page — a production-grade Chinese user agreement for the
+   AmiClaw platform (claw.amio.fans). Mirrors the real service shape: no
+   accounts (device-id identity), the player-supplied AI tool is an
+   uncontrolled third party, nicknames + AI tool are publicly displayed.
+   Platform chrome — every accent is brand yellow; no BombSquad cyan here. */
+export default function TermsPage() {
+  return (
+    <div className={styles.page}>
+      <EyebrowTag variant="section">用户条款 · TERMS</EyebrowTag>
+      <h2 className={styles.title}>
+        使用本服务的<span className={styles.accent}>约定</span>。
+      </h2>
+      <p className={styles.lead}>
+        本条款是你与运营方就使用 AmiClaw 平台达成的协议。请在使用本服务前阅读并接受。
+      </p>
+
+      <GlassCard radius="2xl" className={styles.card}>
+        <article className={styles.prose}>
+          <section className={styles.section}>
+            <h3 className={styles.heading}>一、接受条款</h3>
+            <p>
+              当你访问或使用 AmiClaw 平台（claw.amio.fans，含 BombSquad
+              等其上的游戏，下称「本服务」）时，即表示你已阅读、理解并同意受本条款约束。
+              如你不同意本条款，请勿使用本服务。本服务的运营方为 AMIO 团队。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>二、服务说明</h3>
+            <p>
+              本服务是一个人机语音协作的游戏平台。以 BombSquad 为例，你需要与一个语音 AI
+              搭档仅通过语音沟通，共同完成拆弹挑战。
+            </p>
+            <p>
+              你所使用的语音 AI 工具由你自行选择、自行获取并独立使用，属于不受我们控制的第三方服务。
+              本服务不集成、不提供、不代理任何 AI
+              接口，也不对该第三方工具的可用性、准确性或其表现负责。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>三、身份与昵称</h3>
+            <p>
+              本服务不设账号体系，无须注册。我们通过你浏览器本地生成的设备标识符区分设备。
+              你在提交成绩时填写的昵称仅用于排行榜标识，并非账号，亦不构成对你真实身份的认证。
+              你应自行妥善管理使用本服务的设备。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>四、用户行为规范</h3>
+            <p>使用本服务时，你同意不从事下列行为：</p>
+            <ul className={styles.list}>
+              <li>以伪造成绩、篡改用时、自动化脚本或任何作弊手段刷榜，或干扰排行榜的公平性。</li>
+              <li>使用违法、侮辱、淫秽、仇恨、冒充他人或侵犯他人权利的昵称及内容。</li>
+              <li>干扰、破坏本服务的正常运行，或试图未经授权访问本服务的系统与数据。</li>
+              <li>以任何方式将本服务用于违反适用法律法规的目的。</li>
+            </ul>
+            <p>
+              对于违反上述规范的提交，我们有权移除相关成绩、过滤或清除违规昵称，并在必要时限制相关设备的使用。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>五、用户内容</h3>
+            <p>
+              你提交的昵称，以及你所填写的 AI
+              工具与模型信息，将在每日排行榜上公开展示。提交即表示你授权我们为运营本服务之目的展示、存储与处理这些内容。
+            </p>
+            <p>
+              你应对自己提交的内容负责，并保证其不侵犯任何第三方的合法权利。请勿在昵称等内容中填写你不愿公开的个人信息。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>六、知识产权</h3>
+            <p>
+              本服务及其包含的游戏设计、界面、文案、视觉素材、代码等，除你提交的内容及第三方素材外，其知识产权均归运营方或相应权利人所有。
+              未经书面许可，你不得复制、改编、分发或以其他方式商业利用本服务的内容。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>七、免责声明</h3>
+            <p>
+              本服务按「现状」与「现有可用」基础提供。在适用法律允许的范围内，我们不对本服务的不间断、无错误、满足你的特定需求或与你所用第三方
+              AI 工具的兼容性作出任何明示或默示的保证。
+            </p>
+            <p>
+              你所使用的第三方 AI
+              工具不受我们控制，其表现、内容与可用性由该工具的提供方负责，与本服务无关。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>八、责任限制</h3>
+            <p>
+              在适用法律允许的最大范围内，对于因使用或无法使用本服务而产生的任何间接、附带或后果性损失，运营方不承担责任。
+              本条款的任何内容均不排除或限制依法不可排除或限制的责任。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>九、服务变更与终止</h3>
+            <p>
+              我们可能随时新增、修改、暂停或终止本服务的全部或部分功能，且无须事先逐一通知。
+              我们也可能不时更新本条款，更新后将在本页面公布并更新下方生效日期；你在更新生效后继续使用本服务，即视为接受更新后的条款。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>十、适用法律与争议解决</h3>
+            <p>
+              本条款的订立、解释与争议解决适用中华人民共和国法律。
+              因本服务或本条款产生的争议，双方应先友好协商解决；协商不成的，可依法向有管辖权的人民法院提起诉讼。
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.heading}>十一、联系方式</h3>
+            <p>
+              如对本条款有任何疑问，请联系{' '}
+              <a className={styles.link} href={`mailto:${CONTACT_EMAIL}`}>
+                {CONTACT_EMAIL}
+              </a>
+              。
+            </p>
+            <p className={styles.effective}>生效日期：{EFFECTIVE_DATE}</p>
+          </section>
+        </article>
+      </GlassCard>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add `/privacy` and `/terms` routes inside the platform shell, rendering a production-grade Simplified-Chinese **privacy policy** and **terms of service**.
- The privacy policy is faithful to actual data practices: self-chosen nickname + AI tool shown publicly on the leaderboard, an anonymous local device id + gameplay telemetry, an optional survey; Cloudflare Pages/Workers/KV as processor; 48h leaderboard / 30d telemetry retention; deletion requests via hi@amio.love.
- Wire the footer 隐私 → `/privacy` and 条款 → `/terms` as real links (refactor `FOOTER_LINKS` to support hrefs). 关于 and Discord stay as dead text — owned by a separate footer task.

## Type of change

- [x] New feature

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Added: `PrivacyPage.test.tsx`, `TermsPage.test.tsx`, `PlatformFooter.test.tsx` (footer link contract — 隐私/条款 are links, 关于/Discord are not), and an `e2e/privacy-terms-pages.gherkin` scenario registered in `e2e/flow-inventory.yaml`. All gates re-run green after rebasing onto current `main`: typecheck, format:check, lint, test:run (440 unit tests), build, e2e:audit (16↔16 bijection), test:e2e (22 scenarios incl. the 2 new ones).

The legal-text content was independently verified (cross-model) against the real data-collection code line-by-line — every claim confirmed faithful, no over-claim or under-claim — and the full text was reviewed and approved by the product owner.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

Note: the C4 architecture doc (`docs/architecture/architecture.md`, a symlink into the Obsidian vault) was updated to list the two new pages in the Platform SPA enumeration; that edit lands in the vault SSOT and is not part of this git diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
