### PR TITLE
fix(bombsquad): smooth first-run flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ packages/*/src/**/*.jsx
 
 # Claude Code session state
 .claude/
+
+# Codex local session state
+.codex/
+tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,6 @@ Follow [CONTRIBUTING.md](CONTRIBUTING.md) for all contribution conventions.
 - "Play Again" is the most prominent CTA on the results page.
 - The leaderboard shows time, attempt number, and the AI tool used when
   provided.
-- The post-game summary must stay copyable plain text with no HTML formatting.
 
 ## Development Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**The BombSquad first-run path no longer depends on clipboard permission** —
+If the browser refuses to copy the manual link, the connect screen now says so,
+keeps the manual URL visible, and lets the player continue after manually
+sending it to their AI. The visible manual URL card is now also a click target
+for the same copy action as the primary button. The post-game survey waits
+until the success feedback has had time to land, instead of covering the first
+clear immediately. The mobile BombSquad lobby also keeps its top chrome inside
+the viewport, and the button and keypad modules expose shorter, more useful
+accessible labels for the state a player needs to describe.
+
 **The home page now introduces AmiClaw as a platform, with one BombSquad block** - The
 hero description now explains AmiClaw instead of describing only the defusal game, and
 the hero keeps a single start button. The former daily challenge and weekly feature

--- a/e2e/regression/fix-connect-copy-button-affordance.assert.mjs
+++ b/e2e/regression/fix-connect-copy-button-affordance.assert.mjs
@@ -4,8 +4,9 @@
  *
  * Cheap static source-read backstop over
  *   packages/game-bombsquad/src/pages/ConnectPage.tsx
- * guarding against re-introducing the affordance inversion: a dead
- * (disabled) bottom CTA on step 1 while the real copy hides in a smaller card.
+ * guarding against re-introducing either copy affordance failure:
+ * a dead (disabled) bottom CTA on step 1, or a visible manual URL card that no
+ * longer shares the copy/fallback action.
  *
  * The AUTHORITATIVE executable guard is the React Testing Library unit test in
  * the same package (ConnectPage.test.tsx) — this script is only a no-browser
@@ -74,20 +75,25 @@ function scenarioCta() {
   }
 }
 
-// ---------- Scenario 2: URL preview is passive, not a second button ----------
+// ---------- Scenario 2: URL card shares the copy action ----------
 function scenarioPreview() {
-  const name = 'the URL preview is a passive preview, not a second copy button'
-  // The preview must use the urlPreview class on a <div>, not a <button>.
-  const previewMatch = src.match(/<(\w+)[^>]*className=\{`\$\{styles\.urlPreview\}/)
-  if (!previewMatch) {
-    record(name, 'styles.urlPreview element not found in ConnectPage.tsx')
+  const name = 'the URL card is also a copy target sharing the same handler'
+  const cardMatch = src.match(
+    /<button[\s\S]*?className=\{`\$\{styles\.urlPreview\}[\s\S]*?<\/button>/
+  )
+  if (!cardMatch) {
+    record(name, 'styles.urlPreview is not rendered on a <button> in ConnectPage.tsx')
     return
   }
-  if (previewMatch[1] !== 'div') {
-    record(
-      name,
-      `the URL preview is a <${previewMatch[1]}> — it must be a non-interactive <div> (no second copy control)`
-    )
+  const card = cardMatch[0]
+  if (!/onClick=\{handleCopy\}/.test(card)) {
+    record(name, 'the manual URL card is not wired to handleCopy')
+  }
+  if (!/复制手册链接/.test(card)) {
+    record(name, 'the manual URL card copy aria-label is missing')
+  }
+  if (/\bdisabled(\s*=|[\s/>])/.test(card.replace(/\/\*[\s\S]*?\*\//g, ''))) {
+    record(name, 'the manual URL card is disabled on step 1')
   }
   // The legacy clickable copyCard class must be gone.
   if (/styles\.copyCard\b/.test(src)) {

--- a/e2e/regression/fix-connect-copy-button-affordance.gherkin
+++ b/e2e/regression/fix-connect-copy-button-affordance.gherkin
@@ -7,13 +7,13 @@
 #   prominent URL card above it. Classic affordance inversion: a player taps
 #   the biggest, brightest, bottom-anchored CTA first, gets no feedback, and
 #   assumes the page is frozen.
-# Fix (Option ①): the bottom primary CTA IS the copy action now — label
+# First fix (Option ①): the bottom primary CTA IS the copy action now — label
 #   「复制手册」, tapping it copies the manual URL, flips to the green
 #   「已复制 ✓」 confirmed state, and the existing 0.7s effect auto-advances to
-#   step 2. The former copy card was demoted from a <button> to a passive
-#   read-only <div> preview (keeps the URL visible + turns green on copy). The
-#   redundant manual「下一步 →」step was removed (auto-advance covers it). Step 2
-#   is untouched.
+#   step 2. The redundant manual「下一步 →」step was removed (auto-advance covers
+#   it). Follow-up fix: the visible manual URL card is also a copy target now,
+#   sharing the same handler and fallback path as the primary CTA, so the whole
+#   URL area is tappable while the bottom CTA remains the clearest command.
 #
 # Executable home: this behavior is interaction-natured, so its authoritative
 #   executable guard is the React Testing Library unit test in
@@ -26,7 +26,7 @@
 # Companion static guard: fix-connect-copy-button-affordance.assert.mjs in this
 #   directory is a cheap source-read backstop (no browser, no preview server) —
 #   it asserts the step-1 primary CTA is not rendered with `disabled` and that
-#   the URL preview is no longer a <button>. Run via:
+#   the URL card is also wired to the copy handler. Run via:
 #     node e2e/regression/fix-connect-copy-button-affordance.assert.mjs
 #   It exits 0 on full pass and non-zero on any failure, naming the failing
 #   scenario in stderr — matching the rest of this directory's data-assertion
@@ -56,14 +56,16 @@ Feature: connect-page copy-button affordance regression coverage
     And no control on step 1 is disabled
 
   # Behavior verified executably by ConnectPage.test.tsx
-  # ("renders step 1 with the URL preview and manual URL").
-  # retire-when: the manual URL is no longer shown on the connect page (it is a
-  #   trust requirement that the link stays visible before the player copies it).
-  Scenario: the URL preview is a passive preview, not a second copy button
+  # ("copies the manual link from the URL card too").
+  # retire-when: the manual URL is no longer shown on the connect page, or the
+  #   connect flow is redesigned away from copying a manual link.
+  Scenario: the URL card is also a copy target sharing the same handler
     Given /bombsquad/connect on step 1
     When inspecting the manual-URL card above the CTA
     Then it renders the manual URL (still visible for trust)
-    And it is NOT a <button> (no second/competing copy control)
+    And it is a <button>
+    And tapping it copies the manual URL to the clipboard
+    And it shares the same copy and fallback path as the primary CTA
 
   # Behavior verified executably by ConnectPage.test.tsx
   # ("surfaces the /bombsquad/compatibility discovery link on step 1").

--- a/e2e/result-page-survey.gherkin
+++ b/e2e/result-page-survey.gherkin
@@ -1,7 +1,8 @@
 # Result-page endgame survey — the once-per-device PostGameModal survey shown
-# after any game outcome. On a practice run it is a dismissable survey-only
-# modal; on a first daily win it merges with the nickname gate into a single
-# dialog (never two stacked). Submitting posts a `survey_submit` event to
+# after any game outcome. The survey waits until after the result feedback has
+# had time to land. On a first daily win, the leaderboard nickname / AI metadata
+# gate can still open immediately before score submission; the survey follows
+# later as a separate dialog. Submitting posts a `survey_submit` event to
 # /api/events; submitting or skipping both retire the survey for the device.
 #
 # Gated by localStorage['bombsquad-survey-answered'] (packages/game-bombsquad/src/utils/
@@ -19,6 +20,7 @@ Feature: Result-page endgame survey
   @playwright @survey-fresh
   Scenario Outline: The endgame survey shows once per device and records a submission
     Given I have finished a "<mode>" run on a survey-fresh device and the result page is open
+    And any required leaderboard gate is completed before the survey
     Then the post-game modal opens as a single dialog showing the survey questions
     When I <interaction>
     Then the post-game modal closes
@@ -30,4 +32,4 @@ Feature: Result-page endgame survey
       | mode     | interaction                       | events                                            |
       | practice | answer and submit the survey      | a "survey_submit" event records my survey answers  |
       | practice | skip the survey                   | no "survey_submit" event is recorded               |
-      | daily    | submit a nickname with the survey | a "survey_submit" event records my survey answers  |
+      | daily    | answer and submit the survey      | a "survey_submit" event records my survey answers  |

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -207,11 +207,11 @@ export class World {
 
   /**
    * Connect step 1 — click the primary copy CTA and wait for its copied state.
-   * The copy action now lives on the most prominent element (the bottom
-   * 复制手册 CTA); the URL above is a passive preview, not a button.
+   * The most prominent element (the bottom 复制手册 CTA) and the URL card above
+   * both share the same copy/fallback action.
    */
   async copyManualLink(): Promise<void> {
-    await this.page.getByRole('button', { name: '复制手册' }).click()
+    await this.page.getByRole('button', { name: '复制手册', exact: true }).click()
     await this.page.getByText('已复制到剪贴板').first().waitFor()
   }
 

--- a/e2e/steps/survey.steps.ts
+++ b/e2e/steps/survey.steps.ts
@@ -2,8 +2,10 @@
 import { expect } from '@playwright/test'
 import { Given, When, Then } from './fixtures'
 
-/** Stable test nickname for the merged daily-win modal — mirrors result.steps. */
+/** Stable test player metadata for the daily leaderboard gate — mirrors result.steps. */
 const E2E_NICKNAME = 'E2ERunner'
+const E2E_AI_ASSISTANT_LABEL = 'Claude'
+const SURVEY_DELAY_MS = 2000
 
 /** Answer Q1/Q2/Q3 — the three required survey questions inside an open modal. */
 async function answerRequiredSurvey(dialog: import('@playwright/test').Locator): Promise<void> {
@@ -26,12 +28,30 @@ Given(
   }
 )
 
+Given('any required leaderboard gate is completed before the survey', async ({ page, world }) => {
+  if (world.runMode !== 'daily') return
+
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toHaveCount(1)
+  await dialog.getByRole('textbox', { name: '昵称' }).fill(E2E_NICKNAME)
+  await dialog.getByRole('button', { name: E2E_AI_ASSISTANT_LABEL, exact: true }).click()
+  await dialog.getByRole('button', { name: '确认', exact: true }).click()
+  await expect.poll(() => world.leaderboard.submissions.length).toBeGreaterThan(0)
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+})
+
 Then(
   'the post-game modal opens as a single dialog showing the survey questions',
-  async ({ page }) => {
-    // Exactly one dialog — a merged daily-win modal never stacks two.
-    await expect(page.getByRole('dialog')).toHaveCount(1)
+  async ({ page, world }) => {
+    // The result needs breathing room before the survey opens.
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
     const dialog = page.getByRole('dialog')
+    if ((await dialog.count()) === 0) {
+      await world.advance(SURVEY_DELAY_MS)
+    }
+
+    // Exactly one dialog — daily leaderboard and survey gates never stack.
+    await expect(dialog).toHaveCount(1)
     await expect(dialog.getByText('你这局用的是哪个 AI 工具？')).toBeVisible()
     await expect(dialog.getByText('难度感受')).toBeVisible()
   }
@@ -95,7 +115,8 @@ When('I revisit the result page', async ({ world }) => {
 
 Then('no post-game survey modal appears', async ({ page }) => {
   // The result heading proves ResultPage re-mounted from the persisted state;
-  // the survey modal opens synchronously with it, so its absence is conclusive.
+  // advance past the deferred survey delay before asserting absence.
   await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+  await page.clock.runFor(SURVEY_DELAY_MS)
   await expect(page.getByRole('dialog')).toHaveCount(0)
 })

--- a/packages/game-bombsquad/src/modules/button/ButtonModule.module.css
+++ b/packages/game-bombsquad/src/modules/button/ButtonModule.module.css
@@ -180,6 +180,18 @@
   filter: brightness(0.85);
 }
 
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .display {
   min-width: 64px;
   padding: 8px 18px;

--- a/packages/game-bombsquad/src/modules/button/ButtonModule.test.tsx
+++ b/packages/game-bombsquad/src/modules/button/ButtonModule.test.tsx
@@ -70,6 +70,23 @@ describe('ButtonModule', () => {
     expect(screen.getByText('DETONATE')).toBeInTheDocument()
     expect(screen.getByTestId('button-display')).toHaveTextContent('7')
   })
+
+  it('exposes concise button color, label, display, and light state to assistive tech', () => {
+    const config = { color: 'white', label: 'ABORT', indicatorColor: 'blue', displayNumber: 4 }
+    const answer = { type: 'button' as const, action: 'hold' as const, releaseOnColor: 'red' }
+    render(
+      <ButtonModule
+        config={config}
+        answer={answer}
+        onComplete={vi.fn()}
+        onError={vi.fn()}
+        sceneInfo={sceneInfo}
+      />
+    )
+    const btn = screen.getByRole('button', { name: 'white ABORT button, display 4' })
+    expect(btn).toBeInTheDocument()
+    expect(btn).toHaveAccessibleDescription('Preview light is blue.')
+  })
 })
 
 describe('ButtonModule cycle-legibility cue is target-agnostic', () => {

--- a/packages/game-bombsquad/src/modules/button/ButtonModule.tsx
+++ b/packages/game-bombsquad/src/modules/button/ButtonModule.tsx
@@ -120,6 +120,10 @@ export default function ButtonModule({
   const isPressed = buttonState === 'pressed' || buttonState === 'holding'
   const isHolding = buttonState === 'holding'
   const litColor = isHolding ? indicatorColor : (CSS_COLORS[config.indicatorColor] ?? '#888')
+  const buttonAccessibleName = `${config.color} ${config.label} button, display ${config.displayNumber}`
+  const lightAccessibleState = isHolding
+    ? `Hold light is ${INDICATOR_COLORS[indicatorColorIdx]}.`
+    : `Preview light is ${config.indicatorColor}.`
 
   return (
     <div
@@ -147,6 +151,9 @@ export default function ButtonModule({
           />
         </div>
         <div className={styles.buttonOrbit}>
+          <span id="button-module-state" className={styles.srOnly} aria-live="polite">
+            {lightAccessibleState}
+          </span>
           <button
             type="button"
             className={`${styles.bigButton} ${isPressed ? styles.pressed : ''}`}
@@ -157,7 +164,8 @@ export default function ButtonModule({
             onKeyDown={handleKeyDown}
             onKeyUp={handleKeyUp}
             data-testid="big-button"
-            aria-label={`${config.label} button`}
+            aria-label={buttonAccessibleName}
+            aria-describedby="button-module-state"
           >
             {config.label}
           </button>

--- a/packages/game-bombsquad/src/modules/keypad/KeypadModule.test.tsx
+++ b/packages/game-bombsquad/src/modules/keypad/KeypadModule.test.tsx
@@ -89,4 +89,24 @@ describe('KeypadModule', () => {
     fireEvent.click(screen.getByTestId('keypad-cell-0'))
     expect(screen.getByText('1')).toBeInTheDocument()
   })
+
+  it('uses concise accessible names instead of full symbol descriptions', () => {
+    render(
+      <KeypadModule
+        config={config}
+        answer={answer}
+        onComplete={vi.fn()}
+        onError={vi.fn()}
+        sceneInfo={sceneInfo}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Keypad top-left symbol: omega' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Keypad top-right symbol: delta' })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /马蹄铁形/ })).not.toBeInTheDocument()
+  })
 })

--- a/packages/game-bombsquad/src/modules/keypad/KeypadModule.tsx
+++ b/packages/game-bombsquad/src/modules/keypad/KeypadModule.tsx
@@ -20,6 +20,8 @@ const STAR_MAP: { x: number; y: number }[] = [
   { x: 33, y: 78 },
 ]
 
+const CELL_LABELS = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
+
 export default function KeypadModule({
   config,
   answer,
@@ -98,7 +100,7 @@ export default function KeypadModule({
               className={`${styles.star} ${tapped ? styles.tapped : ''}`}
               style={{ left: `${star.x}%`, top: `${star.y}%` }}
               onClick={() => handleCellClick(position)}
-              aria-label={sym.description}
+              aria-label={`Keypad ${CELL_LABELS[position]} symbol: ${symbolId}`}
               data-testid={`keypad-cell-${position}`}
             >
               <svg viewBox="0 0 100 100" className={styles.symbol}>

--- a/packages/game-bombsquad/src/pages/BombSquadLandingPage.module.css
+++ b/packages/game-bombsquad/src/pages/BombSquadLandingPage.module.css
@@ -45,6 +45,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.aiEyebrow {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .iconBtn {

--- a/packages/game-bombsquad/src/pages/BombSquadLandingPage.tsx
+++ b/packages/game-bombsquad/src/pages/BombSquadLandingPage.tsx
@@ -36,7 +36,7 @@ export default function BombSquadLandingPage() {
               connected. Brand-yellow (not green) keeps it a label, not a
               "ready/online" signal. */}
           <div className={styles.top}>
-            <Eyebrow dot color="var(--y)">
+            <Eyebrow dot color="var(--y)" className={styles.aiEyebrow}>
               <AiToolList prefix="自带语音 AI · 支持" />
             </Eyebrow>
             <button

--- a/packages/game-bombsquad/src/pages/ConnectPage.module.css
+++ b/packages/game-bombsquad/src/pages/ConnectPage.module.css
@@ -176,11 +176,8 @@
   flex-direction: column;
 }
 
-/* ----------  manual-URL preview (passive)  ----------
-   A non-interactive preview of the manual link. The copy action lives on the
-   bottom primary CTA, so this card has no pointer, no hover, and no focus
-   ring — it only shows the URL (trust requirement) and turns green once the
-   CTA has copied it. */
+/* ----------  manual-URL copy card  ----------
+   The whole card copies the manual link, matching the bottom CTA. */
 .urlPreview {
   display: flex;
   align-items: center;
@@ -195,13 +192,33 @@
   font-family: var(--font-body);
   color: #fff;
   text-align: left;
+  appearance: none;
+  cursor: pointer;
   transition: all 0.2s;
+}
+
+.urlPreview:hover,
+.urlPreview:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 229, 62, 0.35);
+  outline: none;
+}
+
+.urlPreview:focus-visible {
+  outline: 2px solid var(--y);
+  outline-offset: 3px;
 }
 
 /* done — the card turns green the moment the link is copied. */
 .urlPreviewDone {
   background: rgba(20, 30, 22, 0.6);
   border-color: rgba(75, 210, 102, 0.4);
+}
+
+.urlPreviewDone:hover,
+.urlPreviewDone:focus-visible {
+  background: rgba(20, 30, 22, 0.72);
+  border-color: rgba(75, 210, 102, 0.55);
 }
 
 .copyCardText {
@@ -328,6 +345,9 @@
 .cta {
   margin-top: auto;
   padding-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 /* `breathe` is BombSquad-specific (not in atlas-animations.css);

--- a/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
@@ -4,10 +4,10 @@
  * Covers the connect-AI flow at /bombsquad/connect — the Atlas redesign's
  * 2-step handoff (design_handoff_bombsquad README §6.2):
  *   1. step 1 renders the URL preview with the manual URL.
- *   2. the most prominent element (the bottom primary CTA「复制手册」) IS the
- *      copy action: tapping it copies the manual link, shows the copied
- *      feedback, and auto-advances to step 2 after ~0.7s; the clipboard
- *      payload is the manual URL.
+ *   2. both the manual URL card and the bottom primary CTA「复制手册」copy the
+ *      manual link, show the copied feedback, and auto-advance to step 2 after
+ *      ~0.7s; if clipboard access fails, the player can manually send the
+ *      visible URL and continue. The clipboard payload is the manual URL.
  *   3. step 1 has no disabled / dead control — the affordance-inversion guard.
  *   4. the 2-step state machine reaches the voice-mode step and hands off.
  *   5. daily mode hands off to the run carrying the manual URL as ?url=.
@@ -89,9 +89,10 @@ async function copyAndReachStep2() {
 
 describe('ConnectPage', () => {
   beforeEach(() => {
-    vi.mocked(copyToClipboard).mockClear()
+    vi.mocked(copyToClipboard).mockReset()
     vi.mocked(copyToClipboard).mockResolvedValue(true)
-    vi.mocked(getAudioContext).mockClear()
+    vi.mocked(getAudioContext).mockReset()
+    vi.mocked(getAudioContext).mockReturnValue(null)
   })
 
   it('renders step 1 with the URL preview and manual URL', () => {
@@ -104,12 +105,15 @@ describe('ConnectPage', () => {
     expect(screen.getByText(DAILY_URL)).toBeInTheDocument()
   })
 
-  it('makes the most prominent CTA the copy action with no dead control on step 1', () => {
+  it('makes the manual URL card and primary CTA active copy controls on step 1', () => {
     renderConnect('daily')
 
-    // The affordance-inversion guard: the bottom primary CTA is the real copy
-    // action ("复制手册"), and step 1 has no disabled / dead control — the old
-    // "biggest button does nothing until you find the smaller card" trap.
+    const copyCard = screen.getByRole('button', { name: '复制手册链接' })
+    expect(copyCard).toBeInTheDocument()
+    expect(copyCard).not.toBeDisabled()
+
+    // The affordance-inversion guard: the bottom primary CTA is also the real
+    // copy action ("复制手册"), and step 1 has no disabled / dead control.
     const copyCta = screen.getByRole('button', { name: '复制手册' })
     expect(copyCta).toBeInTheDocument()
     expect(copyCta).not.toBeDisabled()
@@ -120,8 +124,7 @@ describe('ConnectPage', () => {
       expect(btn).not.toBeDisabled()
     }
 
-    // The URL preview is no longer a button — the only copy control is the CTA.
-    expect(screen.queryByRole('button', { name: /手册链接/ })).not.toBeInTheDocument()
+    expect(screen.getAllByRole('button')).toHaveLength(3)
   })
 
   it('surfaces the /bombsquad/compatibility discovery link on step 1', () => {
@@ -154,6 +157,41 @@ describe('ConnectPage', () => {
     await waitFor(() => {
       expect(screen.getByText('切到语音模式')).toBeInTheDocument()
     })
+  })
+
+  it('copies the manual link from the URL card too', async () => {
+    renderConnect('practice')
+
+    fireEvent.click(screen.getByRole('button', { name: '复制手册链接' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('已复制到剪贴板')).toBeInTheDocument()
+    })
+    expect(copyToClipboard).toHaveBeenCalledTimes(1)
+    expect(copyToClipboard).toHaveBeenCalledWith(PRACTICE_URL)
+
+    await waitFor(() => {
+      expect(screen.getByText('切到语音模式')).toBeInTheDocument()
+    })
+  })
+
+  it('lets the player continue manually if clipboard copy fails', async () => {
+    vi.mocked(copyToClipboard).mockResolvedValueOnce(false)
+    renderConnect('practice')
+
+    fireEvent.click(screen.getByRole('button', { name: '复制手册' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('复制失败，可手动发送')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/你可以重试复制/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '重试复制' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '重试复制手册链接' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /我已发给 AI/ }))
+
+    expect(screen.getByText('第 2/2 步')).toBeInTheDocument()
+    expect(screen.getByText(SYNC_PROMPT)).toBeInTheDocument()
   })
 
   it('walks the 2-step state machine to the voice-mode step', async () => {

--- a/packages/game-bombsquad/src/pages/ConnectPage.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.tsx
@@ -29,6 +29,7 @@ export default function ConnectPage() {
 
   const [step, setStep] = useState<1 | 2>(1)
   const [copied, setCopied] = useState(false)
+  const [copyFailed, setCopyFailed] = useState(false)
 
   /* Once the manual link is copied, the card turns green and the flow
      auto-advances to step 2 after ~0.7s. The timer is owned by an effect
@@ -45,7 +46,16 @@ export default function ConnectPage() {
   const handleCopy = async () => {
     if (copied) return
     const ok = await copyToClipboard(manualUrl)
-    if (ok) setCopied(true)
+    if (ok) {
+      setCopyFailed(false)
+      setCopied(true)
+    } else {
+      setCopyFailed(true)
+    }
+  }
+
+  const continueAfterManualHandoff = () => {
+    setStep(2)
   }
 
   /* Final step → the existing run. Daily carries the manual URL as ?url= so
@@ -155,17 +165,23 @@ export default function ConnectPage() {
             </div>
           </div>
 
-          {/* Step 1 — copy the manual link. The copy action lives on the
-              bottom primary CTA (the most prominent element); this card is a
-              passive read-only preview of the URL so the link stays visible
-              and trustworthy. It is deliberately NOT a button — the only copy
-              control on this step is the CTA below. */}
+          {/* Step 1 — copy the manual link. The full URL card and the bottom
+              primary CTA share the same copy action: the card keeps the link
+              visible and trustworthy, while the CTA remains the strongest
+              explicit command for players scanning fast. */}
           {step === 1 && (
             <div className={styles.action}>
-              <div className={`${styles.urlPreview} ${copied ? styles.urlPreviewDone : ''}`}>
+              <button
+                type="button"
+                className={`${styles.urlPreview} ${copied ? styles.urlPreviewDone : ''}`}
+                onClick={handleCopy}
+                aria-label={
+                  copied ? '已复制手册链接' : copyFailed ? '重试复制手册链接' : '复制手册链接'
+                }
+              >
                 <div className={styles.copyCardText}>
                   <div className={styles.copyCardLabel}>
-                    {copied ? '已复制到剪贴板' : '手册链接'}
+                    {copied ? '已复制到剪贴板' : copyFailed ? '复制失败，可手动发送' : '手册链接'}
                   </div>
                   <div className={styles.copyCardUrl}>{manualUrl}</div>
                 </div>
@@ -197,9 +213,13 @@ export default function ConnectPage() {
                     </svg>
                   )}
                 </div>
-              </div>
+              </button>
 
-              <p className={styles.hint}>粘贴到你常用的 AI，让它读完手册后说「好了」。</p>
+              <p className={styles.hint}>
+                {copyFailed
+                  ? '浏览器没有允许自动复制。你可以重试复制，或手动选择上面的链接发给 AI，等它读完手册后继续。'
+                  : '粘贴到你常用的 AI，让它读完手册后说「好了」。'}
+              </p>
               {/* /compatibility discovery link — re-homed here from the
                  retired PromptModal, which placed it directly under the
                  same send-to-AI content. Step 1 is that moment now. */}
@@ -250,18 +270,25 @@ export default function ConnectPage() {
 
           <div className={styles.cta}>
             {step === 1 ? (
-              /* The most prominent element IS the copy action: tap copies the
+              /* The CTA mirrors the URL card's copy action: tap copies the
                  manual URL, flips to the green confirmed state, and the 0.7s
                  effect above auto-advances to step 2. No disabled / dead
                  control on this step. */
-              <Button
-                variant="primary"
-                full
-                accent={copied ? 'green' : 'yellow'}
-                onClick={handleCopy}
-              >
-                {copied ? '已复制 ✓' : '复制手册'}
-              </Button>
+              <>
+                <Button
+                  variant="primary"
+                  full
+                  accent={copied ? 'green' : copyFailed ? 'rose' : 'yellow'}
+                  onClick={handleCopy}
+                >
+                  {copied ? '已复制 ✓' : copyFailed ? '重试复制' : '复制手册'}
+                </Button>
+                {copyFailed && !copied && (
+                  <Button variant="ghost" full onClick={continueAfterManualHandoff}>
+                    我已发给 AI，继续 →
+                  </Button>
+                )}
+              </>
             ) : (
               <Button variant="primary" full onClick={confirmStart}>
                 进入游戏 →

--- a/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
@@ -2,18 +2,20 @@
  * ResultPage endgame-survey wiring tests.
  *
  * Covers the post-game survey integration on ResultPage:
- *   1. Any outcome on a fresh device opens the survey modal.
+ *   1. Any outcome on a fresh device opens the survey modal after the result
+ *      feedback has had time to land.
  *   2. A device that has already answered/skipped sees no modal.
  *   3. Submitting the survey emits `survey_submit` and marks the device.
  *   4. Skipping marks the device WITHOUT emitting `survey_submit`.
- *   5. First daily win merges the nickname gate and the survey into one modal.
+ *   5. First daily win opens the leaderboard gate first; the survey remains
+ *      deferred until after that gate closes.
  *
  * Setup mirrors the sibling ResultPage tests: pre-seed sessionStorage with a
  * finished-game state so `GameProvider`'s lazy initializer hydrates straight
  * into a renderable ResultPage.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
 vi.mock('@/utils/device-fingerprint', () => ({
@@ -71,6 +73,7 @@ import { GameProvider, type GameState, type GameOutcome } from '@/store/game-con
 import { submitScore } from '@shared/leaderboard-api'
 
 const PERSISTENCE_KEY = 'bombsquad:game-state:v3'
+const RESULT_FEEDBACK_SURVEY_DELAY_MS = 1800
 
 interface FixtureOptions {
   mode: GameState['mode']
@@ -130,8 +133,15 @@ function answerRequiredSurvey({
   fireEvent.click(screen.getByRole('button', { name: difficulty }))
 }
 
+function advancePastResultFeedback() {
+  act(() => {
+    vi.advanceTimersByTime(RESULT_FEEDBACK_SURVEY_DELAY_MS)
+  })
+}
+
 describe('ResultPage endgame survey', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     sessionStorage.clear()
     logEvent.mockReset()
     surveyMock.hasAnsweredSurvey.mockReset()
@@ -141,12 +151,18 @@ describe('ResultPage endgame survey', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     sessionStorage.clear()
   })
 
-  it('opens the survey modal after any outcome on a fresh device', () => {
+  it('opens the survey modal after the result feedback on a fresh device', () => {
     surveyMock.hasAnsweredSurvey.mockReturnValue(false)
     renderResult(finishedState({ mode: 'practice', outcome: 'practice-cleared' }))
+
+    expect(screen.getByText('拆弹成功')).toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    advancePastResultFeedback()
 
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(screen.getByText('你这局用的是哪个 AI 工具？')).toBeInTheDocument()
@@ -158,6 +174,11 @@ describe('ResultPage endgame survey', () => {
     surveyMock.hasAnsweredSurvey.mockReturnValue(false)
     renderResult(finishedState({ mode: 'daily', outcome: 'exploded' }))
 
+    expect(screen.getByText('差一点')).toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    advancePastResultFeedback()
+
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(screen.getByText('难度感受')).toBeInTheDocument()
   })
@@ -166,6 +187,8 @@ describe('ResultPage endgame survey', () => {
     surveyMock.hasAnsweredSurvey.mockReturnValue(true)
     renderResult(finishedState({ mode: 'practice', outcome: 'practice-cleared' }))
 
+    advancePastResultFeedback()
+
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
@@ -173,6 +196,7 @@ describe('ResultPage endgame survey', () => {
     surveyMock.hasAnsweredSurvey.mockReturnValue(false)
     renderResult(finishedState({ mode: 'practice', outcome: 'practice-cleared' }))
 
+    advancePastResultFeedback()
     answerRequiredSurvey()
     fireEvent.click(screen.getByRole('button', { name: '提交' }))
 
@@ -191,6 +215,7 @@ describe('ResultPage endgame survey', () => {
     surveyMock.hasAnsweredSurvey.mockReturnValue(false)
     renderResult(finishedState({ mode: 'practice', outcome: 'practice-cleared' }))
 
+    advancePastResultFeedback()
     fireEvent.click(screen.getByRole('button', { name: '跳过' }))
 
     expect(surveyMock.markSurveyAnswered).toHaveBeenCalledTimes(1)
@@ -199,27 +224,40 @@ describe('ResultPage endgame survey', () => {
     expect(screen.getByRole('button', { name: '再来一局' })).toBeInTheDocument()
   })
 
-  it('first daily win merges the nickname gate and the survey into one modal', async () => {
+  it('first daily win opens the leaderboard gate before the deferred survey', async () => {
     surveyMock.hasAnsweredSurvey.mockReturnValue(false)
     renderResult(finishedState({ mode: 'daily', outcome: 'defused' }))
 
-    // Exactly one dialog — never two stacked.
+    // Exactly one dialog — the leaderboard gate opens first, without the
+    // survey-only fun / difficulty questions.
     expect(screen.getAllByRole('dialog')).toHaveLength(1)
     expect(screen.getByLabelText(/昵称/)).toBeInTheDocument()
     expect(screen.getByText('你这局用的是哪个 AI 工具？')).toBeInTheDocument()
+    expect(screen.queryByText('整体好玩程度')).not.toBeInTheDocument()
     // Score is gated behind the nickname and AI metadata while the modal is open.
     expect(submitScore).not.toHaveBeenCalled()
 
     fireEvent.change(screen.getByLabelText(/昵称/), { target: { value: '小测' } })
-    answerRequiredSurvey()
+    fireEvent.click(screen.getByRole('button', { name: 'Claude' }))
     fireEvent.click(screen.getByRole('button', { name: '确认' }))
 
-    // Nickname path fires the score submission; survey path emits telemetry.
-    await waitFor(() => expect(submitScore).toHaveBeenCalledTimes(1))
+    // Nickname / AI metadata path fires the score submission; survey has not
+    // opened yet, so no survey telemetry or answered marker fires here.
+    expect(submitScore).toHaveBeenCalledTimes(1)
     expect(vi.mocked(submitScore).mock.calls[0][0]).toMatchObject({
       nickname: '小测',
       ai_tool: 'claude',
     })
+    expect(logEvent).not.toHaveBeenCalledWith('survey_submit', expect.anything())
+    expect(surveyMock.markSurveyAnswered).not.toHaveBeenCalled()
+
+    advancePastResultFeedback()
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('整体好玩程度')).toBeInTheDocument()
+    answerRequiredSurvey()
+    fireEvent.click(screen.getByRole('button', { name: '提交' }))
+
     expect(logEvent).toHaveBeenCalledWith('survey_submit', {
       ai_tool: 'claude',
       fun: 4,
@@ -229,7 +267,7 @@ describe('ResultPage endgame survey', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  it('merged modal is confirmable with nickname and AI tool — survey skipped, no survey_submit', async () => {
+  it('daily leaderboard gate is confirmable without answering the deferred survey', async () => {
     surveyMock.hasAnsweredSurvey.mockReturnValue(false)
     renderResult(finishedState({ mode: 'daily', outcome: 'defused' }))
 
@@ -242,13 +280,19 @@ describe('ResultPage endgame survey', () => {
 
     // Score still submits, the device is marked answered, but a skipped
     // survey fires no `survey_submit`.
-    await waitFor(() => expect(submitScore).toHaveBeenCalledTimes(1))
+    expect(submitScore).toHaveBeenCalledTimes(1)
     expect(vi.mocked(submitScore).mock.calls[0][0]).toMatchObject({
       nickname: '小测',
       ai_tool: 'claude',
     })
     expect(logEvent).not.toHaveBeenCalledWith('survey_submit', expect.anything())
-    expect(surveyMock.markSurveyAnswered).toHaveBeenCalledTimes(1)
+    expect(surveyMock.markSurveyAnswered).not.toHaveBeenCalled()
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    advancePastResultFeedback()
+
+    fireEvent.click(screen.getByRole('button', { name: '跳过' }))
+    expect(surveyMock.markSurveyAnswered).toHaveBeenCalledTimes(1)
+    expect(logEvent).not.toHaveBeenCalledWith('survey_submit', expect.anything())
   })
 })

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -42,8 +42,11 @@ const MODULE_GLYPH: Record<string, GlyphKey> = {
   keypad: 'yue',
 }
 
+const RESULT_FEEDBACK_SURVEY_DELAY_MS = 1800
+
 /** The result screen has two visual variants (handoff README §6.6 / §6.7). */
 type ResultVariant = 'success' | 'failure'
+type PostGameModalPurpose = 'leaderboard' | 'survey'
 
 /**
  * Map a frozen game outcome to a result variant. `defused` and
@@ -123,20 +126,27 @@ export default function ResultPage() {
     () => getStoredLeaderboardPlayerMetadata()
   )
 
-  // The unified post-game modal composes two optional sections. The nickname
-  // and AI metadata sections are the daily-leaderboard gates; the survey
-  // section is shown once per device after any outcome. The modal opens when
-  // any section is needed — never as two stacked dialogs. Both `need*` flags
-  // are captured once on mount; the modal closes on confirm/skip rather than
-  // re-deriving.
+  // The post-game modal has two separate purposes. The leaderboard gate can
+  // open immediately when a first daily defuse needs a nickname / AI metadata
+  // before score submission. The once-per-device survey waits until after the
+  // result feedback has had time to land, so a first win is not covered by a
+  // questionnaire before the player can read it.
   const [needNickname] = useState(() => hasFinishedDailyRun && nickname === null)
   const [needLeaderboardMetadata] = useState(
     () => hasFinishedDailyRun && leaderboardMetadata === null
   )
   const [needSurvey] = useState(() => !hasAnsweredSurvey())
-  const [modalOpen, setModalOpen] = useState(
-    () => needNickname || needLeaderboardMetadata || needSurvey
-  )
+  const needsLeaderboardGate = needNickname || needLeaderboardMetadata
+  const [leaderboardGateOpen, setLeaderboardGateOpen] = useState(needsLeaderboardGate)
+  const [surveyReady, setSurveyReady] = useState(false)
+  const [surveyRetired, setSurveyRetired] = useState(false)
+  const surveyOpen = needSurvey && !surveyRetired && surveyReady && !leaderboardGateOpen
+  const modalPurpose: PostGameModalPurpose | null = leaderboardGateOpen
+    ? 'leaderboard'
+    : surveyOpen
+      ? 'survey'
+      : null
+  const modalOpen = modalPurpose !== null
   // Initialize submitting=true only when the effect below will actually fire a
   // request, so we avoid a synchronous setState in the effect body
   // (react-hooks/set-state-in-effect). First-visit daily runs wait for the
@@ -147,7 +157,13 @@ export default function ResultPage() {
 
   // The daily score is still gated while the modal is open with a leaderboard
   // submission section present.
-  const leaderboardGatePending = (needNickname || needLeaderboardMetadata) && modalOpen
+  const leaderboardGatePending = modalPurpose === 'leaderboard'
+
+  useEffect(() => {
+    if (!needSurvey || noRunData) return
+    const id = setTimeout(() => setSurveyReady(true), RESULT_FEEDBACK_SURVEY_DELAY_MS)
+    return () => clearTimeout(id)
+  }, [needSurvey, noRunData])
 
   const buildSubmission = useCallback(
     (nicknameValue: string, metadataValue: LeaderboardPlayerMetadata): ScoreSubmission | null => {
@@ -258,24 +274,40 @@ export default function ResultPage() {
         setSubmitting(true)
         performSubmission(confirmedNickname, confirmedMetadata)
       }
-      if (result.survey !== undefined) {
+      const completingSurvey = modalPurpose === 'survey'
+      if (completingSurvey && result.survey !== undefined) {
         logEvent('survey_submit', { ...result.survey })
       }
-      if (needSurvey) {
+      if (completingSurvey && needSurvey) {
         markSurveyAnswered()
+        setSurveyRetired(true)
       }
-      setModalOpen(false)
+      if (modalPurpose === 'leaderboard') {
+        setLeaderboardGateOpen(false)
+      }
     },
-    [performSubmission, needSurvey, nickname, leaderboardMetadata, hasFinishedDailyRun]
+    [
+      performSubmission,
+      needSurvey,
+      nickname,
+      leaderboardMetadata,
+      hasFinishedDailyRun,
+      modalPurpose,
+    ]
   )
 
   // Survey-only dismissal. The device is marked answered so the survey does
   // not reappear, but no `survey_submit` event fires — a skip is not a
   // response.
   const handleModalSkip = useCallback(() => {
-    markSurveyAnswered()
-    setModalOpen(false)
-  }, [])
+    if (modalPurpose === 'survey') {
+      markSurveyAnswered()
+      setSurveyRetired(true)
+    }
+    if (modalPurpose === 'leaderboard') {
+      setLeaderboardGateOpen(false)
+    }
+  }, [modalPurpose])
 
   const handleRetrySubmit = useCallback(() => {
     if (nickname === null) return
@@ -521,9 +553,9 @@ export default function ResultPage() {
 
       <PostGameModal
         open={modalOpen}
-        showNickname={needNickname}
-        showLeaderboardMetadata={needLeaderboardMetadata}
-        showSurvey={needSurvey}
+        showNickname={modalPurpose === 'leaderboard' && needNickname}
+        showLeaderboardMetadata={modalPurpose === 'leaderboard' && needLeaderboardMetadata}
+        showSurvey={modalPurpose === 'survey' && needSurvey}
         onConfirm={handleModalConfirm}
         onSkip={handleModalSkip}
       />


### PR DESCRIPTION
## Summary

- Make the BombSquad manual URL card use the same copy and clipboard-fallback flow as the primary copy CTA.
- Delay the once-per-device result survey until after victory feedback has had time to land, while keeping the daily leaderboard gate immediate.
- Tighten mobile lobby overflow, improve module accessible labels, update E2E affordance and survey guards, remove stale recap guidance, and ignore local Codex session directories.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [x] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Manual / local checks:

- `pnpm --filter @amiclaw/game-bombsquad test:run src/pages/ConnectPage.test.tsx src/pages/ResultPage.test.tsx src/pages/ResultPage.survey.test.tsx src/pages/ResultPage.nickname.test.tsx src/pages/ResultPage.outcome.test.tsx src/pages/ResultPage.recovery.test.tsx src/pages/ResultPage.feedback.test.tsx src/pages/BombSquadLandingPage.test.tsx src/modules/button/ButtonModule.test.tsx src/modules/keypad/KeypadModule.test.tsx`
- `pnpm --filter @amiclaw/game-bombsquad typecheck`
- `pnpm build`
- `pnpm --filter @amiclaw/ui test:run`
- `pnpm --filter @amiclaw/game-bombsquad test:run`
- `pnpm test:regression`
- `pnpm test:e2e`
- Commit hook: `pnpm -r run test:run`
- `git diff --check`
- Browser pass on assembled preview: manual URL card triggers copy/fallback, practice victory appears before the survey, and the 390px manual URL card does not overflow.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

## Claude Code Attribution

Generated with Codex in the Claude Code-compatible project workflow.
