### PR TITLE
feat(platform): add Discord invite entry to the Game Lab tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Game Lab 区块准备好接上 Discord** — 落地页的 Game Lab 区块写着「在 Discord 写下你
+想和 AI 一起玩的小游戏」,现在这块卡片可以变成真正能点的 Discord 入口:填上邀请链接后,
+卡片就带上「加入 Discord」的提示、点一下在新标签页打开邀请。在链接配置好之前,卡片和原来
+一模一样、不可点,所以这次改动对你看到的页面没有任何影响。
+
 **The small labels on the home page are easier to read** — The little tags
 around the landing page — the section eyebrows, the orbit-stat captions, the
 status and preview badges, the daily-challenge countdown units, the featured

--- a/packages/platform/src/components/home/UpcomingGames.module.css
+++ b/packages/platform/src/components/home/UpcomingGames.module.css
@@ -113,6 +113,18 @@
   color: var(--text-3);
 }
 
+/* Click affordance for the Game Lab Discord tile. Reuses the same violet
+   (yj-yin) accent as .tilePreview / .previewChip so it reads as part of the
+   existing clickable-tile language rather than a new visual element. */
+.discordCue {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 12px;
+  font: 600 13px var(--font-body);
+  letter-spacing: 0.02em;
+  color: #d6c0ff;
+}
+
 /* Local preview-status pill — sized to match Chip.module.css `.soon/.dev/.live`
    for visual parity but tinted with yj-yin to read distinct from the
    yellow `soon` chip. Kept inside this module so the @amiclaw/ui Chip

--- a/packages/platform/src/components/home/UpcomingGames.test.tsx
+++ b/packages/platform/src/components/home/UpcomingGames.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * UpcomingGames — Game Lab Discord tile wiring.
+ *
+ * The Game Lab tile gates on the shared DISCORD_INVITE_URL sentinel:
+ *   1. configured (non-empty) -> a clickable <a> into the invite, opening in a
+ *      new tab with rel="noopener noreferrer" and a「加入 Discord」cue
+ *   2. empty (the current placeholder) -> a non-clickable tile, no link, same
+ *      output as before this change (zero regression)
+ *
+ * The constant module is mocked per-test so both branches are exercised without
+ * editing the real '' sentinel value.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+async function renderWith(discordUrl: string) {
+  vi.resetModules()
+  vi.doMock('@/config/links', () => ({ DISCORD_INVITE_URL: discordUrl }))
+  const { default: UpcomingGames } = await import('./UpcomingGames')
+  render(<UpcomingGames />)
+}
+
+describe('UpcomingGames — Game Lab Discord tile', () => {
+  it('renders the Game Lab tile as a clickable Discord link when the URL is configured', async () => {
+    await renderWith('https://discord.gg/example')
+
+    const link = screen.getByRole('link', { name: /加入 Discord/ })
+    expect(link).toHaveAttribute('href', 'https://discord.gg/example')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    // The Game Lab tile's own copy is still present inside the link.
+    expect(link).toHaveTextContent('Game Lab')
+  })
+
+  it('keeps the Game Lab tile non-clickable when the URL is the empty sentinel', async () => {
+    await renderWith('')
+
+    // No Discord link and no cue exist in the placeholder state.
+    expect(screen.queryByRole('link', { name: /加入 Discord/ })).not.toBeInTheDocument()
+    expect(screen.queryByText('加入 Discord →')).not.toBeInTheDocument()
+    // The Game Lab tile still renders its name as plain (non-link) text.
+    expect(screen.getByText('Game Lab')).toBeInTheDocument()
+  })
+
+  it('does not regress the other upcoming-game tiles', async () => {
+    await renderWith('')
+
+    // The preview tile (易经签卜) stays a clickable link to its prototype.
+    const previewLink = screen.getByRole('link', { name: /易经签卜/ })
+    expect(previewLink).toHaveAttribute('href', '/oracle/')
+    // The non-clickable 'soon' tiles still render (name appears in both the art
+    // label and the heading, hence getAllByText).
+    expect(screen.getAllByText('星海回声').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('共绘星图').length).toBeGreaterThan(0)
+    // Neither 'soon' tile is a link.
+    expect(screen.queryByRole('link', { name: /星海回声/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /共绘星图/ })).not.toBeInTheDocument()
+  })
+})

--- a/packages/platform/src/components/home/UpcomingGames.tsx
+++ b/packages/platform/src/components/home/UpcomingGames.tsx
@@ -1,4 +1,5 @@
 import { Chip, SectionHeader } from '@amiclaw/ui'
+import { DISCORD_INVITE_URL } from '@/config/links'
 import { type GameStatus, type UpcomingGame, upcomingGames } from '@/mocks/upcoming-games'
 import styles from './UpcomingGames.module.css'
 
@@ -24,8 +25,10 @@ function StatusBadge({ status }: { status: GameStatus }) {
 }
 
 /* Inner tile body — shared by both the anchor-wrapped and plain forms so
-   the markup stays in sync. */
-function TileBody({ game }: { game: UpcomingGame }) {
+   the markup stays in sync. `discordCue` renders the「加入 Discord」click
+   affordance and is set only on the Game Lab tile's clickable (linked) form;
+   the non-clickable placeholder leaves it off so its markup is unchanged. */
+function TileBody({ game, discordCue = false }: { game: UpcomingGame; discordCue?: boolean }) {
   const isLab = game.artVariant === 'lab'
   /* echo / draw / yijing show the game's Chinese name; Game Lab shows a
      bespoke Latin-flavored label, matching the atlas.html prototype.
@@ -42,6 +45,7 @@ function TileBody({ game }: { game: UpcomingGame }) {
         <StatusBadge status={game.status} />
       </h5>
       <p className={styles.blurb}>{game.blurb}</p>
+      {discordCue && <span className={styles.discordCue}>加入 Discord →</span>}
     </>
   )
 }
@@ -52,6 +56,12 @@ function TileBody({ game }: { game: UpcomingGame }) {
 
    Round 5 (Yijing Oracle wiring): tiles with `href` + `status === 'preview'`
    render as `<a>` so users can click into the sibling-deployed prototype.
+
+   Game Lab tile: when DISCORD_INVITE_URL is configured (non-empty), it renders
+   as a clickable `<a>` into the Discord invite (new tab); while the constant is
+   the empty-string sentinel it stays a non-clickable placeholder — byte-for-byte
+   the same output as before, so the placeholder state is a zero-regression no-op.
+
    Other tiles stay non-clickable. */
 export default function UpcomingGames() {
   return (
@@ -64,6 +74,20 @@ export default function UpcomingGames() {
             return (
               <a key={game.id} href={game.href} className={`${styles.tile} ${styles.tilePreview}`}>
                 <TileBody game={game} />
+              </a>
+            )
+          }
+          const isDiscordLink = game.artVariant === 'lab' && DISCORD_INVITE_URL !== ''
+          if (isDiscordLink) {
+            return (
+              <a
+                key={game.id}
+                href={DISCORD_INVITE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`${styles.tile} ${styles.tilePreview}`}
+              >
+                <TileBody game={game} discordCue />
               </a>
             )
           }

--- a/packages/platform/src/config/links.ts
+++ b/packages/platform/src/config/links.ts
@@ -1,0 +1,10 @@
+/* Shared external-link constants for the platform package.
+   Single source of truth so any component (Game Lab tile, footer link, …)
+   imports the same value instead of hard-coding it. */
+
+/* Discord community invite. Empty-string sentinel = not yet configured:
+   callers MUST treat '' as "no link" and keep their placeholder (non-clickable)
+   state, so the empty value is a zero-regression no-op.
+   TODO: the user will replace '' with the real invite, e.g.
+   'https://discord.gg/xxxx'. */
+export const DISCORD_INVITE_URL = ''


### PR DESCRIPTION
## Summary

- The landing-page **Game Lab** block tells players to propose games in Discord, but the site had no clickable Discord entry anywhere — the only proposal/feedback channel was a dead end.
- Gates the Game Lab tile on a shared `DISCORD_INVITE_URL` constant (`packages/platform/src/config/links.ts`, single source the footer Discord link can reuse): non-empty → the tile becomes a clickable `<a target="_blank" rel="noopener noreferrer">` with a「加入 Discord →」cue, reusing the existing `tilePreview` style; empty sentinel → the tile keeps its current non-clickable rendering, so the placeholder state is a **zero-regression no-op**.
- The constant ships as `''` by design — once the real invite URL is pasted in, the link goes live; until then nothing on the page changes.

## Test plan

- [x] `pnpm --filter @amiclaw/platform run typecheck` — pass
- [x] `pnpm --filter @amiclaw/platform run test:run` — pass (9 files, 36 tests; new tests cover clickable-state href/target/rel, empty-state no-link, and other-tile no-regression)
- [x] `pnpm --filter @amiclaw/platform run build` — pass
- [x] Full monorepo `pnpm -r run test:run` via pre-commit hook — all suites pass
- [x] Independent verification (Conformance / Coherence / Soundness) — empty-state confirmed byte-equivalent to pre-change; SSOT confirmed single definition; footer untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)