### PR TITLE
fix(platform): 统一落地页文案(去 AI-感官隐喻 + 收敛 play CTA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**The home page now says one thing about how to start, and says it
+honestly** — The landing page used to describe your AI partner as your eyes or
+your ears, which gets the game backwards: you are the one looking at the bomb,
+and the AI is the one reading the manual. The daily-challenge and featured
+sections now say it straight — you describe the panel, the AI looks it up in
+the manual. And the five different buttons that all led to the same place are
+down to two, both reading「开始玩」, so it's obvious where to go to start a game.
+The daily and featured cards are now plain info cards, and the footer is a plain
+pitch — none of them tries to send you off with its own button anymore.
+
 **页脚不再留两个点不动的死链接** — 页脚里的「关于」和「Discord」过去只是两段不能点的
 文字。「关于」没有对应的页面,直接拿掉了。「Discord」改成接上社区邀请链接:邀请链接填好
 之前它不出现,填好之后就变成一个能点、在新标签页打开的入口。隐私和条款两个链接照常可用。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,9 +104,7 @@ control on the page does something.
 — The yellow「登录 / 开始」button in the top-right corner used to do nothing when
 tapped, which made you wonder what else on the page was just for show. There's
 never been a login or a sign-up here — you just play — so that button now reads
-「开始玩」and takes you straight into a game. For the same reason, the footer
-button that said「注册 · 30 秒」now reads「免注册，直接开始玩」: no account, no
-form, you start playing right away.
+「开始玩」and takes you straight into a game.
 
 **Your AI no longer guesses a wire cut it can't pin down** — On one rare wire
 layout, the manual could point your AI at a wire color that wasn't on the

--- a/e2e/homepage.gherkin
+++ b/e2e/homepage.gherkin
@@ -24,12 +24,12 @@ Feature: Amiclaw platform homepage
   Scenario: An anonymous visitor lands on the Atlas homepage
     Given I am not signed in
     When the `/` route renders
-    Then I see the anonymous hero with the「开启旅程 →」and「看看 BombSquad」CTAs
+    Then I see the anonymous hero with the「开始玩 →」and「看看 BombSquad」CTAs
     And I see the daily-challenge section
     And I see the featured BombSquad section
     And I see the "什么是 Amiclaw" section
     And I see the upcoming-games section
-    And I see the registration footer pitch
+    And I see the footer pitch
     And the page is dark-only with no light-mode variant
     And the homepage does not scroll horizontally at a 375-pixel phone viewport
 

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -178,9 +178,12 @@ export class World {
   /** Homepage `/` → BombSquad landing `/bombsquad` via a homepage BombSquad CTA.
    *  BombSquad is now a separate SPA served at `/bombsquad/`, so crossing the app
    *  boundary is a full-page navigation that lands on the directory root
-   *  (`/bombsquad/`, with a trailing slash). Accept both forms. */
+   *  (`/bombsquad/`, with a trailing slash). Accept both forms.
+   *  Uses the AnonHero primary CTA「开始玩 →」. The arrow is load-bearing: the
+   *  TopNav has a bare「开始玩」button, so a name match without the arrow hits two
+   *  buttons and trips Playwright strict mode. */
   async enterBombSquadLanding(): Promise<void> {
-    await this.page.getByRole('button', { name: '立即挑战 →' }).click()
+    await this.page.getByRole('button', { name: '开始玩 →' }).click()
     await this.page.waitForURL((url) => new URL(url).pathname.replace(/\/$/, '') === '/bombsquad', {
       timeout: 12_000,
     })

--- a/e2e/steps/homepage.steps.ts
+++ b/e2e/steps/homepage.steps.ts
@@ -60,13 +60,10 @@ When(/^the `\/` route renders$/, async ({ page }) => {
   await expect(page.getByRole('navigation', { name: NAV })).toBeVisible()
 })
 
-Then(
-  'I see the anonymous hero with the「开启旅程 →」and「看看 BombSquad」CTAs',
-  async ({ page }) => {
-    await expect(page.getByRole('button', { name: '开启旅程 →' })).toBeVisible()
-    await expect(page.getByRole('button', { name: '看看 BombSquad' })).toBeVisible()
-  }
-)
+Then('I see the anonymous hero with the「开始玩 →」and「看看 BombSquad」CTAs', async ({ page }) => {
+  await expect(page.getByRole('button', { name: '开始玩 →' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '看看 BombSquad' })).toBeVisible()
+})
 
 Then('I see the daily-challenge section', async ({ page }) => {
   await expect(page.getByText('每日挑战 · DAILY DROP')).toBeVisible()
@@ -84,8 +81,8 @@ Then('I see the upcoming-games section', async ({ page }) => {
   await expect(page.getByText('即将上线 · IN ORBIT')).toBeVisible()
 })
 
-Then('I see the registration footer pitch', async ({ page }) => {
-  await expect(page.getByRole('button', { name: '免注册，直接开始玩' })).toBeVisible()
+Then('I see the footer pitch', async ({ page }) => {
+  await expect(page.getByText('永久免费，不存档也不出售你的对话。')).toBeVisible()
 })
 
 Then('the page is dark-only with no light-mode variant', async ({ page }) => {
@@ -150,7 +147,7 @@ Then('the account page renders inside the platform shell', async ({ page }) => {
 })
 
 Then('the homepage renders again', async ({ page }) => {
-  await expect(page.getByRole('button', { name: '开启旅程 →' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '开始玩 →' })).toBeVisible()
 })
 
 Then(/^the daily-challenge section shows a countdown in 时 \/ 分 \/ 秒$/, async ({ page }) => {
@@ -187,12 +184,12 @@ Then('the welcome strip shows my streak, completed count, and weekly rank', asyn
 })
 
 Then('the anonymous hero is not shown', async ({ page }) => {
-  await expect(page.getByRole('button', { name: '开启旅程 →' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: '开始玩 →' })).toHaveCount(0)
 })
 
 Then('the "什么是 Amiclaw" section and the footer pitch are not shown', async ({ page }) => {
   await expect(page.getByText('关于 · WHAT IS AMICLAW')).toHaveCount(0)
-  await expect(page.getByRole('button', { name: '免注册，直接开始玩' })).toHaveCount(0)
+  await expect(page.getByText('永久免费，不存档也不出售你的对话。')).toHaveCount(0)
 })
 
 Then(

--- a/packages/platform/src/components/home/AnonHero.tsx
+++ b/packages/platform/src/components/home/AnonHero.tsx
@@ -5,7 +5,7 @@ import styles from './AnonHero.module.css'
 
 interface AnonHeroProps {
   /* Routes to the BombSquad landing page (window.location.assign('/bombsquad/'))
-     — the primary「开启旅程」CTA. */
+     — the primary「开始玩」CTA. */
   onStart: () => void
   /* Scrolls to the FeaturedBombSquad section — the ghost「看看 BombSquad」CTA. */
   onSeeBombSquad: () => void
@@ -37,7 +37,7 @@ export default function AnonHero({ onStart, onSeeBombSquad, board }: AnonHeroPro
         </p>
         <div className={styles.cta}>
           <Button variant="primary" onClick={onStart}>
-            开启旅程 →
+            开始玩 →
           </Button>
           <Button variant="ghost" onClick={onSeeBombSquad}>
             看看 BombSquad

--- a/packages/platform/src/components/home/DailyChallenge.module.css
+++ b/packages/platform/src/components/home/DailyChallenge.module.css
@@ -110,17 +110,6 @@
   color: var(--text-4);
 }
 
-/* atlas .daily-r .play-btn is 14px 28px. The shared Button .sm size is
-   13px 22px; this descendant selector (0,2,0) outranks .sm (0,1,0) so
-   the daily CTA keeps its own padding regardless of stylesheet order. */
-.cta {
-  margin-top: 20px;
-}
-
-.right .cta {
-  padding: 14px 28px;
-}
-
 /* ----------  responsive: medium  ---------- */
 @media (max-width: 1080px) {
   .title {
@@ -169,14 +158,5 @@
   .units {
     justify-content: flex-start;
     gap: 22px;
-  }
-
-  /* atlas .daily-r .play-btn — full-width CTA. Same specificity (0,2,0)
-     as the desktop .right .cta padding rule and later in source, so the
-     desktop 14px 28px padding still stands (separate declaration). */
-  .right .cta {
-    display: flex;
-    width: 100%;
-    justify-content: center;
   }
 }

--- a/packages/platform/src/components/home/DailyChallenge.tsx
+++ b/packages/platform/src/components/home/DailyChallenge.tsx
@@ -1,27 +1,25 @@
-import { Button, EyebrowTag, useDailyCountdown } from '@amiclaw/ui'
+import { EyebrowTag, useDailyCountdown } from '@amiclaw/ui'
 import { formatMs } from '@shared/format-time'
 import type { DailyBoardState } from '@/hooks/useDailyBoard'
 import styles from './DailyChallenge.module.css'
 
 interface DailyChallengeProps {
-  /* Routes to the BombSquad landing page (window.location.assign('/bombsquad/'))
-     — the「立即挑战」CTA. */
-  onChallenge: () => void
   /* Today's real daily board, fetched once in GamesPage. Participation count
      and 日榜首 time are derived from it — no fabricated numbers. */
   board: DailyBoardState
 }
 
-/* Daily-challenge card — handoff §6.3. Left column: the daily pitch and
-   three thin participation stats. Right column: a live countdown to the
-   next UTC 00:00 reset plus the primary CTA. Platform chrome — no cyan.
+/* Daily-challenge card — handoff §6.3. A pure info card: left column carries
+   the daily pitch and three thin participation stats, right column a live
+   countdown to the next UTC 00:00 reset. No play CTA — the homepage routes
+   to /bombsquad/ only via the hero + TopNav. Platform chrome — no cyan.
 
    The 今日上榜 / 日榜首 stats come from the real daily board. An empty board
    renders 今日上榜 0 and 日榜首 — (no leader yet); 你 未参与 stays honest
    because the homepage has no per-player progress signal. The board holds only
    successful defusals, so the count is labelled 今日上榜 (matches AnonHero),
    not 参与. */
-export default function DailyChallenge({ onChallenge, board }: DailyChallengeProps) {
+export default function DailyChallenge({ board }: DailyChallengeProps) {
   const [hours, minutes, seconds] = useDailyCountdown()
 
   return (
@@ -30,7 +28,9 @@ export default function DailyChallenge({ onChallenge, board }: DailyChallengePro
         <div className={styles.left}>
           <EyebrowTag variant="daily">每日挑战 · DAILY DROP</EyebrowTag>
           <h2 className={styles.title}>今日：四模块连拆</h2>
-          <p className={styles.desc}>全球玩家同一套谜题，AI 做你的耳朵。用时越短，名次越高。</p>
+          <p className={styles.desc}>
+            全球玩家同一套谜题。你描述面板，AI 查手册。用时越短，名次越高。
+          </p>
           <div className={styles.foot}>
             <div className={styles.footItem}>
               今日上榜 <strong>{board.participantCount}</strong>
@@ -58,9 +58,6 @@ export default function DailyChallenge({ onChallenge, board }: DailyChallengePro
             <span>分</span>
             <span>秒</span>
           </div>
-          <Button variant="primary" size="sm" className={styles.cta} onClick={onChallenge}>
-            立即挑战 →
-          </Button>
         </div>
       </div>
     </section>

--- a/packages/platform/src/components/home/FeaturedBombSquad.tsx
+++ b/packages/platform/src/components/home/FeaturedBombSquad.tsx
@@ -12,11 +12,6 @@ const AI_CHIPS = ['CLAUDE', 'CHATGPT', 'GEMINI', 'VOICE_MODE']
 const MINI_ROW_BUDGET = 4
 
 interface FeaturedBombSquadProps {
-  /* Routes to the BombSquad landing page (window.location.assign('/bombsquad/'))
-     — the section header's「游戏页 →」action. This is the section's single
-     contextual entry: the showcase points to the game page, the landing page
-     owns the daily / practice choice. */
-  onOpenGamePage: () => void
   /* Today's real daily board, fetched once in GamesPage. The mini panel
      renders its top rows — or an honest empty state — never mock players. */
   board: DailyBoardState
@@ -32,7 +27,7 @@ interface FeaturedBombSquadProps {
    empty it shows the daily board's own empty-state wording instead of
    fabricated rows; the panel is labelled 今日日榜 because the data resets
    daily at UTC 0. */
-export default function FeaturedBombSquad({ onOpenGamePage, board }: FeaturedBombSquadProps) {
+export default function FeaturedBombSquad({ board }: FeaturedBombSquadProps) {
   const topRows = board.entries.slice(0, MINI_ROW_BUDGET)
 
   return (
@@ -44,7 +39,6 @@ export default function FeaturedBombSquad({ onOpenGamePage, board }: FeaturedBom
             BombSquad · <span className={accentClass}>拆弹小队</span>
           </>
         }
-        action={{ label: '游戏页 →', onClick: onOpenGamePage }}
       />
 
       <div className={styles.card}>
@@ -71,7 +65,7 @@ export default function FeaturedBombSquad({ onOpenGamePage, board }: FeaturedBom
           <div>
             <h3 className={styles.sideTitle}>今日日榜</h3>
             <p className={styles.sideBlurb}>
-              每天零点重置。把手册念给 AI 听，让它做你的眼睛 —— 用时越短，名次越高。
+              每天零点重置。你描述面板，AI 查手册指路。用时越短，名次越高。
             </p>
           </div>
 

--- a/packages/platform/src/components/home/FooterPitch.module.css
+++ b/packages/platform/src/components/home/FooterPitch.module.css
@@ -1,4 +1,4 @@
-/* Footer registration pitch — handoff §6.8; pixel values mirror
+/* Footer pitch — handoff §6.8; pixel values mirror
    prototype/atlas/atlas.html (.footer-pitch). Anonymous-only. The
    responsive @media tier (≤768px) carries atlas.html's exact values. */
 
@@ -30,9 +30,7 @@
 }
 
 /* ----------  responsive: mobile  ----------
-   atlas.html ≤768px — tighter card padding, smaller heading, and the
-   atlas mobile .btn-primary pill size on the CTA. .pitch button (0,1,1)
-   outranks Button's .md (0,1,0). */
+   atlas.html ≤768px — tighter card padding and a smaller heading. */
 @media (max-width: 768px) {
   .pitch {
     padding: 40px 24px;
@@ -40,10 +38,5 @@
 
   .title {
     font-size: 30px;
-  }
-
-  .pitch button {
-    padding: 14px 22px;
-    font-size: 14px;
   }
 }

--- a/packages/platform/src/components/home/FooterPitch.test.tsx
+++ b/packages/platform/src/components/home/FooterPitch.test.tsx
@@ -1,31 +1,22 @@
 /**
- * FooterPitch CTA tests.
+ * FooterPitch tests.
  *
  * The product is anonymous-by-design (roadmap: nickname + device fingerprint,
- * no login or registration), so the footer pitch CTA must read honestly — no
- * label that implies a registration step that does not exist:
- *   1. the CTA reads as an honest "no signup, just play" entry
- *   2. clicking it fires onRegister (the existing /bombsquad/ routing)
+ * no login or registration). The footer pitch is now a pure pitch block — no
+ * play CTA of its own (the homepage routes to /bombsquad/ only via the hero +
+ * TopNav). It just renders the headline and the no-signup / no-tracking promise:
+ *   1. the headline renders
+ *   2. the no-signup / no-tracking promise renders
  */
-import { describe, expect, it, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
 import FooterPitch from './FooterPitch'
 
 describe('FooterPitch', () => {
-  it('renders an honest no-signup play CTA', () => {
-    render(<FooterPitch onRegister={() => {}} />)
+  it('renders the headline and the no-signup promise', () => {
+    render(<FooterPitch />)
 
-    expect(screen.getByRole('button', { name: '免注册，直接开始玩' })).toBeInTheDocument()
-    // The old dishonest registration label must be gone.
-    expect(screen.queryByText('注册 · 30 秒')).not.toBeInTheDocument()
-  })
-
-  it('fires onRegister when the CTA is clicked', () => {
-    const onRegister = vi.fn()
-    render(<FooterPitch onRegister={onRegister} />)
-
-    fireEvent.click(screen.getByRole('button', { name: '免注册，直接开始玩' }))
-
-    expect(onRegister).toHaveBeenCalledTimes(1)
+    expect(screen.getByText(/找个人，找一只 AI/)).toBeInTheDocument()
+    expect(screen.getByText('永久免费，不存档也不出售你的对话。')).toBeInTheDocument()
   })
 })

--- a/packages/platform/src/components/home/FooterPitch.tsx
+++ b/packages/platform/src/components/home/FooterPitch.tsx
@@ -1,27 +1,16 @@
-import { Button } from '@amiclaw/ui'
 import styles from './FooterPitch.module.css'
 
-interface FooterPitchProps {
-  /* Routes to the BombSquad landing page (window.location.assign('/bombsquad/'))
-     — the play CTA. Anonymous-by-design: there is no registration (roadmap:
-     nickname + device fingerprint, no login or registration), so the CTA is an
-     honest entry straight into play, consistent with the other anonymous-
-     homepage CTAs. The prop name is kept for call-site stability. */
-  onRegister: () => void
-}
-
-/* Footer registration pitch — handoff §6.8. Anonymous-only; rendered as
-   the last homepage section before the platform footer. */
-export default function FooterPitch({ onRegister }: FooterPitchProps) {
+/* Footer pitch — handoff §6.8. Anonymous-only; rendered as the last homepage
+   section before the platform footer. A pure pitch block: headline + the
+   no-signup / no-tracking promise. The homepage routes to /bombsquad/ only
+   via the hero + TopNav, so this section carries no play CTA of its own. */
+export default function FooterPitch() {
   return (
     <section className={styles.pitch}>
       <h2 className={styles.title}>
         找个人，找一只 AI，<span className={styles.accent}>一起玩。</span>
       </h2>
       <p className={styles.subtitle}>永久免费，不存档也不出售你的对话。</p>
-      <Button variant="primary" onClick={onRegister}>
-        免注册，直接开始玩
-      </Button>
     </section>
   )
 }

--- a/packages/platform/src/pages/GamesPage.test.tsx
+++ b/packages/platform/src/pages/GamesPage.test.tsx
@@ -3,14 +3,15 @@
  *
  * Covers the `/` route — the Amiclaw「星图 / Atlas」homepage:
  *   1. anonymous `/` renders the AnonHero
- *   2. the daily-challenge CTA routes to the BombSquad landing (/bombsquad)
- *   3. the featured-BombSquad「游戏页 →」action routes to /bombsquad
- *   4. the anonymous hero「开启旅程」CTA routes to /bombsquad
- *   5. a signed-in visitor (?auth=in) renders the WelcomeStrip, not the hero
+ *   2. the anonymous hero「开始玩」CTA routes to /bombsquad
+ *   3. a signed-in visitor (?auth=in) renders the WelcomeStrip, not the hero
  *
- * Every BombSquad CTA on the homepage now routes to the BombSquad landing
- * page; the landing owns the daily/practice choice and the connect-AI
- * flow, so the homepage no longer opens a pre-game modal. The
+ * The homepage has a single in-page play CTA — the AnonHero primary「开始玩」
+ * (the other play entry is the TopNav, rendered by the app shell, not here).
+ * The DailyChallenge / FeaturedBombSquad / FooterPitch sections are pure
+ * info / pitch blocks with no play button. The CTA routes to the BombSquad
+ * landing page; the landing owns the daily/practice choice and the
+ * connect-AI flow, so the homepage no longer opens a pre-game modal. The
  * landing → connect → run path is covered by the screen tests.
  *
  * Render the page directly inside a MemoryRouter. A sibling `/bombsquad`
@@ -78,34 +79,18 @@ describe('GamesPage homepage', () => {
   it('renders the anonymous hero on / for a signed-out visitor', () => {
     renderHomepage('/')
 
-    // AnonHero markers: the hero eyebrow pill and the primary「开启旅程」CTA.
+    // AnonHero markers: the hero eyebrow pill and the primary「开始玩」CTA.
     expect(screen.getByText('本周开服 · BOMBSQUAD 公测中')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /开启旅程/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /开始玩/ })).toBeInTheDocument()
     // The signed-in WelcomeStrip greets the mock user by name — it must NOT
     // be present for an anonymous visitor.
     expect(screen.queryByText('星海')).not.toBeInTheDocument()
   })
 
-  it('routes to the BombSquad landing when the daily-challenge CTA is clicked', () => {
+  it('routes to the BombSquad landing from the anonymous hero「开始玩」CTA', () => {
     renderHomepage('/')
 
-    fireEvent.click(screen.getByRole('button', { name: /立即挑战/ }))
-
-    expect(assignSpy).toHaveBeenCalledWith('/bombsquad/')
-  })
-
-  it('routes to the BombSquad landing from the featured「游戏页 →」action', () => {
-    renderHomepage('/')
-
-    fireEvent.click(screen.getByRole('button', { name: '游戏页 →' }))
-
-    expect(assignSpy).toHaveBeenCalledWith('/bombsquad/')
-  })
-
-  it('routes to the BombSquad landing from the anonymous hero「开启旅程」CTA', () => {
-    renderHomepage('/')
-
-    fireEvent.click(screen.getByRole('button', { name: /开启旅程/ }))
+    fireEvent.click(screen.getByRole('button', { name: /开始玩/ }))
 
     expect(assignSpy).toHaveBeenCalledWith('/bombsquad/')
   })
@@ -116,7 +101,7 @@ describe('GamesPage homepage', () => {
     // WelcomeStrip greets the mock user by display name.
     expect(screen.getByText('星海')).toBeInTheDocument()
     // The anonymous hero CTA must NOT be present.
-    expect(screen.queryByRole('button', { name: /开启旅程/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /开始玩/ })).not.toBeInTheDocument()
   })
 
   it('shows honest empty / zero states when the real daily board is empty', async () => {

--- a/packages/platform/src/pages/GamesPage.tsx
+++ b/packages/platform/src/pages/GamesPage.tsx
@@ -10,10 +10,13 @@ import { useDailyBoard } from '@/hooks/useDailyBoard'
 
 /* The `/` route — the Amiclaw platform homepage. Renders the anonymous
    hero or the signed-in welcome strip per useAuth(), then the homepage
-   sections. Every BombSquad「开始游戏」CTA routes to the BombSquad
-   landing page (/bombsquad); the landing owns the daily/practice choice
-   and the connect-AI flow, so the homepage no longer gates the run itself.
-   WhatIsAmiclaw and FooterPitch are anonymous-only (handoff §1).
+   sections. The homepage has exactly two play entries into the BombSquad
+   landing page (/bombsquad): the TopNav「开始玩」and the AnonHero primary
+   「开始玩」CTA. The DailyChallenge and FeaturedBombSquad sections are now
+   pure info cards, and FooterPitch is a pure pitch block — none carry a
+   play CTA. The landing owns the daily/practice choice and the connect-AI
+   flow, so the homepage no longer gates the run itself. WhatIsAmiclaw and
+   FooterPitch are anonymous-only (handoff §1).
 
    Every「今日 / 在线 / 日榜」surface is wired to ONE real source: the daily
    leaderboard API fetched once here via useDailyBoard() and threaded down as
@@ -23,11 +26,11 @@ export default function GamesPage() {
   const { signedIn, user } = useAuth()
   const board = useDailyBoard()
 
-  /* All homepage「玩 BombSquad」CTAs share one target — the BombSquad
-     landing page. Mode is chosen on the landing, not here. BombSquad now
-     lives in its own SPA at /bombsquad/, so crossing the app boundary is a
-     full-page navigation (mirrors the Yijing Oracle's /oracle/ href entry),
-     not a client-side router push. */
+  /* The AnonHero primary CTA's target — the BombSquad landing page. Mode is
+     chosen on the landing, not here. BombSquad now lives in its own SPA at
+     /bombsquad/, so crossing the app boundary is a full-page navigation
+     (mirrors the Yijing Oracle's /oracle/ href entry), not a client-side
+     router push. */
   const enterBombSquad = () => {
     window.location.assign('/bombsquad/')
   }
@@ -46,11 +49,11 @@ export default function GamesPage() {
         <AnonHero onStart={enterBombSquad} onSeeBombSquad={scrollToFeatured} board={board} />
       )}
 
-      <DailyChallenge onChallenge={enterBombSquad} board={board} />
-      <FeaturedBombSquad onOpenGamePage={enterBombSquad} board={board} />
+      <DailyChallenge board={board} />
+      <FeaturedBombSquad board={board} />
       {!signedIn && <WhatIsAmiclaw />}
       <UpcomingGames />
-      {!signedIn && <FooterPitch onRegister={enterBombSquad} />}
+      {!signedIn && <FooterPitch />}
     </>
   )
 }


### PR DESCRIPTION
## Summary

- 落地页(`/`)两处把 AI 说成玩家感官的隐喻(`做你的眼睛` / `做你的耳朵`)改写为符合真实机制的措辞:玩家看屏描述、AI 查手册。与首页既有 `你描述、AI 协助` 同构。
- 首页指向 `/bombsquad/` 的 play 入口从 5 个收敛到 2 个(TopNav + AnonHero 主,均「开始玩」),保留唯一次要「看看 BombSquad」;删 `立即挑战` / `游戏页` / `免注册直接开始玩` 三个冗余按钮,清理 now-unused props / imports / CSS。
- `① 90 秒内通关` 文案此前已由 #139 移除,本次不涉及。

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (`pnpm -r test:run` — platform 30 / bombsquad 276 / api 76 / manual 66 / yijing 21)
- [x] New tests added if behavior changed (updated `GamesPage.test` / `FooterPitch.test` for the renamed/removed CTAs)
- [ ] Tested manually and documented below (pending Cloudflare Pages preview visual check — desktop + mobile)

## Checklist

- [x] Code follows the project style (eslint + prettier + markdownlint clean)
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (CHANGELOG `Unreleased`)
- [x] Breaking changes documented if any (none — pure copy + dead-code cleanup)

Source task: `fix-landing-copy-consistency`

🤖 Generated with [Claude Code](https://claude.com/claude-code)