### PR TITLE
fix(manual): scope the rendered practice manual to the modules practice plays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versions follow [Semantic Versioning](https://semver.org).
 卡片就带上「加入 Discord」的提示、点一下在新标签页打开邀请。在链接配置好之前,卡片和原来
 一模一样、不可点,所以这次改动对你看到的页面没有任何影响。
 
+**Practice mode hands your AI only the two modules you'll play** — In practice
+you only ever face the 光弦 and 星符 modules, but the manual your AI partner reads
+still listed all four. If you misspoke or the screen hiccupped, the AI could
+confidently walk you through a 星盘 or 按钮 step that a practice run never shows.
+The practice manual now carries only the 光弦 and 星符 rules, so your partner stays
+on the two modules in front of you. Daily challenges are unchanged — they still
+use all four.
+
 **The small labels on the home page are easier to read** — The little tags
 around the landing page — the section eyebrows, the orbit-stat captions, the
 status and preview badges, the daily-challenge countdown units, the featured

--- a/packages/manual/build.ts
+++ b/packages/manual/build.ts
@@ -30,7 +30,7 @@ interface MinimalModules {
   keypad?: { sequences?: string[][] }
 }
 interface MinimalManual {
-  meta?: { version?: string }
+  meta?: { version?: string; type?: string }
   modules: MinimalModules
   symbols?: Record<string, { description?: string }>
   ai_instructions?: Record<string, string[]>
@@ -133,6 +133,37 @@ function validateReferencedSymbolsAgainstSSOT(manual: MinimalManual): void {
   }
 }
 
+/**
+ * The module set a PRACTICE run actually plays. The source `practice.yaml`
+ * keeps all four modules (the daily generator derives every daily manual from
+ * it, and the frontend parses the full source), but a practice RUN only
+ * surfaces these two. This is the build-side mirror of `MODULE_SEQUENCE.practice`
+ * in `packages/game-bombsquad/src/store/game-context.tsx` (`practice: ['wire',
+ * 'keypad']`, with the ModuleKind→manual-key mapping wire→wire_routing,
+ * keypad→keypad). The RENDERED practice manual is scoped to this set so the AI
+ * never loads — and so can never confidently match against — rules for a module
+ * (星盘/symbol_dial, 按钮/button) a practice run cannot present. Keep this in
+ * sync with that frontend constant; a drift between the two is the bug this
+ * guards against. Declared here as a build.ts constant rather than a source
+ * `meta` field on purpose: a source field would propagate into all 366 derived
+ * daily YAMLs and break their byte-identical invariant.
+ */
+const PRACTICE_ACTIVE_MODULE_KEYS: ReadonlySet<string> = new Set(['wire_routing', 'keypad'])
+
+/**
+ * Scope a manual's `modules` to the keys in `keep`, preserving the source's
+ * authored key order. Returns a new object; the input is not mutated. Keys not
+ * present in the source are simply absent from the result.
+ */
+function scopeModules(modules: MinimalModules, keep: ReadonlySet<string>): MinimalModules {
+  const all = modules as Record<string, unknown>
+  const scoped: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(all)) {
+    if (keep.has(key)) scoped[key] = value
+  }
+  return scoped as MinimalModules
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const templatePath = resolve(__dirname, 'src/template.html')
@@ -164,6 +195,20 @@ function buildPage(yamlPath: string, slug: string) {
   // a source-level copy would leak descriptions to the dist raw yaml path
   // (Option C invariant).
   validateNoSourceSymbols(parsed)
+
+  // Scope the RENDERED practice manual to the modules a practice run actually
+  // plays (wire_routing + keypad). The source practice.yaml keeps all four
+  // modules for daily derivation + the frontend; only the AI-facing render is
+  // narrowed. This runs AFTER the three validators (so the full source is still
+  // integrity-checked) and BEFORE collectReferencedSymbolIds + the payload
+  // assembly below, so symbol injection and the emitted `modules` block narrow
+  // together — once symbol_dial is gone, only keypad-referenced symbols inject.
+  // Reassigning the existing `modules` key preserves the source's authored
+  // key order (meta / modules / decoy_modules); `decoy_modules` and `meta` are
+  // untouched. Daily manuals (meta.type === 'daily') pass through unchanged.
+  if (parsed.meta?.type === 'practice') {
+    parsed.modules = scopeModules(parsed.modules, PRACTICE_ACTIVE_MODULE_KEYS)
+  }
 
   // Build the symbol-description block from the SYMBOLS SSOT for every id the
   // modules reference. This is the AI's vocabulary bridge from an abstract id

--- a/packages/manual/data-validation.test.ts
+++ b/packages/manual/data-validation.test.ts
@@ -322,6 +322,72 @@ describe('manual set-discrimination invariant', () => {
   })
 })
 
+describe('rendered practice manual is scoped to the practice-active module set', () => {
+  // Practice gameplay runs only wire_routing + keypad (MODULE_SEQUENCE.practice
+  // in packages/game-bombsquad/src/store/game-context.tsx — practice:
+  // ['wire','keypad']). The source practice.yaml keeps all four modules (the
+  // daily generator derives every daily manual from it, and the frontend parses
+  // the full source), but build.ts scopes the RENDERED practice manual to the
+  // practice-active set so the AI never loads — and so can never confidently
+  // match against — rules for a module (星盘/symbol_dial, 按钮/button) a practice
+  // run cannot present. This guards BOTH render paths (dist raw YAML + the
+  // HTML-embedded yaml, which build.ts serialises from one canonical payload)
+  // and confirms the scoping is practice-only: every daily manual still ships
+  // all four modules, and the practice render keeps decoy_modules.
+  beforeAll(() => {
+    buildManualForTests()
+  })
+
+  // Sorted alphabetically to match Object.keys(...).sort() below.
+  const PRACTICE_ACTIVE = ['keypad', 'wire_routing']
+  const DAILY_ALL = ['button', 'keypad', 'symbol_dial', 'wire_routing']
+
+  function distRawModuleKeys(distRawPath: string): string[] {
+    const manual = yaml.load(readFileSync(distRawPath, 'utf8')) as Manual
+    return Object.keys(manual.modules).sort()
+  }
+
+  function embeddedModuleKeys(htmlPath: string): string[] {
+    const html = readFileSync(htmlPath, 'utf8')
+    const m = html.match(/<pre class="anti-human">([\s\S]*?)<\/pre>/)
+    if (!m) throw new Error(`No <pre class="anti-human"> block found in ${htmlPath}`)
+    const manual = yaml.load(m[1]) as Manual
+    return Object.keys(manual.modules).sort()
+  }
+
+  it('practice dist raw YAML modules are exactly { wire_routing, keypad }', () => {
+    expect(distRawModuleKeys(join(MANUAL_DIST, 'data/practice.yaml'))).toEqual(PRACTICE_ACTIVE)
+  })
+
+  it('practice HTML-embedded yaml modules are exactly { wire_routing, keypad }', () => {
+    expect(embeddedModuleKeys(join(MANUAL_DIST, 'practice/index.html'))).toEqual(PRACTICE_ACTIVE)
+  })
+
+  it('practice render drops symbol_dial and button (no stale module rules reach the AI)', () => {
+    const keys = distRawModuleKeys(join(MANUAL_DIST, 'data/practice.yaml'))
+    expect(keys, 'symbol_dial must not ship in the practice render').not.toContain('symbol_dial')
+    expect(keys, 'button must not ship in the practice render').not.toContain('button')
+  })
+
+  it('practice render still carries decoy_modules (universal fake-module content)', () => {
+    const manual = yaml.load(
+      readFileSync(join(MANUAL_DIST, 'data/practice.yaml'), 'utf8')
+    ) as Manual & { decoy_modules?: unknown }
+    expect(manual.decoy_modules, 'decoy_modules must survive the practice scoping').toBeDefined()
+  })
+
+  it('every daily dist raw YAML still ships all four modules (scoping is practice-only)', () => {
+    const dailyFiles = readdirSync(DAILY_DIR).filter((f) => f.endsWith('.yaml'))
+    expect(dailyFiles.length).toBeGreaterThan(0)
+    for (const file of dailyFiles) {
+      expect(
+        distRawModuleKeys(join(MANUAL_DIST, 'data', file)),
+        `${file} should still carry all four modules`
+      ).toEqual(DAILY_ALL)
+    }
+  })
+})
+
 describe('AI_INSTRUCTIONS carries game framing + collaboration philosophy', () => {
   // build.ts injects AI_INSTRUCTIONS into the HTML-embedded yaml AND the dist
   // raw yaml on every render. This block locks in the required-key schema


### PR DESCRIPTION
## Summary

- The AI-facing **rendered** practice manual shipped all four module rulesets (`wire_routing`, `symbol_dial`, `button`, `keypad`), but a practice run only plays `wire_routing` + `keypad`. Besides loading unused rules, this let the AI confidently match phantom `symbol_dial`/`button` rules if a player misspoke — walking them through a module a practice run never shows. The manual's own `game_overview` already says practice uses two modules, so the `modules` block contradicted it.
- Fix at the **render layer** in `packages/manual/build.ts`: when `meta.type === 'practice'`, scope the AI payload's `modules` to a new `PRACTICE_ACTIVE_MODULE_KEYS` constant (`wire_routing` + `keypad`) before symbol collection, so the emitted modules and injected symbols narrow together. `decoy_modules`, `meta`, and `ai_instructions` are untouched.
- The source `packages/manual/data/practice.yaml` is **unchanged** — the daily generator (`scripts/generate-daily-from-practice.mjs`) derives every daily manual from it and the frontend parses the full source, so daily output stays **byte-identical**. The set is a build-side constant (not a source `meta` field) on purpose: a source field would propagate into all 366 derived daily YAMLs and break their byte-identical invariant. The constant cross-references the frontend's `MODULE_SEQUENCE.practice` so drift is visible.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

`packages/manual` 71/71 · `packages/game-bombsquad` 276/276 · regression scripts all pass · `e2e/scripts/audit-coverage.mjs` clean 16↔16 bijection. New `data-validation.test.ts` block asserts the rendered practice manual contains exactly `{wire_routing, keypad}`, drops `symbol_dial`+`button`, keeps `decoy_modules`, and every daily render still carries all four. `git diff` of `packages/manual/data/practice.yaml` and `packages/manual/data/daily/` is empty (source + daily byte-identical). Independently re-verified by a separate reviewer (3-axis: conformance / coherence / soundness — passed).

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [ ] Breaking changes documented if any

> Architecture note: the C4 component doc `arch-component-manual-system.md` was updated (mechanism clause + a "practice render module-scope" invariant) in the docs vault (the repo's `docs/` is a symlink into it), so that change is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)