### PR TITLE
chore(lint-staged): cover .mjs and .cjs in the format glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
+    "*.{js,jsx,ts,tsx,mjs,cjs}": [
       "eslint --fix",
       "prettier --write"
     ],


### PR DESCRIPTION
## Summary

- Extend the lint-staged JS task glob from `*.{js,jsx,ts,tsx}` to `*.{js,jsx,ts,tsx,mjs,cjs}` so editing a `.mjs`/`.cjs` triggers pre-commit `prettier --write` + `eslint --fix`.
- Closes a tooling gap where `.mjs` edits skipped local formatting (husky pre-commit runs only `lint-staged` + `test:run`, not `format:check`) but CI's `prettier --check .` scanned them — format issues stayed silent locally and surfaced as a red CI `format:check` (e.g. PR #134).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [x] CI or configuration

## Testing

- [x] Existing tests pass
- [ ] New tests added if behavior changed
- [x] Tested manually and documented below

**Manual behavioral verification** (in the worktree):
1. Staged a deliberately-misformatted probe `.mjs` (`const   x={a:1,b:2}    ;`).
2. Ran `pnpm exec lint-staged` → glob matched the `.mjs`, ran `eslint --fix` + `prettier --write` with no errors.
3. `cat` confirmed prettier rewrote it to `const x = { a: 1, b: 2 }` / `export default x`.
4. `pnpm exec prettier --check <probe>` → passed; probe then removed (no residue).
5. `pnpm format:check` on the whole repo → green (all 15 existing `.mjs` untouched).

Notes:
- `eslint.config.mjs` already lints `.mjs`/`.cjs` (`files: ['**/*.{js,mjs,cjs,jsx,ts,tsx,mts,cts}']`), so `eslint --fix` over these extensions is safe.
- All existing `.mjs` were already prettier-clean, so no bulk reformat is included — the diff is the single glob key.
- No CHANGELOG entry: internal dev-tooling change with no user-visible impact (per `docs/changelog-style-guide.md`, internal/CI changes are omitted).

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [ ] Breaking changes documented if any

🤖 Generated with [Claude Code](https://claude.com/claude-code)
