### PR TITLE
feat(game-bombsquad): start the run from 进入游戏, drop the separate 开始 gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**进入游戏，直接开局，少点一次** — 对接 AI 的最后一步现在多了一句提醒：等你的 AI
+读完手册说「好了」，点「进入游戏」就开始，计时也随之启动。点下去就直接进入这一局，
+不再跳出一块「准备好了吗？」的黑屏让你再确认一次。该确认 AI 的提示，正好出现在你
+设置 AI 的那一页。
+
 **The homepage is calmer and easier to read** — The fabricated community feed
 at the bottom is gone — those posts were made up, so there was nothing real to
 show. The featured BombSquad section no longer stacks two extra play buttons on

--- a/e2e/game-modes-rework.gherkin
+++ b/e2e/game-modes-rework.gherkin
@@ -50,8 +50,6 @@ Feature: BombSquad daily challenge and practice mode
     Then the URL path is /bombsquad/run
     And the query string carries "mode=daily"
     And the immersive game flow renders without the platform shell
-    And I see the prompt "准备好了吗？"
-    When I tap "开始"
     Then the timer starts at 00:00 and counts up
     And the SceneInfoBar shows the "暗号：" and "电池：" fields
     And the module progress bar shows 4 segments
@@ -75,7 +73,6 @@ Feature: BombSquad daily challenge and practice mode
     When I complete the connect-AI flow
     Then the URL path is /bombsquad/run
     And the query string carries "mode=practice"
-    When I tap "开始"
     Then the timer starts at 00:00 and counts up
     And the SceneInfoBar shows the "暗号：" field with a non-empty Chinese phrase
     And the "暗号：" value is one of the entries from the curated tongue-twister pool

--- a/e2e/steps/common.steps.ts
+++ b/e2e/steps/common.steps.ts
@@ -48,8 +48,8 @@ export async function tapByLabel(page: Page, raw: string): Promise<void> {
 
   if (await clickFirstPresent()) return
 
-  // Slow path: the control may render a beat late (e.g. the GamePage READY
-  // "开始" button only paints after the LOADING→READY transition), so the
+  // Slow path: the control may render a beat late (e.g. the ConnectPage
+  // "进入游戏" CTA only paints after the copy → step-2 auto-advance), so the
   // instantaneous count-check above can miss it. Wait — bounded — for any
   // candidate to become visible, then re-run the selection.
   let combined = candidates[0]

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -221,8 +221,8 @@ export class World {
    * back to seedT with setSystemTime (which fires no timers and keeps the clock
    * paused) before the run navigation — otherwise GamePage's getRunSeed reads a
    * shifted Date.now() and generates a daily puzzle that no longer matches
-   * answers.json. The single readiness confirm was removed (it now lives once on
-   * GamePage's 开始), so step 2 ends with a plain 进入游戏 navigation. Assumes
+   * answers.json. Step 2 ends with a plain 进入游戏 navigation; the run then
+   * auto-starts on the GamePage side (no separate 开始 gate any more). Assumes
    * the manual link is already copied.
    */
   async finishConnectFlow(): Promise<void> {
@@ -241,21 +241,26 @@ export class World {
     await this.finishConnectFlow()
   }
 
-  /** READY -> PLAYING. The 开始 button waits out the route-mocked manual load. */
-  async pressStart(): Promise<void> {
-    await this.page.getByRole('button', { name: '开始', exact: true }).click()
+  /**
+   * Wait out the route-mocked manual load until the run auto-starts. There is
+   * no 开始 gate any more: GamePage dispatches START_GAME the instant the manual
+   * loads (READY), so PLAYING is reached on its own. The running stopwatch
+   * (role=timer) is the observable proof the run entered PLAYING.
+   */
+  async waitForRunStarted(): Promise<void> {
+    await this.page.getByRole('timer').waitFor({ state: 'visible', timeout: 12_000 })
   }
 
   async startDailyRun(): Promise<void> {
     await this.enterConnect('daily')
     await this.runConnectFlow()
-    await this.pressStart()
+    await this.waitForRunStarted()
   }
 
   async startPracticeRun(): Promise<void> {
     await this.enterConnect('practice')
     await this.runConnectFlow()
-    await this.pressStart()
+    await this.waitForRunStarted()
   }
 
   // --- Module solving --------------------------------------------------------

--- a/e2e/steps/game.steps.ts
+++ b/e2e/steps/game.steps.ts
@@ -72,10 +72,6 @@ Then('the immersive game flow renders without the platform shell', async ({ page
   await expect(page.getByRole('navigation', { name: '主导航' })).toHaveCount(0)
 })
 
-Then('I see the prompt {string}', async ({ page }, text: string) => {
-  await expect(page.getByText(text)).toBeVisible()
-})
-
 Then('the timer starts at 00:00 and counts up', async ({ world, page }) => {
   const timer = page.getByRole('timer')
   // A count-up stopwatch shows 00:00 at the start — not a per-mode budget a

--- a/packages/game-bombsquad/src/audio/audio-context.ts
+++ b/packages/game-bombsquad/src/audio/audio-context.ts
@@ -2,9 +2,15 @@
  * Lazy, shared AudioContext with iOS unlock and a decoded-buffer cache.
  *
  * Why lazy: browsers (Safari especially) refuse to create / resume an
- * AudioContext outside a user gesture. We create it on the first call to
- * `getAudioContext()` — which itself is only invoked from inside a click /
- * pointer handler — and resume it once.
+ * AudioContext outside a user gesture. The PRIMARY unlock therefore happens
+ * inside a real user gesture — the ConnectPage 进入游戏 tap calls
+ * `getAudioContext()` before navigating to the run, creating + resuming the
+ * context while a gesture is in scope. Because the call is idempotent (it
+ * returns the existing context and only re-resumes if suspended), later
+ * fallback calls are safe even when they run OUTSIDE a gesture — e.g. the
+ * GamePage START_GAME effect calls it again at game start as a belt-and-braces
+ * fallback. On a browser that already unlocked during the gesture that
+ * fallback is a no-op; on one that did not, the resume is retried.
  *
  * Why a buffer cache: each AudioBufferSourceNode is single-use, but the
  * decoded AudioBuffer is reusable. We decode each of the 4 samples once,

--- a/packages/game-bombsquad/src/game-flow.test.tsx
+++ b/packages/game-bombsquad/src/game-flow.test.tsx
@@ -4,14 +4,17 @@
  * daily manual loader (so the daily run resolves a manual without a network).
  *
  * Covers two runs:
- *   1. practice → START → 2 module completions → result page (拆弹成功)
- *   2. daily    → START → 4 module completions → result page (拆弹成功)
+ *   1. practice → auto-start → 2 module completions → result page (拆弹成功)
+ *   2. daily    → auto-start → 4 module completions → result page (拆弹成功)
  *
- * Practice runs a reduced 2-module sequence (wire + keypad); daily runs the
- * full 4 (wire + dial + button + keypad). Each module has a unique testid so
- * the loop waits for the correct module to be mounted before clicking — this
- * prevents accidentally clicking the previous module's button while the
- * MODULE_COMPLETE overlay is still visible (800 ms auto-advance).
+ * The run auto-starts: once the manual loads (READY), GamePage dispatches
+ * START_GAME from an effect, so PLAYING is reached with no "准备好了吗？"/开始
+ * gate. The first module mounting is the observable proof the run entered
+ * PLAYING. Practice runs a reduced 2-module sequence (wire + keypad); daily
+ * runs the full 4 (wire + dial + button + keypad). Each module has a unique
+ * testid so the loop waits for the correct module to be mounted before
+ * clicking — this prevents accidentally clicking the previous module's button
+ * while the MODULE_COMPLETE overlay is still visible (800 ms auto-advance).
  */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
@@ -100,11 +103,12 @@ describe('full game flow', () => {
       </MemoryRouter>
     )
 
-    // Practice manual is inlined via ?raw — wait for the standard ready
-    // prompt to render, then start the run. Both modes show the same
-    // "ready?" screen; the game page never onboards the player.
-    await waitFor(() => expect(screen.getByText('准备好了吗？')).toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /^开始$/ }))
+    // Practice manual is inlined via ?raw — the run auto-starts the moment it
+    // loads, so the first module mounts with no 开始 gate. Waiting for it is
+    // proof the run reached PLAYING on its own.
+    await waitFor(() => expect(screen.getByTestId('mock-wire-complete')).toBeInTheDocument(), {
+      timeout: 3000,
+    })
 
     // Practice runs only the reduced 2-module sequence.
     await completeModules(PRACTICE_MODULE_TESTIDS)
@@ -124,9 +128,11 @@ describe('full game flow', () => {
       </MemoryRouter>
     )
 
-    // The terse "ready?" prompt appears once the mocked manual resolves.
-    await waitFor(() => expect(screen.getByText('准备好了吗？')).toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /^开始$/ }))
+    // The run auto-starts once the mocked manual resolves — the first module
+    // mounts with no 开始 gate, which is proof the run reached PLAYING on its own.
+    await waitFor(() => expect(screen.getByTestId('mock-wire-complete')).toBeInTheDocument(), {
+      timeout: 3000,
+    })
 
     // Daily runs the full 4-module sequence.
     await completeModules(DAILY_MODULE_TESTIDS)

--- a/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
@@ -15,8 +15,9 @@
  *   7. step 1 surfaces the /bombsquad/compatibility discovery link
  *      (re-homed from the retired PromptModal).
  *
- * The readiness gate now lives once on GamePage's "开始" button, so this flow
- * ends with a plain "进入游戏" navigation — there is no second confirm here.
+ * The AI-readiness sync prompt now lives here on step 2, and "进入游戏" starts
+ * the run directly — there is no separate GamePage 开始 gate, so this flow ends
+ * with a plain navigation and the run auto-starts on the other side.
  *
  * useDailyChallenge is mocked to deterministic URLs; copyToClipboard is
  * stubbed to its success branch so the copy → auto-advance path runs
@@ -43,8 +44,19 @@ vi.mock('@/utils/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
 }))
 
+// The 进入游戏 tap unlocks the shared AudioContext inside the user gesture (iOS
+// Safari needs the gesture). Mock the singleton so the test can assert the call
+// without a real Web Audio context in jsdom.
+vi.mock('@/audio/audio-context', () => ({
+  getAudioContext: vi.fn().mockReturnValue(null),
+}))
+
 import ConnectPage from './ConnectPage'
 import { copyToClipboard } from '@/utils/clipboard'
+import { getAudioContext } from '@/audio/audio-context'
+
+/** The exact AI-readiness sync prompt copy rendered on step 2. */
+const SYNC_PROMPT = '等 AI 说完「好了」，点「进入游戏」就开始，计时随即启动。'
 
 /* Renders the current location so the run-handoff target is assertable
    without mounting the real GamePage. */
@@ -79,6 +91,7 @@ describe('ConnectPage', () => {
   beforeEach(() => {
     vi.mocked(copyToClipboard).mockClear()
     vi.mocked(copyToClipboard).mockResolvedValue(true)
+    vi.mocked(getAudioContext).mockClear()
   })
 
   it('renders step 1 with the URL preview and manual URL', () => {
@@ -149,11 +162,41 @@ describe('ConnectPage', () => {
     // Step 1 → step 2 via copy + auto-advance.
     await copyAndReachStep2()
 
-    // Step 2 — the voice-mode step, with the run handoff CTA. No second
-    // readiness confirm — that gate lives on GamePage's "开始" button.
+    // Step 2 — the voice-mode step, carrying the AI-readiness sync prompt and
+    // the run handoff CTA. 进入游戏 starts the run directly; there is no separate
+    // GamePage 开始 gate.
     expect(screen.getByText('第 2/2 步')).toBeInTheDocument()
     expect(screen.getByText('切到语音模式')).toBeInTheDocument()
+    // The sync prompt re-homed from the deleted GamePage 开始 gate: it confirms
+    // the AI said「好了」and names the one consequence of the next tap (进入即计时).
+    expect(screen.getByText(SYNC_PROMPT)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /进入游戏/ })).toBeInTheDocument()
+  })
+
+  it('unlocks the AudioContext when 进入游戏 is tapped (daily)', async () => {
+    renderConnect('daily')
+
+    await copyAndReachStep2()
+    // No audio unlock has happened yet — it must fire on the run-handoff gesture,
+    // not on render or on the copy step.
+    expect(getAudioContext).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /进入游戏/ }))
+
+    // iOS Safari only permits audio to start from inside a user gesture, so the
+    // 进入游戏 tap is where the shared AudioContext gets unlocked.
+    expect(getAudioContext).toHaveBeenCalledTimes(1)
+  })
+
+  it('unlocks the AudioContext when 进入游戏 is tapped (practice)', async () => {
+    renderConnect('practice')
+
+    await copyAndReachStep2()
+    expect(getAudioContext).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /进入游戏/ }))
+
+    expect(getAudioContext).toHaveBeenCalledTimes(1)
   })
 
   it('hands daily mode off to the run carrying the manual URL as ?url=', async () => {

--- a/packages/game-bombsquad/src/pages/ConnectPage.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.tsx
@@ -5,17 +5,19 @@ import Eyebrow from '@/components/bombsquad/Eyebrow'
 import Button from '@/components/bombsquad/Button'
 import { useDailyChallenge } from '@/hooks/useDailyChallenge'
 import { copyToClipboard } from '@/utils/clipboard'
+import { getAudioContext } from '@/audio/audio-context'
 import styles from './ConnectPage.module.css'
 
 type ConnectMode = 'daily' | 'practice'
 
 /* Connect-AI flow — design_handoff_bombsquad README §6.2. Two steps swap in
    place: copy the manual link in one tap, then switch the AI to voice mode and
-   hand off to the run. The readiness gate lives once, on the GamePage "开始"
-   button (which also unlocks iOS audio inside the user gesture), so this flow
-   ends with a plain "进入游戏" navigation, not a second confirm. The manual URL
-   is derived by useDailyChallenge; voice AIs auto-read a bare pasted link and
-   adopt the role from the now-self-framing manual, so the link alone suffices. */
+   hand off to the run. The AI-readiness sync prompt now lives here, on step 2
+   (where the player is actually setting their AI up); there is no separate
+   GamePage gate — "进入游戏" starts the run directly. Tapping it also unlocks
+   iOS audio inside the user gesture. The manual URL is derived by
+   useDailyChallenge; voice AIs auto-read a bare pasted link and adopt the role
+   from the now-self-framing manual, so the link alone suffices. */
 export default function ConnectPage() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
@@ -48,9 +50,13 @@ export default function ConnectPage() {
 
   /* Final step → the existing run. Daily carries the manual URL as ?url= so
      the AI partner and the run fetch the same manual; practice loads its
-     bundled manual and needs no URL. The run's READY "开始" button is the
-     single readiness gate and unlocks iOS audio on tap. */
+     bundled manual and needs no URL. This tap is the run's only gesture, so
+     unlock the shared AudioContext here — iOS Safari only permits audio to
+     start from inside a user gesture, and the run's stopwatch SFX loop runs
+     outside one. getAudioContext() is idempotent; the run calls it again at
+     game start as a fallback. */
   const confirmStart = () => {
+    getAudioContext()
     if (mode === 'daily') {
       navigate(`/bombsquad/run?mode=daily&url=${encodeURIComponent(dailyUrl)}`)
     } else {
@@ -230,6 +236,15 @@ export default function ConnectPage() {
                 </div>
               </div>
               <p className={styles.hint}>这样你描述、AI 回应，全程不用手离开屏幕。</p>
+              {/* AI-readiness sync prompt — re-homed from the deleted GamePage
+                  「开始」gate to the place the player is actually setting up
+                  their AI. Anchors to step 1's canonical「让它读完手册后说
+                  『好了』」wording and names the one consequence of the next
+                  tap: 进入游戏 starts the run, and the stopwatch starts with
+                  it. Calm, not a countdown — time is a score, not a deadline. */}
+              <p className={styles.hint}>
+                等 AI 说完「好了」，点「进入游戏」就开始，计时随即启动。
+              </p>
             </div>
           )}
 

--- a/packages/game-bombsquad/src/pages/GamePage.module.css
+++ b/packages/game-bombsquad/src/pages/GamePage.module.css
@@ -372,12 +372,6 @@
   }
 }
 
-.readyText {
-  font: 400 clamp(1.6rem, 6vw, 2.4rem) var(--font-display);
-  color: #fff;
-  text-shadow: 0 0 20px var(--y-glow-25);
-}
-
 .loadingText {
   font: 400 1.1rem var(--font-body);
   color: var(--soft);

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -381,6 +381,23 @@ export default function GamePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode])
 
+  // Auto-start once the manual has loaded. READY is a transient bridge state —
+  // the player already committed to the run on the ConnectPage 进入游戏 tap, so
+  // there is no separate GamePage gate. The instant the reducer reaches READY
+  // (only ever via MANUAL_LOADED, which has already populated every
+  // moduleConfig), dispatch START_GAME to enter PLAYING. Keyed on
+  // `state.status`, so it fires exactly once per READY entry; START_GAME's own
+  // READY→PLAYING transition makes a second dispatch a no-op even before this
+  // effect re-runs. A run refresh-restored mid-play comes back at
+  // PLAYING/MODULE_COMPLETE/… (not READY), so this never re-triggers a
+  // restored run. getAudioContext() is an idempotent iOS-audio fallback —
+  // the primary unlock happened inside the ConnectPage 进入游戏 user gesture.
+  useEffect(() => {
+    if (state.status !== 'READY') return
+    getAudioContext()
+    dispatch({ type: 'START_GAME' })
+  }, [state.status, dispatch])
+
   // Navigate to result when ALL_COMPLETE transitions to RESULT
   useEffect(() => {
     if (state.status === 'ALL_COMPLETE') {
@@ -554,25 +571,19 @@ export default function GamePage() {
     )
   }
 
-  // READY state — waiting for the player to start. Both modes show the same
-  // terse "ready?" prompt; the game page never teaches the player — all
-  // guidance comes from the AI voice partner.
+  // READY state — the run auto-starts the instant the manual loads (the
+  // auto-start effect above dispatches START_GAME on entering READY). There is
+  // no separate "ready?" gate any more; the player already committed on the
+  // ConnectPage 进入游戏 tap. READY is therefore a sub-frame bridge between
+  // MANUAL_LOADED and PLAYING — keep showing the loading spinner over it so the
+  // handoff reads as one continuous "加载手册中…" rather than flashing a
+  // half-mounted module panel before the stopwatch starts.
   if (state.status === 'READY') {
-    // Unlock the shared AudioContext inside this user-gesture handler so iOS
-    // Safari permits audio to start when the stopwatch loop begins (the
-    // stopwatch effect itself runs outside a gesture).
-    const handleStart = () => {
-      getAudioContext()
-      dispatch({ type: 'START_GAME' })
-    }
     return (
       <main className={styles.page}>
         {refreshBanner}
         <div className={styles.overlay}>
-          <p className={styles.readyText}>准备好了吗？</p>
-          <button className={styles.startBtn} onClick={handleStart}>
-            开始
-          </button>
+          <p className={styles.loadingText}>加载手册中…</p>
         </div>
       </main>
     )

--- a/packages/game-bombsquad/src/store/game-context.test.ts
+++ b/packages/game-bombsquad/src/store/game-context.test.ts
@@ -114,6 +114,28 @@ describe('gameReducer — START_GAME', () => {
     )
     expect(practice.timeBudgetMs).toBe(TIME_BUDGET_MS.practice)
   })
+
+  it('is a no-op when dispatched from a live PLAYING run (idempotency guard)', () => {
+    // The GamePage auto-start effect dispatches START_GAME on entering READY,
+    // and React StrictMode can double-invoke it. The second dispatch lands while
+    // the run is already PLAYING; the guard must return the live state untouched
+    // so a duplicate never resets the run or re-logs game_start.
+    vi.mocked(logEvent).mockClear()
+    const live = baseState({
+      status: 'PLAYING',
+      currentModuleIndex: 2,
+      strikeCount: 1,
+      moduleStats: [{ moduleType: 'wire', timeMs: 1234, errorCount: 0 }],
+      totalStartTime: 1_700_000_000_000,
+      moduleConfigs: filled4,
+    })
+    const after = gameReducer(live, { type: 'START_GAME' })
+    expect(after).toBe(live) // same reference — no new state object
+    expect(after.currentModuleIndex).toBe(2)
+    expect(after.strikeCount).toBe(1)
+    expect(after.moduleStats).toHaveLength(1)
+    expect(logEvent).not.toHaveBeenCalled()
+  })
 })
 
 describe('gameReducer — MODULE_ERROR (daily 3-strike rule)', () => {

--- a/packages/game-bombsquad/src/store/game-context.tsx
+++ b/packages/game-bombsquad/src/store/game-context.tsx
@@ -215,6 +215,15 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
     }
 
     case 'START_GAME': {
+      // Idempotency guard: START_GAME only starts a run from READY. The GamePage
+      // auto-start effect dispatches it on entering READY, and React StrictMode
+      // can double-invoke that effect — without this guard the second dispatch
+      // would reset a now-live run (currentModuleIndex:0, totalStartTime:now,
+      // strikeCount:0, a second game_start event). Mirrors the
+      // MODULE_COMPLETE / MODULE_ERROR / NEXT_MODULE status guards. Play Again
+      // never reaches here from PLAYING — it dispatches RESET, then a fresh
+      // LOADING → MANUAL_LOADED → READY cycle re-arms this case.
+      if (state.status !== 'READY') return state
       if (import.meta.env.DEV) {
         const missingConfig = state.moduleConfigs.some((c) => c === null)
         if (missingConfig) {


### PR DESCRIPTION
## Summary

- Move the AI-readiness sync prompt onto **ConnectPage step 2** (where the player is actually setting up their AI), anchored to step 1's `让它读完手册后说「好了」` wording.
- **Remove the standalone `准备好了吗? → 开始` gate**: tapping **进入游戏** now starts the run directly — one fewer click, no black ready screen.
- Move the iOS-Safari AudioContext unlock onto the 进入游戏 gesture, with an idempotent `getAudioContext()` fallback at game start.
- READY auto-advances to PLAYING via an effect, guarded by a `START_GAME` reducer `status === 'READY'` check so a duplicate dispatch (e.g. React StrictMode) cannot reset a live run.

## Type of change

- [x] New feature
- [x] Refactor or cleanup

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed (reducer idempotency no-op; ConnectPage step-2 prompt text + getAudioContext-on-进入游戏 for daily & practice)
- [x] Tested manually and documented below

Local gate: `pnpm typecheck` clean · game-bombsquad **271/271** · `pnpm e2e:audit` clean 16↔16 bijection · `pnpm build` clean. **iOS-Safari real-device audio cannot be verified headlessly** — needs a play-confirm on the preview / a real iPhone (the unlock now rides the 进入游戏 gesture + idempotent fallback).

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff (+ independent cross-model verifier pass)
- [x] No debug logging remains
- [x] Documentation updated if needed (architecture docs: recap-skills, game-session — in the vault)
- [x] Breaking changes documented if any (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)