### PR TITLE
fix(platform): drop dead 关于 footer link, bind Discord to shared invite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**页脚不再留两个点不动的死链接** — 页脚里的「关于」和「Discord」过去只是两段不能点的
+文字。「关于」没有对应的页面,直接拿掉了。「Discord」改成接上社区邀请链接:邀请链接填好
+之前它不出现,填好之后就变成一个能点、在新标签页打开的入口。隐私和条款两个链接照常可用。
+
 **Game Lab 区块准备好接上 Discord** — 落地页的 Game Lab 区块写着「在 Discord 写下你
 想和 AI 一起玩的小游戏」,现在这块卡片可以变成真正能点的 Discord 入口:填上邀请链接后,
 卡片就带上「加入 Discord」的提示、点一下在新标签页打开邀请。在链接配置好之前,卡片和原来

--- a/packages/platform/src/components/platform/PlatformFooter.module.css
+++ b/packages/platform/src/components/platform/PlatformFooter.module.css
@@ -32,8 +32,8 @@
   text-decoration: none;
 }
 
-/* Only the real <a> links (隐私 / 条款) are interactive; the dead <span>s
-   (关于 / Discord) keep the default cursor and never brighten on hover. */
+/* Every footer link is an anchor (隐私 / 条款 via react-router <Link>, plus the
+   conditional external Discord <a>), so all of them brighten on hover. */
 a.link:hover {
   color: rgba(255, 255, 255, 0.85);
 }

--- a/packages/platform/src/components/platform/PlatformFooter.test.tsx
+++ b/packages/platform/src/components/platform/PlatformFooter.test.tsx
@@ -1,17 +1,23 @@
 /**
  * PlatformFooter link-wiring test.
  *
- * 隐私 and 条款 must be real react-router links to /privacy and /terms; 关于
- * and Discord are owned by a sibling task and must stay non-link dead text
- * until their destinations land. This test pins both halves of that contract.
+ * 隐私 and 条款 are real react-router links to /privacy and /terms. 关于 is gone
+ * (no destination exists). Discord is an honest-collapse external link bound to
+ * the shared DISCORD_INVITE_URL sentinel: absent while '', a clickable external
+ * <a> once configured. This test pins each half of that contract.
+ *
+ * The constant module is mocked per-test so both Discord branches are exercised
+ * without editing the real '' sentinel value (mirrors UpcomingGames.test.tsx).
  */
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import PlatformFooter from './PlatformFooter'
 
-function renderFooter() {
-  return render(
+async function renderFooter(discordUrl: string) {
+  vi.resetModules()
+  vi.doMock('@/config/links', () => ({ DISCORD_INVITE_URL: discordUrl }))
+  const { default: PlatformFooter } = await import('./PlatformFooter')
+  render(
     <MemoryRouter>
       <PlatformFooter />
     </MemoryRouter>
@@ -19,24 +25,35 @@ function renderFooter() {
 }
 
 describe('PlatformFooter', () => {
-  it('renders 隐私 as a link to /privacy', () => {
-    renderFooter()
+  it('renders 隐私 as a link to /privacy', async () => {
+    await renderFooter('')
     const link = screen.getByRole('link', { name: '隐私' })
     expect(link).toHaveAttribute('href', '/privacy')
   })
 
-  it('renders 条款 as a link to /terms', () => {
-    renderFooter()
+  it('renders 条款 as a link to /terms', async () => {
+    await renderFooter('')
     const link = screen.getByRole('link', { name: '条款' })
     expect(link).toHaveAttribute('href', '/terms')
   })
 
-  it('keeps 关于 and Discord as non-link dead text (owned by a sibling task)', () => {
-    renderFooter()
+  it('never renders 关于', async () => {
+    await renderFooter('')
     expect(screen.queryByRole('link', { name: '关于' })).not.toBeInTheDocument()
+    expect(screen.queryByText('关于')).not.toBeInTheDocument()
+  })
+
+  it('omits Discord while the invite is the empty sentinel', async () => {
+    await renderFooter('')
     expect(screen.queryByRole('link', { name: 'Discord' })).not.toBeInTheDocument()
-    // They still render as text.
-    expect(screen.getByText('关于')).toBeInTheDocument()
-    expect(screen.getByText('Discord')).toBeInTheDocument()
+    expect(screen.queryByText('Discord')).not.toBeInTheDocument()
+  })
+
+  it('renders Discord as an external link once the invite is configured', async () => {
+    await renderFooter('https://discord.gg/example')
+    const link = screen.getByRole('link', { name: 'Discord' })
+    expect(link).toHaveAttribute('href', 'https://discord.gg/example')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
   })
 })

--- a/packages/platform/src/components/platform/PlatformFooter.tsx
+++ b/packages/platform/src/components/platform/PlatformFooter.tsx
@@ -1,14 +1,13 @@
 import { Link } from 'react-router-dom'
+import { DISCORD_INVITE_URL } from '@/config/links'
 import styles from './PlatformFooter.module.css'
 
-/* Secondary footer links. 隐私 / 条款 route to their platform pages; 关于 and
-   Discord have no destination yet (owned by a sibling task) and render as
-   plain text until those pages land. */
-const FOOTER_LINKS: { label: string; to?: string }[] = [
-  { label: '关于' },
+/* Secondary footer links — internal react-router routes only (隐私 / 条款).
+   Discord is rendered separately as a conditional external link bound to the
+   shared DISCORD_INVITE_URL sentinel (see below). */
+const FOOTER_LINKS: { label: string; to: string }[] = [
   { label: '隐私', to: '/privacy' },
   { label: '条款', to: '/terms' },
-  { label: 'Discord' },
 ]
 
 /* Platform footer — copyright line + secondary link row. */
@@ -18,16 +17,22 @@ export default function PlatformFooter() {
       <div className={styles.inner}>
         <span>© 2026 AMIO · amio.love</span>
         <div className={styles.links}>
-          {FOOTER_LINKS.map(({ label, to }) =>
-            to ? (
-              <Link key={label} to={to} className={styles.link}>
-                {label}
-              </Link>
-            ) : (
-              <span key={label} className={styles.link}>
-                {label}
-              </span>
-            )
+          {FOOTER_LINKS.map(({ label, to }) => (
+            <Link key={label} to={to} className={styles.link}>
+              {label}
+            </Link>
+          ))}
+          {/* Honest-collapse: Discord appears only once the shared invite is
+              configured; the empty-string sentinel renders nothing. */}
+          {DISCORD_INVITE_URL && (
+            <a
+              href={DISCORD_INVITE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.link}
+            >
+              Discord
+            </a>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- The footer rendered 关于 and Discord as plain non-interactive `<span>`s — they looked like links but had no `href` and did nothing.
- **关于** has no destination page → removed entirely (honest-collapse, not a fake "coming soon").
- **Discord** no longer renders as a dead span → it reuses the shared `DISCORD_INVITE_URL` SSOT constant (from the Game Lab task, #146): the empty-string sentinel renders nothing, a configured invite renders a clickable external link (`target="_blank" rel="noopener noreferrer"`). The day the real invite is pasted into `config/links.ts`, Discord goes live in both the Game Lab tile and the footer at once.
- **隐私 / 条款** unchanged — still clickable internal routes to `/privacy` and `/terms`.

The footer now collapses to 隐私 | 条款 today (Discord hidden until the invite is set), with no dead clickable elements.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (platform 38/38; full monorepo suite green)
- [x] New tests added if behavior changed (`PlatformFooter.test.tsx` rewritten: 关于 absent, 隐私/条款 links, Discord absent on empty sentinel + clickable external link with href/target/rel when configured — mirrors the Game Lab test's mock pattern)
- [x] Tested manually and documented below

With `DISCORD_INVITE_URL === ''` (current state) the footer shows exactly 隐私 | 条款 and no Discord element; typecheck / build / prettier all clean.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (CHANGELOG Unreleased)
- [x] Breaking changes documented if any (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)