### PR TITLE
refactor(manual): make wire positions 1-indexed (position N = Nth wire from top)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,12 @@ pnpm-lock.yaml
 # Generated golden fixture — build-answers.mjs owns its format
 e2e/fixtures/answers.json
 
+# Manual rulebook data — js-yaml dump owns its format (hand-authored practice
+# source + generate-daily-from-practice.mjs output). Byte-stable single-quote
+# YAML must not be re-quoted by prettier, or committed files diverge from
+# generator output and `gen:daily` can no longer cleanly re-derive them.
+packages/manual/data/
+
 # Playwright-bdd generated dirs (mirror .gitignore)
 .features-gen/
 .features-mirror/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ at the same destination three times. And the copy across the hero, daily
 challenge, and footer is tightened, with a clearer hierarchy so the first thing
 you read is what Amiclaw is and how to start playing.
 
+**The wire manual now numbers wires the way your AI partner talks** — In the
+光弦 module the manual used to number wires starting from 0, so the AI had to
+silently translate "position 0" into "the first wire from the top" every time it
+read you a cut — a quiet off-by-one waiting to happen. The manual now numbers
+wires from 1 top-down, so "position N" reads as exactly「从上数第 N 根」, the same
+words the AI says out loud. The correct wire to cut is unchanged on every board;
+this only removes a translation step that could trip the AI up.
+
 **The 星盘 now shows how many right-arrow presses you've dialed in** — Each of the
 three dials used to leave you guessing whether you'd turned it the right amount,
 with only the shifting center symbol to go on — which isn't the answer. Every dial

--- a/e2e/fixtures/daily-manual.yaml
+++ b/e2e/fixtures/daily-manual.yaml
@@ -16,7 +16,7 @@ modules:
         target: { position: 'last', color: 'red' }
       - condition: { wire_count: 4, color_at_last: 'white' }
         action: 'cut_wire'
-        target: { position: 1 }
+        target: { position: 2 }
       - condition: { wire_count: 4, color_at_last: 'green' }
         action: 'cut_wire'
         target: { position: 'last' }
@@ -28,13 +28,13 @@ modules:
         target: { position: 'last', color: 'red' }
       - condition: { wire_count: 4, battery_count: { gt: 2 } }
         action: 'cut_wire'
-        target: { position: 2 }
+        target: { position: 3 }
       - condition: { wire_count: 4 }
         action: 'cut_wire'
         target: { position: 'first' }
       - condition: { wire_count: 5, color_at_last: 'red' }
         action: 'cut_wire'
-        target: { position: 3 }
+        target: { position: 4 }
       - condition: { wire_count: 5, color_at_last: 'blue' }
         action: 'cut_wire'
         target: { position: 'last' }
@@ -46,10 +46,10 @@ modules:
         target: { position: 'first', color: 'blue' }
       - condition: { wire_count: 5, indicator_FRK_lit: true }
         action: 'cut_wire'
-        target: { position: 2 }
+        target: { position: 3 }
       - condition: { wire_count: 5 }
         action: 'cut_wire'
-        target: { position: 2 }
+        target: { position: 3 }
       - condition: {}
         action: 'cut_wire'
         target: { position: 'first' }

--- a/e2e/regression/fix-bombsquad-cannot-pass-level.assert.mjs
+++ b/e2e/regression/fix-bombsquad-cannot-pass-level.assert.mjs
@@ -48,38 +48,50 @@ function loadPractice() {
 
 // ---------- Scenario A: wire_routing rule preamble ----------
 function scenarioA() {
-  const name = 'Bug A — wire_routing manual declares 0-indexed position + first-match-wins'
+  const name = 'Bug A — wire_routing manual declares 1-indexed position + first-match-wins'
   const manual = loadPractice()
   const rule = manual?.modules?.wire_routing?.rule
   if (typeof rule !== 'string' || rule.length === 0) {
     record(name, `wire_routing.rule is missing or empty (got: ${JSON.stringify(rule)})`)
     return
   }
-  // 0-indexed declaration in Chinese — accept either the phrase 0-indexed
-  // or an explicit "0 = 最上" style statement.
-  if (!/0[\s-]*indexed/i.test(rule) && !/0\s*=\s*最/.test(rule)) {
+  // 1-indexed declaration in Chinese — accept either the phrase 1-indexed
+  // or an explicit "1 = 最上" style statement. The convention was changed from
+  // 0-indexed to 1-indexed top-down so `position N` literally means "从上数第 N
+  // 根" with no 0→1 translation step (the source of off-by-one drift).
+  if (!/1[\s-]*indexed/i.test(rule) && !/1\s*=\s*最/.test(rule)) {
     record(
       name,
-      'rule preamble does not declare 0-indexed semantics (expected "0-indexed" or "0 = 最…" phrasing in Chinese)'
+      'rule preamble does not declare 1-indexed semantics (expected "1-indexed" or "1 = 最…" phrasing in Chinese)'
+    )
+  }
+  // The obsolete 0-indexed semantics + the dead 0→1 translation step must be gone.
+  if (/0[\s-]*indexed/i.test(rule)) {
+    record(name, 'rule preamble still declares obsolete 0-indexed semantics')
+  }
+  if (/翻译成自然语言/.test(rule)) {
+    record(
+      name,
+      'rule preamble still carries the dead 0→1 translation instruction (翻译成自然语言)'
     )
   }
   // first-match-wins declaration.
   if (!/first[\s-]*match[\s-]*wins/i.test(rule)) {
     record(name, 'rule preamble does not declare "first-match-wins"')
   }
-  // first ≡ 0 and last ≡ length-1 equivalence — accept either Chinese 等价 phrasing
-  // or the literal ≡ glyph.
+  // first ≡ position 1 and last ≡ position length equivalence — accept either
+  // Chinese 等价 phrasing or the literal ≡ glyph.
   const declaresFirst =
-    /first\s*[≡=]\s*(?:position\s*)?0/i.test(rule) ||
-    /关键字\s*first[^。]*?(?:等价|≡|=)[^。]*?0/i.test(rule)
+    /first\s*[≡=]\s*(?:position\s*)?1/i.test(rule) ||
+    /关键字\s*first[^。]*?(?:等价|≡|=)[^。]*?1/i.test(rule)
   const declaresLast =
-    /last\s*[≡=]\s*(?:position\s*)?length\s*[-－]\s*1/i.test(rule) ||
-    /关键字\s*last[^。]*?(?:等价|≡|=)[^。]*?length\s*[-－]\s*1/i.test(rule)
+    /last\s*[≡=]\s*(?:position\s*)?length(?!\s*[-－]\s*1)/i.test(rule) ||
+    /关键字\s*last[^。]*?(?:等价|≡|=)[^。]*?length(?!\s*[-－]\s*1)/i.test(rule)
   if (!declaresFirst) {
-    record(name, 'rule preamble does not declare "first ≡ 0" equivalence')
+    record(name, 'rule preamble does not declare "first ≡ position 1" equivalence')
   }
   if (!declaresLast) {
-    record(name, 'rule preamble does not declare "last ≡ length-1" equivalence')
+    record(name, 'rule preamble does not declare "last ≡ position length" equivalence')
   }
 }
 

--- a/e2e/regression/fix-bombsquad-cannot-pass-level.gherkin
+++ b/e2e/regression/fix-bombsquad-cannot-pass-level.gherkin
@@ -32,20 +32,23 @@ Feature: bombsquad-cannot-pass-level regression coverage
   #   matching condition" + 1-indexed positions and produced wrong cut
   #   instructions.
   # fix: practice.yaml wire_routing.rule preamble (Chinese, modeled on
-  #   keypad/dial rule strings) declares first-match-wins, 0-indexed
-  #   top-down positions, first ≡ 0, last ≡ length-1, and the
-  #   target.color refinement semantics. Propagates to 366 daily files via
-  #   the seeded shuffle generator. The corresponding solver enforcement
-  #   lives in packages/game-bombsquad/src/modules/wire/solver.ts:resolvePosition.
+  #   keypad/dial rule strings) declares first-match-wins, 1-indexed
+  #   top-down positions, first ≡ position 1, last ≡ position length, and the
+  #   target.color refinement semantics. (The position convention was later
+  #   flipped from 0-indexed to 1-indexed top-down so `position N` literally
+  #   reads as "从上数第 N 根" with no 0→1 translation step — the prior source of
+  #   off-by-one drift.) Propagates to 366 daily files via the seeded shuffle
+  #   generator. The corresponding solver enforcement lives in
+  #   packages/game-bombsquad/src/modules/wire/solver.ts:resolvePosition.
   # retire-when: docs/architecture/arch-component-manual-system.md
   #   §Invariants `每模块规则前言不变量` + `Wire 下标语义不变量` are removed.
-  Scenario: wire_routing manual declares 0-indexed position + first-match-wins (Bug A)
+  Scenario: wire_routing manual declares 1-indexed position + first-match-wins (Bug A)
     Given the practice manual YAML at packages/manual/data/practice.yaml
     When parsing the wire_routing.rule field
     Then the field is a non-empty string
-    And it declares 0-indexed position semantics in Chinese
+    And it declares 1-indexed position semantics in Chinese
     And it declares first-match-wins in Chinese
-    And it declares first ≡ 0 and last ≡ length-1 in Chinese
+    And it declares first ≡ position 1 and last ≡ position length in Chinese
 
   # bug: Bug B — button manual had no rule preamble. Without a preamble the
   #   AI partner could not infer first-match-wins; it tried multiple

--- a/packages/game-bombsquad/src/modules/wire/solver.test.ts
+++ b/packages/game-bombsquad/src/modules/wire/solver.test.ts
@@ -21,7 +21,7 @@ const rules: WireRule[] = [
     action: 'cut_wire',
     target: { position: 'first', color: 'blue' },
   },
-  { condition: { wire_count: 5 }, action: 'cut_wire', target: { position: 2 } },
+  { condition: { wire_count: 5 }, action: 'cut_wire', target: { position: 3 } },
   // Fallback
   { condition: {}, action: 'cut_wire', target: { position: 'first' } },
 ]
@@ -63,5 +63,92 @@ describe('generateWire', () => {
     const { config: c2, answer: a2 } = generateWire(createRng(99), rules2, sceneInfo)
     expect(c1).toEqual(c2)
     expect(a1).toEqual(a2)
+  })
+})
+
+// Pins the contract that wire `target.position` integers are 1-indexed
+// top-down, and `resolvePosition` maps integer N → 0-indexed array index N-1
+// for 1 ≤ N ≤ length (else null). Each case is written so that reverting the
+// numeric branch to the old 0-indexed `return n >= 0 && n < length ? n : null`
+// would FAIL it. Fixtures are local and self-contained — they do not touch the
+// file-level `rules` used by the suites above.
+describe('solveWire — numeric position (1-indexed → 0-indexed)', () => {
+  const fourWires = {
+    wires: [
+      { color: 'blue' as const },
+      { color: 'yellow' as const },
+      { color: 'green' as const },
+      { color: 'white' as const },
+    ],
+  }
+
+  it('position 1 cuts the topmost wire → cutPosition 0', () => {
+    // New solver: 1 - 1 = 0. Old `return n`: 1. Expect 0 → old solver fails.
+    const numericRules: WireRule[] = [
+      { condition: { wire_count: 4 }, action: 'cut_wire', target: { position: 1 } },
+    ]
+    expect(solveWire(fourWires, numericRules, sceneInfo)).toEqual({
+      type: 'wire',
+      cutPosition: 0,
+    })
+  })
+
+  it('position 3 on a 4-wire config cuts the 3rd wire from top → cutPosition 2', () => {
+    // New solver: 3 - 1 = 2. Old `return n`: 3. Expect 2 → old solver fails.
+    const numericRules: WireRule[] = [
+      { condition: { wire_count: 4 }, action: 'cut_wire', target: { position: 3 } },
+    ]
+    expect(solveWire(fourWires, numericRules, sceneInfo)).toEqual({
+      type: 'wire',
+      cutPosition: 2,
+    })
+  })
+
+  it('position === wire count cuts the bottommost wire (last ≡ position length) → cutPosition length-1', () => {
+    // position 4 on a 4-wire config. New solver: 4 - 1 = 3 (= length - 1).
+    // Old `return n`: 4 (out of range). Expect 3 → old solver fails.
+    const numericRules: WireRule[] = [
+      { condition: { wire_count: 4 }, action: 'cut_wire', target: { position: 4 } },
+    ]
+    const lastRule: WireRule[] = [
+      { condition: { wire_count: 4 }, action: 'cut_wire', target: { position: 'last' } },
+    ]
+    expect(solveWire(fourWires, numericRules, sceneInfo)).toEqual({
+      type: 'wire',
+      cutPosition: fourWires.wires.length - 1,
+    })
+    // position length and 'last' resolve to the same index.
+    expect(solveWire(fourWires, numericRules, sceneInfo)).toEqual(
+      solveWire(fourWires, lastRule, sceneInfo)
+    )
+  })
+
+  it('invalid position 0 is skipped (no longer a valid 1-indexed target) → falls through to next rule', () => {
+    // New solver: 0 < 1 → null → continue → fallback 'last' resolves to 3.
+    // Old solver: 0 is in range → returns cutPosition 0 immediately, never
+    // falling through. Expect 3 → old solver fails.
+    const withFallback: WireRule[] = [
+      { condition: { wire_count: 4 }, action: 'cut_wire', target: { position: 0 } },
+      { condition: {}, action: 'cut_wire', target: { position: 'last' } },
+    ]
+    expect(solveWire(fourWires, withFallback, sceneInfo)).toEqual({
+      type: 'wire',
+      cutPosition: 3,
+    })
+
+    // With no fallback rule, the unresolvable numeric rule yields null overall.
+    const noFallback: WireRule[] = [
+      { condition: { wire_count: 4 }, action: 'cut_wire', target: { position: 0 } },
+    ]
+    expect(solveWire(fourWires, noFallback, sceneInfo)).toBeNull()
+  })
+
+  it('invalid position length+1 is skipped → null (out-of-range high rejected)', () => {
+    // position 5 on a 4-wire config. New solver: 5 > 4 → null. (Both old and
+    // new reject this high out-of-range value; this case pins the upper bound.)
+    const noFallback: WireRule[] = [
+      { condition: { wire_count: 4 }, action: 'cut_wire', target: { position: 5 } },
+    ]
+    expect(solveWire(fourWires, noFallback, sceneInfo)).toBeNull()
   })
 })

--- a/packages/game-bombsquad/src/modules/wire/solver.ts
+++ b/packages/game-bombsquad/src/modules/wire/solver.ts
@@ -14,6 +14,8 @@ export function solveWire(
   for (const rule of rules) {
     if (matchCondition(rule.condition, config as unknown as Record<string, unknown>, sceneInfo)) {
       const pos = resolvePosition(rule.target, config)
+      // null = a defensive skip for an invalid manual (e.g. an out-of-range
+      // numeric position or a color not present); fall through to the next rule.
       if (pos === null) continue
       return { type: 'wire', cutPosition: pos }
     }
@@ -44,5 +46,5 @@ function resolvePosition(
     return wires.length - 1
   }
   const n = target.position as number
-  return n >= 0 && n < wires.length ? n : null
+  return n >= 1 && n <= wires.length ? n - 1 : null
 }

--- a/packages/manual/data/daily/2026-03-16.yaml
+++ b/packages/manual/data/daily/2026-03-16.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -37,7 +37,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-12.yaml
+++ b/packages/manual/data/daily/2026-05-12.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -37,7 +37,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-13.yaml
+++ b/packages/manual/data/daily/2026-05-13.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -24,7 +24,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -77,7 +77,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-14.yaml
+++ b/packages/manual/data/daily/2026-05-14.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-15.yaml
+++ b/packages/manual/data/daily/2026-05-15.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,7 +25,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-16.yaml
+++ b/packages/manual/data/daily/2026-05-16.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-17.yaml
+++ b/packages/manual/data/daily/2026-05-17.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,13 +25,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-18.yaml
+++ b/packages/manual/data/daily/2026-05-18.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -23,7 +23,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-19.yaml
+++ b/packages/manual/data/daily/2026-05-19.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,7 +22,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-20.yaml
+++ b/packages/manual/data/daily/2026-05-20.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -20,7 +20,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-21.yaml
+++ b/packages/manual/data/daily/2026-05-21.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -45,7 +45,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-22.yaml
+++ b/packages/manual/data/daily/2026-05-22.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,7 +25,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-23.yaml
+++ b/packages/manual/data/daily/2026-05-23.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -77,13 +77,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-24.yaml
+++ b/packages/manual/data/daily/2026-05-24.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -46,13 +46,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -77,13 +77,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-25.yaml
+++ b/packages/manual/data/daily/2026-05-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -38,7 +38,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-26.yaml
+++ b/packages/manual/data/daily/2026-05-26.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -30,7 +30,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-27.yaml
+++ b/packages/manual/data/daily/2026-05-27.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,7 +22,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -77,13 +77,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-28.yaml
+++ b/packages/manual/data/daily/2026-05-28.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -49,7 +49,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-29.yaml
+++ b/packages/manual/data/daily/2026-05-29.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -44,7 +44,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-30.yaml
+++ b/packages/manual/data/daily/2026-05-30.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -33,14 +33,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-05-31.yaml
+++ b/packages/manual/data/daily/2026-05-31.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,13 +11,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-01.yaml
+++ b/packages/manual/data/daily/2026-06-01.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -37,7 +37,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-02.yaml
+++ b/packages/manual/data/daily/2026-06-02.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -31,7 +31,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-03.yaml
+++ b/packages/manual/data/daily/2026-06-03.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -49,7 +49,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-04.yaml
+++ b/packages/manual/data/daily/2026-06-04.yaml
@@ -3,21 +3,21 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-05.yaml
+++ b/packages/manual/data/daily/2026-06-05.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -29,7 +29,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-06.yaml
+++ b/packages/manual/data/daily/2026-06-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -23,7 +23,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -77,7 +77,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-07.yaml
+++ b/packages/manual/data/daily/2026-06-07.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-08.yaml
+++ b/packages/manual/data/daily/2026-06-08.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -40,7 +40,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-09.yaml
+++ b/packages/manual/data/daily/2026-06-09.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -43,13 +43,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-10.yaml
+++ b/packages/manual/data/daily/2026-06-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -37,13 +37,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-11.yaml
+++ b/packages/manual/data/daily/2026-06-11.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,7 +22,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-12.yaml
+++ b/packages/manual/data/daily/2026-06-12.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -37,14 +37,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-13.yaml
+++ b/packages/manual/data/daily/2026-06-13.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-14.yaml
+++ b/packages/manual/data/daily/2026-06-14.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,13 +75,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-15.yaml
+++ b/packages/manual/data/daily/2026-06-15.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-16.yaml
+++ b/packages/manual/data/daily/2026-06-16.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -30,7 +30,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-17.yaml
+++ b/packages/manual/data/daily/2026-06-17.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -44,7 +44,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -77,13 +77,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-18.yaml
+++ b/packages/manual/data/daily/2026-06-18.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -37,7 +37,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-19.yaml
+++ b/packages/manual/data/daily/2026-06-19.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-20.yaml
+++ b/packages/manual/data/daily/2026-06-20.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -20,7 +20,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-21.yaml
+++ b/packages/manual/data/daily/2026-06-21.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -39,7 +39,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-22.yaml
+++ b/packages/manual/data/daily/2026-06-22.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -20,7 +20,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -32,7 +32,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-23.yaml
+++ b/packages/manual/data/daily/2026-06-23.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -50,7 +50,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-24.yaml
+++ b/packages/manual/data/daily/2026-06-24.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -51,14 +51,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -81,13 +81,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-25.yaml
+++ b/packages/manual/data/daily/2026-06-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-26.yaml
+++ b/packages/manual/data/daily/2026-06-26.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-27.yaml
+++ b/packages/manual/data/daily/2026-06-27.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -23,7 +23,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-28.yaml
+++ b/packages/manual/data/daily/2026-06-28.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -19,7 +19,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -37,7 +37,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-29.yaml
+++ b/packages/manual/data/daily/2026-06-29.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -30,7 +30,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-06-30.yaml
+++ b/packages/manual/data/daily/2026-06-30.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -34,7 +34,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -81,13 +81,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-01.yaml
+++ b/packages/manual/data/daily/2026-07-01.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,7 +25,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-02.yaml
+++ b/packages/manual/data/daily/2026-07-02.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -19,7 +19,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -40,7 +40,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-03.yaml
+++ b/packages/manual/data/daily/2026-07-03.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-04.yaml
+++ b/packages/manual/data/daily/2026-07-04.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -39,7 +39,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -75,13 +75,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-05.yaml
+++ b/packages/manual/data/daily/2026-07-05.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -45,14 +45,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-06.yaml
+++ b/packages/manual/data/daily/2026-07-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -46,13 +46,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-07.yaml
+++ b/packages/manual/data/daily/2026-07-07.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -36,7 +36,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -49,7 +49,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-08.yaml
+++ b/packages/manual/data/daily/2026-07-08.yaml
@@ -3,21 +3,21 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -77,13 +77,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-09.yaml
+++ b/packages/manual/data/daily/2026-07-09.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-10.yaml
+++ b/packages/manual/data/daily/2026-07-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-11.yaml
+++ b/packages/manual/data/daily/2026-07-11.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -40,13 +40,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-12.yaml
+++ b/packages/manual/data/daily/2026-07-12.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,13 +11,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -83,13 +83,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-13.yaml
+++ b/packages/manual/data/daily/2026-07-13.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,7 +25,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -83,13 +83,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-14.yaml
+++ b/packages/manual/data/daily/2026-07-14.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-15.yaml
+++ b/packages/manual/data/daily/2026-07-15.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -38,7 +38,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-16.yaml
+++ b/packages/manual/data/daily/2026-07-16.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -18,7 +18,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -37,7 +37,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-17.yaml
+++ b/packages/manual/data/daily/2026-07-17.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -43,7 +43,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-18.yaml
+++ b/packages/manual/data/daily/2026-07-18.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,7 +28,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-19.yaml
+++ b/packages/manual/data/daily/2026-07-19.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-20.yaml
+++ b/packages/manual/data/daily/2026-07-20.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -33,7 +33,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-21.yaml
+++ b/packages/manual/data/daily/2026-07-21.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -24,7 +24,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-22.yaml
+++ b/packages/manual/data/daily/2026-07-22.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -25,7 +25,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-23.yaml
+++ b/packages/manual/data/daily/2026-07-23.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -34,7 +34,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-24.yaml
+++ b/packages/manual/data/daily/2026-07-24.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -46,13 +46,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -77,13 +77,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-25.yaml
+++ b/packages/manual/data/daily/2026-07-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-26.yaml
+++ b/packages/manual/data/daily/2026-07-26.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -30,7 +30,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-27.yaml
+++ b/packages/manual/data/daily/2026-07-27.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-28.yaml
+++ b/packages/manual/data/daily/2026-07-28.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-29.yaml
+++ b/packages/manual/data/daily/2026-07-29.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,14 +16,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -81,13 +81,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-30.yaml
+++ b/packages/manual/data/daily/2026-07-30.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-07-31.yaml
+++ b/packages/manual/data/daily/2026-07-31.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -45,7 +45,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-01.yaml
+++ b/packages/manual/data/daily/2026-08-01.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-02.yaml
+++ b/packages/manual/data/daily/2026-08-02.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-03.yaml
+++ b/packages/manual/data/daily/2026-08-03.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -18,7 +18,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -37,7 +37,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-04.yaml
+++ b/packages/manual/data/daily/2026-08-04.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -27,7 +27,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -77,7 +77,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-05.yaml
+++ b/packages/manual/data/daily/2026-08-05.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-06.yaml
+++ b/packages/manual/data/daily/2026-08-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -29,7 +29,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-07.yaml
+++ b/packages/manual/data/daily/2026-08-07.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -19,7 +19,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-08.yaml
+++ b/packages/manual/data/daily/2026-08-08.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,13 +23,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-09.yaml
+++ b/packages/manual/data/daily/2026-08-09.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -38,13 +38,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-10.yaml
+++ b/packages/manual/data/daily/2026-08-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,14 +25,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-11.yaml
+++ b/packages/manual/data/daily/2026-08-11.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-12.yaml
+++ b/packages/manual/data/daily/2026-08-12.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -52,13 +52,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-13.yaml
+++ b/packages/manual/data/daily/2026-08-13.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,13 +11,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-14.yaml
+++ b/packages/manual/data/daily/2026-08-14.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,7 +22,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-15.yaml
+++ b/packages/manual/data/daily/2026-08-15.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-16.yaml
+++ b/packages/manual/data/daily/2026-08-16.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,14 +16,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-17.yaml
+++ b/packages/manual/data/daily/2026-08-17.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,7 +22,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-18.yaml
+++ b/packages/manual/data/daily/2026-08-18.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -41,7 +41,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-19.yaml
+++ b/packages/manual/data/daily/2026-08-19.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -29,7 +29,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-20.yaml
+++ b/packages/manual/data/daily/2026-08-20.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -31,7 +31,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -75,13 +75,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-21.yaml
+++ b/packages/manual/data/daily/2026-08-21.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,14 +28,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-22.yaml
+++ b/packages/manual/data/daily/2026-08-22.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -19,13 +19,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-23.yaml
+++ b/packages/manual/data/daily/2026-08-23.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -81,13 +81,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-24.yaml
+++ b/packages/manual/data/daily/2026-08-24.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -31,13 +31,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-25.yaml
+++ b/packages/manual/data/daily/2026-08-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -29,13 +29,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-26.yaml
+++ b/packages/manual/data/daily/2026-08-26.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -29,13 +29,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-27.yaml
+++ b/packages/manual/data/daily/2026-08-27.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -18,7 +18,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-28.yaml
+++ b/packages/manual/data/daily/2026-08-28.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,7 +22,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-29.yaml
+++ b/packages/manual/data/daily/2026-08-29.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -20,7 +20,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-30.yaml
+++ b/packages/manual/data/daily/2026-08-30.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,7 +22,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-08-31.yaml
+++ b/packages/manual/data/daily/2026-08-31.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -29,7 +29,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-01.yaml
+++ b/packages/manual/data/daily/2026-09-01.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-02.yaml
+++ b/packages/manual/data/daily/2026-09-02.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -36,7 +36,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-03.yaml
+++ b/packages/manual/data/daily/2026-09-03.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -24,7 +24,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-04.yaml
+++ b/packages/manual/data/daily/2026-09-04.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -31,7 +31,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-05.yaml
+++ b/packages/manual/data/daily/2026-09-05.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -37,7 +37,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-06.yaml
+++ b/packages/manual/data/daily/2026-09-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -49,7 +49,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-07.yaml
+++ b/packages/manual/data/daily/2026-09-07.yaml
@@ -3,21 +3,21 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -83,13 +83,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-08.yaml
+++ b/packages/manual/data/daily/2026-09-08.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,7 +28,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -44,7 +44,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-09.yaml
+++ b/packages/manual/data/daily/2026-09-09.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,7 +28,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-10.yaml
+++ b/packages/manual/data/daily/2026-09-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -19,14 +19,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-11.yaml
+++ b/packages/manual/data/daily/2026-09-11.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -44,7 +44,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-12.yaml
+++ b/packages/manual/data/daily/2026-09-12.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,7 +25,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -37,7 +37,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -77,7 +77,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-13.yaml
+++ b/packages/manual/data/daily/2026-09-13.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-14.yaml
+++ b/packages/manual/data/daily/2026-09-14.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-15.yaml
+++ b/packages/manual/data/daily/2026-09-15.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -23,7 +23,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-16.yaml
+++ b/packages/manual/data/daily/2026-09-16.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-17.yaml
+++ b/packages/manual/data/daily/2026-09-17.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,14 +28,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-18.yaml
+++ b/packages/manual/data/daily/2026-09-18.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-19.yaml
+++ b/packages/manual/data/daily/2026-09-19.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,14 +16,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-20.yaml
+++ b/packages/manual/data/daily/2026-09-20.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -31,7 +31,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -50,7 +50,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-21.yaml
+++ b/packages/manual/data/daily/2026-09-21.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-22.yaml
+++ b/packages/manual/data/daily/2026-09-22.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-23.yaml
+++ b/packages/manual/data/daily/2026-09-23.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-24.yaml
+++ b/packages/manual/data/daily/2026-09-24.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-25.yaml
+++ b/packages/manual/data/daily/2026-09-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -31,7 +31,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-26.yaml
+++ b/packages/manual/data/daily/2026-09-26.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -34,7 +34,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-27.yaml
+++ b/packages/manual/data/daily/2026-09-27.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -37,7 +37,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -50,7 +50,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-28.yaml
+++ b/packages/manual/data/daily/2026-09-28.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -50,7 +50,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-29.yaml
+++ b/packages/manual/data/daily/2026-09-29.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -25,7 +25,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-09-30.yaml
+++ b/packages/manual/data/daily/2026-09-30.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-01.yaml
+++ b/packages/manual/data/daily/2026-10-01.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,13 +11,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-02.yaml
+++ b/packages/manual/data/daily/2026-10-02.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -77,7 +77,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-03.yaml
+++ b/packages/manual/data/daily/2026-10-03.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -52,13 +52,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-04.yaml
+++ b/packages/manual/data/daily/2026-10-04.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,7 +22,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-05.yaml
+++ b/packages/manual/data/daily/2026-10-05.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -39,7 +39,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-06.yaml
+++ b/packages/manual/data/daily/2026-10-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,7 +22,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -35,7 +35,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-07.yaml
+++ b/packages/manual/data/daily/2026-10-07.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -40,7 +40,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-08.yaml
+++ b/packages/manual/data/daily/2026-10-08.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -24,7 +24,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -37,7 +37,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -83,13 +83,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-09.yaml
+++ b/packages/manual/data/daily/2026-10-09.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -29,7 +29,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -49,7 +49,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-10.yaml
+++ b/packages/manual/data/daily/2026-10-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-11.yaml
+++ b/packages/manual/data/daily/2026-10-11.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -37,7 +37,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -81,13 +81,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-12.yaml
+++ b/packages/manual/data/daily/2026-10-12.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -27,7 +27,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-13.yaml
+++ b/packages/manual/data/daily/2026-10-13.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -35,7 +35,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-14.yaml
+++ b/packages/manual/data/daily/2026-10-14.yaml
@@ -3,21 +3,21 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-15.yaml
+++ b/packages/manual/data/daily/2026-10-15.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,7 +25,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -38,7 +38,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-16.yaml
+++ b/packages/manual/data/daily/2026-10-16.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,7 +28,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-17.yaml
+++ b/packages/manual/data/daily/2026-10-17.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -39,7 +39,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -77,7 +77,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-18.yaml
+++ b/packages/manual/data/daily/2026-10-18.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -19,7 +19,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-19.yaml
+++ b/packages/manual/data/daily/2026-10-19.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-20.yaml
+++ b/packages/manual/data/daily/2026-10-20.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -38,7 +38,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-21.yaml
+++ b/packages/manual/data/daily/2026-10-21.yaml
@@ -3,21 +3,21 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-22.yaml
+++ b/packages/manual/data/daily/2026-10-22.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -45,14 +45,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-23.yaml
+++ b/packages/manual/data/daily/2026-10-23.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-24.yaml
+++ b/packages/manual/data/daily/2026-10-24.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -45,14 +45,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-25.yaml
+++ b/packages/manual/data/daily/2026-10-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -81,13 +81,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-26.yaml
+++ b/packages/manual/data/daily/2026-10-26.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-27.yaml
+++ b/packages/manual/data/daily/2026-10-27.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -39,7 +39,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-28.yaml
+++ b/packages/manual/data/daily/2026-10-28.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -39,7 +39,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-29.yaml
+++ b/packages/manual/data/daily/2026-10-29.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -30,7 +30,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-30.yaml
+++ b/packages/manual/data/daily/2026-10-30.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-10-31.yaml
+++ b/packages/manual/data/daily/2026-10-31.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-01.yaml
+++ b/packages/manual/data/daily/2026-11-01.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,7 +28,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-02.yaml
+++ b/packages/manual/data/daily/2026-11-02.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -31,7 +31,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-03.yaml
+++ b/packages/manual/data/daily/2026-11-03.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -51,14 +51,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-04.yaml
+++ b/packages/manual/data/daily/2026-11-04.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -38,7 +38,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-05.yaml
+++ b/packages/manual/data/daily/2026-11-05.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -20,7 +20,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-06.yaml
+++ b/packages/manual/data/daily/2026-11-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -19,7 +19,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-07.yaml
+++ b/packages/manual/data/daily/2026-11-07.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -18,7 +18,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -31,7 +31,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-08.yaml
+++ b/packages/manual/data/daily/2026-11-08.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -52,13 +52,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-09.yaml
+++ b/packages/manual/data/daily/2026-11-09.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,13 +75,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-10.yaml
+++ b/packages/manual/data/daily/2026-11-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -24,7 +24,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-11.yaml
+++ b/packages/manual/data/daily/2026-11-11.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -52,13 +52,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-12.yaml
+++ b/packages/manual/data/daily/2026-11-12.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -39,14 +39,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-13.yaml
+++ b/packages/manual/data/daily/2026-11-13.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,7 +28,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-14.yaml
+++ b/packages/manual/data/daily/2026-11-14.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -29,7 +29,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -44,7 +44,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-15.yaml
+++ b/packages/manual/data/daily/2026-11-15.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -37,13 +37,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -77,13 +77,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-16.yaml
+++ b/packages/manual/data/daily/2026-11-16.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -34,7 +34,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-17.yaml
+++ b/packages/manual/data/daily/2026-11-17.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -39,14 +39,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-18.yaml
+++ b/packages/manual/data/daily/2026-11-18.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-19.yaml
+++ b/packages/manual/data/daily/2026-11-19.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -26,13 +26,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-20.yaml
+++ b/packages/manual/data/daily/2026-11-20.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-21.yaml
+++ b/packages/manual/data/daily/2026-11-21.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -39,7 +39,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-22.yaml
+++ b/packages/manual/data/daily/2026-11-22.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -45,7 +45,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-23.yaml
+++ b/packages/manual/data/daily/2026-11-23.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -38,7 +38,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-24.yaml
+++ b/packages/manual/data/daily/2026-11-24.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -29,7 +29,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-25.yaml
+++ b/packages/manual/data/daily/2026-11-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -32,13 +32,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-26.yaml
+++ b/packages/manual/data/daily/2026-11-26.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -29,7 +29,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -50,7 +50,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-27.yaml
+++ b/packages/manual/data/daily/2026-11-27.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -29,7 +29,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-28.yaml
+++ b/packages/manual/data/daily/2026-11-28.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -36,14 +36,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-29.yaml
+++ b/packages/manual/data/daily/2026-11-29.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -38,7 +38,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-11-30.yaml
+++ b/packages/manual/data/daily/2026-11-30.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-01.yaml
+++ b/packages/manual/data/daily/2026-12-01.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,14 +25,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-02.yaml
+++ b/packages/manual/data/daily/2026-12-02.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -45,7 +45,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-03.yaml
+++ b/packages/manual/data/daily/2026-12-03.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -49,7 +49,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -77,13 +77,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-04.yaml
+++ b/packages/manual/data/daily/2026-12-04.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-05.yaml
+++ b/packages/manual/data/daily/2026-12-05.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -23,7 +23,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-06.yaml
+++ b/packages/manual/data/daily/2026-12-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -44,7 +44,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-07.yaml
+++ b/packages/manual/data/daily/2026-12-07.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -20,7 +20,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -38,7 +38,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-08.yaml
+++ b/packages/manual/data/daily/2026-12-08.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -27,7 +27,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-09.yaml
+++ b/packages/manual/data/daily/2026-12-09.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -29,7 +29,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-10.yaml
+++ b/packages/manual/data/daily/2026-12-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -49,7 +49,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-11.yaml
+++ b/packages/manual/data/daily/2026-12-11.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -37,7 +37,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-12.yaml
+++ b/packages/manual/data/daily/2026-12-12.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -44,7 +44,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -77,13 +77,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-13.yaml
+++ b/packages/manual/data/daily/2026-12-13.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -32,13 +32,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-14.yaml
+++ b/packages/manual/data/daily/2026-12-14.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -37,14 +37,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-15.yaml
+++ b/packages/manual/data/daily/2026-12-15.yaml
@@ -3,21 +3,21 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-16.yaml
+++ b/packages/manual/data/daily/2026-12-16.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -36,14 +36,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-17.yaml
+++ b/packages/manual/data/daily/2026-12-17.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,7 +25,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -38,7 +38,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-18.yaml
+++ b/packages/manual/data/daily/2026-12-18.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,13 +11,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-19.yaml
+++ b/packages/manual/data/daily/2026-12-19.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -19,14 +19,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -81,13 +81,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-20.yaml
+++ b/packages/manual/data/daily/2026-12-20.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -38,7 +38,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-21.yaml
+++ b/packages/manual/data/daily/2026-12-21.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -19,7 +19,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-22.yaml
+++ b/packages/manual/data/daily/2026-12-22.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -33,7 +33,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-23.yaml
+++ b/packages/manual/data/daily/2026-12-23.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,13 +25,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-24.yaml
+++ b/packages/manual/data/daily/2026-12-24.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,14 +16,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-25.yaml
+++ b/packages/manual/data/daily/2026-12-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -31,7 +31,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-26.yaml
+++ b/packages/manual/data/daily/2026-12-26.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-27.yaml
+++ b/packages/manual/data/daily/2026-12-27.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -38,13 +38,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-28.yaml
+++ b/packages/manual/data/daily/2026-12-28.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -45,14 +45,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -77,13 +77,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-29.yaml
+++ b/packages/manual/data/daily/2026-12-29.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -32,7 +32,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-30.yaml
+++ b/packages/manual/data/daily/2026-12-30.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2026-12-31.yaml
+++ b/packages/manual/data/daily/2026-12-31.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -39,7 +39,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-01.yaml
+++ b/packages/manual/data/daily/2027-01-01.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -19,14 +19,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-02.yaml
+++ b/packages/manual/data/daily/2027-01-02.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -18,14 +18,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-03.yaml
+++ b/packages/manual/data/daily/2027-01-03.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -31,7 +31,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-04.yaml
+++ b/packages/manual/data/daily/2027-01-04.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -49,7 +49,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-05.yaml
+++ b/packages/manual/data/daily/2027-01-05.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -38,13 +38,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -77,13 +77,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-06.yaml
+++ b/packages/manual/data/daily/2027-01-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-07.yaml
+++ b/packages/manual/data/daily/2027-01-07.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -33,7 +33,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -77,7 +77,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-08.yaml
+++ b/packages/manual/data/daily/2027-01-08.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -18,7 +18,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-09.yaml
+++ b/packages/manual/data/daily/2027-01-09.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -23,7 +23,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-10.yaml
+++ b/packages/manual/data/daily/2027-01-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,7 +25,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -44,7 +44,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -77,13 +77,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-11.yaml
+++ b/packages/manual/data/daily/2027-01-11.yaml
@@ -3,21 +3,21 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-12.yaml
+++ b/packages/manual/data/daily/2027-01-12.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-13.yaml
+++ b/packages/manual/data/daily/2027-01-13.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -52,13 +52,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-14.yaml
+++ b/packages/manual/data/daily/2027-01-14.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -46,13 +46,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-15.yaml
+++ b/packages/manual/data/daily/2027-01-15.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-16.yaml
+++ b/packages/manual/data/daily/2027-01-16.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-17.yaml
+++ b/packages/manual/data/daily/2027-01-17.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -27,7 +27,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-18.yaml
+++ b/packages/manual/data/daily/2027-01-18.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -44,7 +44,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -75,13 +75,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-19.yaml
+++ b/packages/manual/data/daily/2027-01-19.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -45,14 +45,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-20.yaml
+++ b/packages/manual/data/daily/2027-01-20.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -50,7 +50,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-21.yaml
+++ b/packages/manual/data/daily/2027-01-21.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -42,7 +42,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-22.yaml
+++ b/packages/manual/data/daily/2027-01-22.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-23.yaml
+++ b/packages/manual/data/daily/2027-01-23.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -43,13 +43,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -75,13 +75,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-24.yaml
+++ b/packages/manual/data/daily/2027-01-24.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -52,13 +52,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-25.yaml
+++ b/packages/manual/data/daily/2027-01-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,7 +22,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -35,7 +35,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-26.yaml
+++ b/packages/manual/data/daily/2027-01-26.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-27.yaml
+++ b/packages/manual/data/daily/2027-01-27.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -34,14 +34,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-28.yaml
+++ b/packages/manual/data/daily/2027-01-28.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -30,7 +30,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -49,7 +49,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-29.yaml
+++ b/packages/manual/data/daily/2027-01-29.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -52,13 +52,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-30.yaml
+++ b/packages/manual/data/daily/2027-01-30.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -50,7 +50,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-01-31.yaml
+++ b/packages/manual/data/daily/2027-01-31.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -51,14 +51,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-01.yaml
+++ b/packages/manual/data/daily/2027-02-01.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-02.yaml
+++ b/packages/manual/data/daily/2027-02-02.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -38,7 +38,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-03.yaml
+++ b/packages/manual/data/daily/2027-02-03.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -31,7 +31,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -81,13 +81,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-04.yaml
+++ b/packages/manual/data/daily/2027-02-04.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -37,7 +37,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-05.yaml
+++ b/packages/manual/data/daily/2027-02-05.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -44,7 +44,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-06.yaml
+++ b/packages/manual/data/daily/2027-02-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -77,13 +77,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-07.yaml
+++ b/packages/manual/data/daily/2027-02-07.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -29,7 +29,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-08.yaml
+++ b/packages/manual/data/daily/2027-02-08.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -77,7 +77,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-09.yaml
+++ b/packages/manual/data/daily/2027-02-09.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-10.yaml
+++ b/packages/manual/data/daily/2027-02-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-11.yaml
+++ b/packages/manual/data/daily/2027-02-11.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -31,13 +31,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-12.yaml
+++ b/packages/manual/data/daily/2027-02-12.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,13 +25,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-13.yaml
+++ b/packages/manual/data/daily/2027-02-13.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -45,14 +45,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -81,13 +81,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-14.yaml
+++ b/packages/manual/data/daily/2027-02-14.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-15.yaml
+++ b/packages/manual/data/daily/2027-02-15.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -38,7 +38,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-16.yaml
+++ b/packages/manual/data/daily/2027-02-16.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -29,7 +29,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-17.yaml
+++ b/packages/manual/data/daily/2027-02-17.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-18.yaml
+++ b/packages/manual/data/daily/2027-02-18.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-19.yaml
+++ b/packages/manual/data/daily/2027-02-19.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -49,7 +49,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-20.yaml
+++ b/packages/manual/data/daily/2027-02-20.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -43,14 +43,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-21.yaml
+++ b/packages/manual/data/daily/2027-02-21.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -38,7 +38,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-22.yaml
+++ b/packages/manual/data/daily/2027-02-22.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,7 +22,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -50,7 +50,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-23.yaml
+++ b/packages/manual/data/daily/2027-02-23.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-24.yaml
+++ b/packages/manual/data/daily/2027-02-24.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -30,7 +30,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-25.yaml
+++ b/packages/manual/data/daily/2027-02-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,13 +17,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-26.yaml
+++ b/packages/manual/data/daily/2027-02-26.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -30,7 +30,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-27.yaml
+++ b/packages/manual/data/daily/2027-02-27.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-02-28.yaml
+++ b/packages/manual/data/daily/2027-02-28.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -43,13 +43,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -81,13 +81,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-01.yaml
+++ b/packages/manual/data/daily/2027-03-01.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,13 +17,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -75,13 +75,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-02.yaml
+++ b/packages/manual/data/daily/2027-03-02.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -77,7 +77,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-03.yaml
+++ b/packages/manual/data/daily/2027-03-03.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -29,7 +29,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -41,7 +41,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-04.yaml
+++ b/packages/manual/data/daily/2027-03-04.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,13 +83,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-05.yaml
+++ b/packages/manual/data/daily/2027-03-05.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,7 +25,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-06.yaml
+++ b/packages/manual/data/daily/2027-03-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -19,7 +19,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-07.yaml
+++ b/packages/manual/data/daily/2027-03-07.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -29,7 +29,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -83,13 +83,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-08.yaml
+++ b/packages/manual/data/daily/2027-03-08.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -83,7 +83,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-09.yaml
+++ b/packages/manual/data/daily/2027-03-09.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -52,13 +52,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,13 +75,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-10.yaml
+++ b/packages/manual/data/daily/2027-03-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -42,14 +42,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-11.yaml
+++ b/packages/manual/data/daily/2027-03-11.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -38,7 +38,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-12.yaml
+++ b/packages/manual/data/daily/2027-03-12.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,14 +25,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-13.yaml
+++ b/packages/manual/data/daily/2027-03-13.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -29,7 +29,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-14.yaml
+++ b/packages/manual/data/daily/2027-03-14.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -37,13 +37,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-15.yaml
+++ b/packages/manual/data/daily/2027-03-15.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -20,7 +20,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-16.yaml
+++ b/packages/manual/data/daily/2027-03-16.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -49,7 +49,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-17.yaml
+++ b/packages/manual/data/daily/2027-03-17.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-18.yaml
+++ b/packages/manual/data/daily/2027-03-18.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -18,7 +18,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -77,7 +77,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-19.yaml
+++ b/packages/manual/data/daily/2027-03-19.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -50,7 +50,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-20.yaml
+++ b/packages/manual/data/daily/2027-03-20.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-21.yaml
+++ b/packages/manual/data/daily/2027-03-21.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -46,7 +46,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-22.yaml
+++ b/packages/manual/data/daily/2027-03-22.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -77,13 +77,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-23.yaml
+++ b/packages/manual/data/daily/2027-03-23.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -38,7 +38,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-24.yaml
+++ b/packages/manual/data/daily/2027-03-24.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -36,14 +36,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-25.yaml
+++ b/packages/manual/data/daily/2027-03-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-26.yaml
+++ b/packages/manual/data/daily/2027-03-26.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-27.yaml
+++ b/packages/manual/data/daily/2027-03-27.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -52,13 +52,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-28.yaml
+++ b/packages/manual/data/daily/2027-03-28.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -52,13 +52,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-29.yaml
+++ b/packages/manual/data/daily/2027-03-29.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -32,7 +32,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-30.yaml
+++ b/packages/manual/data/daily/2027-03-30.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -29,7 +29,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-03-31.yaml
+++ b/packages/manual/data/daily/2027-03-31.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-01.yaml
+++ b/packages/manual/data/daily/2027-04-01.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-02.yaml
+++ b/packages/manual/data/daily/2027-04-02.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -30,7 +30,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-03.yaml
+++ b/packages/manual/data/daily/2027-04-03.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -34,13 +34,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-04.yaml
+++ b/packages/manual/data/daily/2027-04-04.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -17,7 +17,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -50,7 +50,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -81,13 +81,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-05.yaml
+++ b/packages/manual/data/daily/2027-04-05.yaml
@@ -3,21 +3,21 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-06.yaml
+++ b/packages/manual/data/daily/2027-04-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -43,14 +43,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-07.yaml
+++ b/packages/manual/data/daily/2027-04-07.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -37,7 +37,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-08.yaml
+++ b/packages/manual/data/daily/2027-04-08.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,7 +28,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -52,7 +52,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-09.yaml
+++ b/packages/manual/data/daily/2027-04-09.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -23,7 +23,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -50,7 +50,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -77,13 +77,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-10.yaml
+++ b/packages/manual/data/daily/2027-04-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -89,18 +89,18 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-11.yaml
+++ b/packages/manual/data/daily/2027-04-11.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,13 +11,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-12.yaml
+++ b/packages/manual/data/daily/2027-04-12.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -25,7 +25,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-13.yaml
+++ b/packages/manual/data/daily/2027-04-13.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -44,7 +44,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -69,13 +69,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-14.yaml
+++ b/packages/manual/data/daily/2027-04-14.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-15.yaml
+++ b/packages/manual/data/daily/2027-04-15.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -52,13 +52,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-16.yaml
+++ b/packages/manual/data/daily/2027-04-16.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -39,14 +39,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -75,7 +75,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-17.yaml
+++ b/packages/manual/data/daily/2027-04-17.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,7 +25,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -37,7 +37,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -83,13 +83,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-18.yaml
+++ b/packages/manual/data/daily/2027-04-18.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -44,7 +44,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -81,13 +81,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-19.yaml
+++ b/packages/manual/data/daily/2027-04-19.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,7 +69,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -81,7 +81,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-20.yaml
+++ b/packages/manual/data/daily/2027-04-20.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,7 +28,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -41,7 +41,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -81,13 +81,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-21.yaml
+++ b/packages/manual/data/daily/2027-04-21.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -49,7 +49,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -69,13 +69,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-22.yaml
+++ b/packages/manual/data/daily/2027-04-22.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -16,7 +16,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -83,13 +83,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-23.yaml
+++ b/packages/manual/data/daily/2027-04-23.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -40,7 +40,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -77,7 +77,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-24.yaml
+++ b/packages/manual/data/daily/2027-04-24.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -24,7 +24,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -37,7 +37,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-25.yaml
+++ b/packages/manual/data/daily/2027-04-25.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -45,7 +45,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -87,7 +87,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-26.yaml
+++ b/packages/manual/data/daily/2027-04-26.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -32,7 +32,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -83,7 +83,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-27.yaml
+++ b/packages/manual/data/daily/2027-04-27.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -23,7 +23,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: green
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-28.yaml
+++ b/packages/manual/data/daily/2027-04-28.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-29.yaml
+++ b/packages/manual/data/daily/2027-04-29.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,13 +11,13 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -75,7 +75,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-04-30.yaml
+++ b/packages/manual/data/daily/2027-04-30.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -25,7 +25,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: black
@@ -37,7 +37,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -75,13 +75,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-05-01.yaml
+++ b/packages/manual/data/daily/2027-05-01.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -83,13 +83,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-05-02.yaml
+++ b/packages/manual/data/daily/2027-05-02.yaml
@@ -3,14 +3,14 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -34,7 +34,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -83,13 +83,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-05-03.yaml
+++ b/packages/manual/data/daily/2027-05-03.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,7 +28,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -75,13 +75,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-05-04.yaml
+++ b/packages/manual/data/daily/2027-05-04.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -28,7 +28,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           count_red:
@@ -43,7 +43,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: red
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-05-05.yaml
+++ b/packages/manual/data/daily/2027-05-05.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -30,7 +30,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -58,7 +58,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
         action: cut_wire
@@ -75,13 +75,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-05-06.yaml
+++ b/packages/manual/data/daily/2027-05-06.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -46,7 +46,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: green
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -77,13 +77,13 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-05-07.yaml
+++ b/packages/manual/data/daily/2027-05-07.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -29,7 +29,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -77,7 +77,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -95,12 +95,12 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-05-08.yaml
+++ b/packages/manual/data/daily/2027-05-08.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -31,7 +31,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -58,7 +58,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
         action: cut_wire
@@ -81,7 +81,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           count_blue:
@@ -95,12 +95,12 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-05-09.yaml
+++ b/packages/manual/data/daily/2027-05-09.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -26,7 +26,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           count_red:
@@ -40,7 +40,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: black
@@ -77,13 +77,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           color_at_last: blue
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-05-10.yaml
+++ b/packages/manual/data/daily/2027-05-10.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -22,14 +22,14 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           battery_count:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: blue
@@ -81,13 +81,13 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/daily/2027-05-11.yaml
+++ b/packages/manual/data/daily/2027-05-11.yaml
@@ -3,7 +3,7 @@ meta:
   type: daily
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition:
           wire_count: 4
@@ -11,7 +11,7 @@ modules:
             gt: 2
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 4
           color_at_last: yellow
@@ -52,7 +52,7 @@ modules:
           color_at_last: white
         action: cut_wire
         target:
-          position: 1
+          position: 2
       - condition:
           wire_count: 4
           color_at_last: red
@@ -69,7 +69,7 @@ modules:
           indicator_FRK_lit: true
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition:
           wire_count: 5
           count_blue:
@@ -89,7 +89,7 @@ modules:
           color_at_last: red
         action: cut_wire
         target:
-          position: 3
+          position: 4
       - condition:
           wire_count: 5
           color_at_last: yellow
@@ -100,7 +100,7 @@ modules:
           wire_count: 5
         action: cut_wire
         target:
-          position: 2
+          position: 3
       - condition: {}
         action: cut_wire
         target:

--- a/packages/manual/data/practice.yaml
+++ b/packages/manual/data/practice.yaml
@@ -4,7 +4,7 @@ meta:
 
 modules:
   wire_routing:
-    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 0-indexed 自上而下编号：0 = 最上面那根，N-1 = 最底下那根（4 根线时 last = 3，5 根线时 last = 4）；关键字 first 与整数等价：first ≡ position 0；关键字 last 也与整数等价：last ≡ position length-1。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。指示玩家时把 0-indexed 翻译成自然语言（position 0 = "从上数第 1 根"，last = "最底下那根"）——玩家不会读 YAML。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 2，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
+    rule: '光弦模块（玩家屏幕上叫光弦，就是一排彩色电线）面前有一排自上而下 4 到 5 根彩色电线（颜色可重复）。你看不到屏幕，所以让玩家从上到下把每根线的颜色依次报给你，再据此查表。在下方 rules 里按出现顺序找第一条 condition 与当前局面匹配的规则——first-match-wins，匹配到就停，绝不再尝试后续规则。condition 可能涉及 wire_count（电线数量）、color_at_last（最底端电线颜色）、count_red / count_blue / count_yellow / count_green / count_white / count_black 这类颜色计数、battery_count（电池数量,可用 { gt: N } / { lte: N } 这类比较）、indicator_FRK_lit 这类指示灯状态；空 condition: {} 是 catchall，恒为真，永远是最后一条兜底。target.position 是 1-indexed 自上而下编号：1 = 最上面那根，length = 最底下那根；position N 字面就是「从上数第 N 根」，与你念给玩家的自然语言指令逐字同构，无需任何换算。关键字 first 与整数等价：first ≡ position 1；关键字 last 也与整数等价：last ≡ position length（4 根线时 last = position 4，5 根线时 last = position 5）。如果 target 同时带 color 字段（例如 { position: ''last'', color: ''red'' }），含义是「按 position 方向（first 从顶部出发、last 从底部出发）找第一根该颜色的线」——color 是更强的过滤而不是位置覆盖；带 color 的规则其 condition 已保证该色在场上至少存在一根，所以一旦命中、沿 position 方向必定找得到那根目标色的线，color 目标恒可解。【严格按序，绝不跳读】必须严格自上而下逐条走规则，命中的判据是「这一条 condition 的每一个键都成立」；绝不因为某个特征最显眼、看起来最相关（例如全是黄线就直奔那条带 yellow 的规则）就跳过它前面的规则——哪怕前面那条看起来不起眼，只要它先命中就用它、并立即停止。举个会出错的反例：4 根线、电池 4、底端黄线时，按序第一条命中的是 battery_count>2 那条（剪 position 3，即从上数第 3 根），绝不能跳到后面那条 color_at_last:yellow 的规则。【颜色过滤是更强的过滤——绝不擅自换色】当一条规则的 target 带 color 字段时，它要剪的是「沿 position 方向（first 从顶部、last 从底部出发）找到的第一根该颜色的线」，触发它的 condition 颜色和它要剪的 action 颜色可以不一样。这类带 color 的规则其 condition 已保证该色在场上至少存在一根（例如要剪红线的规则，其 condition 必含一个保证红线存在的判据），所以一旦命中，沿 position 方向总能找到那根目标色的线、color 目标恒可解。color 是更强的过滤而不是位置覆盖：先按 position 方向走、只在该方向上挑出该颜色的线。绝不擅自把要剪的颜色换成场上有的别的颜色——要剪红就剪红，绝不因为某色更显眼或更顺手就改剪它。【场景信息缺了就先问，别猜】有些规则依赖电池数量、指示灯这类全局场景信息（玩家开局只会念一次）。轮到这类规则、而你手上没有对应数值时，先问玩家「现在电池几个 / 某指示灯亮没亮」，拿到确切值再回答；绝不靠猜一个场景信息去硬套规则——猜错会直接引爆。【只取被点名的指示灯，其余忽略】只有被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）才与本模块相关；场景信息栏里其余指示灯玩家照念无妨，你按规则只取需要的那一个、其余一律忽略，绝不拿没被点名的指示灯去套规则。【被点名的指示灯本局若没有，按"不亮"处理】被规则 condition 点名的指示灯（如 indicator_FRK_lit 里的 FRK）若不在玩家开局念出的那串指示灯里，就是本局根本没有这颗灯；一律按"该灯未亮"处理——凡是要求它亮（indicator_FRK_lit: true）的 condition 直接判为不成立，按 first-match 继续往下走下一条规则，绝不卡在这条、也绝不反过来假设它亮。注意和「缺了就先问」的区别：只有玩家还没报过指示灯、你确实不知道某灯亮没亮时才追问；玩家已经把本局指示灯报全、那串里没有它，就是确定它不存在=不亮，无须再问。'
     rules:
       - condition: { wire_count: 4, color_at_last: 'red' }
         action: 'cut_wire'
@@ -17,7 +17,7 @@ modules:
         target: { position: 'last', color: 'red' }
       - condition: { wire_count: 4, color_at_last: 'white' }
         action: 'cut_wire'
-        target: { position: 1 }
+        target: { position: 2 }
       - condition: { wire_count: 4, color_at_last: 'green' }
         action: 'cut_wire'
         target: { position: 'last' }
@@ -29,13 +29,13 @@ modules:
         target: { position: 'last', color: 'red' }
       - condition: { wire_count: 4, battery_count: { gt: 2 } }
         action: 'cut_wire'
-        target: { position: 2 }
+        target: { position: 3 }
       - condition: { wire_count: 4 }
         action: 'cut_wire'
         target: { position: 'first' }
       - condition: { wire_count: 5, color_at_last: 'red' }
         action: 'cut_wire'
-        target: { position: 3 }
+        target: { position: 4 }
       - condition: { wire_count: 5, color_at_last: 'blue' }
         action: 'cut_wire'
         target: { position: 'last' }
@@ -47,10 +47,10 @@ modules:
         target: { position: 'first', color: 'blue' }
       - condition: { wire_count: 5, indicator_FRK_lit: true }
         action: 'cut_wire'
-        target: { position: 2 }
+        target: { position: 3 }
       - condition: { wire_count: 5 }
         action: 'cut_wire'
-        target: { position: 2 }
+        target: { position: 3 }
       - condition: {}
         action: 'cut_wire'
         target: { position: 'first' }

--- a/shared/manual-schema.ts
+++ b/shared/manual-schema.ts
@@ -79,7 +79,7 @@ export interface WireRule {
   condition: Record<string, unknown> // flexible — matched by rule engine
   action: 'cut_wire'
   target: {
-    position: 'first' | 'last' | number // 0-indexed number or keyword
+    position: 'first' | 'last' | number // 1-indexed top-down (1 = top, length = bottom); first ≡ position 1, last ≡ position length
     color?: WireColor
   }
 }


### PR DESCRIPTION
## Summary

The 光弦 (wire) module manual encoded cut positions as **0-indexed** integers, so the AI partner had to silently translate `position N` into "the (N+1)th wire from the top" before every spoken instruction. That translation was the off-by-one hazard surfaced in playtest finding **F11** (the AI even read the 0-indexed reasoning aloud to the player). This change makes `target.position` **1-indexed**, so `position N` literally means 「从上数第 N 根」 — the same words the AI says — removing the translation step entirely.

**Behavior-preserving.** The solver's `resolvePosition` now maps the 1-indexed integer `N` → 0-indexed array index `N-1` (the `first`/`last` keyword branches are unchanged), so combined with the `+1` bump of every YAML integer position, the resolved `cutPosition` for every board is byte-identical. No puzzle's correct answer changes.

## Changes

- `packages/manual/data/practice.yaml` — bumped every integer `target.position` +1; rewrote the wire preamble's indexing paragraph to state 1-indexing and dropped the now-dead 0→1 translation instruction. Hardening clauses (strict-first-match / color structural invariant / scene-info ask-gate) preserved.
- `packages/game-bombsquad/src/modules/wire/solver.ts` — `resolvePosition` numeric branch `n → n-1` (bounds `1 ≤ n ≤ length`); `first`/`last` unchanged.
- `shared/manual-schema.ts` — position-convention comment updated to 1-indexed (`cutPosition` stays 0-indexed).
- `packages/game-bombsquad/src/modules/wire/solver.test.ts` — added a numeric-branch regression `describe` (5 cases) that fails under the old 0-indexed solver; existing expected `cutPosition` values unchanged.
- `e2e/regression/fix-bombsquad-cannot-pass-level.{assert.mjs,gherkin}` — updated to assert the 1-indexed semantics and guard that the obsolete 0-indexed text + translation step are gone.
- `packages/manual/data/daily/*.yaml` — all 366 daily manuals regenerated from the updated practice (exact date set preserved; 0 added / 0 deleted).
- `CHANGELOG.md` — player-voice Unreleased entry.
- `.prettierignore` — added `packages/manual/data/` (incidental but necessary): the data is generator-owned single-quote js-yaml; without this, lint-staged's `prettier --write` would re-quote all 366 files on commit, diverging them from `gen:daily` output. Mirrors the existing `answers.json` "generator owns its format" entry.

## Test plan

- [x] `pnpm --filter manual test:run` — 60 passed (incl. 366-daily wire-preamble char-equality + hardening-clause guards)
- [x] `pnpm --filter @amiclaw/game-bombsquad test:run` — 273 passed (incl. new numeric-branch tests)
- [x] `pnpm test:regression` — all scenarios passed
- [x] `pnpm --filter @amiclaw/game-bombsquad typecheck` — clean
- [x] Behavior preservation hand-verified: old `(K-1 → K-1)` == new `(K → K-1)` across sampled rules; the new tests fail under the reverted 0-indexed solver
- [x] Rebased on latest `main` (picks up #137/#138/#140); dailies regenerated from the merged practice so both the dial and wire changes are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
