### PR TITLE
feat(platform-ai): add platform AI interface (route-one STT→LLM→TTS, swappable providers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,19 @@ numbers. The old `?auth=in` URL mock is gone from the shipped site; a
 development-only sign-in shortcut remains for local work and is compiled out of
 the production build.
 
+**Games can now plug in a shared AI voice partner** — AmiClaw gains a reusable
+platform AI layer (`@amiclaw/platform-ai`) so any game can hand the player a
+voice partner instead of building one from scratch. It runs a modular
+speech-to-text → language-model → text-to-speech pipeline behind one
+game-agnostic session contract; the model reads only the manual the platform
+injects for the current step, so it guides without inventing rules. DeepSeek and
+Volcengine (火山) are the default providers, and switching a vendor is a config
+change, not a rewrite. The session lives in a per-player Durable Object over a
+same-origin WebSocket, bound to the signed-in player; provider keys and the
+system prompt stay server-side and never reach the browser. A first-party demo
+harness runs the whole speak-to-reply loop locally with deterministic mock
+providers — no real credentials needed.
+
 **The home page now introduces AmiClaw as a platform, with one BombSquad block** - The
 hero description now explains AmiClaw instead of describing only the defusal game, and
 the hero keeps a single start button. The former daily challenge and weekly feature

--- a/packages/platform-ai/demo/README.md
+++ b/packages/platform-ai/demo/README.md
@@ -1,0 +1,51 @@
+# Platform AI — Voice Session Demo
+
+A minimal first-party harness that drives the whole `@amiclaw/platform-ai`
+pipeline (STT → LLM → TTS) over the same-origin `/ai-ws/*` WebSocket, with **no
+real provider credentials**.
+
+It exists to prove the locked acceptance end to end: _speak → ASR → LLM (grounded
+in the injected manual) → TTS → see / hear a deterministic reply_, and to show
+the security invariant holds — the browser holds no key and no system prompt.
+
+## How it works
+
+- The page connects to the Worker WebSocket and creates a session with the
+  `demo-mock` gameId.
+- `demo-mock` (see `../src/provider-config.ts`) selects the deterministic **mock**
+  provider on all three layers (`../src/providers/mock.ts`). No DeepSeek /
+  Volcengine keys are read or required.
+- The mock STT maps any audio to a fixed example transcript; the mock LLM replies
+  with a sentence grounded in the manual section the platform injected
+  server-side; the mock TTS emits placeholder audio frames per sentence.
+- `DEV_AUTH_BYPASS=true` (set only in the demo wrangler config) makes the WS
+  handshake resolve a fixed dev identity, so you can connect without a signed-in
+  session cookie.
+
+## Run it
+
+From the package root (`packages/platform-ai/`):
+
+```sh
+pnpm exec wrangler dev --config demo/wrangler.dev.toml
+```
+
+Then open the printed local URL (default `http://localhost:8787/`) and:
+
+1. Click **Connect session** — the log shows `Session created: …`.
+2. **Hold to speak** — grant microphone access (or deny it; the mock STT yields
+   its fixed transcript either way, so the turn still completes). Release to send.
+3. The AI's streamed reply appears in the log, grounded in the injected manual.
+4. **End session** to close and see the turn count.
+
+## Security note (load-bearing)
+
+This page connects **only** to the server-side Worker. It never holds a provider
+API key or a system prompt — those live exclusively server-side (Cloudflare
+secrets + `provider-config.ts`). The only game material the client sends is the
+`demo-mock` gameId and per-run manual data, which is non-secret by design.
+
+The mock TTS frame is the UTF-8 bytes of the sentence (a placeholder, not a real
+codec), so audio playback is best-effort in mock mode. The point of the demo is
+that the text and audio chunks arrive end to end; a real TTS adapter emits
+decodable audio in the same slot.

--- a/packages/platform-ai/demo/demo.js
+++ b/packages/platform-ai/demo/demo.js
@@ -1,0 +1,194 @@
+// Platform AI voice-session demo client.
+//
+// Minimal browser harness that drives the full session over the `/ai-ws/*`
+// WebSocket: create -> stream player audio frames -> `turn` -> render the AI's
+// streamed text + audio response.
+//
+// SECURITY INVARIANT (load-bearing): this client connects ONLY to the
+// same-origin Worker WebSocket. It holds NO provider API key and NO system
+// prompt. The gameId (`demo-mock`) is the only game material it sends; the
+// prompt + manual injection + provider credentials all live server-side. Do not
+// add any key or prompt text to this file.
+//
+// With the demo wrangler config, the server resolves `demo-mock` to the
+// deterministic mock providers, so the round trip works with no real
+// credentials. Note: the mock TTS frame is the UTF-8 bytes of the sentence (a
+// placeholder, not a real audio codec), so playback is best-effort — the point
+// of the demo is to show the text + audio chunks arriving end to end.
+
+const els = {
+  connect: document.getElementById('connect'),
+  speak: document.getElementById('speak'),
+  end: document.getElementById('end'),
+  status: document.getElementById('status'),
+  log: document.getElementById('log'),
+}
+
+const GAME_ID = 'demo-mock'
+
+// A tiny example manual so the mock LLM has an injected section to ground its
+// reply in. This is per-run game data (allowed on the wire), NOT a system
+// prompt.
+const MANUAL_DATA = {
+  version: 'demo-v1',
+  sections: {
+    'button-module': {
+      rule: 'If the button is red and labeled ABORT, hold it until the strip turns blue, then release.',
+    },
+  },
+}
+const GAME_STATE = { relevantSections: ['button-module'] }
+
+let ws = null
+let mediaStream = null
+let mediaRecorder = null
+let currentAiTurn = null
+
+function setStatus(text) {
+  els.status.textContent = text
+}
+
+function appendTurn(who, cssClass) {
+  const wrap = document.createElement('div')
+  wrap.className = `turn ${cssClass}`
+  const label = document.createElement('div')
+  label.className = 'who'
+  label.textContent = who
+  const body = document.createElement('div')
+  body.className = 'body'
+  wrap.append(label, body)
+  els.log.append(wrap)
+  els.log.scrollTop = els.log.scrollHeight
+  return body
+}
+
+function base64ToBytes(b64) {
+  const binary = atob(b64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i)
+  return bytes
+}
+
+function playAudioFrame(bytes) {
+  // Best-effort playback. The mock TTS emits placeholder bytes, so decoding may
+  // fail; that is expected in mock mode. A real TTS adapter would emit decodable
+  // audio here.
+  try {
+    const blob = new Blob([bytes], { type: 'audio/mpeg' })
+    const url = URL.createObjectURL(blob)
+    const audio = new Audio(url)
+    audio.play().catch(() => {})
+    audio.addEventListener('ended', () => URL.revokeObjectURL(url))
+  } catch {
+    // ignore — placeholder bytes are not playable in mock mode
+  }
+}
+
+function handleServerMessage(raw) {
+  let msg
+  try {
+    msg = JSON.parse(raw)
+  } catch {
+    return
+  }
+  switch (msg.type) {
+    case 'created':
+      setStatus(`Session created: ${msg.sessionId}`)
+      els.speak.disabled = false
+      els.end.disabled = false
+      break
+    case 'chunk':
+      if (!currentAiTurn) currentAiTurn = appendTurn('AI', 'ai')
+      if (msg.kind === 'text' && msg.text) {
+        currentAiTurn.textContent += msg.text
+        els.log.scrollTop = els.log.scrollHeight
+      } else if (msg.kind === 'audio' && msg.audio) {
+        playAudioFrame(base64ToBytes(msg.audio))
+      }
+      if (msg.done) {
+        currentAiTurn = null
+        setStatus('Turn complete. Hold to speak again.')
+      }
+      break
+    case 'summary':
+      setStatus(`Session ended. Turns: ${msg.summary.turnCount}`)
+      break
+    default:
+      break
+  }
+}
+
+function connect() {
+  const sessionName = `demo-${Math.random().toString(36).slice(2, 10)}`
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws'
+  ws = new WebSocket(`${proto}://${location.host}/ai-ws/${sessionName}`)
+
+  ws.addEventListener('open', () => {
+    setStatus('Connected. Creating session…')
+    ws.send(
+      JSON.stringify({
+        type: 'create',
+        gameId: GAME_ID,
+        manualData: MANUAL_DATA,
+        gameState: GAME_STATE,
+      })
+    )
+  })
+  ws.addEventListener('message', (event) => handleServerMessage(event.data))
+  ws.addEventListener('close', (event) => {
+    setStatus(`Disconnected (${event.code}).`)
+    els.speak.disabled = true
+    els.end.disabled = true
+  })
+  ws.addEventListener('error', () => setStatus('WebSocket error.'))
+}
+
+async function startSpeaking() {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return
+  appendTurn('You (speaking…)', 'user')
+  try {
+    mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true })
+  } catch {
+    setStatus('Microphone permission denied — sending a silent frame instead.')
+    // Even without a mic, the mock STT yields its fixed transcript, so the demo
+    // still completes a turn. Send one empty frame to stand in for audio.
+    ws.send(new Uint8Array([0]).buffer)
+    return
+  }
+  mediaRecorder = new MediaRecorder(mediaStream)
+  mediaRecorder.addEventListener('dataavailable', async (event) => {
+    if (event.data.size > 0 && ws && ws.readyState === WebSocket.OPEN) {
+      const buf = await event.data.arrayBuffer()
+      ws.send(buf)
+    }
+  })
+  mediaRecorder.start(250) // emit a frame every 250ms
+  setStatus('Listening… release to send.')
+}
+
+function stopSpeaking() {
+  if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+    mediaRecorder.stop()
+  }
+  if (mediaStream) {
+    mediaStream.getTracks().forEach((t) => t.stop())
+    mediaStream = null
+  }
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    // Give the last audio frame a moment to flush, then request the AI turn.
+    setStatus('Thinking…')
+    setTimeout(() => ws.send(JSON.stringify({ type: 'turn' })), 300)
+  }
+}
+
+els.connect.addEventListener('click', () => {
+  els.connect.disabled = true
+  connect()
+})
+// Hold-to-speak: press starts capture, release sends the turn.
+els.speak.addEventListener('pointerdown', startSpeaking)
+els.speak.addEventListener('pointerup', stopSpeaking)
+els.speak.addEventListener('pointerleave', stopSpeaking)
+els.end.addEventListener('click', () => {
+  if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'end' }))
+})

--- a/packages/platform-ai/demo/index.html
+++ b/packages/platform-ai/demo/index.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Platform AI — Voice Session Demo</title>
+    <style>
+      /* Dark-only by design (platform constraint). CSS-only; no JS animation. */
+      :root {
+        color-scheme: dark;
+        --bg: #0b0d12;
+        --panel: #151922;
+        --border: #262c38;
+        --text: #e6e9ef;
+        --muted: #8b93a3;
+        --accent: #e9c46a;
+        --user: #6aa9e9;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font:
+          15px/1.5 system-ui,
+          -apple-system,
+          sans-serif;
+        display: flex;
+        justify-content: center;
+        padding: 24px 16px 64px;
+      }
+      main {
+        width: 100%;
+        max-width: 560px;
+      }
+      h1 {
+        font-size: 18px;
+        margin: 0 0 4px;
+      }
+      p.lede {
+        color: var(--muted);
+        margin: 0 0 20px;
+      }
+      .row {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 16px;
+        flex-wrap: wrap;
+      }
+      button {
+        background: var(--panel);
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 10px 16px;
+        font-size: 15px;
+        cursor: pointer;
+      }
+      button:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+      button.primary {
+        background: var(--accent);
+        color: #1a1206;
+        border-color: var(--accent);
+        font-weight: 600;
+      }
+      #status {
+        color: var(--muted);
+        font-size: 13px;
+        margin-bottom: 16px;
+      }
+      #log {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 14px;
+        min-height: 200px;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .turn {
+        margin-bottom: 14px;
+      }
+      .turn .who {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+        margin-bottom: 2px;
+      }
+      .turn.ai .who {
+        color: var(--accent);
+      }
+      .turn.user .who {
+        color: var(--user);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Platform AI — Voice Session Demo</h1>
+      <p class="lede">
+        Speak → ASR → LLM (manual-grounded) → TTS, end to end over the
+        <code>/ai-ws/*</code> WebSocket. This page never holds a provider key or a system prompt —
+        everything runs server-side. With
+        <code>wrangler dev --config demo/wrangler.dev.toml</code> the <code>demo-mock</code> game
+        uses deterministic mock providers, so no real credentials are needed.
+      </p>
+
+      <div class="row">
+        <button id="connect" class="primary">Connect session</button>
+        <button id="speak" disabled>Hold to speak</button>
+        <button id="end" disabled>End session</button>
+      </div>
+
+      <div id="status">Not connected.</div>
+      <div id="log"></div>
+    </main>
+    <script type="module" src="./demo.js"></script>
+  </body>
+</html>

--- a/packages/platform-ai/demo/wrangler.dev.toml
+++ b/packages/platform-ai/demo/wrangler.dev.toml
@@ -1,0 +1,45 @@
+# Demo-only wrangler config for the Platform AI Interface.
+#
+# This is a LOCAL-DEV config, not a deploy config. It runs the same Worker as
+# the production `wrangler.toml` (../src/worker.ts) but with three demo-friendly
+# changes so the full STT -> LLM -> TTS pipeline runs with NO real credentials:
+#
+#   1. DEV_AUTH_BYPASS = "true" — the WS handshake auth seam returns a fixed dev
+#      identity instead of doing a real AUTH KV lookup, so you can connect
+#      without a signed-in session cookie.
+#   2. The demo uses the `demo-mock` gameId (see ../src/provider-config.ts),
+#      whose three layers all select the deterministic `mock` provider — no
+#      DeepSeek / Volcengine keys are read or required.
+#   3. `[assets]` serves this `demo/` directory as static files, and
+#      `run_worker_first` lets the Worker claim `/ai-ws/*` while every other
+#      path (the demo page itself) is served as a static asset.
+#
+# Run from the package root:
+#   pnpm exec wrangler dev --config demo/wrangler.dev.toml
+# then open the printed http://localhost:8787/ URL.
+
+name = "platform-ai-demo"
+main = "../src/worker.ts"
+compatibility_date = "2026-06-08"
+
+# Serve the demo page + client as static assets; the Worker is invoked first so
+# it can handle the `/ai-ws/*` WebSocket upgrade before asset routing.
+[assets]
+directory = "."
+run_worker_first = ["/ai-ws/*"]
+
+# Per-session voice pipeline DO (same class as production).
+[[durable_objects.bindings]]
+name = "VOICE_SESSION"
+class_name = "VoiceSessionDO"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["VoiceSessionDO"]
+
+[vars]
+# Dev auth bypass ON for local demo only — never set in production.
+DEV_AUTH_BYPASS = "true"
+
+# NOTE: no [[kv_namespaces]] AUTH binding and no provider secrets here. The mock
+# provider path needs neither, and DEV_AUTH_BYPASS short-circuits the AUTH read.

--- a/packages/platform-ai/package.json
+++ b/packages/platform-ai/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@amiclaw/platform-ai",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260608.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/platform-ai/src/auth-seam.test.ts
+++ b/packages/platform-ai/src/auth-seam.test.ts
@@ -28,6 +28,62 @@ describe('parseCookies / readSessionId', () => {
     expect(readSessionId('other=1')).toBeNull()
     expect(readSessionId(null)).toBeNull()
   })
+
+  it('percent-decodes a well-formed cookie value', () => {
+    expect(parseCookies('session=a%20b')).toEqual({ session: 'a b' })
+  })
+})
+
+// --- malformed-cookie robustness (F-D) ----------------------------------
+//
+// The `Cookie` header is attacker-controlled. A malformed percent-escape makes
+// `decodeURIComponent` throw a `URIError`; at the WS handshake an uncaught throw
+// would surface as a Worker error (500) instead of the intended "no valid
+// session" → 401. `parseCookies` must be total: keep the raw value, never throw,
+// so a bad cookie fails closed (resolves to no/garbage session id, which the
+// reader rejects).
+
+describe('parseCookies — malformed percent-escapes do not throw (F-D)', () => {
+  it('keeps a lone-percent value raw instead of throwing', () => {
+    expect(() => parseCookies('session=%')).not.toThrow()
+    expect(parseCookies('session=%')).toEqual({ session: '%' })
+  })
+
+  it('keeps a truncated escape raw instead of throwing', () => {
+    expect(() => parseCookies('session=%E')).not.toThrow()
+    expect(parseCookies('session=%E')).toEqual({ session: '%E' })
+  })
+
+  it('keeps an illegal-byte escape raw instead of throwing', () => {
+    // %ZZ is not a valid hex escape; %C3%28 is an invalid UTF-8 sequence.
+    expect(() => parseCookies('session=%ZZ')).not.toThrow()
+    expect(parseCookies('session=%ZZ')).toEqual({ session: '%ZZ' })
+    expect(() => parseCookies('session=%C3%28')).not.toThrow()
+    expect(parseCookies('session=%C3%28')).toEqual({ session: '%C3%28' })
+  })
+
+  it('isolates a malformed value to its own pair, keeping siblings decoded', () => {
+    // A bad `session` value must not poison a well-formed sibling cookie.
+    expect(() => parseCookies('a=ok; session=%; b=%41')).not.toThrow()
+    expect(parseCookies('a=ok; session=%; b=%41')).toEqual({ a: 'ok', session: '%', b: 'A' })
+  })
+
+  it('readSessionId stays total on a malformed session cookie', () => {
+    // The malformed value survives as a raw string; it does not match a real
+    // session record downstream, so the KV reader rejects it (fail-closed).
+    expect(() => readSessionId('session=%')).not.toThrow()
+    expect(readSessionId('session=%')).toBe('%')
+  })
+})
+
+describe('createKvSessionReader — malformed cookie fails closed, never throws (F-D)', () => {
+  it('returns null (unauthorized) for a malformed session cookie', async () => {
+    const reader = createKvSessionReader(mockKv({ 'session:s1': { userId: 'u1' } }))
+    // `session:%` is not a stored key → no record → null, not a thrown error.
+    await expect(reader.resolve('session=%')).resolves.toBeNull()
+    await expect(reader.resolve('session=%E')).resolves.toBeNull()
+    await expect(reader.resolve('session=%C3%28')).resolves.toBeNull()
+  })
 })
 
 // --- dev bypass stub -----------------------------------------------------

--- a/packages/platform-ai/src/auth-seam.test.ts
+++ b/packages/platform-ai/src/auth-seam.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertSessionOwnership,
+  createDevAuthBypassReader,
+  createKvSessionReader,
+  DEV_AUTH_USER_ID,
+  isDevAuthBypassEnabled,
+  parseCookies,
+  readSessionId,
+  resolveSessionReader,
+  type SessionKvReader,
+} from './auth-seam'
+
+// --- cookie parsing (pure) ----------------------------------------------
+
+describe('parseCookies / readSessionId', () => {
+  it('parses a cookie header into a name->value map', () => {
+    expect(parseCookies('a=1; session=abc; b=2')).toEqual({ a: '1', session: 'abc', b: '2' })
+  })
+
+  it('returns an empty map for a null/empty header', () => {
+    expect(parseCookies(null)).toEqual({})
+    expect(parseCookies('')).toEqual({})
+  })
+
+  it('extracts the session id, or null when absent', () => {
+    expect(readSessionId('session=xyz')).toBe('xyz')
+    expect(readSessionId('other=1')).toBeNull()
+    expect(readSessionId(null)).toBeNull()
+  })
+})
+
+// --- dev bypass stub -----------------------------------------------------
+
+describe('dev auth bypass', () => {
+  it('isDevAuthBypassEnabled reads on-ish values', () => {
+    expect(isDevAuthBypassEnabled({ DEV_AUTH_BYPASS: 'true' })).toBe(true)
+    expect(isDevAuthBypassEnabled({ DEV_AUTH_BYPASS: '1' })).toBe(true)
+    expect(isDevAuthBypassEnabled({ DEV_AUTH_BYPASS: 'false' })).toBe(false)
+    expect(isDevAuthBypassEnabled({})).toBe(false)
+  })
+
+  it('dev stub returns a fixed identity for any request', async () => {
+    const reader = createDevAuthBypassReader()
+    expect(await reader.resolve(null)).toEqual({ userId: DEV_AUTH_USER_ID })
+    expect(await reader.resolve('session=anything')).toEqual({ userId: DEV_AUTH_USER_ID })
+  })
+})
+
+// --- real KV reader ------------------------------------------------------
+
+function mockKv(records: Record<string, unknown>): SessionKvReader {
+  return {
+    async get(key: string): Promise<unknown> {
+      return key in records ? records[key] : null
+    },
+  }
+}
+
+describe('createKvSessionReader', () => {
+  it('resolves a valid session record to its userId', async () => {
+    const reader = createKvSessionReader(mockKv({ 'session:s1': { userId: 'u1' } }))
+    expect(await reader.resolve('session=s1')).toEqual({ userId: 'u1' })
+  })
+
+  it('rejects a missing cookie', async () => {
+    const reader = createKvSessionReader(mockKv({ 'session:s1': { userId: 'u1' } }))
+    expect(await reader.resolve(null)).toBeNull()
+    expect(await reader.resolve('other=1')).toBeNull()
+  })
+
+  it('rejects a session id with no stored record', async () => {
+    const reader = createKvSessionReader(mockKv({}))
+    expect(await reader.resolve('session=ghost')).toBeNull()
+  })
+
+  it('rejects a revoked record', async () => {
+    const reader = createKvSessionReader(mockKv({ 'session:s1': { userId: 'u1', revoked: true } }))
+    expect(await reader.resolve('session=s1')).toBeNull()
+  })
+
+  it('rejects an expired record (injectable clock)', async () => {
+    const reader = createKvSessionReader(
+      mockKv({ 'session:s1': { userId: 'u1', expiresAt: 1000 } }),
+      () => 2000
+    )
+    expect(await reader.resolve('session=s1')).toBeNull()
+  })
+
+  it('accepts a not-yet-expired record', async () => {
+    const reader = createKvSessionReader(
+      mockKv({ 'session:s1': { userId: 'u1', expiresAt: 5000 } }),
+      () => 2000
+    )
+    expect(await reader.resolve('session=s1')).toEqual({ userId: 'u1' })
+  })
+})
+
+// --- reader resolution gate ---------------------------------------------
+
+describe('resolveSessionReader', () => {
+  it('returns the dev stub when bypass is on', async () => {
+    const reader = resolveSessionReader({ DEV_AUTH_BYPASS: 'true' })
+    expect(await reader.resolve(null)).toEqual({ userId: DEV_AUTH_USER_ID })
+  })
+
+  it('returns the real KV reader when bypass is off and AUTH is bound', async () => {
+    const reader = resolveSessionReader({
+      DEV_AUTH_BYPASS: 'false',
+      AUTH: mockKv({ 'session:s1': { userId: 'u1' } }),
+    })
+    expect(await reader.resolve('session=s1')).toEqual({ userId: 'u1' })
+  })
+
+  it('throws when bypass is off and AUTH is not bound', () => {
+    expect(() => resolveSessionReader({ DEV_AUTH_BYPASS: 'false' })).toThrow(/AUTH KV/)
+  })
+})
+
+// --- per-operation ownership check --------------------------------------
+
+describe('assertSessionOwnership', () => {
+  const bound = { boundSessionId: 's1', boundUserId: 'u1' }
+
+  it('passes for the bound session + bound user', () => {
+    expect(() => assertSessionOwnership(bound, 's1', 'u1')).not.toThrow()
+  })
+
+  it('rejects an operation before createSession', () => {
+    expect(() =>
+      assertSessionOwnership({ boundSessionId: undefined, boundUserId: undefined }, 's1', 'u1')
+    ).toThrow(/before createSession/)
+  })
+
+  it('rejects a mismatched sessionId (cross-session)', () => {
+    expect(() => assertSessionOwnership(bound, 'other-session', 'u1')).toThrow(
+      /sessionId does not match/
+    )
+  })
+
+  it('rejects a mismatched userId (cross-user access)', () => {
+    expect(() => assertSessionOwnership(bound, 's1', 'intruder')).toThrow(/does not own/)
+  })
+})

--- a/packages/platform-ai/src/auth-seam.test.ts
+++ b/packages/platform-ai/src/auth-seam.test.ts
@@ -48,6 +48,40 @@ describe('parseCookies / readSessionId', () => {
   })
 })
 
+// --- duplicate-cookie first-match (F-V) ---------------------------------
+//
+// A browser can send the same cookie name more than once in one `Cookie` header
+// (a host-only cookie alongside a domain/path variant). The real auth reader
+// (`packages/api/src/auth/session.ts` `readCookie`) iterates `header.split(';')`
+// and RETURNS ON THE FIRST name match — first-match wins. The seam must align:
+// if it kept the LAST value (a naive last-wins map) it would bind a different
+// `amiclaw_session` id at `/ai-ws/*` than the rest of the app, mis-binding the
+// session or 401-ing an already-signed-in user.
+
+describe('parseCookies / readSessionId — duplicate name keeps the FIRST value (F-V)', () => {
+  it('parseCookies keeps the first value for a repeated name', () => {
+    expect(parseCookies(`${COOKIE}=first; ${COOKIE}=second`)).toEqual({ [COOKIE]: 'first' })
+  })
+
+  it('readSessionId reads the first duplicate, matching the real reader’s first-match', () => {
+    expect(readSessionId(`${COOKIE}=first; ${COOKIE}=second`)).toBe('first')
+  })
+
+  it('first-match holds with other cookies interleaved around the duplicates', () => {
+    // host-only variant first, then a domain/path variant of the same name, with
+    // unrelated cookies on either side — the first `amiclaw_session` still wins.
+    expect(readSessionId(`a=1; ${COOKIE}=host; b=2; ${COOKIE}=domain; c=3`)).toBe('host')
+  })
+
+  it('a malformed first duplicate still wins (no fallthrough to a later value)', () => {
+    // First-match is positional, not "first decodable": a malformed first value is
+    // kept raw (F-D fail-closed) and still shadows a well-formed later duplicate,
+    // exactly as the real reader returns the first match regardless of its content.
+    expect(parseCookies(`${COOKIE}=%; ${COOKIE}=good`)).toEqual({ [COOKIE]: '%' })
+    expect(readSessionId(`${COOKIE}=%; ${COOKIE}=good`)).toBe('%')
+  })
+})
+
 // --- malformed-cookie robustness (F-D) ----------------------------------
 //
 // The `Cookie` header is attacker-controlled. A malformed percent-escape makes

--- a/packages/platform-ai/src/auth-seam.test.ts
+++ b/packages/platform-ai/src/auth-seam.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { SESSION_COOKIE_NAME } from '../../../shared/auth-types'
 import {
   assertSessionOwnership,
   createDevAuthBypassReader,
@@ -11,11 +12,16 @@ import {
   type SessionKvReader,
 } from './auth-seam'
 
+// The real auth-session cookie name (`amiclaw_session`), reused from the shared
+// contract so these tests track the same constant the seam imports rather than a
+// hard-coded literal — if the shared name changes, the tests follow.
+const COOKIE = SESSION_COOKIE_NAME
+
 // --- cookie parsing (pure) ----------------------------------------------
 
 describe('parseCookies / readSessionId', () => {
   it('parses a cookie header into a name->value map', () => {
-    expect(parseCookies('a=1; session=abc; b=2')).toEqual({ a: '1', session: 'abc', b: '2' })
+    expect(parseCookies(`a=1; ${COOKIE}=abc; b=2`)).toEqual({ a: '1', [COOKIE]: 'abc', b: '2' })
   })
 
   it('returns an empty map for a null/empty header', () => {
@@ -24,13 +30,21 @@ describe('parseCookies / readSessionId', () => {
   })
 
   it('extracts the session id, or null when absent', () => {
-    expect(readSessionId('session=xyz')).toBe('xyz')
+    expect(readSessionId(`${COOKIE}=xyz`)).toBe('xyz')
     expect(readSessionId('other=1')).toBeNull()
     expect(readSessionId(null)).toBeNull()
   })
 
+  it('reads the real auth cookie name, not a bare `session`', () => {
+    // Guards F-T: a record exists under the legacy `session` cookie name but the
+    // reader must key off the real `amiclaw_session` name. The bare-`session`
+    // cookie carries no session id as far as the seam is concerned.
+    expect(COOKIE).toBe('amiclaw_session')
+    expect(readSessionId('session=xyz')).toBeNull()
+  })
+
   it('percent-decodes a well-formed cookie value', () => {
-    expect(parseCookies('session=a%20b')).toEqual({ session: 'a b' })
+    expect(parseCookies(`${COOKIE}=a%20b`)).toEqual({ [COOKIE]: 'a b' })
   })
 })
 
@@ -45,44 +59,44 @@ describe('parseCookies / readSessionId', () => {
 
 describe('parseCookies — malformed percent-escapes do not throw (F-D)', () => {
   it('keeps a lone-percent value raw instead of throwing', () => {
-    expect(() => parseCookies('session=%')).not.toThrow()
-    expect(parseCookies('session=%')).toEqual({ session: '%' })
+    expect(() => parseCookies(`${COOKIE}=%`)).not.toThrow()
+    expect(parseCookies(`${COOKIE}=%`)).toEqual({ [COOKIE]: '%' })
   })
 
   it('keeps a truncated escape raw instead of throwing', () => {
-    expect(() => parseCookies('session=%E')).not.toThrow()
-    expect(parseCookies('session=%E')).toEqual({ session: '%E' })
+    expect(() => parseCookies(`${COOKIE}=%E`)).not.toThrow()
+    expect(parseCookies(`${COOKIE}=%E`)).toEqual({ [COOKIE]: '%E' })
   })
 
   it('keeps an illegal-byte escape raw instead of throwing', () => {
     // %ZZ is not a valid hex escape; %C3%28 is an invalid UTF-8 sequence.
-    expect(() => parseCookies('session=%ZZ')).not.toThrow()
-    expect(parseCookies('session=%ZZ')).toEqual({ session: '%ZZ' })
-    expect(() => parseCookies('session=%C3%28')).not.toThrow()
-    expect(parseCookies('session=%C3%28')).toEqual({ session: '%C3%28' })
+    expect(() => parseCookies(`${COOKIE}=%ZZ`)).not.toThrow()
+    expect(parseCookies(`${COOKIE}=%ZZ`)).toEqual({ [COOKIE]: '%ZZ' })
+    expect(() => parseCookies(`${COOKIE}=%C3%28`)).not.toThrow()
+    expect(parseCookies(`${COOKIE}=%C3%28`)).toEqual({ [COOKIE]: '%C3%28' })
   })
 
   it('isolates a malformed value to its own pair, keeping siblings decoded', () => {
-    // A bad `session` value must not poison a well-formed sibling cookie.
-    expect(() => parseCookies('a=ok; session=%; b=%41')).not.toThrow()
-    expect(parseCookies('a=ok; session=%; b=%41')).toEqual({ a: 'ok', session: '%', b: 'A' })
+    // A bad session value must not poison a well-formed sibling cookie.
+    expect(() => parseCookies(`a=ok; ${COOKIE}=%; b=%41`)).not.toThrow()
+    expect(parseCookies(`a=ok; ${COOKIE}=%; b=%41`)).toEqual({ a: 'ok', [COOKIE]: '%', b: 'A' })
   })
 
   it('readSessionId stays total on a malformed session cookie', () => {
     // The malformed value survives as a raw string; it does not match a real
     // session record downstream, so the KV reader rejects it (fail-closed).
-    expect(() => readSessionId('session=%')).not.toThrow()
-    expect(readSessionId('session=%')).toBe('%')
+    expect(() => readSessionId(`${COOKIE}=%`)).not.toThrow()
+    expect(readSessionId(`${COOKIE}=%`)).toBe('%')
   })
 })
 
 describe('createKvSessionReader — malformed cookie fails closed, never throws (F-D)', () => {
   it('returns null (unauthorized) for a malformed session cookie', async () => {
-    const reader = createKvSessionReader(mockKv({ 'session:s1': { userId: 'u1' } }))
+    const reader = createKvSessionReader(mockKv({ 'session:s1': realRecord('u1') }))
     // `session:%` is not a stored key → no record → null, not a thrown error.
-    await expect(reader.resolve('session=%')).resolves.toBeNull()
-    await expect(reader.resolve('session=%E')).resolves.toBeNull()
-    await expect(reader.resolve('session=%C3%28')).resolves.toBeNull()
+    await expect(reader.resolve(`${COOKIE}=%`)).resolves.toBeNull()
+    await expect(reader.resolve(`${COOKIE}=%E`)).resolves.toBeNull()
+    await expect(reader.resolve(`${COOKIE}=%C3%28`)).resolves.toBeNull()
   })
 })
 
@@ -99,7 +113,7 @@ describe('dev auth bypass', () => {
   it('dev stub returns a fixed identity for any request', async () => {
     const reader = createDevAuthBypassReader()
     expect(await reader.resolve(null)).toEqual({ userId: DEV_AUTH_USER_ID })
-    expect(await reader.resolve('session=anything')).toEqual({ userId: DEV_AUTH_USER_ID })
+    expect(await reader.resolve(`${COOKIE}=anything`)).toEqual({ userId: DEV_AUTH_USER_ID })
   })
 })
 
@@ -113,42 +127,48 @@ function mockKv(records: Record<string, unknown>): SessionKvReader {
   }
 }
 
+/**
+ * The real stored record shape written by auth-session
+ * (`packages/api/src/auth/session.ts` `SessionRecord`): snake_case `user_id`
+ * plus `email` / `created_at`. The reader resolves identity off `user_id`.
+ */
+function realRecord(userId: string): { user_id: string; email: string; created_at: string } {
+  return { user_id: userId, email: `${userId}@example.com`, created_at: '2026-01-01T00:00:00.000Z' }
+}
+
 describe('createKvSessionReader', () => {
-  it('resolves a valid session record to its userId', async () => {
+  it('resolves a real auth-session record (snake_case user_id) to its userId', async () => {
+    // F-U: the real `session:<id>` record is `{ user_id, email, created_at }`.
+    // The reader keys off `user_id` and surfaces the seam's `{ userId }` identity.
+    const reader = createKvSessionReader(mockKv({ 'session:s1': realRecord('u1') }))
+    expect(await reader.resolve(`${COOKIE}=s1`)).toEqual({ userId: 'u1' })
+  })
+
+  it('rejects a legacy camelCase-only record (F-U)', async () => {
+    // A record carrying only the old camelCase `userId` (the pre-fix stub shape)
+    // has no real `user_id` field → not a valid real session → 401.
     const reader = createKvSessionReader(mockKv({ 'session:s1': { userId: 'u1' } }))
-    expect(await reader.resolve('session=s1')).toEqual({ userId: 'u1' })
+    expect(await reader.resolve(`${COOKIE}=s1`)).toBeNull()
+  })
+
+  it('rejects the right id under the wrong (legacy) cookie name (F-T)', async () => {
+    // The session id is stored, but presented under the bare `session` cookie
+    // name instead of the real `amiclaw_session` → no session id read → 401.
+    const reader = createKvSessionReader(mockKv({ 'session:s1': realRecord('u1') }))
+    expect(await reader.resolve('session=s1')).toBeNull()
   })
 
   it('rejects a missing cookie', async () => {
-    const reader = createKvSessionReader(mockKv({ 'session:s1': { userId: 'u1' } }))
+    const reader = createKvSessionReader(mockKv({ 'session:s1': realRecord('u1') }))
     expect(await reader.resolve(null)).toBeNull()
     expect(await reader.resolve('other=1')).toBeNull()
   })
 
   it('rejects a session id with no stored record', async () => {
+    // A deleted (logout/revoked) or TTL-expired session is an absent KV record;
+    // the real contract has no in-record revoked/expiresAt flag.
     const reader = createKvSessionReader(mockKv({}))
-    expect(await reader.resolve('session=ghost')).toBeNull()
-  })
-
-  it('rejects a revoked record', async () => {
-    const reader = createKvSessionReader(mockKv({ 'session:s1': { userId: 'u1', revoked: true } }))
-    expect(await reader.resolve('session=s1')).toBeNull()
-  })
-
-  it('rejects an expired record (injectable clock)', async () => {
-    const reader = createKvSessionReader(
-      mockKv({ 'session:s1': { userId: 'u1', expiresAt: 1000 } }),
-      () => 2000
-    )
-    expect(await reader.resolve('session=s1')).toBeNull()
-  })
-
-  it('accepts a not-yet-expired record', async () => {
-    const reader = createKvSessionReader(
-      mockKv({ 'session:s1': { userId: 'u1', expiresAt: 5000 } }),
-      () => 2000
-    )
-    expect(await reader.resolve('session=s1')).toEqual({ userId: 'u1' })
+    expect(await reader.resolve(`${COOKIE}=ghost`)).toBeNull()
   })
 })
 
@@ -163,9 +183,9 @@ describe('resolveSessionReader', () => {
   it('returns the real KV reader when bypass is off and AUTH is bound', async () => {
     const reader = resolveSessionReader({
       DEV_AUTH_BYPASS: 'false',
-      AUTH: mockKv({ 'session:s1': { userId: 'u1' } }),
+      AUTH: mockKv({ 'session:s1': realRecord('u1') }),
     })
-    expect(await reader.resolve('session=s1')).toEqual({ userId: 'u1' })
+    expect(await reader.resolve(`${COOKIE}=s1`)).toEqual({ userId: 'u1' })
   })
 
   it('throws when bypass is off and AUTH is not bound', () => {

--- a/packages/platform-ai/src/auth-seam.ts
+++ b/packages/platform-ai/src/auth-seam.ts
@@ -167,6 +167,44 @@ export function assertSessionOwnership(
 }
 
 /**
+ * Resolve the operating user from THIS socket's bound identity and assert it owns
+ * the DO's bound session — the single ownership predicate shared by every inbound
+ * path (control messages AND binary audio frames). Returns the verified operating
+ * user id on success; throws (fail-loud) on any reject path.
+ *
+ * Reject paths:
+ *  - the socket carries no bound identity (never authenticated / never bound) →
+ *    `socket has no authenticated identity`;
+ *  - the DO has no session yet (`boundUserId`/`boundSessionId` undefined) →
+ *    `operation before createSession` (from `assertSessionOwnership`);
+ *  - the socket's user is not the session owner → `userId does not own this
+ *    session` (from `assertSessionOwnership`).
+ *
+ * The binary audio path MUST funnel through this before touching the shared audio
+ * bridge: without it, a second authenticated socket on the same DO (which only
+ * needs to know the session name) could push frames the owner's next `turn`
+ * transcribes — injecting/forging the owner's utterance and bypassing the
+ * per-socket ownership invariant the control path already enforces. Pure and
+ * generic over the socket type, so it is unit-testable in Node without the
+ * Workers `WebSocket` runtime.
+ */
+export function assertSocketOwnsBoundSession<Socket>(
+  registry: SocketIdentityRegistry<Socket>,
+  socket: Socket,
+  bound: { boundSessionId: string | undefined; boundUserId: string | undefined }
+): string {
+  const socketUserId = registry.resolve(socket)
+  if (socketUserId === undefined) {
+    throw new Error('auth-seam: socket has no authenticated identity')
+  }
+  // `boundSessionId` is the operating session id: a socket connected to this DO
+  // operates on this DO's session, so the session axis is satisfied by identity
+  // while the user axis enforces "this socket's user owns the bound session".
+  assertSessionOwnership(bound, bound.boundSessionId as string, socketUserId)
+  return socketUserId
+}
+
+/**
  * Per-socket authenticated identity (L2 §Mechanism Variant 3, step 3).
  *
  * The forwarded `X-Session-User-Id` is the identity of ONE accepted socket, not

--- a/packages/platform-ai/src/auth-seam.ts
+++ b/packages/platform-ai/src/auth-seam.ts
@@ -48,8 +48,28 @@ export const DEV_AUTH_USER_ID = 'dev-user'
 const SESSION_COOKIE_NAME = 'session'
 
 /**
+ * Best-effort percent-decode of a cookie value. The `Cookie` header is
+ * attacker-controlled, and `decodeURIComponent` throws a `URIError` on a
+ * malformed escape (a lone `%`, a half-finished `%E`, an illegal byte). At the
+ * WS handshake an uncaught throw here would surface as a Worker error (500)
+ * instead of the intended "no valid session" outcome — turning a bad cookie into
+ * a crash rather than a clean 401. We catch the decode failure and keep the raw
+ * value: a malformed cookie then simply fails to resolve to a real session id,
+ * which the reader rejects (fail-closed). Pure and total — never throws.
+ */
+function decodeCookieValue(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+/**
  * Parse a `Cookie` request header into a name->value map. Pure and total:
- * a `null`/empty header yields an empty map; malformed pairs are skipped.
+ * a `null`/empty header yields an empty map; malformed pairs are skipped; a
+ * value with a malformed percent-escape is kept raw rather than throwing (the
+ * header is attacker-controlled — see `decodeCookieValue`).
  */
 export function parseCookies(cookieHeader: string | null): Record<string, string> {
   const out: Record<string, string> = {}
@@ -60,7 +80,7 @@ export function parseCookies(cookieHeader: string | null): Record<string, string
     const name = part.slice(0, eq).trim()
     if (name === '') continue
     const value = part.slice(eq + 1).trim()
-    out[name] = decodeURIComponent(value)
+    out[name] = decodeCookieValue(value)
   }
   return out
 }
@@ -202,6 +222,31 @@ export function assertSocketOwnsBoundSession<Socket>(
   // while the user axis enforces "this socket's user owns the bound session".
   assertSessionOwnership(bound, bound.boundSessionId as string, socketUserId)
   return socketUserId
+}
+
+/**
+ * Non-throwing sibling of `assertSocketOwnsBoundSession` for total (no-throw)
+ * call sites such as the socket-close handler. Returns `true` only when THIS
+ * socket carries a bound identity AND that identity owns the DO's bound session
+ * (same predicate the throwing version enforces); `false` for every reject path
+ * — no bound identity, no session yet, or a non-owner socket.
+ *
+ * The close path must be total: a close event fires for owner and non-owner
+ * sockets alike, and a non-owner's close must NOT tear down the owner's shared
+ * audio bridge / in-flight turn (otherwise a second authenticated client on the
+ * same `/ai-ws/{sessionName}` could disconnect and truncate the owner's turn).
+ * Gating bridge teardown on this predicate closes that path while leaving the
+ * non-owner free to release only its own identity binding.
+ */
+export function socketOwnsBoundSession<Socket>(
+  registry: SocketIdentityRegistry<Socket>,
+  socket: Socket,
+  bound: { boundSessionId: string | undefined; boundUserId: string | undefined }
+): boolean {
+  const socketUserId = registry.resolve(socket)
+  if (socketUserId === undefined) return false
+  if (bound.boundUserId === undefined || bound.boundSessionId === undefined) return false
+  return socketUserId === bound.boundUserId
 }
 
 /**

--- a/packages/platform-ai/src/auth-seam.ts
+++ b/packages/platform-ai/src/auth-seam.ts
@@ -13,18 +13,26 @@
  *  - `SessionReader` is the one-method contract: cookie header in, resolved
  *    identity out (or `null` when there is no valid session).
  *  - `createDevAuthBypassReader` is the dev-only stub: when `DEV_AUTH_BYPASS`
- *    is on it returns a fixed development identity, standing in for the real
- *    `AUTH` KV lookup until auth-session's shared session-reader lands.
- *  - `createKvSessionReader` is the real-reader plug-in seam: it reads
- *    `session:<id>` from the bound `AUTH` KV and resolves the identity. The
- *    concrete `session:<id>` value schema is owned by auth-session; this reader
- *    consumes a minimal structural view and never writes.
+ *    is on it returns a fixed development identity for demo / local runs,
+ *    standing in for the real `AUTH` KV lookup.
+ *  - `createKvSessionReader` is the real reader: it reads `session:<id>` from
+ *    the bound `AUTH` KV and resolves the identity. The cookie name and the
+ *    `session:<id>` key + value schema are auth-session's real contract
+ *    (`shared/auth-types.ts` `SESSION_COOKIE_NAME`,
+ *    `packages/api/src/auth/{kv-keys,session}.ts`); this reader consumes a
+ *    minimal structural view of that real record and never writes.
  *  - `resolveSessionReader` is the compile/run-time gate that picks the dev
  *    stub vs. the real reader from env, so the prod path never carries the stub.
  *
  * The mounting contract ("validate at handshake, reject if invalid, bind
  * userId") is fixed regardless of which reader is active.
  */
+
+// The cookie name and the stored-record shape are the real auth-session
+// contract (`implement-magic-link-auth`, merged to main). Reuse the shared
+// cookie constant verbatim, and mirror the stored record shape from
+// `packages/api/src/auth/session.ts` (`SessionRecord`) — see `StoredSession`.
+import { SESSION_COOKIE_NAME } from '../../../shared/auth-types'
 
 /** Resolved, already-authenticated identity for a WS session. */
 export interface AuthIdentity {
@@ -43,9 +51,6 @@ export interface SessionReader {
 
 /** Fixed identity returned by the dev bypass stub. */
 export const DEV_AUTH_USER_ID = 'dev-user'
-
-/** Cookie name carrying the auth-session id (owned by auth-session). */
-const SESSION_COOKIE_NAME = 'session'
 
 /**
  * Best-effort percent-decode of a cookie value. The `Cookie` header is
@@ -116,44 +121,44 @@ export interface SessionKvReader {
 }
 
 /**
- * Minimal structural view of a stored `session:<id>` record. The full schema is
- * owned by auth-session; this reader consumes only what it needs to resolve an
- * identity and honour revocation. Unknown extra fields are ignored.
+ * Minimal structural view of a stored `session:<id>` record.
+ *
+ * Shape authority: `packages/api/src/auth/session.ts` `SessionRecord`
+ * (`{ user_id, email, created_at }`, snake_case) — this view MUST stay aligned
+ * with it. The reader only needs `user_id` to resolve identity; `email` /
+ * `created_at` are present in the real record but unused here. Unknown extra
+ * fields are ignored.
+ *
+ * Validity, per the real contract: a session is valid iff its record is present
+ * in KV. Revocation is a KV delete (logout) and expiry is the KV `expirationTtl`
+ * — both surface as an absent record, so there is no in-record `revoked` /
+ * `expiresAt` field to inspect. Presence of the record is the single check.
  */
 interface StoredSession {
-  userId?: string
-  /** Optional epoch-ms expiry; a past value is treated as no valid session. */
-  expiresAt?: number
-  /** Optional revocation flag; `true` is treated as no valid session. */
-  revoked?: boolean
+  user_id?: string
 }
 
 /**
  * Real session-reader plug-in seam: cookie -> session id -> `AUTH` KV `session:<id>`
- * -> identity. Read-only. Returns `null` for a missing cookie, a missing
- * record, a revoked record, or an expired record. `now` is injectable so expiry
- * is testable without wall-clock coupling.
+ * -> identity. Read-only. Returns `null` for a missing cookie or a missing
+ * record (a deleted/expired session is an absent record — see `StoredSession`).
  *
- * The exact `session:<id>` value schema is auth-session's contract; once its
- * shared reader lands this wrapper is the single plug-in point to swap in.
+ * The `session:<id>` key shape and value schema are the auth-session contract
+ * (`packages/api/src/auth/kv-keys.ts` `sessionKey`, `session.ts` `SessionRecord`);
+ * this reader consumes that real shape directly.
  */
-export function createKvSessionReader(
-  kv: SessionKvReader,
-  now: () => number = Date.now
-): SessionReader {
+export function createKvSessionReader(kv: SessionKvReader): SessionReader {
   return {
     async resolve(cookieHeader: string | null): Promise<AuthIdentity | null> {
       const sessionId = readSessionId(cookieHeader)
       if (sessionId === null) return null
 
       const record = (await kv.get(`session:${sessionId}`, 'json')) as StoredSession | null
-      if (record === null || typeof record.userId !== 'string' || record.userId === '') {
+      if (record === null || typeof record.user_id !== 'string' || record.user_id === '') {
         return null
       }
-      if (record.revoked === true) return null
-      if (typeof record.expiresAt === 'number' && record.expiresAt <= now()) return null
 
-      return { userId: record.userId }
+      return { userId: record.user_id }
     },
   }
 }

--- a/packages/platform-ai/src/auth-seam.ts
+++ b/packages/platform-ai/src/auth-seam.ts
@@ -166,6 +166,53 @@ export function assertSessionOwnership(
   }
 }
 
+/**
+ * Per-socket authenticated identity (L2 §Mechanism Variant 3, step 3).
+ *
+ * The forwarded `X-Session-User-Id` is the identity of ONE accepted socket, not
+ * a property of the DO instance. Two already-authenticated clients connecting to
+ * the same-named DO share one instance, so storing the forwarded id in a single
+ * instance field lets the later upgrade overwrite the earlier one — after which
+ * a `create`/`turn`/`end` from socket A would run under socket B's user. Binding
+ * the id to the specific accepted socket and resolving it per message removes
+ * that cross-socket contamination.
+ *
+ * `WebSocket` identity (reference equality) is the map key, so this works
+ * regardless of how the socket is accepted (hibernation or plain `accept()`):
+ * each accepted socket maps to its own forwarded user id, and a control message
+ * resolves the id of the exact socket it arrived on.
+ *
+ * Kept generic over the socket type (`Socket`) so it is unit-testable in Node
+ * without the Workers `WebSocket` runtime — the DO instantiates it with the real
+ * `WebSocket` type.
+ */
+export class SocketIdentityRegistry<Socket> {
+  private readonly bySocket = new Map<Socket, string>()
+
+  /** Bind the authenticated user id to a freshly accepted socket. */
+  bind(socket: Socket, userId: string): void {
+    this.bySocket.set(socket, userId)
+  }
+
+  /**
+   * The user id bound to THIS socket, or `undefined` if the socket was never
+   * bound (e.g. a control message before the upgrade bound an identity).
+   */
+  resolve(socket: Socket): string | undefined {
+    return this.bySocket.get(socket)
+  }
+
+  /** Drop a socket's binding when it closes, so the map does not leak entries. */
+  release(socket: Socket): void {
+    this.bySocket.delete(socket)
+  }
+
+  /** Number of currently bound sockets — test/inspection aid. */
+  get size(): number {
+    return this.bySocket.size
+  }
+}
+
 /** Env shape the seam reads to decide which reader to construct. */
 export interface AuthSeamEnv {
   DEV_AUTH_BYPASS?: string

--- a/packages/platform-ai/src/auth-seam.ts
+++ b/packages/platform-ai/src/auth-seam.ts
@@ -75,6 +75,17 @@ function decodeCookieValue(value: string): string {
  * a `null`/empty header yields an empty map; malformed pairs are skipped; a
  * value with a malformed percent-escape is kept raw rather than throwing (the
  * header is attacker-controlled — see `decodeCookieValue`).
+ *
+ * Duplicate cookie names resolve to the FIRST occurrence, matching the real
+ * auth reader (`packages/api/src/auth/session.ts` `readCookie`, which iterates
+ * `Cookie.split(';')` and returns on the first name match). A browser can send
+ * the same `amiclaw_session` name more than once (a host-only cookie alongside
+ * a domain/path variant); the real reader binds the first, so this seam must
+ * too — otherwise `/ai-ws/*` would bind a different session id (last value)
+ * than the rest of the app, mis-binding or 401-ing an already-signed-in user.
+ * Split-and-trim semantics (name + value `.trim()`, case-sensitive exact name
+ * match, single `Cookie` header) also mirror that reader; only the duplicate
+ * resolution differs from a naive last-wins map, so it is pinned here.
  */
 export function parseCookies(cookieHeader: string | null): Record<string, string> {
   const out: Record<string, string> = {}
@@ -84,6 +95,10 @@ export function parseCookies(cookieHeader: string | null): Record<string, string
     if (eq === -1) continue
     const name = part.slice(0, eq).trim()
     if (name === '') continue
+    // First-match wins: a later duplicate of the same name is ignored, aligning
+    // `readSessionId` with the real reader's first-match. (A naive `out[name] =`
+    // would keep the LAST value and diverge.)
+    if (Object.prototype.hasOwnProperty.call(out, name)) continue
     const value = part.slice(eq + 1).trim()
     out[name] = decodeCookieValue(value)
   }
@@ -230,28 +245,36 @@ export function assertSocketOwnsBoundSession<Socket>(
 }
 
 /**
- * Non-throwing sibling of `assertSocketOwnsBoundSession` for total (no-throw)
- * call sites such as the socket-close handler. Returns `true` only when THIS
- * socket carries a bound identity AND that identity owns the DO's bound session
- * (same predicate the throwing version enforces); `false` for every reject path
- * — no bound identity, no session yet, or a non-owner socket.
+ * Total (no-throw) predicate for the socket-close handler: is the closing socket
+ * the EXACT socket that created/bound the session?
  *
- * The close path must be total: a close event fires for owner and non-owner
- * sockets alike, and a non-owner's close must NOT tear down the owner's shared
- * audio bridge / in-flight turn (otherwise a second authenticated client on the
- * same `/ai-ws/{sessionName}` could disconnect and truncate the owner's turn).
- * Gating bridge teardown on this predicate closes that path while leaving the
- * non-owner free to release only its own identity binding.
+ * Returns `true` only when (a) a session is currently bound (`boundUserId`/
+ * `boundSessionId` defined) and (b) `socket` is reference-equal to
+ * `ownerSocket` — the WebSocket recorded at `createSession`. `false` for every
+ * other case: no session yet, no owner socket recorded, or a different socket
+ * (even one whose user id matches the bound owner).
+ *
+ * Why socket identity, NOT user id: the same already-authenticated user can open
+ * a SECOND socket to the same `/ai-ws/{sessionName}` DO (a duplicate tab or a
+ * reconnect). A user-id match would mark that second socket as an owner, so when
+ * IT closes the handler would `clearSession()` and tear down the STILL-ACTIVE
+ * original session / in-flight turn. Binding teardown to the creator socket's
+ * reference means only the socket that actually owns the session can end it; a
+ * same-user duplicate socket's close releases just its own identity binding.
+ *
+ * The registry param is unused for the owner check (kept for call-site symmetry
+ * with `assertSocketOwnsBoundSession` and to leave room for a future
+ * identity-aware variant); ownership here is purely the recorded-socket identity
+ * plus the bound-session guard.
  */
-export function socketOwnsBoundSession<Socket>(
-  registry: SocketIdentityRegistry<Socket>,
+export function socketIsBoundSessionOwner<Socket>(
   socket: Socket,
+  ownerSocket: Socket | undefined,
   bound: { boundSessionId: string | undefined; boundUserId: string | undefined }
 ): boolean {
-  const socketUserId = registry.resolve(socket)
-  if (socketUserId === undefined) return false
   if (bound.boundUserId === undefined || bound.boundSessionId === undefined) return false
-  return socketUserId === bound.boundUserId
+  if (ownerSocket === undefined) return false
+  return socket === ownerSocket
 }
 
 /**

--- a/packages/platform-ai/src/auth-seam.ts
+++ b/packages/platform-ai/src/auth-seam.ts
@@ -1,0 +1,197 @@
+/**
+ * Handshake-time session authentication seam (L2 §Mechanism Variant 3).
+ *
+ * The Platform AI Worker mounts a same-origin WS route (`claw.amio.fans/ai-ws/*`)
+ * so the auth-session cookie rides along on the upgrade request. Before the
+ * upgrade is accepted, the Worker must validate that cookie and resolve a
+ * `userId`; an invalid/absent session is rejected at the handshake (401, no
+ * upgrade).
+ *
+ * This module is the seam for that check, kept pure and dependency-light so it
+ * is unit-testable without a live KV / network:
+ *
+ *  - `SessionReader` is the one-method contract: cookie header in, resolved
+ *    identity out (or `null` when there is no valid session).
+ *  - `createDevAuthBypassReader` is the dev-only stub: when `DEV_AUTH_BYPASS`
+ *    is on it returns a fixed development identity, standing in for the real
+ *    `AUTH` KV lookup until auth-session's shared session-reader lands.
+ *  - `createKvSessionReader` is the real-reader plug-in seam: it reads
+ *    `session:<id>` from the bound `AUTH` KV and resolves the identity. The
+ *    concrete `session:<id>` value schema is owned by auth-session; this reader
+ *    consumes a minimal structural view and never writes.
+ *  - `resolveSessionReader` is the compile/run-time gate that picks the dev
+ *    stub vs. the real reader from env, so the prod path never carries the stub.
+ *
+ * The mounting contract ("validate at handshake, reject if invalid, bind
+ * userId") is fixed regardless of which reader is active.
+ */
+
+/** Resolved, already-authenticated identity for a WS session. */
+export interface AuthIdentity {
+  userId: string
+}
+
+/**
+ * Handshake-time session validator. Given the raw `Cookie` request header,
+ * resolve the authenticated identity, or `null` when there is no valid session.
+ * Pure with respect to its inputs aside from the (async) KV read in the real
+ * implementation; the dev stub is fully synchronous in spirit.
+ */
+export interface SessionReader {
+  resolve(cookieHeader: string | null): Promise<AuthIdentity | null>
+}
+
+/** Fixed identity returned by the dev bypass stub. */
+export const DEV_AUTH_USER_ID = 'dev-user'
+
+/** Cookie name carrying the auth-session id (owned by auth-session). */
+const SESSION_COOKIE_NAME = 'session'
+
+/**
+ * Parse a `Cookie` request header into a name->value map. Pure and total:
+ * a `null`/empty header yields an empty map; malformed pairs are skipped.
+ */
+export function parseCookies(cookieHeader: string | null): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!cookieHeader) return out
+  for (const part of cookieHeader.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    const name = part.slice(0, eq).trim()
+    if (name === '') continue
+    const value = part.slice(eq + 1).trim()
+    out[name] = decodeURIComponent(value)
+  }
+  return out
+}
+
+/** Extract the auth-session id from a `Cookie` header, or `null` if absent. */
+export function readSessionId(cookieHeader: string | null): string | null {
+  const cookies = parseCookies(cookieHeader)
+  const id = cookies[SESSION_COOKIE_NAME]
+  return id && id.length > 0 ? id : null
+}
+
+/**
+ * Dev-only stub reader. When `DEV_AUTH_BYPASS` is on, returns a fixed
+ * development identity for any request — standing in for the real `AUTH` KV
+ * lookup. The prod build gates this branch out via `resolveSessionReader`, so
+ * the stub never reaches a production handshake.
+ */
+export function createDevAuthBypassReader(): SessionReader {
+  return {
+    async resolve(): Promise<AuthIdentity | null> {
+      return { userId: DEV_AUTH_USER_ID }
+    },
+  }
+}
+
+/**
+ * Minimal structural view of a bound KV namespace — just the read we need.
+ * Narrower than the full `KVNamespace` lib type so the reader stays testable
+ * with a plain object mock.
+ */
+export interface SessionKvReader {
+  get(key: string, type: 'json'): Promise<unknown>
+}
+
+/**
+ * Minimal structural view of a stored `session:<id>` record. The full schema is
+ * owned by auth-session; this reader consumes only what it needs to resolve an
+ * identity and honour revocation. Unknown extra fields are ignored.
+ */
+interface StoredSession {
+  userId?: string
+  /** Optional epoch-ms expiry; a past value is treated as no valid session. */
+  expiresAt?: number
+  /** Optional revocation flag; `true` is treated as no valid session. */
+  revoked?: boolean
+}
+
+/**
+ * Real session-reader plug-in seam: cookie -> session id -> `AUTH` KV `session:<id>`
+ * -> identity. Read-only. Returns `null` for a missing cookie, a missing
+ * record, a revoked record, or an expired record. `now` is injectable so expiry
+ * is testable without wall-clock coupling.
+ *
+ * The exact `session:<id>` value schema is auth-session's contract; once its
+ * shared reader lands this wrapper is the single plug-in point to swap in.
+ */
+export function createKvSessionReader(
+  kv: SessionKvReader,
+  now: () => number = Date.now
+): SessionReader {
+  return {
+    async resolve(cookieHeader: string | null): Promise<AuthIdentity | null> {
+      const sessionId = readSessionId(cookieHeader)
+      if (sessionId === null) return null
+
+      const record = (await kv.get(`session:${sessionId}`, 'json')) as StoredSession | null
+      if (record === null || typeof record.userId !== 'string' || record.userId === '') {
+        return null
+      }
+      if (record.revoked === true) return null
+      if (typeof record.expiresAt === 'number' && record.expiresAt <= now()) return null
+
+      return { userId: record.userId }
+    },
+  }
+}
+
+/**
+ * Per-operation ownership check (L2 §Mechanism Variant 3, step 3): every
+ * post-create operation must target the bound session and bound user. Throws a
+ * precise error on any mismatch so an out-of-order or cross-user call is
+ * rejected loudly. Pure — extracted from the DO so it is unit-testable without
+ * the Workers runtime.
+ *
+ * @param bound        identity bound at `createSession` (`undefined` if not yet created)
+ * @param boundSession this DO's session id (`undefined` if not yet created)
+ * @param sessionId    session id the caller is operating on
+ * @param userId       user id the caller claims
+ */
+export function assertSessionOwnership(
+  bound: { boundSessionId: string | undefined; boundUserId: string | undefined },
+  sessionId: string,
+  userId: string
+): void {
+  if (bound.boundUserId === undefined || bound.boundSessionId === undefined) {
+    throw new Error('auth-seam: operation before createSession')
+  }
+  if (sessionId !== bound.boundSessionId) {
+    throw new Error('auth-seam: sessionId does not match this session')
+  }
+  if (userId !== bound.boundUserId) {
+    throw new Error('auth-seam: userId does not own this session')
+  }
+}
+
+/** Env shape the seam reads to decide which reader to construct. */
+export interface AuthSeamEnv {
+  DEV_AUTH_BYPASS?: string
+  AUTH?: SessionKvReader
+}
+
+/** True when the `DEV_AUTH_BYPASS` env var is set to an on-ish value. */
+export function isDevAuthBypassEnabled(env: AuthSeamEnv): boolean {
+  const flag = env.DEV_AUTH_BYPASS
+  return flag === 'true' || flag === '1'
+}
+
+/**
+ * Pick the active reader from env. Dev bypass wins when enabled; otherwise the
+ * real `AUTH` KV reader is required. Throwing on a missing `AUTH` binding (when
+ * not in dev bypass) makes a mis-wired prod deploy fail loudly at the first
+ * handshake rather than silently letting everyone in.
+ */
+export function resolveSessionReader(env: AuthSeamEnv): SessionReader {
+  if (isDevAuthBypassEnabled(env)) {
+    return createDevAuthBypassReader()
+  }
+  if (!env.AUTH) {
+    throw new Error(
+      'auth-seam: AUTH KV namespace is not bound and DEV_AUTH_BYPASS is off — cannot validate sessions'
+    )
+  }
+  return createKvSessionReader(env.AUTH)
+}

--- a/packages/platform-ai/src/contract.ts
+++ b/packages/platform-ai/src/contract.ts
@@ -1,0 +1,139 @@
+/**
+ * Four-method voice-session contract for the Platform AI Interface.
+ *
+ * This is the type-shape SSOT for the game-agnostic session orchestration
+ * contract: `createSession` / `onPlayerAudio` / `onAiResponse` / `endSession`.
+ * It defines the *semantic* contract only — the Durable Object / WebSocket
+ * server that implements it lands in a later round.
+ *
+ * Architectural rationale lives in the L2 component spec
+ * (arch-component-platform-ai-interface). Two load-bearing constraints from
+ * that spec are encoded directly in these signatures:
+ *
+ *  1. The system prompt is NOT a `createSession` parameter. It is resolved
+ *     server-side from `gameId` via `provider-config` (see `provider-config.ts`).
+ *     Browser-side consumers connect over WebSocket and must never carry prompt
+ *     material on the wire — this keeps "system prompt is server-side only"
+ *     intact. Only the per-run `manualData` is passed in.
+ *
+ *  2. The contract is protocol-neutral: it names the session lifecycle
+ *     (create / feed audio / receive response / end) without coupling to any
+ *     vendor protocol. Provider-protocol differences are encapsulated inside
+ *     each adapter (see `providers/types.ts`).
+ */
+
+/** Opaque server-issued identifier for a single voice collaboration session. */
+export type SessionId = string
+
+/** Identifier for a game registered in `provider-config` (e.g. 'yijing-oracle'). */
+export type GameId = string
+
+/** Already-authenticated user identifier, bound into the session on creation. */
+export type UserId = string
+
+/**
+ * One inbound audio frame from the player, streamed in over the session
+ * WebSocket. The platform-ai layer treats it as an opaque binary frame; the
+ * STT adapter owns the concrete encoding/sample-rate contract.
+ */
+export type AudioChunk = Uint8Array
+
+/**
+ * Game-agnostic manual payload handed to the platform per run. The platform
+ * deterministically selects a relevant subset by game state and injects it
+ * into the LLM context (it does NOT rely on model function-calling to fetch
+ * manual content). Kept structurally open here because each game's manual
+ * schema differs; a concrete game (e.g. BombSquad) narrows `sections` to its
+ * own typed manual shape at its call site.
+ */
+export interface ManualData {
+  /** Manual version / build identifier, for provenance and cache keys. */
+  version: string
+  /**
+   * Addressable manual sections keyed by a stable section id. The platform
+   * selects a subset of these keys by game state for deterministic injection.
+   * Values are intentionally untyped at the platform layer — the game owns the
+   * concrete section schema.
+   */
+  sections: Record<string, unknown>
+}
+
+/**
+ * One chunk of the AI's streamed response. A turn produces an ordered stream of
+ * these: incremental assistant text plus the synthesized audio frames pushed
+ * back over the same WebSocket. `kind` discriminates the two; `done` marks the
+ * final chunk of a turn so the consumer can close out the turn without a
+ * separate end signal.
+ */
+export interface AiResponseChunk {
+  /** Which modality this chunk carries. */
+  kind: 'text' | 'audio'
+  /** Incremental assistant text (present when `kind === 'text'`). */
+  text?: string
+  /** Synthesized TTS audio frame (present when `kind === 'audio'`). */
+  audio?: Uint8Array
+  /** True on the last chunk of the current turn. */
+  done: boolean
+}
+
+/**
+ * Returned by `endSession`. Carries session metadata and the metering mount
+ * point (token / audio-duration counters) for the downstream usage-metering
+ * task. The platform-ai layer only *populates* these counts; aggregation by
+ * user/date is a separate downstream component.
+ */
+export interface SessionSummary {
+  sessionId: SessionId
+  gameId: GameId
+  userId: UserId
+  /** Number of completed player->AI turns in this session. */
+  turnCount: number
+  /** Mount point for usage metering — concrete accounting is downstream. */
+  usage: {
+    /** LLM input tokens consumed across the session. */
+    llmInputTokens: number
+    /** LLM output tokens produced across the session. */
+    llmOutputTokens: number
+    /** STT input audio seconds sent to the speech provider. */
+    sttInputSeconds: number
+    /** TTS output audio seconds synthesized by the speech provider. */
+    ttsOutputSeconds: number
+  }
+}
+
+/**
+ * The four-method session contract. Implemented by the Durable Object backed
+ * server in a later round; defined here as the type-shape SSOT so consumers and
+ * the future implementation share one contract.
+ */
+export interface VoiceSessionContract {
+  /**
+   * Create a voice collaboration session. Called by a game-specific consumer
+   * with the game id, the already-authenticated user id, and this run's manual
+   * data. The platform resolves the game's system-prompt config from `gameId`
+   * via `provider-config` (the consumer does NOT pass a system prompt),
+   * assembles the system prompt, initializes session state, and returns a
+   * `SessionId`.
+   */
+  createSession(gameId: GameId, userId: UserId, manualData: ManualData): Promise<SessionId>
+
+  /**
+   * Feed one player audio frame into the session. Drives the
+   * STT -> LLM -> TTS turn pipeline. Fire-and-forget at the contract level; the
+   * resulting AI output surfaces via `onAiResponse`.
+   */
+  onPlayerAudio(sessionId: SessionId, audioChunk: AudioChunk): Promise<void>
+
+  /**
+   * Subscribe to the session's AI response stream — incremental assistant text
+   * and synthesized audio frames. Semantic placeholder: does not promise a
+   * synchronous or one-shot shape.
+   */
+  onAiResponse(sessionId: SessionId): AsyncIterable<AiResponseChunk>
+
+  /**
+   * End the session: close the long connection, settle session state, and
+   * return the `SessionSummary` (for the metering mount point and ops review).
+   */
+  endSession(sessionId: SessionId): Promise<SessionSummary>
+}

--- a/packages/platform-ai/src/index.ts
+++ b/packages/platform-ai/src/index.ts
@@ -1,0 +1,89 @@
+/**
+ * Public surface of `@amiclaw/platform-ai`.
+ *
+ * Exports the foundation layer (four-method session contract, three-layer
+ * provider interfaces, provider-config selection, deterministic manual
+ * injection) plus the runtime core: the provider factory, the handshake auth
+ * seam, the testable turn-pipeline orchestration, the `VoiceSessionDO` Durable
+ * Object class (required as a named export for wrangler's DO class binding),
+ * and the Worker `fetch` entry as the module default.
+ */
+
+// Four-method session contract + wire types.
+export type {
+  SessionId,
+  GameId,
+  UserId,
+  AudioChunk,
+  ManualData,
+  AiResponseChunk,
+  SessionSummary,
+  VoiceSessionContract,
+} from './contract'
+
+// Three-layer provider semantic interfaces.
+export type {
+  ChatRole,
+  ChatMessage,
+  LlmCompletionRequest,
+  LlmCompletionChunk,
+  LlmUsage,
+  LlmProvider,
+  SttTranscriptChunk,
+  SttProvider,
+  TtsAudioChunk,
+  TtsProvider,
+} from './providers/types'
+
+// Provider selection layer.
+export type {
+  ProviderLayer,
+  LayerSelection,
+  SystemPromptConfig,
+  ProviderConfig,
+  ResolvedConfig,
+} from './provider-config'
+export { resolveConfig } from './provider-config'
+
+// Deterministic manual injection.
+export type { GameState, AssembleLlmContextInput } from './manual-injection'
+export { assembleLlmContext } from './manual-injection'
+
+// Provider factory — wire a resolved config to concrete R2 adapters.
+export type { ProviderEnv, SessionProviders } from './providers/factory'
+export { createProviders } from './providers/factory'
+
+// Deterministic mock providers — no-credential demo / e2e harness backend.
+export type { MockLlmProvider, MockLlmProviderOptions } from './providers/mock'
+export {
+  createMockLlmProvider,
+  createMockSttProvider,
+  createMockTtsProvider,
+  createMockSpeechProvider,
+  MOCK_TRANSCRIPT,
+} from './providers/mock'
+
+// Handshake-time auth seam.
+export type { AuthIdentity, SessionReader, SessionKvReader, AuthSeamEnv } from './auth-seam'
+export {
+  parseCookies,
+  readSessionId,
+  isDevAuthBypassEnabled,
+  resolveSessionReader,
+  createDevAuthBypassReader,
+  createKvSessionReader,
+  assertSessionOwnership,
+  DEV_AUTH_USER_ID,
+} from './auth-seam'
+
+// Testable turn-pipeline orchestration (DO is a thin shell over this).
+export type { UsageCounters, SessionState, TurnProviders } from './turn-pipeline'
+export { runTurn, splitSentences } from './turn-pipeline'
+
+// Durable Object class (named export required for the wrangler DO binding).
+export { VoiceSessionDO } from './session-do'
+export type { SessionDoEnv } from './session-do'
+
+// Worker fetch entry + its env shape.
+export type { WorkerEnv } from './worker'
+export { default } from './worker'

--- a/packages/platform-ai/src/index.ts
+++ b/packages/platform-ai/src/index.ts
@@ -73,6 +73,7 @@ export {
   createDevAuthBypassReader,
   createKvSessionReader,
   assertSessionOwnership,
+  SocketIdentityRegistry,
   DEV_AUTH_USER_ID,
 } from './auth-seam'
 

--- a/packages/platform-ai/src/manual-injection.test.ts
+++ b/packages/platform-ai/src/manual-injection.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { assembleLlmContext, type GameState } from './manual-injection'
+import type { ManualData } from './contract'
+import type { SystemPromptConfig } from './provider-config'
+
+const systemPromptConfig: SystemPromptConfig = {
+  role: 'You are the demo manual-explainer partner.',
+  ruleTemplate: ['Only use the provided manual.', 'Give one next action at a time.'],
+}
+
+const manualData: ManualData = {
+  version: '2026-06-08',
+  sections: {
+    wire_routing: { rules: ['cut the third wire if two batteries'] },
+    keypad: { sequences: ['psi', 'omega'] },
+    button: { rules: ['hold if red'] },
+  },
+}
+
+describe('assembleLlmContext — system prompt', () => {
+  it('puts role and every rule into the single system message', () => {
+    const messages = assembleLlmContext({
+      systemPromptConfig,
+      manualData,
+      gameState: { relevantSections: [] },
+    })
+    expect(messages).toHaveLength(1)
+    expect(messages[0].role).toBe('system')
+    expect(messages[0].content).toContain('You are the demo manual-explainer partner.')
+    expect(messages[0].content).toContain('Only use the provided manual.')
+    expect(messages[0].content).toContain('Give one next action at a time.')
+  })
+
+  it('handles an empty rule template by emitting just the role line', () => {
+    const messages = assembleLlmContext({
+      systemPromptConfig: { role: 'Bare role.', ruleTemplate: [] },
+      manualData,
+      gameState: { relevantSections: [] },
+    })
+    expect(messages[0].content).toContain('Bare role.')
+    expect(messages[0].content).not.toContain('Rules:')
+  })
+})
+
+describe('assembleLlmContext — manual subset selection by game state', () => {
+  it('injects only the sections named by game state, in the requested order', () => {
+    const gameState: GameState = { relevantSections: ['keypad', 'wire_routing'] }
+    const messages = assembleLlmContext({ systemPromptConfig, manualData, gameState })
+    const content = messages[0].content
+    expect(content).toContain('### keypad')
+    expect(content).toContain('### wire_routing')
+    // The unselected section must NOT appear.
+    expect(content).not.toContain('### button')
+    // Order: keypad heading precedes wire_routing heading.
+    expect(content.indexOf('### keypad')).toBeLessThan(content.indexOf('### wire_routing'))
+  })
+
+  it('silently drops unknown section ids rather than throwing', () => {
+    const gameState: GameState = { relevantSections: ['wire_routing', 'does_not_exist'] }
+    const messages = assembleLlmContext({ systemPromptConfig, manualData, gameState })
+    expect(messages[0].content).toContain('### wire_routing')
+    expect(messages[0].content).not.toContain('does_not_exist')
+  })
+
+  it('emits an explicit "no relevant sections" marker when nothing is selected', () => {
+    const messages = assembleLlmContext({
+      systemPromptConfig,
+      manualData,
+      gameState: { relevantSections: [] },
+    })
+    expect(messages[0].content).toContain('no relevant manual sections')
+  })
+
+  it('includes the manual version for provenance', () => {
+    const messages = assembleLlmContext({
+      systemPromptConfig,
+      manualData,
+      gameState: { relevantSections: ['button'] },
+    })
+    expect(messages[0].content).toContain('2026-06-08')
+  })
+
+  it('is deterministic: identical inputs yield byte-identical messages', () => {
+    const gameState: GameState = { relevantSections: ['button', 'keypad'] }
+    const a = assembleLlmContext({ systemPromptConfig, manualData, gameState })
+    const b = assembleLlmContext({ systemPromptConfig, manualData, gameState })
+    expect(a).toEqual(b)
+  })
+})
+
+describe('assembleLlmContext — server-side-only confinement', () => {
+  it('keeps all prompt and manual material in the system role, never in a client-facing role', () => {
+    const messages = assembleLlmContext({
+      systemPromptConfig,
+      manualData,
+      gameState: { relevantSections: ['wire_routing', 'keypad', 'button'] },
+    })
+    // Every message produced here must be a system message — the role/rules and
+    // the injected manual subset are server-side material. No user/assistant
+    // message (the roles that round-trip toward the client/transcript) may
+    // carry this content. This is the structural guard for "system prompt and
+    // manual stay server-side, never client-held".
+    for (const message of messages) {
+      expect(message.role).toBe('system')
+    }
+    const clientFacing = messages.filter((m) => m.role === 'user' || m.role === 'assistant')
+    expect(clientFacing).toHaveLength(0)
+  })
+})

--- a/packages/platform-ai/src/manual-injection.ts
+++ b/packages/platform-ai/src/manual-injection.ts
@@ -1,0 +1,97 @@
+/**
+ * Deterministic manual injection.
+ *
+ * Pure function `assembleLlmContext` builds the OpenAI-compatible `messages[]`
+ * for one turn:
+ *   - The role + rule template (from `provider-config`'s `systemPromptConfig`)
+ *     go into the system message.
+ *   - The manual subset selected by game state is injected directly into the
+ *     context, deterministically — the platform decides which manual sections
+ *     are relevant, rather than relying on the model's function-calling to go
+ *     fetch them.
+ *
+ * Determinism is the point: given the same config, manual, and game state, the
+ * assembled messages are byte-identical. No model in the loop here.
+ */
+
+import type { ManualData } from './contract'
+import type { ChatMessage } from './providers/types'
+import type { SystemPromptConfig } from './provider-config'
+
+/**
+ * Game state that drives manual-subset selection. `relevantSections` is the
+ * ordered list of manual section ids the platform deems relevant for the
+ * current turn (e.g. the current module/phase). The game owns how it derives
+ * this list; injection only consumes it.
+ */
+export interface GameState {
+  /** Ordered manual section ids to inject for this turn. */
+  relevantSections: string[]
+}
+
+/** Input to `assembleLlmContext`. */
+export interface AssembleLlmContextInput {
+  systemPromptConfig: SystemPromptConfig
+  manualData: ManualData
+  gameState: GameState
+}
+
+/**
+ * Build the system-message text from a game's system-prompt config: the role
+ * line followed by the rule template, one rule per line.
+ */
+function buildSystemPrompt(config: SystemPromptConfig): string {
+  if (config.ruleTemplate.length === 0) {
+    return config.role
+  }
+  const rules = config.ruleTemplate.map((rule) => `- ${rule}`).join('\n')
+  return `${config.role}\n\nRules:\n${rules}`
+}
+
+/**
+ * Serialize the selected manual subset into a single injected block. Only the
+ * sections named in `gameState.relevantSections` that actually exist in the
+ * manual are included, in the order requested. Selection is deterministic and
+ * silent-drops unknown ids (the game owns its own id space; an unknown id just
+ * contributes nothing rather than throwing — a missing optional section is a
+ * normal game-state condition, not an error).
+ */
+function buildManualInjection(manualData: ManualData, gameState: GameState): string {
+  const blocks: string[] = []
+  for (const sectionId of gameState.relevantSections) {
+    if (Object.prototype.hasOwnProperty.call(manualData.sections, sectionId)) {
+      const value = manualData.sections[sectionId]
+      blocks.push(`### ${sectionId}\n${JSON.stringify(value, null, 2)}`)
+    }
+  }
+  const header = `Manual (version ${manualData.version}) — relevant sections for the current state:`
+  if (blocks.length === 0) {
+    return `${header}\n(no relevant manual sections for the current state)`
+  }
+  return `${header}\n\n${blocks.join('\n\n')}`
+}
+
+/**
+ * Assemble the OpenAI-compatible message array for one turn.
+ *
+ * Returns exactly two messages:
+ *   1. a `system` message carrying role + rules + the injected manual subset
+ *      (all server-side material — it never leaves the server boundary), and
+ *   2. nothing else here: conversation history / the player's transcribed turn
+ *      are appended by the turn pipeline downstream. Keeping this function to
+ *      the deterministic, server-side-only portion makes it pure and testable,
+ *      and guarantees the prompt material lives only in the system message.
+ *
+ * Pure: no I/O, no clock, no randomness.
+ */
+export function assembleLlmContext(input: AssembleLlmContextInput): ChatMessage[] {
+  const { systemPromptConfig, manualData, gameState } = input
+  const systemPrompt = buildSystemPrompt(systemPromptConfig)
+  const manualInjection = buildManualInjection(manualData, gameState)
+  return [
+    {
+      role: 'system',
+      content: `${systemPrompt}\n\n${manualInjection}`,
+    },
+  ]
+}

--- a/packages/platform-ai/src/provider-config.test.ts
+++ b/packages/platform-ai/src/provider-config.test.ts
@@ -27,14 +27,18 @@ describe('resolveConfig — hit', () => {
     expect(stt.model).not.toBe('bigmodel-asr')
   })
 
-  it('registers a legal Volcengine TTS wire model for the demo TTS layer (P2)', () => {
-    // P2 regression: the demo TTS model is passed verbatim into the Doubao TTS 2.0
-    // `StartSession` req_params.model (factory F-K passthrough). The legal wire
-    // value is the model-family token `seed-tts-2.0`; the product alias
-    // `doubao-tts-2.0` is NOT a request value and could be rejected / mis-routed.
-    // Guard the alias from creeping back at the config layer.
+  it('registers the omit-by-default TTS model sentinel for the demo TTS layer', () => {
+    // The demo TTS model is the empty-string sentinel: "use the resource-id
+    // default model". The factory threads it (F-K passthrough), and the adapter
+    // omits `req_params.model` from the Doubao TTS 2.0 StartSession frame for an
+    // empty model — so the session is bound by the paired resource id
+    // (`volc.service_type.10029`) alone, matching Volcengine's first-party clients.
+    // This guards a guessed concrete model token (a reject / mis-route risk) from
+    // creeping back at the config layer; the exact `req_params.model` wire value
+    // (`seed-tts-2.0-standard` / `-expressive` vs omitted) is a deploy-time
+    // verification item, set here once confirmed.
     const { tts } = resolveConfig('demo')
-    expect(tts.model).toBe('seed-tts-2.0')
+    expect(tts.model).toBe('')
     expect(tts.model).not.toBe('doubao-tts-2.0')
   })
 

--- a/packages/platform-ai/src/provider-config.test.ts
+++ b/packages/platform-ai/src/provider-config.test.ts
@@ -17,6 +17,16 @@ describe('resolveConfig — hit', () => {
     expect(tts.provider).toBe('volcengine')
   })
 
+  it('registers a legal Volcengine ASR wire model for the demo STT layer (P2)', () => {
+    // P2 regression: the demo STT model is passed verbatim into the ASR
+    // `request.model_name` (factory F-K passthrough), and the Volcengine v3
+    // streaming ASR endpoint accepts ONLY `bigmodel`. Guard the alias `bigmodel-asr`
+    // (illegal model id → failed turn) from creeping back at the config layer.
+    const { stt } = resolveConfig('demo')
+    expect(stt.model).toBe('bigmodel')
+    expect(stt.model).not.toBe('bigmodel-asr')
+  })
+
   it('a layer selection carries provider + model only (no unwired fallback field)', () => {
     // F-H regression: `fallback` was defined but never executed (createProviders
     // builds one provider per layer, runTurn calls each once and fails loud on

--- a/packages/platform-ai/src/provider-config.test.ts
+++ b/packages/platform-ai/src/provider-config.test.ts
@@ -17,9 +17,16 @@ describe('resolveConfig — hit', () => {
     expect(tts.provider).toBe('volcengine')
   })
 
-  it('carries a fallback chain on the LLM layer', () => {
-    const { llm } = resolveConfig('demo')
-    expect(llm.fallback).toEqual(['deepseek-v4-pro'])
+  it('a layer selection carries provider + model only (no unwired fallback field)', () => {
+    // F-H regression: `fallback` was defined but never executed (createProviders
+    // builds one provider per layer, runTurn calls each once and fails loud on
+    // first error). The dead config field is removed; a resolved layer must be
+    // exactly { provider, model } so it cannot reappear unwired. Timeout +
+    // fallback is a deferred L3 followup (see provider-config.ts docblock).
+    const { llm, stt, tts } = resolveConfig('demo')
+    for (const layer of [llm, stt, tts]) {
+      expect(Object.keys(layer).sort()).toEqual(['model', 'provider'])
+    }
   })
 })
 
@@ -57,13 +64,11 @@ describe('resolveConfig — switchability and isolation', () => {
     const first = resolveConfig('demo')
     first.llm.provider = 'rogue-mutation'
     first.llm.model = 'rogue-model'
-    first.llm.fallback.push('rogue-fallback')
     first.systemPromptConfig.role = 'rogue-role'
 
     const second = resolveConfig('demo')
     expect(second.llm.provider).toBe('deepseek')
     expect(second.llm.model).toBe('deepseek-v4-flash')
-    expect(second.llm.fallback).toEqual(['deepseek-v4-pro'])
     expect(second.systemPromptConfig.role).toContain('manual-explainer')
   })
 })

--- a/packages/platform-ai/src/provider-config.test.ts
+++ b/packages/platform-ai/src/provider-config.test.ts
@@ -27,6 +27,17 @@ describe('resolveConfig — hit', () => {
     expect(stt.model).not.toBe('bigmodel-asr')
   })
 
+  it('registers a legal Volcengine TTS wire model for the demo TTS layer (P2)', () => {
+    // P2 regression: the demo TTS model is passed verbatim into the Doubao TTS 2.0
+    // `StartSession` req_params.model (factory F-K passthrough). The legal wire
+    // value is the model-family token `seed-tts-2.0`; the product alias
+    // `doubao-tts-2.0` is NOT a request value and could be rejected / mis-routed.
+    // Guard the alias from creeping back at the config layer.
+    const { tts } = resolveConfig('demo')
+    expect(tts.model).toBe('seed-tts-2.0')
+    expect(tts.model).not.toBe('doubao-tts-2.0')
+  })
+
   it('a layer selection carries provider + model only (no unwired fallback field)', () => {
     // F-H regression: `fallback` was defined but never executed (createProviders
     // builds one provider per layer, runTurn calls each once and fails loud on

--- a/packages/platform-ai/src/provider-config.test.ts
+++ b/packages/platform-ai/src/provider-config.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { resolveConfig } from './provider-config'
+
+describe('resolveConfig — hit', () => {
+  it('resolves the built-in demo game config', () => {
+    const resolved = resolveConfig('demo')
+    expect(resolved.gameId).toBe('demo')
+    expect(resolved.systemPromptConfig.role).toContain('manual-explainer')
+    expect(resolved.systemPromptConfig.ruleTemplate.length).toBeGreaterThan(0)
+  })
+
+  it('registers the spec defaults for the demo game: DeepSeek v4 LLM, Volcengine voice', () => {
+    const { llm, stt, tts } = resolveConfig('demo')
+    expect(llm.provider).toBe('deepseek')
+    expect(llm.model).toBe('deepseek-v4-flash')
+    expect(stt.provider).toBe('volcengine')
+    expect(tts.provider).toBe('volcengine')
+  })
+
+  it('carries a fallback chain on the LLM layer', () => {
+    const { llm } = resolveConfig('demo')
+    expect(llm.fallback).toEqual(['deepseek-v4-pro'])
+  })
+})
+
+describe('resolveConfig — miss', () => {
+  it('throws an explicit error on an unregistered gameId (no silent fallback)', () => {
+    expect(() => resolveConfig('not-a-real-game')).toThrowError(
+      /no configuration registered for gameId "not-a-real-game"/
+    )
+  })
+
+  it('names the known gameIds in the miss error to aid debugging', () => {
+    expect(() => resolveConfig('missing')).toThrowError(/Known gameIds: .*demo/)
+  })
+})
+
+describe('resolveConfig — switchability and isolation', () => {
+  it('switchability is read-faithful: every resolve reports the same registered selection', () => {
+    // The registry is the single switch point — switching a vendor is an edit
+    // to the registered config, and resolveConfig reports exactly what is
+    // registered, so a config edit (not a game-logic change) is what flips the
+    // provider. We prove the read-faithful half here: two resolves of the same
+    // game report identical selections.
+    const a = resolveConfig('demo')
+    const b = resolveConfig('demo')
+    expect(a.llm).toEqual(b.llm)
+    expect(a.stt).toEqual(b.stt)
+    expect(a.tts).toEqual(b.tts)
+  })
+
+  it('returns an isolated deep copy — mutating a resolved config cannot corrupt the registry', () => {
+    // The flip side of switchability: the registry must be the ONLY switch
+    // point, so a caller that mutates a resolved object must not silently
+    // rewire every later resolve. This guards the "switch vendor = edit config
+    // only" property against accidental in-flight mutation.
+    const first = resolveConfig('demo')
+    first.llm.provider = 'rogue-mutation'
+    first.llm.model = 'rogue-model'
+    first.llm.fallback.push('rogue-fallback')
+    first.systemPromptConfig.role = 'rogue-role'
+
+    const second = resolveConfig('demo')
+    expect(second.llm.provider).toBe('deepseek')
+    expect(second.llm.model).toBe('deepseek-v4-flash')
+    expect(second.llm.fallback).toEqual(['deepseek-v4-pro'])
+    expect(second.systemPromptConfig.role).toContain('manual-explainer')
+  })
+})

--- a/packages/platform-ai/src/provider-config.ts
+++ b/packages/platform-ai/src/provider-config.ts
@@ -1,0 +1,170 @@
+/**
+ * Provider selection layer.
+ *
+ * Registers, per `gameId`: that game's system-prompt config plus the chosen
+ * provider/model/fallback for each of the three layers (STT / LLM / TTS).
+ * Switching vendors is a config change here — game logic does not change.
+ *
+ * This is also the single authoritative path for the system prompt: it is
+ * resolved from `gameId` here (NOT passed into `createSession`), which keeps
+ * "system prompt is server-side only, never client-held" intact.
+ *
+ * `resolveConfig` is a pure function: a miss is an explicit error, never a
+ * silent fallback to some default game.
+ */
+
+import type { GameId } from './contract'
+
+/** The three pipeline layers a provider can be selected for. */
+export type ProviderLayer = 'stt' | 'llm' | 'tts'
+
+/**
+ * Selection for one pipeline layer: which provider, which model, and the
+ * ordered fallback chain to try on failure/timeout. `fallback` entries are
+ * provider ids to switch to, in order; an empty array means no fallback.
+ */
+export interface LayerSelection {
+  /** Provider id (adapter selector), e.g. 'deepseek' or 'volcengine'. */
+  provider: string
+  /** Concrete model id for that provider, e.g. 'deepseek-v4-flash'. */
+  model: string
+  /** Ordered fallback provider ids, tried left-to-right on failure. */
+  fallback: string[]
+}
+
+/**
+ * The system-prompt config for a game: the role + rule template the platform
+ * assembles into the system message at session creation. This material is
+ * server-side only.
+ */
+export interface SystemPromptConfig {
+  /** The AI partner's role / persona for this game. */
+  role: string
+  /**
+   * Rule-template lines describing how the partner should behave and read the
+   * manual. Assembled (with `role`) into the system message by the manual
+   * injection step.
+   */
+  ruleTemplate: string[]
+}
+
+/** Full per-game provider configuration, keyed by `gameId` in the registry. */
+export interface ProviderConfig {
+  systemPromptConfig: SystemPromptConfig
+  llm: LayerSelection
+  stt: LayerSelection
+  tts: LayerSelection
+}
+
+/**
+ * Resolved config returned by `resolveConfig`. Carries the `gameId` it was
+ * resolved for plus the registered `ProviderConfig`, so downstream code never
+ * has to re-key the registry.
+ */
+export interface ResolvedConfig extends ProviderConfig {
+  gameId: GameId
+}
+
+/**
+ * Built-in registry. Keyed by `gameId`. Adding a game = adding an entry;
+ * switching a layer's vendor = editing that entry's `provider`/`model`.
+ *
+ * The `demo` entry backs the later demo harness: LLM = DeepSeek v4 flash
+ * (OpenAI-compatible SSE), voice = Volcengine (火山), and a sample
+ * manual-explainer system prompt.
+ *
+ * The `demo-mock` entry backs the no-credential demo / e2e harness: all three
+ * layers select the deterministic `mock` provider, so the full
+ * STT -> LLM -> TTS pipeline runs locally without real DeepSeek / Volcengine
+ * keys. It reuses the same sample manual-explainer system prompt as `demo`.
+ */
+const PROVIDER_REGISTRY: Record<GameId, ProviderConfig> = {
+  demo: {
+    systemPromptConfig: {
+      role: 'You are a calm, precise manual-explainer partner for a cooperative puzzle game. You can see the reference manual; the player can only see the device. You guide the player by voice.',
+      ruleTemplate: [
+        'Only rely on the manual content provided to you in context; never invent rules.',
+        'Ask the player to describe what they see, then map it to the manual deterministically.',
+        'Give one concrete next action at a time; confirm before moving on.',
+        'Never reveal that you are reading from an injected manual subset.',
+      ],
+    },
+    llm: {
+      provider: 'deepseek',
+      model: 'deepseek-v4-flash',
+      fallback: ['deepseek-v4-pro'],
+    },
+    stt: {
+      provider: 'volcengine',
+      model: 'bigmodel-asr',
+      fallback: [],
+    },
+    tts: {
+      provider: 'volcengine',
+      model: 'doubao-tts-2.0',
+      fallback: [],
+    },
+  },
+  'demo-mock': {
+    systemPromptConfig: {
+      role: 'You are a calm, precise manual-explainer partner for a cooperative puzzle game. You can see the reference manual; the player can only see the device. You guide the player by voice.',
+      ruleTemplate: [
+        'Only rely on the manual content provided to you in context; never invent rules.',
+        'Ask the player to describe what they see, then map it to the manual deterministically.',
+        'Give one concrete next action at a time; confirm before moving on.',
+        'Never reveal that you are reading from an injected manual subset.',
+      ],
+    },
+    llm: {
+      provider: 'mock',
+      model: 'mock-llm',
+      fallback: [],
+    },
+    stt: {
+      provider: 'mock',
+      model: 'mock-stt',
+      fallback: [],
+    },
+    tts: {
+      provider: 'mock',
+      model: 'mock-tts',
+      fallback: [],
+    },
+  },
+}
+
+/** Deep-clone a layer selection so callers cannot mutate the registry. */
+function cloneLayer(layer: LayerSelection): LayerSelection {
+  return { provider: layer.provider, model: layer.model, fallback: [...layer.fallback] }
+}
+
+/**
+ * Resolve the provider configuration for a game.
+ *
+ * Pure function. Throws a precise error on a miss (no silent fallback to a
+ * default game) — the L2 spec requires an explicit error so a mis-registered
+ * `gameId` fails loudly instead of silently running the wrong prompt/providers.
+ *
+ * Returns a deep copy of the registered config: the registry is the single
+ * switch point for provider selection, and handing out copies keeps it from
+ * being corrupted by a caller mutating a resolved object.
+ */
+export function resolveConfig(gameId: GameId): ResolvedConfig {
+  const config = PROVIDER_REGISTRY[gameId]
+  if (config === undefined) {
+    const known = Object.keys(PROVIDER_REGISTRY).join(', ') || '<none>'
+    throw new Error(
+      `provider-config: no configuration registered for gameId "${gameId}". Known gameIds: ${known}.`
+    )
+  }
+  return {
+    gameId,
+    systemPromptConfig: {
+      role: config.systemPromptConfig.role,
+      ruleTemplate: [...config.systemPromptConfig.ruleTemplate],
+    },
+    llm: cloneLayer(config.llm),
+    stt: cloneLayer(config.stt),
+    tts: cloneLayer(config.tts),
+  }
+}

--- a/packages/platform-ai/src/provider-config.ts
+++ b/packages/platform-ai/src/provider-config.ts
@@ -105,10 +105,23 @@ const PROVIDER_REGISTRY: Record<GameId, ProviderConfig> = {
       model: 'deepseek-v4-flash',
     },
     stt: {
+      // `bigmodel` is the only `model_name` the Volcengine v3 streaming ASR
+      // endpoint (`/api/v3/sauc/bigmodel`) accepts — it is passed verbatim as the
+      // wire `request.model_name` (the factory threads it through; see F-K). A
+      // non-wire alias like `bigmodel-asr` would now produce an illegal model id
+      // and fail the turn. Doc: https://www.volcengine.com/docs/6561/1354869
       provider: 'volcengine',
-      model: 'bigmodel-asr',
+      model: 'bigmodel',
     },
     tts: {
+      // Doubao TTS 2.0 binds the model via the endpoint resource id
+      // (`X-Api-Resource-Id: volc.service_type.10029`), NOT a `req_params` field:
+      // the documented bidirectional `StartSession` `req_params` carries only
+      // `speaker` + `audio_params`. This value is threaded into `req_params.model`
+      // as a non-breaking additive (the server ignores unknown fields), so a model
+      // switch here is wire-visible without altering the documented request shape;
+      // whether the server consumes it is a deploy-time open question.
+      // Doc: https://www.volcengine.com/docs/6561/1329505
       provider: 'volcengine',
       model: 'doubao-tts-2.0',
     },

--- a/packages/platform-ai/src/provider-config.ts
+++ b/packages/platform-ai/src/provider-config.ts
@@ -2,8 +2,8 @@
  * Provider selection layer.
  *
  * Registers, per `gameId`: that game's system-prompt config plus the chosen
- * provider/model/fallback for each of the three layers (STT / LLM / TTS).
- * Switching vendors is a config change here — game logic does not change.
+ * provider + model for each of the three layers (STT / LLM / TTS). Switching
+ * vendors is a config change here — game logic does not change.
  *
  * This is also the single authoritative path for the system prompt: it is
  * resolved from `gameId` here (NOT passed into `createSession`), which keeps
@@ -11,6 +11,17 @@
  *
  * `resolveConfig` is a pure function: a miss is an explicit error, never a
  * silent fallback to some default game.
+ *
+ * FOLLOWUP — provider timeout + fallback chain (NOT implemented in v1): the L2
+ * spec (`docs/architecture/arch-component-platform-ai-interface.md` §L3 验收目标)
+ * lists per-layer provider timeouts and a `provider-config`-defined fallback
+ * order as explicit L3 acceptance targets, to be landed against real CF-edge +
+ * real-provider measurements. v1 deliberately ships provider + model switching
+ * only (the wired "vendor is swappable" core) and does NOT carry an unwired
+ * `fallback` config field: `createProviders` builds one provider per layer and
+ * `runTurn` calls each once and fails loud on first error, so a `fallback` array
+ * would have been a promised-but-unimplemented capability. It is re-added when
+ * the timeout + fallback followup is actually implemented and wired.
  */
 
 import type { GameId } from './contract'
@@ -19,17 +30,17 @@ import type { GameId } from './contract'
 export type ProviderLayer = 'stt' | 'llm' | 'tts'
 
 /**
- * Selection for one pipeline layer: which provider, which model, and the
- * ordered fallback chain to try on failure/timeout. `fallback` entries are
- * provider ids to switch to, in order; an empty array means no fallback.
+ * Selection for one pipeline layer: which provider and which model. Switching a
+ * vendor is an edit to these two fields (the wired "vendor is swappable" core).
+ *
+ * No `fallback` field: a provider timeout + fallback chain is a deferred L3
+ * followup (see the file docblock) and v1 does not carry unwired config for it.
  */
 export interface LayerSelection {
   /** Provider id (adapter selector), e.g. 'deepseek' or 'volcengine'. */
   provider: string
   /** Concrete model id for that provider, e.g. 'deepseek-v4-flash'. */
   model: string
-  /** Ordered fallback provider ids, tried left-to-right on failure. */
-  fallback: string[]
 }
 
 /**
@@ -92,17 +103,14 @@ const PROVIDER_REGISTRY: Record<GameId, ProviderConfig> = {
     llm: {
       provider: 'deepseek',
       model: 'deepseek-v4-flash',
-      fallback: ['deepseek-v4-pro'],
     },
     stt: {
       provider: 'volcengine',
       model: 'bigmodel-asr',
-      fallback: [],
     },
     tts: {
       provider: 'volcengine',
       model: 'doubao-tts-2.0',
-      fallback: [],
     },
   },
   'demo-mock': {
@@ -118,24 +126,21 @@ const PROVIDER_REGISTRY: Record<GameId, ProviderConfig> = {
     llm: {
       provider: 'mock',
       model: 'mock-llm',
-      fallback: [],
     },
     stt: {
       provider: 'mock',
       model: 'mock-stt',
-      fallback: [],
     },
     tts: {
       provider: 'mock',
       model: 'mock-tts',
-      fallback: [],
     },
   },
 }
 
 /** Deep-clone a layer selection so callers cannot mutate the registry. */
 function cloneLayer(layer: LayerSelection): LayerSelection {
-  return { provider: layer.provider, model: layer.model, fallback: [...layer.fallback] }
+  return { provider: layer.provider, model: layer.model }
 }
 
 /**

--- a/packages/platform-ai/src/provider-config.ts
+++ b/packages/platform-ai/src/provider-config.ts
@@ -114,16 +114,20 @@ const PROVIDER_REGISTRY: Record<GameId, ProviderConfig> = {
       model: 'bigmodel',
     },
     tts: {
-      // Doubao TTS 2.0 binds the model via the endpoint resource id
-      // (`X-Api-Resource-Id: volc.service_type.10029`), NOT a `req_params` field:
-      // the documented bidirectional `StartSession` `req_params` carries only
-      // `speaker` + `audio_params`. This value is threaded into `req_params.model`
-      // as a non-breaking additive (the server ignores unknown fields), so a model
-      // switch here is wire-visible without altering the documented request shape;
-      // whether the server consumes it is a deploy-time open question.
+      // `seed-tts-2.0` is the legal wire value for the Doubao TTS 2.0
+      // bidirectional `StartSession` `req_params.model` field; the factory threads
+      // it through (F-K) so a model switch here reaches the wire. The product
+      // alias `doubao-tts-2.0` is NOT a request value — sending it would risk the
+      // turn being rejected or routed to the wrong model. The model is also pinned
+      // by the paired resource id (`X-Api-Resource-Id: volc.service_type.10029`,
+      // the adapter's `DEFAULT_TTS_RESOURCE_ID`): `req_params.model` is the
+      // optional in-payload selector that must agree with that resource id. The
+      // exact model token and its resource-id pairing need a deploy-time check
+      // against the real endpoint (the official docs render via JS; this value is
+      // corroborated by production Doubao seed-tts-2.0 clients).
       // Doc: https://www.volcengine.com/docs/6561/1329505
       provider: 'volcengine',
-      model: 'doubao-tts-2.0',
+      model: 'seed-tts-2.0',
     },
   },
   'demo-mock': {

--- a/packages/platform-ai/src/provider-config.ts
+++ b/packages/platform-ai/src/provider-config.ts
@@ -114,20 +114,24 @@ const PROVIDER_REGISTRY: Record<GameId, ProviderConfig> = {
       model: 'bigmodel',
     },
     tts: {
-      // `seed-tts-2.0` is the legal wire value for the Doubao TTS 2.0
-      // bidirectional `StartSession` `req_params.model` field; the factory threads
-      // it through (F-K) so a model switch here reaches the wire. The product
-      // alias `doubao-tts-2.0` is NOT a request value — sending it would risk the
-      // turn being rejected or routed to the wrong model. The model is also pinned
-      // by the paired resource id (`X-Api-Resource-Id: volc.service_type.10029`,
-      // the adapter's `DEFAULT_TTS_RESOURCE_ID`): `req_params.model` is the
-      // optional in-payload selector that must agree with that resource id. The
-      // exact model token and its resource-id pairing need a deploy-time check
-      // against the real endpoint (the official docs render via JS; this value is
-      // corroborated by production Doubao seed-tts-2.0 clients).
-      // Doc: https://www.volcengine.com/docs/6561/1329505
+      // Empty string = the "use the resource-id default model" sentinel: the
+      // Doubao TTS 2.0 model is bound by the paired resource id
+      // (`X-Api-Resource-Id: volc.service_type.10029`, the adapter's
+      // `DEFAULT_TTS_RESOURCE_ID`), and `req_params.model` is left OUT of the
+      // `StartSession` frame by default. This aligns with Volcengine's own
+      // first-party speech clients (`volcengine/ai-app-lab` and the bigmodel
+      // ASR/TTS clients), which omit `req_params.model` and let the resource id
+      // pick the model. An empty model here makes the factory's F-K passthrough a
+      // no-op for the wire (the adapter only attaches `req_params.model` when the
+      // threaded model is non-empty), so no model token is guessed onto the wire —
+      // sending a wrong token is rejected by the server, sending none is the safe
+      // default. The concrete `req_params.model` wire value (`seed-tts-2.0-standard`
+      // / `-expressive` vs omitted) is a DEPLOY-TIME verification item: once the
+      // real endpoint confirms the exact token, set it here and the same F-K
+      // passthrough carries it onto the wire — the mechanism stays available, only
+      // the default is "omit". Doc: https://www.volcengine.com/docs/6561/1329505
       provider: 'volcengine',
-      model: 'seed-tts-2.0',
+      model: '',
     },
   },
   'demo-mock': {

--- a/packages/platform-ai/src/providers/deepseek.test.ts
+++ b/packages/platform-ai/src/providers/deepseek.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createDeepSeekLlmProvider, parseSseLine, sseStreamToChunks } from './deepseek'
+import {
+  createDeepSeekLlmProvider,
+  parseSseLine,
+  sseStreamToChunks,
+  trimTrailingSlashes,
+} from './deepseek'
 import type { LlmCompletionChunk, LlmCompletionRequest } from './types'
 
 // --- helpers -------------------------------------------------------------
@@ -92,6 +97,41 @@ describe('parseSseLine', () => {
       type: 'usage',
       usage: { inputTokens: 12, outputTokens: 34 },
     })
+  })
+})
+
+// --- trimTrailingSlashes (linear, no ReDoS) ------------------------------
+
+describe('trimTrailingSlashes', () => {
+  it('strips one or more trailing slashes', () => {
+    expect(trimTrailingSlashes('https://api.deepseek.com/v1/')).toBe('https://api.deepseek.com/v1')
+    expect(trimTrailingSlashes('https://proxy.example.com/v1///')).toBe(
+      'https://proxy.example.com/v1'
+    )
+  })
+
+  it('leaves a slash-free base url unchanged', () => {
+    expect(trimTrailingSlashes('https://api.deepseek.com/v1')).toBe('https://api.deepseek.com/v1')
+  })
+
+  it('handles an all-slash and empty string without underflow', () => {
+    expect(trimTrailingSlashes('////')).toBe('')
+    expect(trimTrailingSlashes('')).toBe('')
+  })
+
+  it('returns fast on a long run of slashes that fails the end-anchor (no ReDoS)', () => {
+    // The replaced `/\/+$/` regex backtracks polynomially on this exact shape
+    // (a long run of `/` immediately followed by a non-`/`, so the `$` anchor
+    // fails and the engine re-tries every start position). The linear scan must
+    // stay well under any reasonable bound regardless of length.
+    const adversarial = `${'/'.repeat(200_000)}x`
+    const start = performance.now()
+    const result = trimTrailingSlashes(adversarial)
+    const elapsedMs = performance.now() - start
+    // No trailing slash to strip (input ends in 'x'), so the value is unchanged.
+    expect(result).toBe(adversarial)
+    // The vulnerable regex took ~19s for this input; linear is sub-millisecond.
+    expect(elapsedMs).toBeLessThan(50)
   })
 })
 

--- a/packages/platform-ai/src/providers/deepseek.test.ts
+++ b/packages/platform-ai/src/providers/deepseek.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createDeepSeekLlmProvider, parseSseLine, sseStreamToChunks } from './deepseek'
+import type { LlmCompletionChunk, LlmCompletionRequest } from './types'
+
+// --- helpers -------------------------------------------------------------
+
+/** Build a `ReadableStream<Uint8Array>` that emits `sse` as one or more byte
+ * pushes. Passing multiple strings simulates the body arriving in several
+ * network reads (exercising cross-chunk line buffering). */
+function sseStream(...pushes: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const push of pushes) controller.enqueue(encoder.encode(push))
+      controller.close()
+    },
+  })
+}
+
+/** One DeepSeek-shaped content delta SSE line. */
+function deltaLine(content: string): string {
+  return `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n`
+}
+
+/** Drain an async iterable of chunks into an array. */
+async function collect(iterable: AsyncIterable<LlmCompletionChunk>): Promise<LlmCompletionChunk[]> {
+  const out: LlmCompletionChunk[] = []
+  for await (const chunk of iterable) out.push(chunk)
+  return out
+}
+
+/** Stub `fetch` to return a streaming Response built from `body`. The mock is
+ * typed with an explicit `(url, init)` signature so `mock.calls` carries the
+ * request tuple for assertions. */
+function stubFetch(body: ReadableStream<Uint8Array> | null, init?: ResponseInit) {
+  const fetchMock = vi.fn(
+    async (_url: string, _init?: RequestInit): Promise<Response> => new Response(body, init)
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+const baseRequest: LlmCompletionRequest = {
+  model: 'deepseek-v4-flash',
+  messages: [{ role: 'user', content: 'hi' }],
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+// --- parseSseLine (pure) -------------------------------------------------
+
+describe('parseSseLine', () => {
+  it('parses a content delta line', () => {
+    expect(parseSseLine(deltaLine('hello').trimEnd())).toEqual({
+      type: 'delta',
+      content: 'hello',
+    })
+  })
+
+  it('maps the [DONE] sentinel to a done event', () => {
+    expect(parseSseLine('data: [DONE]')).toEqual({ type: 'done' })
+  })
+
+  it('ignores the role-only first chunk (empty delta)', () => {
+    const roleOnly = `data: ${JSON.stringify({ choices: [{ delta: { role: 'assistant' } }] })}`
+    expect(parseSseLine(roleOnly)).toEqual({ type: 'ignore' })
+  })
+
+  it('ignores an explicit empty-string content delta', () => {
+    expect(parseSseLine(deltaLine('').trimEnd())).toEqual({ type: 'ignore' })
+  })
+
+  it('ignores blank lines, comments, and non-data fields', () => {
+    expect(parseSseLine('')).toEqual({ type: 'ignore' })
+    expect(parseSseLine(': keep-alive')).toEqual({ type: 'ignore' })
+    expect(parseSseLine('event: message')).toEqual({ type: 'ignore' })
+  })
+
+  it('ignores an unparseable data payload rather than throwing', () => {
+    expect(parseSseLine('data: {not json')).toEqual({ type: 'ignore' })
+  })
+
+  it('extracts a usage report from the final chunk', () => {
+    const usageLine = `data: ${JSON.stringify({
+      choices: [],
+      usage: { prompt_tokens: 12, completion_tokens: 34 },
+    })}`
+    expect(parseSseLine(usageLine)).toEqual({
+      type: 'usage',
+      usage: { inputTokens: 12, outputTokens: 34 },
+    })
+  })
+})
+
+// --- sseStreamToChunks (pure) --------------------------------------------
+
+describe('sseStreamToChunks', () => {
+  it('concatenates multiple deltas and ends with a single done chunk', async () => {
+    const stream = sseStream(
+      deltaLine('Hel'),
+      deltaLine('lo, '),
+      deltaLine('world'),
+      'data: [DONE]\n'
+    )
+    const chunks = await collect(sseStreamToChunks(stream))
+    expect(chunks).toEqual([
+      { content: 'Hel', done: false },
+      { content: 'lo, ', done: false },
+      { content: 'world', done: false },
+      { content: '', done: true },
+    ])
+  })
+
+  it('reassembles a delta split across two network reads', async () => {
+    // The JSON for one delta is cut mid-line; the buffer must stitch it back.
+    const full = deltaLine('spanning')
+    const cut = Math.floor(full.length / 2)
+    const stream = sseStream(full.slice(0, cut), `${full.slice(cut)}data: [DONE]\n`)
+    const chunks = await collect(sseStreamToChunks(stream))
+    expect(chunks).toEqual([
+      { content: 'spanning', done: false },
+      { content: '', done: true },
+    ])
+  })
+
+  it('skips empty deltas in the stream', async () => {
+    const stream = sseStream(deltaLine('a'), deltaLine(''), deltaLine('b'), 'data: [DONE]\n')
+    const chunks = await collect(sseStreamToChunks(stream))
+    expect(chunks).toEqual([
+      { content: 'a', done: false },
+      { content: 'b', done: false },
+      { content: '', done: true },
+    ])
+  })
+
+  it('emits a terminal done chunk even when the stream omits [DONE]', async () => {
+    const stream = sseStream(deltaLine('only'))
+    const chunks = await collect(sseStreamToChunks(stream))
+    expect(chunks).toEqual([
+      { content: 'only', done: false },
+      { content: '', done: true },
+    ])
+  })
+
+  it('reports usage via the callback without placing it on the chunk stream', async () => {
+    const usageLine = `data: ${JSON.stringify({
+      choices: [],
+      usage: { prompt_tokens: 5, completion_tokens: 7 },
+    })}\n`
+    const stream = sseStream(deltaLine('x'), usageLine, 'data: [DONE]\n')
+    const onUsage = vi.fn()
+    const chunks = await collect(sseStreamToChunks(stream, onUsage))
+    expect(chunks).toEqual([
+      { content: 'x', done: false },
+      { content: '', done: true },
+    ])
+    expect(onUsage).toHaveBeenCalledWith({ inputTokens: 5, outputTokens: 7 })
+  })
+})
+
+// --- createDeepSeekLlmProvider (mocked fetch) ----------------------------
+
+describe('createDeepSeekLlmProvider', () => {
+  it('streams concatenated deltas and a done chunk through the provider', async () => {
+    stubFetch(sseStream(deltaLine('Po'), deltaLine('ng'), 'data: [DONE]\n'))
+    const provider = createDeepSeekLlmProvider({ apiKey: 'sk-test' })
+    const chunks = await collect(provider.streamCompletion(baseRequest))
+    expect(chunks).toEqual([
+      { content: 'Po', done: false },
+      { content: 'ng', done: false },
+      { content: '', done: true },
+    ])
+  })
+
+  it('sends Authorization, stream:true, and the request body to the endpoint', async () => {
+    const fetchMock = stubFetch(sseStream('data: [DONE]\n'))
+    const provider = createDeepSeekLlmProvider({ apiKey: 'sk-secret' })
+    await collect(
+      provider.streamCompletion({
+        model: 'deepseek-v4-pro',
+        messages: [{ role: 'user', content: 'ask' }],
+        temperature: 0.3,
+      })
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://api.deepseek.com/v1/chat/completions')
+    expect(init?.method).toBe('POST')
+
+    const headers = init?.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer sk-secret')
+    expect(headers['Content-Type']).toBe('application/json')
+
+    const sentBody = JSON.parse(init?.body as string)
+    expect(sentBody.stream).toBe(true)
+    expect(sentBody.model).toBe('deepseek-v4-pro')
+    expect(sentBody.messages).toEqual([{ role: 'user', content: 'ask' }])
+    expect(sentBody.temperature).toBe(0.3)
+  })
+
+  it('omits temperature from the body when not provided', async () => {
+    const fetchMock = stubFetch(sseStream('data: [DONE]\n'))
+    const provider = createDeepSeekLlmProvider({ apiKey: 'sk-test' })
+    await collect(provider.streamCompletion(baseRequest))
+    const sentBody = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)
+    expect('temperature' in sentBody).toBe(false)
+  })
+
+  it('uses the configured baseUrl (trailing slash trimmed)', async () => {
+    const fetchMock = stubFetch(sseStream('data: [DONE]\n'))
+    const provider = createDeepSeekLlmProvider({
+      apiKey: 'sk-test',
+      baseUrl: 'https://proxy.example.com/v1/',
+    })
+    await collect(provider.streamCompletion(baseRequest))
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://proxy.example.com/v1/chat/completions')
+  })
+
+  it('falls back to the configured default model when the request omits one', async () => {
+    const fetchMock = stubFetch(sseStream('data: [DONE]\n'))
+    const provider = createDeepSeekLlmProvider({
+      apiKey: 'sk-test',
+      model: 'deepseek-v4-flash',
+    })
+    await collect(provider.streamCompletion({ model: '', messages: baseRequest.messages }))
+    const sentBody = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)
+    expect(sentBody.model).toBe('deepseek-v4-flash')
+  })
+
+  it('throws a descriptive error on a non-2xx response', async () => {
+    stubFetch(sseStream('rate limited'), {
+      status: 429,
+      statusText: 'Too Many Requests',
+    })
+    const provider = createDeepSeekLlmProvider({ apiKey: 'sk-test' })
+    await expect(collect(provider.streamCompletion(baseRequest))).rejects.toThrow(
+      /deepseek: chat completions request failed with 429/
+    )
+  })
+
+  it('exposes lastUsage after the stream is fully consumed', async () => {
+    const usageLine = `data: ${JSON.stringify({
+      choices: [],
+      usage: { prompt_tokens: 11, completion_tokens: 22 },
+    })}\n`
+    stubFetch(sseStream(deltaLine('hi'), usageLine, 'data: [DONE]\n'))
+    const provider = createDeepSeekLlmProvider({ apiKey: 'sk-test' })
+    await collect(provider.streamCompletion(baseRequest))
+    expect(provider.lastUsage).toEqual({ inputTokens: 11, outputTokens: 22 })
+  })
+})

--- a/packages/platform-ai/src/providers/deepseek.ts
+++ b/packages/platform-ai/src/providers/deepseek.ts
@@ -1,0 +1,307 @@
+/**
+ * DeepSeek v4 LLM adapter — the default OpenAI-compatible chat-completions
+ * provider for the platform's LLM layer.
+ *
+ * DeepSeek exposes an OpenAI-compatible chat-completions endpoint. With
+ * `stream: true` the response is a `text/event-stream`: one `data: {json}` line
+ * per delta, where the incremental assistant text is `choices[0].delta.content`,
+ * and the stream terminates with a `data: [DONE]` sentinel. This adapter maps
+ * that wire format onto the layer's `LlmProvider` contract.
+ *
+ * The SSE parsing is factored into pure functions (`parseSseLine`,
+ * `sseStreamToChunks`) so the byte-level decoding logic is unit-testable with a
+ * constructed `ReadableStream` and no network. `createDeepSeekLlmProvider` is
+ * the thin networking shell: it builds the request, asserts a 2xx response, and
+ * hands the body stream to the pure parser.
+ *
+ * Security: `apiKey` is server-side only. It is read from `opts` (which the
+ * caller sources from a Worker env binding) and placed in the `Authorization`
+ * header — never hardcoded, never sent to or held by the browser.
+ */
+
+import type {
+  ChatMessage,
+  LlmCompletionChunk,
+  LlmCompletionRequest,
+  LlmProvider,
+  LlmUsage,
+} from './types'
+
+/** Default DeepSeek OpenAI-compatible base URL (includes the `/v1` prefix). */
+const DEFAULT_BASE_URL = 'https://api.deepseek.com/v1'
+
+/** Options for constructing a DeepSeek LLM provider. */
+export interface DeepSeekProviderOptions {
+  /** Server-side API key, placed in the `Authorization: Bearer` header. */
+  apiKey: string
+  /**
+   * Override the API base URL. Defaults to `https://api.deepseek.com/v1`.
+   * A trailing slash is tolerated and trimmed.
+   */
+  baseUrl?: string
+  /**
+   * Default model id (e.g. 'deepseek-v4-flash'), supplied by the caller from
+   * the resolved `LayerSelection.model`. A model on the per-request
+   * `LlmCompletionRequest` takes precedence when present.
+   */
+  model?: string
+}
+
+/**
+ * A DeepSeek provider instance. Extends `LlmProvider` with an optional
+ * `lastUsage` field: when the vendor reports token usage on the final stream
+ * chunk, it is captured here after the stream is fully consumed. Usage is kept
+ * off the per-token chunk stream so the hot path stays text-only.
+ */
+export interface DeepSeekLlmProvider extends LlmProvider {
+  /** Token usage from the most recently consumed completion, if reported. */
+  lastUsage?: LlmUsage
+}
+
+/**
+ * Wire shape of one streamed completion chunk's `usage` object (present only on
+ * the final chunk, and only when usage reporting is enabled).
+ */
+interface DeepSeekUsage {
+  prompt_tokens?: number
+  completion_tokens?: number
+}
+
+/** Wire shape of one parsed SSE `data:` JSON payload we care about. */
+interface DeepSeekStreamPayload {
+  choices?: Array<{ delta?: { content?: string | null } }>
+  usage?: DeepSeekUsage | null
+}
+
+/**
+ * One parsed SSE line. The parser maps a raw line to a discriminated event the
+ * stream driver acts on:
+ *  - `delta`: a non-empty incremental content fragment to yield
+ *  - `usage`: a usage report to record on the provider (not yielded)
+ *  - `done`: the `[DONE]` sentinel — emit the terminal `done` chunk
+ *  - `ignore`: a blank line, a comment, a non-`data:` line, a role-only/empty
+ *    delta, or an unparseable payload — produce nothing
+ */
+export type SseEvent =
+  | { type: 'delta'; content: string }
+  | { type: 'usage'; usage: LlmUsage }
+  | { type: 'done' }
+  | { type: 'ignore' }
+
+/**
+ * Parse a single SSE line into an {@link SseEvent}. Pure and total: every input
+ * maps to exactly one event, and malformed JSON is treated as `ignore` rather
+ * than throwing, so one bad line cannot abort an otherwise valid stream.
+ */
+export function parseSseLine(line: string): SseEvent {
+  const trimmed = line.trim()
+
+  // Blank separators and SSE comment lines carry no payload.
+  if (trimmed === '' || trimmed.startsWith(':')) return { type: 'ignore' }
+
+  // Only `data:` lines carry chunk payloads; event/id/retry fields are ignored.
+  if (!trimmed.startsWith('data:')) return { type: 'ignore' }
+
+  const data = trimmed.slice('data:'.length).trim()
+  if (data === '[DONE]') return { type: 'done' }
+
+  let payload: DeepSeekStreamPayload
+  try {
+    payload = JSON.parse(data) as DeepSeekStreamPayload
+  } catch {
+    return { type: 'ignore' }
+  }
+
+  // Usage (final chunk only, when enabled) is recorded, not streamed as text.
+  if (payload.usage) {
+    return {
+      type: 'usage',
+      usage: {
+        inputTokens: payload.usage.prompt_tokens ?? 0,
+        outputTokens: payload.usage.completion_tokens ?? 0,
+      },
+    }
+  }
+
+  // The role-only first chunk and any keep-alive chunk carry no content; skip.
+  const content = payload.choices?.[0]?.delta?.content
+  if (typeof content === 'string' && content.length > 0) {
+    return { type: 'delta', content }
+  }
+
+  return { type: 'ignore' }
+}
+
+/**
+ * Convert a DeepSeek SSE byte stream into the layer's chunk stream. Pure with
+ * respect to the network: it only decodes and parses the given
+ * `ReadableStream`, so it is fully unit-testable against a constructed stream.
+ *
+ * Yields one `{ content, done: false }` chunk per non-empty content delta, then
+ * a single terminal `{ content: '', done: true }` chunk. The terminal chunk is
+ * emitted exactly once — at the `[DONE]` sentinel, or, if the stream ends
+ * without one, when the body closes — so consumers always observe a clean end.
+ *
+ * `onUsage` is invoked if the vendor reports token usage on the final chunk.
+ */
+export async function* sseStreamToChunks(
+  stream: ReadableStream<Uint8Array>,
+  onUsage?: (usage: LlmUsage) => void
+): AsyncIterable<LlmCompletionChunk> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let doneEmitted = false
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+
+      if (value !== undefined) buffer += decoder.decode(value, { stream: true })
+
+      if (done) {
+        // Flush any trailing bytes, then process whatever remains as a last line.
+        buffer += decoder.decode()
+        const trailing = processSse(buffer, onUsage)
+        for (const chunk of trailing.chunks) yield chunk
+        if (trailing.done && !doneEmitted) {
+          doneEmitted = true
+          yield { content: '', done: true }
+        }
+        break
+      }
+
+      // Process whole lines; keep the unterminated remainder in the buffer.
+      const newlineIdx = buffer.lastIndexOf('\n')
+      if (newlineIdx === -1) continue
+
+      const ready = buffer.slice(0, newlineIdx)
+      buffer = buffer.slice(newlineIdx + 1)
+
+      const processed = processSse(ready, onUsage)
+      for (const chunk of processed.chunks) yield chunk
+      if (processed.done && !doneEmitted) {
+        doneEmitted = true
+        yield { content: '', done: true }
+        // `[DONE]` is the logical end; stop reading further bytes.
+        return
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  // Stream closed without an explicit `[DONE]` — still give consumers a clean
+  // terminal chunk so the contract's `done` guarantee holds.
+  if (!doneEmitted) yield { content: '', done: true }
+}
+
+/**
+ * Parse a block of complete SSE lines into ready chunks plus a `done` flag.
+ * Side effects (usage recording) are pushed through `onUsage`; content deltas
+ * become chunks. Splitting this out keeps {@link sseStreamToChunks} focused on
+ * buffering and termination bookkeeping.
+ */
+function processSse(
+  block: string,
+  onUsage?: (usage: LlmUsage) => void
+): { chunks: LlmCompletionChunk[]; done: boolean } {
+  const chunks: LlmCompletionChunk[] = []
+  let done = false
+
+  for (const line of block.split('\n')) {
+    const event = parseSseLine(line)
+    switch (event.type) {
+      case 'delta':
+        chunks.push({ content: event.content, done: false })
+        break
+      case 'usage':
+        onUsage?.(event.usage)
+        break
+      case 'done':
+        done = true
+        break
+      case 'ignore':
+        break
+    }
+    if (done) break
+  }
+
+  return { chunks, done }
+}
+
+/**
+ * Create a DeepSeek v4 LLM provider implementing the OpenAI-compatible,
+ * streaming `LlmProvider` contract.
+ */
+export function createDeepSeekLlmProvider(opts: DeepSeekProviderOptions): DeepSeekLlmProvider {
+  const baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '')
+  const endpoint = `${baseUrl}/chat/completions`
+
+  const provider: DeepSeekLlmProvider = {
+    async *streamCompletion(request: LlmCompletionRequest): AsyncIterable<LlmCompletionChunk> {
+      const model = request.model || opts.model
+      if (!model) {
+        throw new Error(
+          'deepseek: no model specified (set DeepSeekProviderOptions.model or LlmCompletionRequest.model)'
+        )
+      }
+
+      const body: {
+        model: string
+        messages: ChatMessage[]
+        stream: true
+        stream_options: { include_usage: true }
+        temperature?: number
+      } = {
+        model,
+        messages: request.messages,
+        stream: true,
+        // Ask the vendor to report token usage on the final chunk so `lastUsage`
+        // can be populated without a separate metering call.
+        stream_options: { include_usage: true },
+      }
+      if (request.temperature !== undefined) body.temperature = request.temperature
+
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${opts.apiKey}`,
+        },
+        body: JSON.stringify(body),
+      })
+
+      if (!response.ok) {
+        const detail = await safeReadText(response)
+        throw new Error(
+          `deepseek: chat completions request failed with ${response.status} ${response.statusText}${
+            detail ? `: ${detail}` : ''
+          }`
+        )
+      }
+
+      if (response.body === null) {
+        throw new Error('deepseek: response had no body to stream')
+      }
+
+      // Reset before consuming so a half-consumed prior stream cannot leak a
+      // stale usage value into this completion.
+      provider.lastUsage = undefined
+      yield* sseStreamToChunks(response.body, (usage) => {
+        provider.lastUsage = usage
+      })
+    },
+  }
+
+  return provider
+}
+
+/** Read an error response body for diagnostics; never throw while doing so. */
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 500)
+  } catch {
+    return ''
+  }
+}

--- a/packages/platform-ai/src/providers/deepseek.ts
+++ b/packages/platform-ai/src/providers/deepseek.ts
@@ -30,6 +30,23 @@ import type {
 /** Default DeepSeek OpenAI-compatible base URL (includes the `/v1` prefix). */
 const DEFAULT_BASE_URL = 'https://api.deepseek.com/v1'
 
+/** ASCII code point for `/`, used by the linear trailing-slash trim. */
+const SLASH_CODE = 0x2f
+
+/**
+ * Strip any run of trailing `/` from a base URL. A single linear backward scan,
+ * deliberately NOT a regex: the equivalent `/\/+$/` pattern backtracks
+ * polynomially on a long run of slashes that fails the end-anchor (a
+ * `js/polynomial-redos` shape), so on an adversarial input it can stall the
+ * isolate. The character walk is O(n) with no backtracking and yields the
+ * identical result. Pure and total.
+ */
+export function trimTrailingSlashes(value: string): string {
+  let end = value.length
+  while (end > 0 && value.charCodeAt(end - 1) === SLASH_CODE) end -= 1
+  return value.slice(0, end)
+}
+
 /** Options for constructing a DeepSeek LLM provider. */
 export interface DeepSeekProviderOptions {
   /** Server-side API key, placed in the `Authorization: Bearer` header. */
@@ -235,7 +252,7 @@ function processSse(
  * streaming `LlmProvider` contract.
  */
 export function createDeepSeekLlmProvider(opts: DeepSeekProviderOptions): DeepSeekLlmProvider {
-  const baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '')
+  const baseUrl = trimTrailingSlashes(opts.baseUrl ?? DEFAULT_BASE_URL)
   const endpoint = `${baseUrl}/chat/completions`
 
   const provider: DeepSeekLlmProvider = {

--- a/packages/platform-ai/src/providers/factory.test.ts
+++ b/packages/platform-ai/src/providers/factory.test.ts
@@ -95,7 +95,7 @@ describe('createProviders', () => {
       createProviders(
         config({
           stt: { provider: 'volcengine', model: 'bigmodel-asr-pro' },
-          tts: { provider: 'volcengine', model: 'doubao-tts-2.0-pro' },
+          tts: { provider: 'volcengine', model: 'seed-tts-2.0-standard' },
         }),
         fullEnv
       )
@@ -103,7 +103,33 @@ describe('createProviders', () => {
       expect(spy).toHaveBeenCalledWith(
         expect.objectContaining({
           sttModel: 'bigmodel-asr-pro',
-          ttsModel: 'doubao-tts-2.0-pro',
+          ttsModel: 'seed-tts-2.0-standard',
+        })
+      )
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('threads the empty-string TTS model sentinel through unchanged (omit-by-default)', () => {
+    // The `demo` TTS model is `''` ("use the resource-id default model"). The
+    // factory must forward it verbatim — it does NOT substitute a default token —
+    // so the adapter is the single place that decides omission (an empty model
+    // omits `req_params.model`). This proves the passthrough mechanism stays
+    // intact for the omit case as well as for a concrete deploy-time token.
+    const spy = vi.spyOn(volcengine, 'createVolcengineSpeechProvider')
+    try {
+      createProviders(
+        config({
+          stt: { provider: 'volcengine', model: 'bigmodel' },
+          tts: { provider: 'volcengine', model: '' },
+        }),
+        fullEnv
+      )
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sttModel: 'bigmodel',
+          ttsModel: '',
         })
       )
     } finally {

--- a/packages/platform-ai/src/providers/factory.test.ts
+++ b/packages/platform-ai/src/providers/factory.test.ts
@@ -6,9 +6,9 @@ function config(over: Partial<ResolvedConfig> = {}): ResolvedConfig {
   return {
     gameId: 'demo',
     systemPromptConfig: { role: 'guide', ruleTemplate: [] },
-    llm: { provider: 'deepseek', model: 'deepseek-v4-flash', fallback: [] },
-    stt: { provider: 'volcengine', model: 'bigmodel', fallback: [] },
-    tts: { provider: 'volcengine', model: 'doubao', fallback: [] },
+    llm: { provider: 'deepseek', model: 'deepseek-v4-flash' },
+    stt: { provider: 'volcengine', model: 'bigmodel' },
+    tts: { provider: 'volcengine', model: 'doubao' },
     ...over,
   }
 }
@@ -29,19 +29,19 @@ describe('createProviders', () => {
 
   it('throws a precise error for an unknown llm provider id', () => {
     expect(() =>
-      createProviders(config({ llm: { provider: 'mystery', model: 'x', fallback: [] } }), fullEnv)
+      createProviders(config({ llm: { provider: 'mystery', model: 'x' } }), fullEnv)
     ).toThrow(/unknown llm provider id "mystery"/)
   })
 
   it('throws a precise error for an unknown stt provider id', () => {
     expect(() =>
-      createProviders(config({ stt: { provider: 'mystery', model: 'x', fallback: [] } }), fullEnv)
+      createProviders(config({ stt: { provider: 'mystery', model: 'x' } }), fullEnv)
     ).toThrow(/unknown stt provider id "mystery"/)
   })
 
   it('throws a precise error for an unknown tts provider id', () => {
     expect(() =>
-      createProviders(config({ tts: { provider: 'mystery', model: 'x', fallback: [] } }), fullEnv)
+      createProviders(config({ tts: { provider: 'mystery', model: 'x' } }), fullEnv)
     ).toThrow(/unknown tts provider id "mystery"/)
   })
 
@@ -61,9 +61,9 @@ describe('createProviders', () => {
 
   it('wires all-mock providers with no credentials in env', () => {
     const mockConfig = config({
-      llm: { provider: 'mock', model: 'mock-llm', fallback: [] },
-      stt: { provider: 'mock', model: 'mock-stt', fallback: [] },
-      tts: { provider: 'mock', model: 'mock-tts', fallback: [] },
+      llm: { provider: 'mock', model: 'mock-llm' },
+      stt: { provider: 'mock', model: 'mock-stt' },
+      tts: { provider: 'mock', model: 'mock-tts' },
     })
     // Empty env: the mock path must require no provider credentials.
     const providers = createProviders(mockConfig, {})
@@ -74,9 +74,9 @@ describe('createProviders', () => {
 
   it('shares one mock speech instance across the stt and tts slots', () => {
     const mockConfig = config({
-      stt: { provider: 'mock', model: 'mock-stt', fallback: [] },
-      tts: { provider: 'mock', model: 'mock-tts', fallback: [] },
-      llm: { provider: 'mock', model: 'mock-llm', fallback: [] },
+      stt: { provider: 'mock', model: 'mock-stt' },
+      tts: { provider: 'mock', model: 'mock-tts' },
+      llm: { provider: 'mock', model: 'mock-llm' },
     })
     const providers = createProviders(mockConfig, {})
     // The shared-instance build means stt and tts come from the same pair; we

--- a/packages/platform-ai/src/providers/factory.test.ts
+++ b/packages/platform-ai/src/providers/factory.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { createProviders, type ProviderEnv } from './factory'
+import type { ResolvedConfig } from '../provider-config'
+
+function config(over: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return {
+    gameId: 'demo',
+    systemPromptConfig: { role: 'guide', ruleTemplate: [] },
+    llm: { provider: 'deepseek', model: 'deepseek-v4-flash', fallback: [] },
+    stt: { provider: 'volcengine', model: 'bigmodel', fallback: [] },
+    tts: { provider: 'volcengine', model: 'doubao', fallback: [] },
+    ...over,
+  }
+}
+
+const fullEnv: ProviderEnv = {
+  DEEPSEEK_API_KEY: 'ds-key',
+  VOLC_APP_ID: 'app',
+  VOLC_ACCESS_KEY: 'token',
+}
+
+describe('createProviders', () => {
+  it('wires all three layers from the resolved config + env', () => {
+    const providers = createProviders(config(), fullEnv)
+    expect(typeof providers.llm.streamCompletion).toBe('function')
+    expect(typeof providers.stt.transcribe).toBe('function')
+    expect(typeof providers.tts.synthesize).toBe('function')
+  })
+
+  it('throws a precise error for an unknown llm provider id', () => {
+    expect(() =>
+      createProviders(config({ llm: { provider: 'mystery', model: 'x', fallback: [] } }), fullEnv)
+    ).toThrow(/unknown llm provider id "mystery"/)
+  })
+
+  it('throws a precise error for an unknown stt provider id', () => {
+    expect(() =>
+      createProviders(config({ stt: { provider: 'mystery', model: 'x', fallback: [] } }), fullEnv)
+    ).toThrow(/unknown stt provider id "mystery"/)
+  })
+
+  it('throws a precise error for an unknown tts provider id', () => {
+    expect(() =>
+      createProviders(config({ tts: { provider: 'mystery', model: 'x', fallback: [] } }), fullEnv)
+    ).toThrow(/unknown tts provider id "mystery"/)
+  })
+
+  it('throws when a selected vendor credential is missing', () => {
+    expect(() =>
+      createProviders(config(), { VOLC_APP_ID: 'app', VOLC_ACCESS_KEY: 'token' })
+    ).toThrow(/DEEPSEEK_API_KEY is not set/)
+    expect(() =>
+      createProviders(config(), { DEEPSEEK_API_KEY: 'ds', VOLC_ACCESS_KEY: 'token' })
+    ).toThrow(/VOLC_APP_ID is not set/)
+  })
+
+  it('sources credentials only from env (not config)', () => {
+    // No throw means the factory read the creds from env; absence would throw.
+    expect(() => createProviders(config(), fullEnv)).not.toThrow()
+  })
+
+  it('wires all-mock providers with no credentials in env', () => {
+    const mockConfig = config({
+      llm: { provider: 'mock', model: 'mock-llm', fallback: [] },
+      stt: { provider: 'mock', model: 'mock-stt', fallback: [] },
+      tts: { provider: 'mock', model: 'mock-tts', fallback: [] },
+    })
+    // Empty env: the mock path must require no provider credentials.
+    const providers = createProviders(mockConfig, {})
+    expect(typeof providers.llm.streamCompletion).toBe('function')
+    expect(typeof providers.stt.transcribe).toBe('function')
+    expect(typeof providers.tts.synthesize).toBe('function')
+  })
+
+  it('shares one mock speech instance across the stt and tts slots', () => {
+    const mockConfig = config({
+      stt: { provider: 'mock', model: 'mock-stt', fallback: [] },
+      tts: { provider: 'mock', model: 'mock-tts', fallback: [] },
+      llm: { provider: 'mock', model: 'mock-llm', fallback: [] },
+    })
+    const providers = createProviders(mockConfig, {})
+    // The shared-instance build means stt and tts come from the same pair; we
+    // assert both are present and distinct method surfaces (stt vs tts).
+    expect(providers.stt).not.toBe(providers.tts)
+  })
+})

--- a/packages/platform-ai/src/providers/factory.test.ts
+++ b/packages/platform-ai/src/providers/factory.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createProviders, type ProviderEnv } from './factory'
 import type { ResolvedConfig } from '../provider-config'
+import * as volcengine from './volcengine'
 
 function config(over: Partial<ResolvedConfig> = {}): ResolvedConfig {
   return {
@@ -82,5 +83,31 @@ describe('createProviders', () => {
     // The shared-instance build means stt and tts come from the same pair; we
     // assert both are present and distinct method surfaces (stt vs tts).
     expect(providers.stt).not.toBe(providers.tts)
+  })
+
+  it('threads the resolved stt/tts models into the volcengine provider (F-K)', () => {
+    // F-K: a model switch in `provider-config` must reach the speech adapter.
+    // Spy on the volcengine factory and assert `createProviders` forwards
+    // `resolved.stt.model` / `resolved.tts.model` (not just env/resource ids) so
+    // the per-layer model is no longer a no-op for the voice layer.
+    const spy = vi.spyOn(volcengine, 'createVolcengineSpeechProvider')
+    try {
+      createProviders(
+        config({
+          stt: { provider: 'volcengine', model: 'bigmodel-asr-pro' },
+          tts: { provider: 'volcengine', model: 'doubao-tts-2.0-pro' },
+        }),
+        fullEnv
+      )
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sttModel: 'bigmodel-asr-pro',
+          ttsModel: 'doubao-tts-2.0-pro',
+        })
+      )
+    } finally {
+      spy.mockRestore()
+    }
   })
 })

--- a/packages/platform-ai/src/providers/factory.ts
+++ b/packages/platform-ai/src/providers/factory.ts
@@ -1,0 +1,157 @@
+/**
+ * Provider factory — wire a `ResolvedConfig` to concrete R2 adapters.
+ *
+ * `resolveConfig(gameId)` (see `provider-config.ts`) yields a `ResolvedConfig`
+ * whose three `LayerSelection`s name a `provider` id + `model` per layer. This
+ * factory routes each provider id to the matching R2 adapter factory and pulls
+ * credentials *only* from the Worker `env` — never from config, never from the
+ * wire. An unknown provider id throws a precise error so a mis-registered
+ * config fails loudly rather than silently running the wrong vendor.
+ *
+ * The Volcengine speech adapter is the shared voice layer: one
+ * `createVolcengineSpeechProvider` call backs BOTH the STT and TTS slots when
+ * both layers select `volcengine`. We do not build it twice.
+ */
+
+import type { LlmProvider, SttProvider, TtsProvider } from './types'
+import type { ResolvedConfig } from '../provider-config'
+import { createDeepSeekLlmProvider } from './deepseek'
+import { createVolcengineSpeechProvider } from './volcengine'
+import { createMockLlmProvider, createMockSpeechProvider } from './mock'
+
+/** Provider id selecting the DeepSeek (OpenAI-compatible) LLM adapter. */
+const PROVIDER_DEEPSEEK = 'deepseek'
+/** Provider id selecting the shared Volcengine (火山) speech adapter. */
+const PROVIDER_VOLCENGINE = 'volcengine'
+/**
+ * Provider id selecting the deterministic mock adapters (no network, no
+ * credentials). Used by the demo harness and e2e scenarios so the full pipeline
+ * runs without real provider keys. Valid on all three layers.
+ */
+const PROVIDER_MOCK = 'mock'
+
+/**
+ * Server-side credential surface the factory reads. Mirrors the Worker env
+ * bindings declared in `wrangler.toml`; every field is optional here so the
+ * factory can throw a precise "missing credential" error for the specific
+ * vendor a config actually selects, rather than failing on an unrelated one.
+ */
+export interface ProviderEnv {
+  /** DeepSeek API key, server-side only. */
+  DEEPSEEK_API_KEY?: string
+  /** Optional DeepSeek base URL override. */
+  DEEPSEEK_BASE_URL?: string
+  /** Volcengine (火山) speech app id. */
+  VOLC_APP_ID?: string
+  /** Volcengine (火山) access token / key for the speech endpoints. */
+  VOLC_ACCESS_KEY?: string
+  /** Optional Volcengine ASR resource id override. */
+  VOLC_STT_RESOURCE_ID?: string
+  /** Optional Volcengine TTS resource id override. */
+  VOLC_TTS_RESOURCE_ID?: string
+}
+
+/** The three wired provider instances for one session. */
+export interface SessionProviders {
+  stt: SttProvider
+  llm: LlmProvider
+  tts: TtsProvider
+}
+
+/** Throw a precise error for a credential the selected vendor requires. */
+function requireCredential(value: string | undefined, name: string, providerId: string): string {
+  if (value === undefined || value === '') {
+    throw new Error(`provider-factory: ${providerId} provider selected but env.${name} is not set`)
+  }
+  return value
+}
+
+/** Build the LLM provider for the resolved LLM layer selection. */
+function createLlmProvider(resolved: ResolvedConfig, env: ProviderEnv): LlmProvider {
+  const { provider, model } = resolved.llm
+  switch (provider) {
+    case PROVIDER_MOCK:
+      return createMockLlmProvider()
+    case PROVIDER_DEEPSEEK:
+      return createDeepSeekLlmProvider({
+        apiKey: requireCredential(env.DEEPSEEK_API_KEY, 'DEEPSEEK_API_KEY', provider),
+        baseUrl: env.DEEPSEEK_BASE_URL,
+        model,
+      })
+    default:
+      throw new Error(
+        `provider-factory: unknown llm provider id "${provider}" (known: ${PROVIDER_MOCK}, ${PROVIDER_DEEPSEEK})`
+      )
+  }
+}
+
+/**
+ * Build the shared Volcengine speech pair once. Both the STT and TTS layers map
+ * to this single instance when they select `volcengine`; building it once keeps
+ * the voice layer shared (one socket pair per modality, one adapter).
+ */
+function createVolcengineSpeech(env: ProviderEnv): { stt: SttProvider; tts: TtsProvider } {
+  return createVolcengineSpeechProvider({
+    appId: requireCredential(env.VOLC_APP_ID, 'VOLC_APP_ID', PROVIDER_VOLCENGINE),
+    accessToken: requireCredential(env.VOLC_ACCESS_KEY, 'VOLC_ACCESS_KEY', PROVIDER_VOLCENGINE),
+    sttResourceId: env.VOLC_STT_RESOURCE_ID,
+    ttsResourceId: env.VOLC_TTS_RESOURCE_ID,
+  })
+}
+
+/**
+ * Wire all three provider layers from a resolved config + the Worker env.
+ *
+ * Routes each `LayerSelection.provider` id to its R2 adapter factory. When both
+ * the STT and TTS layers select `volcengine`, the same shared speech instance
+ * backs both. An unknown provider id on any layer throws.
+ */
+export function createProviders(resolved: ResolvedConfig, env: ProviderEnv): SessionProviders {
+  const llm = createLlmProvider(resolved, env)
+
+  // Build each shared speech pair at most once, lazily, only if a voice layer
+  // actually selects it. Both the mock and Volcengine voice layers are shared
+  // STT+TTS instances — one build backs both slots.
+  let volcengine: { stt: SttProvider; tts: TtsProvider } | undefined
+  const getVolcengine = (): { stt: SttProvider; tts: TtsProvider } => {
+    if (volcengine === undefined) volcengine = createVolcengineSpeech(env)
+    return volcengine
+  }
+  let mock: { stt: SttProvider; tts: TtsProvider } | undefined
+  const getMock = (): { stt: SttProvider; tts: TtsProvider } => {
+    if (mock === undefined) mock = createMockSpeechProvider()
+    return mock
+  }
+
+  const knownSpeech = `${PROVIDER_MOCK}, ${PROVIDER_VOLCENGINE}`
+
+  let stt: SttProvider
+  switch (resolved.stt.provider) {
+    case PROVIDER_MOCK:
+      stt = getMock().stt
+      break
+    case PROVIDER_VOLCENGINE:
+      stt = getVolcengine().stt
+      break
+    default:
+      throw new Error(
+        `provider-factory: unknown stt provider id "${resolved.stt.provider}" (known: ${knownSpeech})`
+      )
+  }
+
+  let tts: TtsProvider
+  switch (resolved.tts.provider) {
+    case PROVIDER_MOCK:
+      tts = getMock().tts
+      break
+    case PROVIDER_VOLCENGINE:
+      tts = getVolcengine().tts
+      break
+    default:
+      throw new Error(
+        `provider-factory: unknown tts provider id "${resolved.tts.provider}" (known: ${knownSpeech})`
+      )
+  }
+
+  return { stt, llm, tts }
+}

--- a/packages/platform-ai/src/providers/factory.ts
+++ b/packages/platform-ai/src/providers/factory.ts
@@ -89,13 +89,27 @@ function createLlmProvider(resolved: ResolvedConfig, env: ProviderEnv): LlmProvi
  * Build the shared Volcengine speech pair once. Both the STT and TTS layers map
  * to this single instance when they select `volcengine`; building it once keeps
  * the voice layer shared (one socket pair per modality, one adapter).
+ *
+ * The resolved STT and TTS model ids from `provider-config` are threaded in so
+ * the config's "each layer's model is swappable" contract actually reaches the
+ * wire: `sttModel` becomes the ASR `request.model_name`, `ttsModel` the Doubao
+ * TTS `req_params.model`. Without this passthrough the adapter would fall back to
+ * its built-in defaults and the config model would be a silent no-op (the F-K
+ * bug). The shared pair is built from BOTH layers' models, which is correct: when
+ * both voice slots select `volcengine` the spec already binds them to one shared
+ * voice instance, and a single Volcengine config registers STT + TTS together.
  */
-function createVolcengineSpeech(env: ProviderEnv): { stt: SttProvider; tts: TtsProvider } {
+function createVolcengineSpeech(
+  resolved: ResolvedConfig,
+  env: ProviderEnv
+): { stt: SttProvider; tts: TtsProvider } {
   return createVolcengineSpeechProvider({
     appId: requireCredential(env.VOLC_APP_ID, 'VOLC_APP_ID', PROVIDER_VOLCENGINE),
     accessToken: requireCredential(env.VOLC_ACCESS_KEY, 'VOLC_ACCESS_KEY', PROVIDER_VOLCENGINE),
     sttResourceId: env.VOLC_STT_RESOURCE_ID,
     ttsResourceId: env.VOLC_TTS_RESOURCE_ID,
+    sttModel: resolved.stt.model,
+    ttsModel: resolved.tts.model,
   })
 }
 
@@ -114,7 +128,7 @@ export function createProviders(resolved: ResolvedConfig, env: ProviderEnv): Ses
   // STT+TTS instances — one build backs both slots.
   let volcengine: { stt: SttProvider; tts: TtsProvider } | undefined
   const getVolcengine = (): { stt: SttProvider; tts: TtsProvider } => {
-    if (volcengine === undefined) volcengine = createVolcengineSpeech(env)
+    if (volcengine === undefined) volcengine = createVolcengineSpeech(resolved, env)
     return volcengine
   }
   let mock: { stt: SttProvider; tts: TtsProvider } | undefined

--- a/packages/platform-ai/src/providers/factory.ts
+++ b/packages/platform-ai/src/providers/factory.ts
@@ -93,9 +93,14 @@ function createLlmProvider(resolved: ResolvedConfig, env: ProviderEnv): LlmProvi
  * The resolved STT and TTS model ids from `provider-config` are threaded in so
  * the config's "each layer's model is swappable" contract actually reaches the
  * wire: `sttModel` becomes the ASR `request.model_name`, `ttsModel` the Doubao
- * TTS `req_params.model`. Without this passthrough the adapter would fall back to
- * its built-in defaults and the config model would be a silent no-op (the F-K
- * bug). The shared pair is built from BOTH layers' models, which is correct: when
+ * TTS `req_params.model` when it is a non-empty concrete value. The `demo` TTS
+ * model is the empty-string sentinel ("use the resource-id default model"), so
+ * this passthrough omits `req_params.model` by default — the mechanism stays
+ * available for a concrete deploy-time-confirmed token without guessing one onto
+ * the wire now. Without this passthrough the adapter would fall back to its
+ * built-in defaults and the config model would be a silent no-op (the F-K bug,
+ * for the STT side and any future concrete TTS token). The shared pair is built
+ * from BOTH layers' models, which is correct: when
  * both voice slots select `volcengine` the spec already binds them to one shared
  * voice instance, and a single Volcengine config registers STT + TTS together.
  */

--- a/packages/platform-ai/src/providers/mock.test.ts
+++ b/packages/platform-ai/src/providers/mock.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createMockLlmProvider,
+  createMockSpeechProvider,
+  createMockSttProvider,
+  createMockTtsProvider,
+  MOCK_TRANSCRIPT,
+} from './mock'
+import type { ChatMessage } from './types'
+import type { AudioChunk } from '../contract'
+
+async function collect<T>(stream: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = []
+  for await (const item of stream) out.push(item)
+  return out
+}
+
+async function* audioFrames(...frames: AudioChunk[]): AsyncIterable<AudioChunk> {
+  for (const f of frames) yield f
+}
+
+async function* sentences(...items: string[]): AsyncIterable<string> {
+  for (const s of items) yield s
+}
+
+const decoder = new TextDecoder()
+
+describe('createMockSttProvider', () => {
+  it('drains the audio stream and yields the fixed final transcript', async () => {
+    const stt = createMockSttProvider()
+    const chunks = await collect(
+      stt.transcribe(audioFrames(new Uint8Array([1, 2]), new Uint8Array([3, 4])))
+    )
+    expect(chunks).toEqual([{ text: MOCK_TRANSCRIPT, isFinal: true }])
+  })
+
+  it('yields the fixed transcript even for an empty audio stream', async () => {
+    const stt = createMockSttProvider()
+    const chunks = await collect(stt.transcribe(audioFrames()))
+    expect(chunks).toEqual([{ text: MOCK_TRANSCRIPT, isFinal: true }])
+  })
+})
+
+describe('createMockLlmProvider', () => {
+  function systemWithManual(manualLine: string): ChatMessage[] {
+    return [
+      {
+        role: 'system',
+        content: `You are a guide.\n\nManual (version v1) — relevant sections:\n\n### module-a\n${manualLine}`,
+      },
+      { role: 'user', content: MOCK_TRANSCRIPT },
+    ]
+  }
+
+  it('streams a deterministic manual-grounded reply ending in a done chunk', async () => {
+    const llm = createMockLlmProvider()
+    const chunks = await collect(
+      llm.streamCompletion({ model: 'mock-llm', messages: systemWithManual('"红色按钮" => ABORT') })
+    )
+    const last = chunks[chunks.length - 1]
+    expect(last).toEqual({ content: '', done: true })
+    const text = chunks
+      .slice(0, -1)
+      .map((c) => c.content)
+      .join('')
+    // The reply visibly depends on the injected manual line.
+    expect(text).toContain('"红色按钮" => ABORT')
+  })
+
+  it('is deterministic for identical input', async () => {
+    const llm = createMockLlmProvider()
+    const a = await collect(
+      llm.streamCompletion({ model: 'mock-llm', messages: systemWithManual('X') })
+    )
+    const b = await collect(
+      llm.streamCompletion({ model: 'mock-llm', messages: systemWithManual('X') })
+    )
+    expect(a).toEqual(b)
+  })
+
+  it('exposes lastUsage after the stream is drained', async () => {
+    const llm = createMockLlmProvider({ usage: { inputTokens: 7, outputTokens: 9 } })
+    await collect(llm.streamCompletion({ model: 'mock-llm', messages: systemWithManual('X') }))
+    expect(llm.lastUsage).toEqual({ inputTokens: 7, outputTokens: 9 })
+  })
+})
+
+describe('createMockTtsProvider', () => {
+  it('maps each sentence to a UTF-8 audio frame plus a terminal done frame', async () => {
+    const tts = createMockTtsProvider()
+    const chunks = await collect(tts.synthesize(sentences('一句话。', '第二句。')))
+    expect(chunks).toHaveLength(3)
+    expect(decoder.decode(chunks[0].audio)).toBe('一句话。')
+    expect(decoder.decode(chunks[1].audio)).toBe('第二句。')
+    expect(chunks[2]).toEqual({ audio: new Uint8Array(0), done: true })
+  })
+})
+
+describe('createMockSpeechProvider', () => {
+  it('returns a shared stt + tts pair', () => {
+    const pair = createMockSpeechProvider()
+    expect(typeof pair.stt.transcribe).toBe('function')
+    expect(typeof pair.tts.synthesize).toBe('function')
+  })
+})

--- a/packages/platform-ai/src/providers/mock.ts
+++ b/packages/platform-ai/src/providers/mock.ts
@@ -1,0 +1,160 @@
+/**
+ * Deterministic mock provider layer — first-party demo / e2e harness backend.
+ *
+ * These mocks implement the same three semantic interfaces as the real R2
+ * adapters (`SttProvider` / `LlmProvider` / `TtsProvider`) but with NO network,
+ * NO credentials, and fully deterministic output. They let the demo harness and
+ * e2e scenarios drive the whole STT -> LLM -> TTS pipeline ("speak -> see/hear an
+ * AI reply grounded in the injected manual") without provisioning real DeepSeek
+ * or Volcengine (火山) keys.
+ *
+ * Determinism is the contract:
+ *   - STT maps any non-empty inbound audio stream to one fixed example
+ *     transcript, so a turn always has a stable player utterance.
+ *   - LLM reads the injected manual subset out of its `system` message and
+ *     replies with a deterministic, manual-grounded sentence (no randomness, no
+ *     clock). Given the same messages it yields byte-identical deltas.
+ *   - TTS maps each input sentence to a fake audio frame whose bytes are the
+ *     UTF-8 encoding of the sentence, so "audio was produced for this text" is
+ *     observable in tests without a codec.
+ *
+ * The mocks hold no secrets and no system prompt of their own: the LLM mock
+ * only echoes back the manual material the platform already injected server-side
+ * (the same injection path the real adapter sees), so the "prompt is
+ * server-side only" invariant is unaffected.
+ */
+
+import type {
+  ChatMessage,
+  LlmCompletionChunk,
+  LlmCompletionRequest,
+  LlmProvider,
+  LlmUsage,
+  SttProvider,
+  SttTranscriptChunk,
+  TtsAudioChunk,
+  TtsProvider,
+} from './types'
+import type { AudioChunk } from '../contract'
+
+/** The fixed transcript the mock STT resolves every spoken turn to. */
+export const MOCK_TRANSCRIPT = '我看到面板上有一个红色的按钮，旁边写着 ABORT。'
+
+const textEncoder = new TextEncoder()
+
+/** Options for the mock LLM provider. */
+export interface MockLlmProviderOptions {
+  /**
+   * Fixed token usage reported after each completion, so the pipeline's usage
+   * accounting path is exercised deterministically. Defaults to a small
+   * non-zero pair.
+   */
+  usage?: LlmUsage
+}
+
+/**
+ * A mock LLM provider. Mirrors the `DeepSeekLlmProvider` shape (exposes an
+ * optional `lastUsage` the turn pipeline reads structurally) so it is a
+ * drop-in substitute on the LLM slot.
+ */
+export interface MockLlmProvider extends LlmProvider {
+  /** Token usage from the most recently consumed completion. */
+  lastUsage?: LlmUsage
+}
+
+/**
+ * Extract the first injected manual line from the assembled system message.
+ *
+ * The platform injects the manual subset into the `system` message (see
+ * `manual-injection.ts`) under a `### <sectionId>` block. We surface the first
+ * such block's first content line so the deterministic reply visibly depends on
+ * the injected manual — demonstrating "the AI answers from the injected manual"
+ * end to end. Falls back to a fixed phrase when no manual block is present.
+ */
+function firstInjectedManualLine(messages: ChatMessage[]): string {
+  const system = messages.find((m) => m.role === 'system')
+  if (!system) return '（无注入手册）'
+  const lines = system.content.split('\n')
+  const headerIdx = lines.findIndex((line) => line.startsWith('### '))
+  if (headerIdx === -1) return '（无注入手册）'
+  for (let i = headerIdx + 1; i < lines.length; i += 1) {
+    const line = lines[i].trim()
+    if (line.length > 0) return line
+  }
+  return '（无注入手册）'
+}
+
+/**
+ * Create a deterministic mock LLM provider. It reads the manual subset the
+ * platform injected into the system message and streams a fixed, manual-grounded
+ * reply as a few content deltas (so the streaming + sentence-segmentation path
+ * is exercised), followed by the terminal `done` chunk. No network, no key.
+ */
+export function createMockLlmProvider(options: MockLlmProviderOptions = {}): MockLlmProvider {
+  const usage: LlmUsage = options.usage ?? { inputTokens: 12, outputTokens: 24 }
+
+  const provider: MockLlmProvider = {
+    async *streamCompletion(request: LlmCompletionRequest): AsyncIterable<LlmCompletionChunk> {
+      provider.lastUsage = undefined
+      const manualLine = firstInjectedManualLine(request.messages)
+      // Deterministic, manual-grounded reply. Split into sentences so the
+      // pipeline's sentence segmentation + TTS hand-off is exercised.
+      const reply = [
+        `好的，根据手册我看到这一条：${manualLine}`,
+        '请先确认你看到的按钮颜色，再告诉我。',
+      ]
+      for (const sentence of reply) {
+        yield { content: sentence, done: false }
+      }
+      provider.lastUsage = usage
+      yield { content: '', done: true }
+    },
+  }
+
+  return provider
+}
+
+/**
+ * Create a deterministic mock STT provider. Drains the inbound audio stream
+ * (so the audio bridge is consumed exactly like the real adapter) and yields a
+ * single final transcript chunk carrying the fixed example utterance. An empty
+ * audio stream still yields the fixed transcript so a turn always has text.
+ */
+export function createMockSttProvider(): SttProvider {
+  return {
+    async *transcribe(audio: AsyncIterable<AudioChunk>): AsyncIterable<SttTranscriptChunk> {
+      // Consume the inbound frames so the bridge drains; the content is ignored
+      // (deterministic transcript), but draining matches real-adapter behavior.
+      for await (const _frame of audio) {
+        // intentionally empty — frames are consumed, not inspected
+      }
+      yield { text: MOCK_TRANSCRIPT, isFinal: true }
+    },
+  }
+}
+
+/**
+ * Create a deterministic mock TTS provider. Maps each input sentence to one
+ * fake audio frame whose bytes are the UTF-8 encoding of the sentence, then a
+ * terminal `done` frame. This makes "audio was synthesized for this text"
+ * observable in tests without a real codec.
+ */
+export function createMockTtsProvider(): TtsProvider {
+  return {
+    async *synthesize(text: AsyncIterable<string>): AsyncIterable<TtsAudioChunk> {
+      for await (const sentence of text) {
+        yield { audio: textEncoder.encode(sentence), done: false }
+      }
+      yield { audio: new Uint8Array(0), done: true }
+    },
+  }
+}
+
+/**
+ * Build the shared mock speech pair (STT + TTS). Mirrors
+ * `createVolcengineSpeechProvider`'s return shape so the factory wires the mock
+ * voice layer through the same code path as the real shared speech adapter.
+ */
+export function createMockSpeechProvider(): { stt: SttProvider; tts: TtsProvider } {
+  return { stt: createMockSttProvider(), tts: createMockTtsProvider() }
+}

--- a/packages/platform-ai/src/providers/types.ts
+++ b/packages/platform-ai/src/providers/types.ts
@@ -1,0 +1,131 @@
+/**
+ * Three-layer provider semantic interfaces: STT / LLM / TTS.
+ *
+ * Each layer defines one streaming-shaped semantic interface; concrete vendor
+ * adapters implement them in a later round (R2). The platform picks which
+ * adapter each game/layer uses via `provider-config`.
+ *
+ * Design constraints from the L2 spec encoded here:
+ *  - The LLM interface is shaped as "OpenAI-compatible chat completions,
+ *    streaming". One adapter then covers every OpenAI-compatible vendor
+ *    (DeepSeek v4 is the default), rather than one adapter per vendor.
+ *  - The voice layer (STT + TTS) is a shared platform layer — a single
+ *    Volcengine (火山) speech adapter backs both, not one per LLM provider.
+ *  - These are streaming forms: STT and TTS consume/produce async chunk
+ *    streams; the LLM yields incremental completion deltas.
+ */
+
+import type { AudioChunk } from '../contract'
+
+// --- LLM layer (OpenAI-compatible chat completions, streaming) ---
+
+/** OpenAI-compatible message role. */
+export type ChatRole = 'system' | 'user' | 'assistant'
+
+/**
+ * One OpenAI-compatible chat message. This is the shape produced by the
+ * deterministic manual-injection step (see `manual-injection.ts`) and consumed
+ * by the LLM provider.
+ */
+export interface ChatMessage {
+  role: ChatRole
+  content: string
+}
+
+/**
+ * Request to the LLM layer, mirroring an OpenAI-compatible chat completions
+ * call with `stream: true`. `model` selects the concrete model behind the
+ * adapter (e.g. 'deepseek-v4-flash'); `messages` is the fully-assembled context.
+ */
+export interface LlmCompletionRequest {
+  model: string
+  messages: ChatMessage[]
+  /** Optional sampling temperature, passed through to the vendor as-is. */
+  temperature?: number
+}
+
+/**
+ * One streamed completion delta — the OpenAI-compatible `choices[].delta`
+ * shape reduced to what the turn pipeline needs. `content` is the incremental
+ * assistant text for this chunk; `done` marks the final delta of the stream
+ * (the adapter maps the vendor's `data: [DONE]` sentinel onto it).
+ */
+export interface LlmCompletionChunk {
+  content: string
+  done: boolean
+}
+
+/**
+ * Token usage for one completion. Populated by the adapter from the vendor's
+ * usage report (or estimated) and forwarded to the session's metering mount.
+ */
+export interface LlmUsage {
+  inputTokens: number
+  outputTokens: number
+}
+
+/**
+ * LLM provider layer. One OpenAI-compatible streaming adapter implements this
+ * for all OpenAI-compatible vendors.
+ */
+export interface LlmProvider {
+  /**
+   * Stream a chat completion. Yields incremental text deltas until a `done`
+   * chunk. The final usage report is exposed via `lastUsage` after the stream
+   * is fully consumed (kept off the chunk stream so the per-token hot path
+   * stays text-only).
+   */
+  streamCompletion(request: LlmCompletionRequest): AsyncIterable<LlmCompletionChunk>
+}
+
+// --- STT layer (streaming speech-to-text) ---
+
+/**
+ * One streamed transcription result. `text` is the cumulative-or-incremental
+ * transcript for this chunk (the adapter owns which); `isFinal` marks a
+ * stabilized segment the turn pipeline may forward to the LLM.
+ */
+export interface SttTranscriptChunk {
+  text: string
+  isFinal: boolean
+}
+
+/**
+ * STT provider layer. The first adapter is Volcengine (火山) modular ASR over
+ * its self-owned WebSocket protocol; that adapter is shared with TTS as the
+ * platform voice layer.
+ */
+export interface SttProvider {
+  /**
+   * Stream player audio frames in, yield transcription chunks out. The input
+   * is an async stream of audio frames (the session WebSocket's inbound side);
+   * the output is the transcript stream consumed by the LLM step.
+   */
+  transcribe(audio: AsyncIterable<AudioChunk>): AsyncIterable<SttTranscriptChunk>
+}
+
+// --- TTS layer (streaming text-to-speech) ---
+
+/**
+ * One synthesized audio frame produced by the TTS layer. `audio` is the frame
+ * pushed back over the session WebSocket; `done` marks the final frame for the
+ * synthesized utterance.
+ */
+export interface TtsAudioChunk {
+  audio: Uint8Array
+  done: boolean
+}
+
+/**
+ * TTS provider layer. The first adapter shares the Volcengine (火山) speech
+ * adapter with STT (Doubao TTS 2.0 streaming) — the voice layer is shared, not
+ * duplicated per LLM provider.
+ */
+export interface TtsProvider {
+  /**
+   * Stream LLM text in, yield synthesized audio frames out. The input is the
+   * sentence-segmented assistant text from the LLM step; the output is the
+   * audio-frame stream pushed back to the player.
+   */
+  synthesize(text: AsyncIterable<string>): AsyncIterable<TtsAudioChunk>
+}

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -1019,3 +1019,73 @@ describe('defaultConnect — outbound socket binary delivery type (F-N)', () => 
     )
   })
 })
+
+describe('defaultConnect — fetch-upgrade URL scheme rewrite', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  /** Minimal accept-only socket so `defaultConnect` resolves past the upgrade. */
+  class AcceptableSocket {
+    binaryType: 'blob' | 'arraybuffer' = 'blob'
+    accept(): void {}
+  }
+
+  /**
+   * Stub `fetch` so the test can read back the exact URL it received. The
+   * Cloudflare custom-header WebSocket upgrade requires an `http(s)://` URL —
+   * `ws:`/`wss:` are reserved for `new WebSocket()` and fail the `fetch` upgrade
+   * before any turn starts. These tests pin the `wss:`->`https:` / `ws:`->`http:`
+   * rewrite (and that host/path/query + the Upgrade + auth headers survive
+   * untouched) so a scheme regression is caught here, not at deploy time.
+   */
+  function captureFetchUrl(): { calls: Array<{ url: string; init?: RequestInit }> } {
+    const calls: Array<{ url: string; init?: RequestInit }> = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init })
+        return { webSocket: new AcceptableSocket() } as unknown as Response
+      })
+    )
+    return { calls }
+  }
+
+  it('rewrites wss:// to https:// while preserving host/path/query', async () => {
+    const captured = captureFetchUrl()
+
+    await defaultConnect('wss://openspeech.bytedance.com/api/v3/tts/bidirection?x=1', {
+      Upgrade: 'websocket',
+    })
+
+    expect(captured.calls).toHaveLength(1)
+    expect(captured.calls[0].url).toBe(
+      'https://openspeech.bytedance.com/api/v3/tts/bidirection?x=1'
+    )
+  })
+
+  it('rewrites ws:// to http:// while preserving host/path/query', async () => {
+    const captured = captureFetchUrl()
+
+    await defaultConnect('ws://example.test:8080/v3/sauc/bigmodel?a=b', { Upgrade: 'websocket' })
+
+    expect(captured.calls).toHaveLength(1)
+    expect(captured.calls[0].url).toBe('http://example.test:8080/v3/sauc/bigmodel?a=b')
+  })
+
+  it('passes the Upgrade + auth headers through unchanged after the rewrite', async () => {
+    const captured = captureFetchUrl()
+    const headers = {
+      Upgrade: 'websocket',
+      'X-Api-App-Key': 'app-123',
+      'X-Api-Access-Key': 'token-456',
+      'X-Api-Resource-Id': 'volc.bigasr.sauc.duration',
+      'X-Api-Connect-Id': 'connect-789',
+    }
+
+    await defaultConnect('wss://openspeech.bytedance.com/api/v3/sauc/bigmodel', headers)
+
+    expect(captured.calls[0].url.startsWith('https://')).toBe(true)
+    expect(captured.calls[0].init?.headers).toEqual(headers)
+  })
+})

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -97,6 +97,13 @@ async function asyncFrom<T>(items: T[]): Promise<AsyncIterable<T>> {
   })()
 }
 
+/** Synchronous variant of {@link asyncFrom} for call sites that need the iterable inline. */
+function asyncFromSync<T>(items: T[]): AsyncIterable<T> {
+  return (async function* () {
+    for (const item of items) yield item
+  })()
+}
+
 async function collect<T>(stream: AsyncIterable<T>): Promise<T[]> {
   const out: T[] = []
   for await (const item of stream) out.push(item)
@@ -391,6 +398,62 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
     expect(last.sequence).toBeLessThan(0)
   })
 
+  it('sends the configured sttModel as request.model_name, not the default (F-K)', async () => {
+    // F-K: the factory must thread `resolved.stt.model` into the adapter so the
+    // config-selected ASR model reaches `request.model_name`. Here we set a
+    // non-default `sttModel` and assert the FIRST outbound frame (the JSON config
+    // request) carries it — proving the option is not dropped in favour of the
+    // built-in `DEFAULT_STT_MODEL`.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({
+      appId: 'a',
+      accessToken: 't',
+      sttModel: 'bigmodel-asr-pro',
+      connect,
+    })
+
+    const consumed = (async () => {
+      for await (const _chunk of stt.transcribe(await asyncFrom([encoder.encode('f1')]))) {
+        break
+      }
+    })()
+    await tick()
+
+    const configFrame = parseFrame(socket.sent[0])
+    const body = JSON.parse(decoder.decode(configFrame.payload)) as {
+      request: { model_name: string }
+    }
+    expect(body.request.model_name).toBe('bigmodel-asr-pro')
+    expect(body.request.model_name).not.toBe('bigmodel') // not the default
+
+    // Unblock the consumer so nothing is left pending.
+    socket.emitMessage(sttServerFrame({ result: { text: 'x', utterances: [{ definite: true }] } }))
+    await consumed
+  })
+
+  it('falls back to the default sttModel when none is configured', async () => {
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const consumed = (async () => {
+      for await (const _chunk of stt.transcribe(await asyncFrom([encoder.encode('f1')]))) {
+        break
+      }
+    })()
+    await tick()
+
+    const configFrame = parseFrame(socket.sent[0])
+    const body = JSON.parse(decoder.decode(configFrame.payload)) as {
+      request: { model_name: string }
+    }
+    expect(body.request.model_name).toBe('bigmodel')
+
+    socket.emitMessage(sttServerFrame({ result: { text: 'x', utterances: [{ definite: true }] } }))
+    await consumed
+  })
+
   it('ends the iteration on a definite transcript without waiting for a WS close', async () => {
     // Regression: `collectFinalTranscript` drains `transcribe` to iterator end
     // (it does not break early like the test above). If the adapter only closed
@@ -598,6 +661,54 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
       TtsEvent.FinishSession,
       TtsEvent.FinishConnection,
     ])
+  })
+
+  it('puts the configured ttsModel in the StartSession req_params, omitting it when unset (F-K)', async () => {
+    // F-K: the factory threads `resolved.tts.model` into the adapter so a TTS
+    // model switch in `provider-config` reaches the wire (the StartSession
+    // `req_params.model`) instead of being silently dropped. With a model set it
+    // must appear; with none set the field must be absent (default request shape).
+    const withModelSocket = new MockSocket()
+    const withModel = mockConnector(withModelSocket)
+    const provider = createVolcengineSpeechProvider({
+      appId: 'a',
+      accessToken: 't',
+      ttsModel: 'doubao-tts-2.0-pro',
+      connect: withModel.connect,
+    })
+    void collect(provider.tts.synthesize(asyncFromSync(['句一'])))
+    await tick()
+    withModelSocket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+
+    const startSession = withModelSocket.sent
+      .map((b) => parseFrame(b))
+      .find((f) => f.event === TtsEvent.StartSession)
+    const body = JSON.parse(decoder.decode(startSession?.payload ?? new Uint8Array(0))) as {
+      req_params: { model?: string }
+    }
+    expect(body.req_params.model).toBe('doubao-tts-2.0-pro')
+
+    // With no ttsModel configured, the StartSession req_params omits `model`.
+    const noModelSocket = new MockSocket()
+    const noModel = mockConnector(noModelSocket)
+    const plain = createVolcengineSpeechProvider({
+      appId: 'a',
+      accessToken: 't',
+      connect: noModel.connect,
+    })
+    void collect(plain.tts.synthesize(asyncFromSync(['句一'])))
+    await tick()
+    noModelSocket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+
+    const plainStartSession = noModelSocket.sent
+      .map((b) => parseFrame(b))
+      .find((f) => f.event === TtsEvent.StartSession)
+    const plainBody = JSON.parse(
+      decoder.decode(plainStartSession?.payload ?? new Uint8Array(0))
+    ) as { req_params: { model?: string } }
+    expect(plainBody.req_params.model).toBeUndefined()
   })
 
   it('does NOT send StartSession until the server accepts the connection', async () => {

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -493,6 +493,21 @@ describe('TtsHandshake', () => {
     expect(hs.handleEvent(undefined, () => '')).toBe(false)
   })
 
+  it('resolves sessionFinished on a SessionFinished event (but reports it not consumed)', async () => {
+    // SessionFinished (152) resolves the finish gate so the pump may send
+    // FinishConnection, yet handleEvent returns false because the provider's
+    // listener still owns pushing the final done chunk + closing the queue on it.
+    const hs = new TtsHandshake()
+    expect(hs.handleEvent(TtsEvent.SessionFinished, () => '')).toBe(false)
+    await expect(hs.sessionFinished).resolves.toBeUndefined()
+  })
+
+  it('abort rejects the sessionFinished gate when the session never finishes', async () => {
+    const hs = new TtsHandshake()
+    hs.abort(new Error('socket closed before finish'))
+    await expect(hs.sessionFinished).rejects.toThrow(/socket closed before finish/)
+  })
+
   it('abort rejects every not-yet-settled gate', async () => {
     const hs = new TtsHandshake()
     hs.abort(new Error('socket closed early'))
@@ -639,6 +654,68 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
 
     socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
     await collected
+  })
+
+  it('does NOT send FinishConnection until the server finishes the session (no tail-audio truncation)', async () => {
+    // Regression for the close-side timing P2: the previous pump sent
+    // FinishConnection immediately after FinishSession, before the server had
+    // returned its remaining TTSResponse audio frames + SessionFinished (152).
+    // Closing the connection at that point truncates the last synthesized audio.
+    // The fix gates FinishConnection on SessionFinished, symmetric to the
+    // start-side handshake — so the server's tail audio is fully drained first.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const collected = collect(tts.synthesize(await asyncFrom(['念完整一段话'])))
+
+    // Walk the start-side handshake to where FinishSession has just been sent.
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+    const sessionId =
+      socket.sent.map((b) => parseFrame(b)).find((f) => f.event === TtsEvent.StartSession)
+        ?.sessionId ?? 's'
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    await tick()
+
+    // After FinishSession, the pump must NOT have sent FinishConnection yet — it
+    // is gated on SessionFinished, which has not arrived.
+    expect(sentEvents(socket)).toContain(TtsEvent.FinishSession)
+    expect(sentEvents(socket)).not.toContain(TtsEvent.FinishConnection)
+
+    // Server streams the remaining tail audio AFTER FinishSession. Each frame
+    // arrives while the connection is still open and FinishConnection unsent.
+    for (const tail of ['TAIL1', 'TAIL2', 'TAIL3']) {
+      socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode(tail), sessionId))
+      // Still no FinishConnection and the socket is still open mid-stream — the
+      // close is strictly gated behind SessionFinished, so no frame is dropped.
+      expect(sentEvents(socket)).not.toContain(TtsEvent.FinishConnection)
+      expect(socket.closed).toBe(false)
+    }
+
+    // Only now does the server acknowledge the session is complete.
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
+    const chunks = await collected
+    await tick()
+
+    // Every tail audio frame was produced (none truncated), in order, followed by
+    // the final done chunk — the iteration ended normally on SessionFinished.
+    const audio = chunks.filter((c) => !c.done).map((c) => decoder.decode(c.audio))
+    expect(audio).toEqual(['TAIL1', 'TAIL2', 'TAIL3'])
+    expect(chunks[chunks.length - 1].done).toBe(true)
+
+    // FinishConnection is sent exactly once, and only after FinishSession — i.e.
+    // it is the last outbound frame, never racing ahead of the tail audio.
+    const events = sentEvents(socket)
+    expect(events).toEqual([
+      TtsEvent.StartConnection,
+      TtsEvent.StartSession,
+      TtsEvent.TaskRequest,
+      TtsEvent.FinishSession,
+      TtsEvent.FinishConnection,
+    ])
+    expect(events.indexOf(TtsEvent.FinishConnection)).toBe(events.length - 1)
   })
 
   it('fails loudly on ConnectionFailed instead of hanging the handshake', async () => {

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -1147,6 +1147,214 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
   })
 })
 
+// --- Resource cleanup on consumer cancellation (iterator.return) -------------
+
+describe('createVolcengineSpeechProvider — cancellation cleanup (iterator.return)', () => {
+  it('TTS synthesize: return() closes the outbound socket and stops the pump sending frames', async () => {
+    // Resource-leak P2: when a turn exits early (owner `end` / socket close /
+    // upstream STT|LLM failure) `runTurn` calls `ttsIterator.return()`. Before the
+    // fix the generator unwound but left the outbound Volcengine TTS socket open
+    // and the background pump parked on a handshake gate — leaking the connection
+    // and possibly continuing to bill the session. The fix wraps `yield* queue` in
+    // try/finally so cancellation: (1) closes the socket; (2) aborts the handshake
+    // gates so the parked pump unblocks; (3) stops any further outbound frames.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    // Never-ending text source: the synthesis session stays open (the pump parks on
+    // a handshake gate), modelling a turn cancelled mid-flight rather than one that
+    // completes on its own.
+    const neverEndingText: AsyncIterable<string> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: () => new Promise<IteratorResult<string>>(() => {}),
+        }
+      },
+    }
+    const iterator = tts.synthesize(neverEndingText)[Symbol.asyncIterator]()
+
+    // Walk the handshake to where the pump is parked awaiting the next text piece /
+    // a gate, having produced one audio frame.
+    const first = iterator.next()
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+    const sessionId =
+      socket.sent.map((b) => parseFrame(b)).find((f) => f.event === TtsEvent.StartSession)
+        ?.sessionId ?? 's'
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('AUDIO1'), sessionId))
+    const firstChunk = await first
+    expect(firstChunk.done).toBe(false)
+    expect(decoder.decode((firstChunk.value as { audio: Uint8Array }).audio)).toBe('AUDIO1')
+
+    // The socket is open and the pump has not finished the session.
+    expect(socket.closed).toBe(false)
+    const sentBeforeCancel = socket.sent.length
+
+    // Consumer cancels (mirrors `runTurn`'s `finally`: `ttsIterator.return()`).
+    const ret = await iterator.return?.(undefined)
+    expect(ret).toEqual({ value: undefined, done: true })
+
+    // (1) The outbound Volcengine TTS socket was deterministically closed.
+    expect(socket.closed).toBe(true)
+
+    // (2)+(3) The pump issues no further frames after cancellation — even if late
+    // server events arrive, nothing more is sent (the gates were aborted and the
+    // `cancelled` guard short-circuits every send).
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
+    await tick()
+    await tick()
+    expect(socket.sent.length).toBe(sentBeforeCancel)
+  })
+
+  it('ASR transcribe: return() closes the outbound socket and stops the pump pushing audio', async () => {
+    // ASR dual of the TTS cancellation fix. `collectFinalTranscript` drains the
+    // transcript stream; a turn that breaks early (or aborts) calls the iterator's
+    // `return()`. Before the fix the generator unwound but left the outbound ASR
+    // socket open and the pump parked pulling the next audio frame — leaking the
+    // connection and able to keep streaming audio. The fix's try/finally closes the
+    // socket, returns the audio iterator (ending the pump loop), and stops sends.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    // Audio source that yields one frame then parks, so the pump is mid-stream
+    // (awaiting the next frame) when the consumer cancels. `returned` flips when
+    // the adapter's `finally` returns this iterator — proving the upstream audio
+    // generator is released, not left dangling.
+    let returned = false
+    const pausingAudio: AsyncIterable<Uint8Array> = {
+      [Symbol.asyncIterator]() {
+        let sent = false
+        return {
+          next: () => {
+            if (!sent) {
+              sent = true
+              return Promise.resolve({ value: encoder.encode('f1'), done: false })
+            }
+            return new Promise<IteratorResult<Uint8Array>>(() => {})
+          },
+          return: () => {
+            returned = true
+            return Promise.resolve({ value: undefined, done: true })
+          },
+        }
+      },
+    }
+
+    const iterator = stt.transcribe(pausingAudio)[Symbol.asyncIterator]()
+
+    // Start the iteration and let the pump send the config frame + the first audio
+    // frame, then emit a non-final transcript so the consumer receives one chunk.
+    const first = iterator.next()
+    await tick()
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '你', utterances: [{ definite: false }] } })
+    )
+    const firstChunk = await first
+    expect(firstChunk.value).toEqual({ text: '你', isFinal: false })
+
+    // The socket is still open mid-stream and the pump is parked awaiting the next
+    // audio frame (no final transcript yet).
+    expect(socket.closed).toBe(false)
+    const sentBeforeCancel = socket.sent.length
+
+    // Consumer cancels mid-stream (the `collectFinalTranscript`-break path).
+    const ret = await iterator.return?.(undefined)
+    expect(ret).toEqual({ value: undefined, done: true })
+
+    // The outbound ASR socket was deterministically closed and the upstream audio
+    // generator was released (its `return` ran).
+    expect(socket.closed).toBe(true)
+    expect(returned).toBe(true)
+
+    // No further audio frames are sent after cancellation — the pump stopped.
+    await tick()
+    await tick()
+    expect(socket.sent.length).toBe(sentBeforeCancel)
+  })
+
+  it('TTS normal completion still closes via SessionFinished — the finally does not regress it', async () => {
+    // Guard: the cancellation `finally` must not break the normal-completion path.
+    // A run that reaches SessionFinished ends with the final done chunk intact and
+    // the full outbound event sequence unchanged (StartConnection -> StartSession
+    // -> TaskRequest -> FinishSession -> FinishConnection).
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const collected = collect(tts.synthesize(await asyncFrom(['句一'])))
+
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+    const sessionId =
+      socket.sent.map((b) => parseFrame(b)).find((f) => f.event === TtsEvent.StartSession)
+        ?.sessionId ?? 's'
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('AUDIO'), sessionId))
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
+
+    const chunks = await collected
+    const audio = chunks.filter((c) => !c.done).map((c) => decoder.decode(c.audio))
+    expect(audio).toEqual(['AUDIO'])
+    expect(chunks[chunks.length - 1].done).toBe(true)
+    // The full outbound event sequence is unchanged by the cleanup finally.
+    expect(sentEvents(socket)).toEqual([
+      TtsEvent.StartConnection,
+      TtsEvent.StartSession,
+      TtsEvent.TaskRequest,
+      TtsEvent.FinishSession,
+      TtsEvent.FinishConnection,
+    ])
+  })
+
+  it('TTS premature-close fail-loud is not reverted by the cleanup finally', async () => {
+    // Guard: a socket close before SessionFinished still rejects the consumer (the
+    // earlier premature-close fix), and the cleanup finally on that error unwind
+    // does not swallow the rejection.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const consumed = collect(tts.synthesize(await asyncFrom(['x'])))
+    await tick()
+    socket.emitClose()
+
+    const guard = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('synthesize did not settle after an early close')), 50)
+    )
+    await expect(Promise.race([consumed, guard])).rejects.toThrow(/closed before session finished/)
+  })
+
+  it('ASR premature-close fail-loud is not reverted by the cleanup finally', async () => {
+    // ASR guard dual: a socket close before a final transcript still rejects the
+    // consumer; the cleanup finally on the error unwind does not mask it.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const consumed = collect(stt.transcribe(await asyncFrom([encoder.encode('f1')])))
+
+    await tick()
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '你', utterances: [{ definite: false }] } })
+    )
+    socket.emitClose()
+
+    const guard = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('transcribe did not settle after an early close')), 50)
+    )
+    await expect(Promise.race([consumed, guard])).rejects.toThrow(
+      /closed before a final transcript/
+    )
+  })
+})
+
 // --- Default Workers connector: binary frame delivery type (F-N) -------------
 
 describe('defaultConnect — outbound socket binary delivery type (F-N)', () => {

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -18,6 +18,7 @@ import {
   parseSttResponse,
   Serialization,
   TtsEvent,
+  TtsHandshake,
   type AdapterSocket,
   type WebSocketConnector,
 } from './volcengine'
@@ -459,23 +460,103 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
 
 // --- Streaming logic: synthesize (mock WS) ----------------------------------
 
+// --- TTS handshake state machine (pure, server-gated) -----------------------
+
+describe('TtsHandshake', () => {
+  it('resolves connectionStarted on a ConnectionStarted event', async () => {
+    const hs = new TtsHandshake()
+    let resolved = false
+    void hs.connectionStarted.then(() => {
+      resolved = true
+    })
+    expect(hs.handleEvent(TtsEvent.ConnectionStarted, () => '')).toBe(true)
+    await hs.connectionStarted
+    expect(resolved).toBe(true)
+  })
+
+  it('resolves sessionStarted on a SessionStarted event', async () => {
+    const hs = new TtsHandshake()
+    expect(hs.handleEvent(TtsEvent.SessionStarted, () => '')).toBe(true)
+    await expect(hs.sessionStarted).resolves.toBeUndefined()
+  })
+
+  it('rejects connectionStarted on a ConnectionFailed event', async () => {
+    const hs = new TtsHandshake()
+    expect(hs.handleEvent(TtsEvent.ConnectionFailed, () => 'bad key')).toBe(true)
+    await expect(hs.connectionStarted).rejects.toThrow(/connection failed: bad key/)
+  })
+
+  it('treats non-handshake events (audio / completion) as not consumed', () => {
+    const hs = new TtsHandshake()
+    expect(hs.handleEvent(TtsEvent.TtsResponse, () => '')).toBe(false)
+    expect(hs.handleEvent(TtsEvent.SessionFinished, () => '')).toBe(false)
+    expect(hs.handleEvent(undefined, () => '')).toBe(false)
+  })
+
+  it('abort rejects every not-yet-settled gate', async () => {
+    const hs = new TtsHandshake()
+    hs.abort(new Error('socket closed early'))
+    await expect(hs.connectionStarted).rejects.toThrow(/socket closed early/)
+    await expect(hs.sessionStarted).rejects.toThrow(/socket closed early/)
+  })
+
+  it('abort after a gate already resolved does not override it', async () => {
+    const hs = new TtsHandshake()
+    hs.handleEvent(TtsEvent.ConnectionStarted, () => '')
+    hs.abort(new Error('late close'))
+    // The already-resolved connection gate stays resolved; only the still-pending
+    // session gate is rejected.
+    await expect(hs.connectionStarted).resolves.toBeUndefined()
+    await expect(hs.sessionStarted).rejects.toThrow(/late close/)
+  })
+})
+
+/**
+ * Yield to the microtask/timer loop so the event-driven pump can react to the
+ * server event we just emitted before we inspect outbound frames or emit the
+ * next one. The handshake is now server-gated, so the pump only sends the next
+ * client frame *after* the gating event arrives — the test must interleave.
+ */
+function tick(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0))
+}
+
+/** Outbound event codes captured on the mock socket so far. */
+function sentEvents(socket: MockSocket): Array<number | undefined> {
+  return socket.sent.map((b) => parseFrame(b).event)
+}
+
 describe('createVolcengineSpeechProvider.tts.synthesize', () => {
-  it('drives the event sequence and maps TTSResponse frames to audio chunks', async () => {
+  it('drives the server-gated event sequence and maps TTSResponse frames to audio', async () => {
     const socket = new MockSocket()
     const { connect, calls } = mockConnector(socket)
     const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
 
     const text = await asyncFrom(['句一', '句二'])
-    const stream = tts.synthesize(text)
-    const collected = collect(stream)
+    const collected = collect(tts.synthesize(text))
 
-    await new Promise((r) => setTimeout(r, 0))
-    // Read the session id the adapter assigned (from a session-scoped frame).
+    // 1. The pump sends StartConnection FIRST and then waits — it must NOT have
+    //    sent StartSession before the server accepts the connection.
+    await tick()
+    expect(sentEvents(socket)).toEqual([TtsEvent.StartConnection])
+
+    // 2. Server accepts the connection -> the pump may now send StartSession.
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+    expect(sentEvents(socket)).toEqual([TtsEvent.StartConnection, TtsEvent.StartSession])
+
+    // Read the session id the adapter assigned (from the StartSession frame).
     const startSession = socket.sent
       .map((b) => parseFrame(b))
       .find((f) => f.event === TtsEvent.StartSession)
     const sessionId = startSession?.sessionId ?? 's'
 
+    // 3. Server accepts the session -> the pump sends the TaskRequests, then
+    //    FinishSession + FinishConnection.
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    await tick()
+
+    // 4. Server streams audio + SessionFinished.
     socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('AUDIO1'), sessionId))
     socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('AUDIO2'), sessionId))
     socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
@@ -492,10 +573,9 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
     expect(calls[0].url).toContain('/tts/bidirection')
     expect(calls[0].headers['X-Api-Resource-Id']).toBe('volc.service_type.10029')
 
-    // The outbound event sequence is StartConnection -> StartSession ->
+    // Full outbound event sequence: StartConnection -> StartSession ->
     // TaskRequest(x2) -> FinishSession -> FinishConnection.
-    const events = socket.sent.map((b) => parseFrame(b).event)
-    expect(events).toEqual([
+    expect(sentEvents(socket)).toEqual([
       TtsEvent.StartConnection,
       TtsEvent.StartSession,
       TtsEvent.TaskRequest,
@@ -505,18 +585,119 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
     ])
   })
 
+  it('does NOT send StartSession until the server accepts the connection', async () => {
+    // Regression for F-G: the previous pump fired StartSession immediately after
+    // StartConnection without waiting for ConnectionStarted, racing the server.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const collected = collect(tts.synthesize(await asyncFrom(['hi'])))
+
+    // Several microtasks pass; with no ConnectionStarted the pump must stay at
+    // StartConnection only — StartSession is gated.
+    await tick()
+    await tick()
+    expect(sentEvents(socket)).toEqual([TtsEvent.StartConnection])
+
+    // Unblock the rest of the handshake so the stream can terminate cleanly.
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+    const sessionId =
+      socket.sent.map((b) => parseFrame(b)).find((f) => f.event === TtsEvent.StartSession)
+        ?.sessionId ?? 's'
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
+    await collected
+  })
+
+  it('does NOT send TaskRequest until the server accepts the session', async () => {
+    // Regression for F-G: TaskRequest frames are session-scoped and must wait for
+    // SessionStarted; sending them before the session is accepted gets them
+    // rejected/ignored, yielding no audio.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const collected = collect(tts.synthesize(await asyncFrom(['念这句'])))
+
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+    // Connection accepted, session NOT yet accepted: only StartConnection +
+    // StartSession sent, no TaskRequest.
+    expect(sentEvents(socket)).toEqual([TtsEvent.StartConnection, TtsEvent.StartSession])
+
+    const sessionId =
+      socket.sent.map((b) => parseFrame(b)).find((f) => f.event === TtsEvent.StartSession)
+        ?.sessionId ?? 's'
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    await tick()
+    // Now the TaskRequest is allowed.
+    expect(sentEvents(socket)).toContain(TtsEvent.TaskRequest)
+
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
+    await collected
+  })
+
+  it('fails loudly on ConnectionFailed instead of hanging the handshake', async () => {
+    // If the server rejects the connection, the gate the pump awaits must reject
+    // so the turn fails fast rather than awaiting a frame that never comes.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const consumed = collect(tts.synthesize(await asyncFrom(['x'])))
+    await tick()
+    expect(sentEvents(socket)).toEqual([TtsEvent.StartConnection])
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionFailed, encoder.encode('bad app key')))
+
+    await expect(consumed).rejects.toThrow(/Volcengine TTS connection failed/)
+    // The pump must NOT have advanced past StartConnection.
+    expect(sentEvents(socket)).toEqual([TtsEvent.StartConnection])
+  })
+
   it('surfaces a SessionFailed event as a thrown error', async () => {
     const socket = new MockSocket()
     const { connect } = mockConnector(socket)
     const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
 
-    const stream = tts.synthesize(await asyncFrom(['x']))
-    const consumed = collect(stream)
+    const consumed = collect(tts.synthesize(await asyncFrom(['x'])))
 
-    await new Promise((r) => setTimeout(r, 0))
-    socket.emitMessage(ttsServerFrame(TtsEvent.SessionFailed, encoder.encode('quota exceeded')))
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+    const sessionId =
+      socket.sent.map((b) => parseFrame(b)).find((f) => f.event === TtsEvent.StartSession)
+        ?.sessionId ?? 's'
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    await tick()
+    socket.emitMessage(
+      ttsServerFrame(TtsEvent.SessionFailed, encoder.encode('quota exceeded'), sessionId)
+    )
 
     await expect(consumed).rejects.toThrow(/Volcengine TTS session failed/)
+  })
+
+  it('rejects the pending gate if the socket closes before the handshake completes', async () => {
+    // A socket close before ConnectionStarted must reject the awaited gate so the
+    // pump fails loudly instead of awaiting a connection frame forever.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const consumed = collect(tts.synthesize(await asyncFrom(['x'])))
+    await tick()
+    socket.emitClose()
+
+    // Close ends the queue (no audio); the pump's awaited gate rejected, but the
+    // queue closing means the consumer simply sees an empty stream — assert it
+    // terminates rather than hanging.
+    const guard = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('synthesize did not terminate after an early close')), 50)
+    )
+    await Promise.race([consumed, guard])
   })
 
   it('skips empty text pieces (no TaskRequest emitted for them)', async () => {
@@ -524,16 +705,17 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
     const { connect } = mockConnector(socket)
     const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
 
-    const stream = tts.synthesize(await asyncFrom(['', 'real', '']))
-    const collected = collect(stream)
+    const collected = collect(tts.synthesize(await asyncFrom(['', 'real', ''])))
 
-    await new Promise((r) => setTimeout(r, 0))
-    const startSession = socket.sent
-      .map((b) => parseFrame(b))
-      .find((f) => f.event === TtsEvent.StartSession)
-    socket.emitMessage(
-      ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), startSession?.sessionId ?? 's')
-    )
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+    const sessionId =
+      socket.sent.map((b) => parseFrame(b)).find((f) => f.event === TtsEvent.StartSession)
+        ?.sessionId ?? 's'
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
 
     await collected
     const taskRequests = socket.sent

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -228,6 +228,37 @@ describe('STT frame codec', () => {
     expect(parsed.flags).toBe(MessageFlag.PositiveSequence)
     expect(parsed.sequence).toBe(3)
   })
+
+  it('ASR request frames use the sequence-carrying client dialect (request-side flag pin)', () => {
+    // Ground-truth pin: the /api/v3/sauc/bigmodel streaming ASR server accepts a
+    // sequence-carrying client dialect where the config + non-last audio frames
+    // are flagged PositiveSequence (0b0001) and the final audio frame is flagged
+    // NegativeWithSequence (0b0011), each carrying a 4-byte sequence field.
+    // `0b0001`/`0b0011` are legitimate CLIENT-request flags (positive / negative
+    // sequence), NOT server-response-only markers. This is exactly what
+    // Volcengine's own first-party client (volcengine/ai-app-lab asr_client.py:
+    // config = POS_SEQUENCE + sequence=1) and the sequence-carrying demo
+    // (thundersoft-td/mcp-server-speech asr_ws.py: config/audio POS_SEQUENCE,
+    // last NEG_WITH_SEQUENCE) send. This test locks the request-side flags so a
+    // future "fix" toward a (mistaken) response-only reading of 0b0001/0b0011 is
+    // caught here instead of failing the whole stream at deploy time.
+    const config = parseFrame(
+      buildSttConfigFrame({ uid: 'u', format: 'pcm', sampleRate: 16000, model: 'bigmodel' })
+    )
+    expect(config.messageType).toBe(MessageType.FullClientRequest)
+    expect(config.flags).toBe(MessageFlag.PositiveSequence) // 0b0001, NOT 0b0000
+    expect(config.sequence).toBe(1) // sequence field IS present (== 1)
+
+    const mid = parseFrame(buildSttAudioFrame(encoder.encode('aud'), 4, false))
+    expect(mid.messageType).toBe(MessageType.AudioOnlyClient)
+    expect(mid.flags).toBe(MessageFlag.PositiveSequence) // 0b0001
+    expect(mid.sequence).toBe(4) // positive sequence present
+
+    const last = parseFrame(buildSttAudioFrame(encoder.encode('aud'), 4, true))
+    expect(last.messageType).toBe(MessageType.AudioOnlyClient)
+    expect(last.flags).toBe(MessageFlag.NegativeWithSequence) // 0b0011, the end-data marker
+    expect(last.sequence).toBe(-4) // negative sequence present
+  })
 })
 
 // --- ASR server-response mapping --------------------------------------------

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -563,6 +563,59 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
 
     await expect(consumed).rejects.toThrow(/Volcengine ASR error/)
   })
+
+  it('fails loudly if the socket closes before a final transcript (premature close)', async () => {
+    // The ASR dual of the TTS premature-close fix. A socket close that arrives
+    // before any final/definite transcript — handshake-period failure or a
+    // mid-stream network drop — must REJECT the consumer, not settle it as a clean
+    // empty/incomplete end-of-stream. Otherwise `collectFinalTranscript` would
+    // proceed with an empty (or partial, non-definite) transcript and the turn
+    // would continue silently on bad input. Here the server emits only a
+    // non-definite chunk, then the socket drops.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const consumed = collect(stt.transcribe(await asyncFrom([encoder.encode('f1')])))
+
+    await new Promise((r) => setTimeout(r, 0))
+    // A partial (non-definite) transcript arrives, then the socket closes BEFORE
+    // any definite/final result — a premature close.
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '你', utterances: [{ definite: false }] } })
+    )
+    socket.emitClose()
+
+    const guard = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('transcribe did not settle after an early close')), 50)
+    )
+    await expect(Promise.race([consumed, guard])).rejects.toThrow(
+      /closed before a final transcript/
+    )
+  })
+
+  it('treats a socket close AFTER a final transcript as a clean end-of-stream', async () => {
+    // The dual of the premature-close test: once a final/definite transcript has
+    // arrived (the normal completion), a subsequent socket close is the expected
+    // end-of-stream and must NOT fail the already-completed stream. Guards against
+    // the fail-loud fix over-firing on the normal path.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const collected = collect(stt.transcribe(await asyncFrom([encoder.encode('f1')])))
+
+    await new Promise((r) => setTimeout(r, 0))
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '你好', utterances: [{ definite: true }] } })
+    )
+    // A close arriving after the definite transcript is the normal teardown
+    // (the adapter itself also closes the socket on a final transcript).
+    socket.emitClose()
+
+    const chunks = await collected
+    expect(chunks).toEqual([{ text: '你好', isFinal: true }])
+  })
 })
 
 // --- Streaming logic: synthesize (mock WS) ----------------------------------
@@ -948,9 +1001,12 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
     await expect(consumed).rejects.toThrow(/Volcengine TTS session failed/)
   })
 
-  it('rejects the pending gate if the socket closes before the handshake completes', async () => {
-    // A socket close before ConnectionStarted must reject the awaited gate so the
-    // pump fails loudly instead of awaiting a connection frame forever.
+  it('fails loudly if the socket closes before the session finishes (premature close)', async () => {
+    // A socket close before SessionFinished (152) — handshake-period failure or a
+    // mid-stream network drop — must REJECT the consumer, not settle it as a clean
+    // empty end-of-stream. Otherwise `runTurn`'s TTS extraction would silently
+    // settle a turn with text but no audio. The close also rejects the pump's
+    // awaited handshake gate so the pump never hangs awaiting a connection frame.
     const socket = new MockSocket()
     const { connect } = mockConnector(socket)
     const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
@@ -959,13 +1015,44 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
     await tick()
     socket.emitClose()
 
-    // Close ends the queue (no audio); the pump's awaited gate rejected, but the
-    // queue closing means the consumer simply sees an empty stream — assert it
-    // terminates rather than hanging.
+    // Race against a timer so a hang fails the test rather than stalling: the
+    // close must surface as a thrown error promptly, not a silent termination.
     const guard = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error('synthesize did not terminate after an early close')), 50)
+      setTimeout(() => reject(new Error('synthesize did not settle after an early close')), 50)
     )
-    await Promise.race([consumed, guard])
+    await expect(Promise.race([consumed, guard])).rejects.toThrow(/closed before session finished/)
+  })
+
+  it('treats a socket close AFTER SessionFinished as a clean end-of-stream', async () => {
+    // The dual of the premature-close test: once SessionFinished (152) has been
+    // delivered (the normal completion), a subsequent socket close is the expected
+    // end-of-stream and must NOT fail the already-completed stream. Guards against
+    // the fail-loud fix over-firing on the normal path.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const collected = collect(tts.synthesize(await asyncFrom(['句一'])))
+
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+    const sessionId =
+      socket.sent.map((b) => parseFrame(b)).find((f) => f.event === TtsEvent.StartSession)
+        ?.sessionId ?? 's'
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('AUDIO'), sessionId))
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
+    // A close arriving after SessionFinished is the normal teardown.
+    socket.emitClose()
+
+    const chunks = await collected
+    // The audio + final done chunk are intact; the post-completion close is a
+    // no-op, not a failure.
+    const audio = chunks.filter((c) => !c.done).map((c) => decoder.decode(c.audio))
+    expect(audio).toEqual(['AUDIO'])
+    expect(chunks[chunks.length - 1].done).toBe(true)
   })
 
   it('skips empty text pieces (no TaskRequest emitted for them)', async () => {

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { resolveConfig } from '../provider-config'
 import {
   buildAuthHeaders,
   buildSttAudioFrame,
@@ -449,6 +450,48 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
       request: { model_name: string }
     }
     expect(body.request.model_name).toBe('bigmodel')
+
+    socket.emitMessage(sttServerFrame({ result: { text: 'x', utterances: [{ definite: true }] } }))
+    await consumed
+  })
+
+  it("resolveConfig('demo').stt.model is a legal Volcengine ASR wire model_name", async () => {
+    // P2 regression: the `demo` config's STT model is threaded verbatim into the
+    // ASR `request.model_name` (factory F-K passthrough). The Volcengine v3
+    // streaming ASR endpoint (`/api/v3/sauc/bigmodel`) accepts ONLY `bigmodel` as
+    // `model_name` — a config alias like `bigmodel-asr` was harmless before F-K
+    // only because the adapter fell back to its own DEFAULT_STT_MODEL; now that
+    // the resolved model is really transmitted, the alias would send an illegal
+    // model id and fail the turn. This stitches the resolved config model directly
+    // into the real adapter and asserts the wire frame, so the bad alias cannot
+    // come back. Doc: https://www.volcengine.com/docs/6561/1354869
+    const resolved = resolveConfig('demo')
+    expect(resolved.stt.model).toBe('bigmodel')
+    expect(resolved.stt.model).not.toBe('bigmodel-asr')
+
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({
+      appId: 'a',
+      accessToken: 't',
+      // Exactly what the factory threads through: `resolved.stt.model`.
+      sttModel: resolved.stt.model,
+      connect,
+    })
+
+    const consumed = (async () => {
+      for await (const _chunk of stt.transcribe(await asyncFrom([encoder.encode('f1')]))) {
+        break
+      }
+    })()
+    await tick()
+
+    const configFrame = parseFrame(socket.sent[0])
+    const body = JSON.parse(decoder.decode(configFrame.payload)) as {
+      request: { model_name: string }
+    }
+    expect(body.request.model_name).toBe('bigmodel')
+    expect(body.request.model_name).not.toBe('bigmodel-asr')
 
     socket.emitMessage(sttServerFrame({ result: { text: 'x', utterances: [{ definite: true }] } }))
     await consumed

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -801,7 +801,7 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
     const provider = createVolcengineSpeechProvider({
       appId: 'a',
       accessToken: 't',
-      ttsModel: 'doubao-tts-2.0-pro',
+      ttsModel: 'seed-tts-2.0-standard',
       connect: withModel.connect,
     })
     void collect(provider.tts.synthesize(asyncFromSync(['句一'])))
@@ -815,7 +815,7 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
     const body = JSON.parse(decoder.decode(startSession?.payload ?? new Uint8Array(0))) as {
       req_params: { model?: string }
     }
-    expect(body.req_params.model).toBe('doubao-tts-2.0-pro')
+    expect(body.req_params.model).toBe('seed-tts-2.0-standard')
 
     // With no ttsModel configured, the StartSession req_params omits `model`.
     const noModelSocket = new MockSocket()
@@ -839,25 +839,55 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
     expect(plainBody.req_params.model).toBeUndefined()
   })
 
-  it("resolveConfig('demo').tts.model is a legal Doubao TTS 2.0 wire req_params.model", async () => {
-    // P2 regression: the `demo` config's TTS model is threaded verbatim into the
-    // Doubao TTS 2.0 `StartSession` req_params.model (factory F-K passthrough).
-    // The legal wire value is the model-family token `seed-tts-2.0`; the product
-    // alias `doubao-tts-2.0` is NOT a request value and could be rejected / routed
-    // to the wrong model. This stitches the resolved config model straight into the
-    // real adapter and asserts the StartSession wire frame, so the bad alias cannot
-    // come back. Doc: https://www.volcengine.com/docs/6561/1329505
+  it("resolveConfig('demo') TTS omits req_params.model — bound by resource id, not a guessed token", async () => {
+    // The `demo` config's TTS model is the empty-string sentinel ("use the
+    // resource-id default model"). It is threaded into the adapter (factory F-K
+    // passthrough), but the adapter omits `req_params.model` from the StartSession
+    // frame for an empty model — so the Doubao TTS 2.0 session is bound by the
+    // paired resource id (`volc.service_type.10029`) alone, matching Volcengine's
+    // first-party clients. This pins the default-omit so a guessed concrete token
+    // (a reject / mis-route risk) cannot creep back at the config layer; the exact
+    // `req_params.model` wire value is a deploy-time verification item.
+    // Doc: https://www.volcengine.com/docs/6561/1329505
     const resolved = resolveConfig('demo')
-    expect(resolved.tts.model).toBe('seed-tts-2.0')
-    expect(resolved.tts.model).not.toBe('doubao-tts-2.0')
+    expect(resolved.tts.model).toBe('')
 
     const socket = new MockSocket()
     const { connect } = mockConnector(socket)
     const { tts } = createVolcengineSpeechProvider({
       appId: 'a',
       accessToken: 't',
-      // Exactly what the factory threads through: `resolved.tts.model`.
+      // Exactly what the factory threads through: `resolved.tts.model` ('').
       ttsModel: resolved.tts.model,
+      connect,
+    })
+    void collect(tts.synthesize(asyncFromSync(['句一'])))
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+
+    const startSession = socket.sent
+      .map((b) => parseFrame(b))
+      .find((f) => f.event === TtsEvent.StartSession)
+    const body = JSON.parse(decoder.decode(startSession?.payload ?? new Uint8Array(0))) as {
+      req_params: Record<string, unknown>
+    }
+    expect(body.req_params.model).toBeUndefined()
+    expect('model' in body.req_params).toBe(false)
+  })
+
+  it('threads an explicit concrete ttsModel onto the wire (mechanism preserved for deploy-time token)', async () => {
+    // The omit-by-default for `demo` does NOT remove the passthrough mechanism:
+    // once the concrete `req_params.model` wire value is confirmed at deploy time,
+    // setting a non-empty model in `provider-config` must reach the StartSession
+    // frame. Use a concrete candidate variant (`seed-tts-2.0-standard`) to prove
+    // the threaded non-empty model is attached verbatim.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({
+      appId: 'a',
+      accessToken: 't',
+      ttsModel: 'seed-tts-2.0-standard',
       connect,
     })
     void collect(tts.synthesize(asyncFromSync(['句一'])))
@@ -871,8 +901,7 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
     const body = JSON.parse(decoder.decode(startSession?.payload ?? new Uint8Array(0))) as {
       req_params: { model?: string }
     }
-    expect(body.req_params.model).toBe('seed-tts-2.0')
-    expect(body.req_params.model).not.toBe('doubao-tts-2.0')
+    expect(body.req_params.model).toBe('seed-tts-2.0-standard')
   })
 
   it('does NOT send StartSession until the server accepts the connection', async () => {

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -755,6 +755,42 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
     expect(plainBody.req_params.model).toBeUndefined()
   })
 
+  it("resolveConfig('demo').tts.model is a legal Doubao TTS 2.0 wire req_params.model", async () => {
+    // P2 regression: the `demo` config's TTS model is threaded verbatim into the
+    // Doubao TTS 2.0 `StartSession` req_params.model (factory F-K passthrough).
+    // The legal wire value is the model-family token `seed-tts-2.0`; the product
+    // alias `doubao-tts-2.0` is NOT a request value and could be rejected / routed
+    // to the wrong model. This stitches the resolved config model straight into the
+    // real adapter and asserts the StartSession wire frame, so the bad alias cannot
+    // come back. Doc: https://www.volcengine.com/docs/6561/1329505
+    const resolved = resolveConfig('demo')
+    expect(resolved.tts.model).toBe('seed-tts-2.0')
+    expect(resolved.tts.model).not.toBe('doubao-tts-2.0')
+
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({
+      appId: 'a',
+      accessToken: 't',
+      // Exactly what the factory threads through: `resolved.tts.model`.
+      ttsModel: resolved.tts.model,
+      connect,
+    })
+    void collect(tts.synthesize(asyncFromSync(['句一'])))
+    await tick()
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await tick()
+
+    const startSession = socket.sent
+      .map((b) => parseFrame(b))
+      .find((f) => f.event === TtsEvent.StartSession)
+    const body = JSON.parse(decoder.decode(startSession?.payload ?? new Uint8Array(0))) as {
+      req_params: { model?: string }
+    }
+    expect(body.req_params.model).toBe('seed-tts-2.0')
+    expect(body.req_params.model).not.toBe('doubao-tts-2.0')
+  })
+
   it('does NOT send StartSession until the server accepts the connection', async () => {
     // Regression for F-G: the previous pump fired StartSession immediately after
     // StartConnection without waiting for ConnectionStarted, racing the server.

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { resolveConfig } from '../provider-config'
 import {
   buildAuthHeaders,
@@ -13,6 +13,7 @@ import {
   buildTtsTaskRequestFrame,
   Compression,
   createVolcengineSpeechProvider,
+  defaultConnect,
   MessageFlag,
   MessageType,
   parseFrame,
@@ -960,5 +961,61 @@ describe('createVolcengineSpeechProvider.tts.synthesize', () => {
     const provider = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't' })
     expect(typeof provider.stt.transcribe).toBe('function')
     expect(typeof provider.tts.synthesize).toBe('function')
+  })
+})
+
+// --- Default Workers connector: binary frame delivery type (F-N) -------------
+
+describe('defaultConnect — outbound socket binary delivery type (F-N)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  /**
+   * A stand-in for the Cloudflare `response.webSocket`. Records the order of the
+   * `binaryType` write relative to `accept()` so the test can prove the opt-in is
+   * applied BEFORE the socket is accepted (the runtime only honors it pre-accept).
+   */
+  class FakeRuntimeSocket {
+    binaryType: 'blob' | 'arraybuffer' = 'blob'
+    accepted = false
+    /** `binaryType` value captured at the moment `accept()` ran. */
+    binaryTypeAtAccept: 'blob' | 'arraybuffer' | undefined
+    accept(): void {
+      this.accepted = true
+      this.binaryTypeAtAccept = this.binaryType
+    }
+  }
+
+  function stubFetchWith(socket: FakeRuntimeSocket | undefined): void {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ webSocket: socket }) as unknown as Response)
+    )
+  }
+
+  it('opts the outbound socket into arraybuffer delivery BEFORE accepting it', async () => {
+    // F-N root fix: with compatibility_date 2026-06-08 the runtime delivers
+    // inbound binary WS frames as Blob unless binaryType='arraybuffer' is set
+    // before accept(). The synchronous `toBytes` codec only accepts ArrayBuffer /
+    // views / strings, so a Blob would fail every ASR/TTS turn. Assert the real
+    // connector both sets the type and sets it pre-accept (ordering is load-bearing).
+    const socket = new FakeRuntimeSocket()
+    stubFetchWith(socket)
+
+    const returned = await defaultConnect('wss://example.test/v3', { Upgrade: 'websocket' })
+
+    expect(socket.binaryType).toBe('arraybuffer')
+    expect(socket.accepted).toBe(true)
+    // The crux: arraybuffer was already in effect at the instant accept() ran.
+    expect(socket.binaryTypeAtAccept).toBe('arraybuffer')
+    expect(returned).toBe(socket as unknown as AdapterSocket)
+  })
+
+  it('throws when the upgrade response carries no webSocket', async () => {
+    stubFetchWith(undefined)
+    await expect(defaultConnect('wss://example.test/v3', { Upgrade: 'websocket' })).rejects.toThrow(
+      /no webSocket on response/
+    )
   })
 })

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -390,6 +390,51 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
     expect(last.sequence).toBeLessThan(0)
   })
 
+  it('ends the iteration on a definite transcript without waiting for a WS close', async () => {
+    // Regression: `collectFinalTranscript` drains `transcribe` to iterator end
+    // (it does not break early like the test above). If the adapter only closed
+    // on a separate WS `close` event, a server that keeps the socket open after
+    // the definite result would hang the whole turn. Here the server emits a
+    // definite frame and never closes the socket; the iterator must still end
+    // and surface the final chunk.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const audio = await asyncFrom([encoder.encode('f1')])
+    // Drain to iterator end (no early break) — the exact shape the turn pipeline
+    // uses. Race against a timer so a hang fails the test instead of stalling.
+    const drained = (async () => {
+      const out = []
+      for await (const chunk of stt.transcribe(audio)) out.push(chunk)
+      return out
+    })()
+    const guard = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error('transcribe did not terminate on a definite transcript')),
+        50
+      )
+    )
+
+    await new Promise((r) => setTimeout(r, 0))
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '在', utterances: [{ definite: false }] } })
+    )
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '在的', utterances: [{ definite: true }] } })
+    )
+    // Intentionally do NOT emit a WS `close` — termination must come from the
+    // definite transcript alone.
+
+    const chunks = await Promise.race([drained, guard])
+    expect(chunks).toEqual([
+      { text: '在', isFinal: false },
+      { text: '在的', isFinal: true },
+    ])
+    // The adapter also closes the ASR socket as the normal end-of-stream path.
+    expect(socket.closed).toBe(true)
+  })
+
   it('propagates a server error frame as a thrown error', async () => {
     const socket = new MockSocket()
     const { connect } = mockConnector(socket)

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -1,0 +1,506 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAuthHeaders,
+  buildSttAudioFrame,
+  buildSttConfigFrame,
+  buildSttRequestFrame,
+  buildTtsEventFrame,
+  buildTtsFinishConnectionFrame,
+  buildTtsFinishSessionFrame,
+  buildTtsStartConnectionFrame,
+  buildTtsStartSessionFrame,
+  buildTtsTaskRequestFrame,
+  Compression,
+  createVolcengineSpeechProvider,
+  MessageFlag,
+  MessageType,
+  parseFrame,
+  parseSttResponse,
+  Serialization,
+  TtsEvent,
+  type AdapterSocket,
+  type WebSocketConnector,
+} from './volcengine'
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+// --- Test doubles -----------------------------------------------------------
+
+type Listener = (event: { data: unknown }) => void
+
+/**
+ * Mock WebSocket: records every outbound frame and lets the test drive inbound
+ * messages / lifecycle events. No real network — this is how the streaming glue
+ * is exercised end to end.
+ */
+class MockSocket implements AdapterSocket {
+  sent: Uint8Array[] = []
+  closed = false
+  private messageListeners: Listener[] = []
+  private closeListeners: Array<() => void> = []
+  private errorListeners: Array<(event: unknown) => void> = []
+
+  send(data: ArrayBuffer | ArrayBufferView): void {
+    this.sent.push(
+      data instanceof ArrayBuffer
+        ? new Uint8Array(data)
+        : new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+    )
+  }
+
+  close(): void {
+    this.closed = true
+  }
+
+  // The adapter registers exactly one listener per event kind; we fan out so
+  // the test can emit messages/close/error after wiring. A single permissive
+  // overload keeps the implementation signature compatible with the interface.
+  addEventListener(
+    type: 'message' | 'close' | 'error',
+    listener: ((event: { data: unknown }) => void) | (() => void) | ((event: unknown) => void)
+  ): void {
+    if (type === 'message') this.messageListeners.push(listener as Listener)
+    else if (type === 'close') this.closeListeners.push(listener as () => void)
+    else if (type === 'error') this.errorListeners.push(listener as (event: unknown) => void)
+  }
+
+  emitMessage(data: Uint8Array): void {
+    for (const l of this.messageListeners) l({ data })
+  }
+
+  emitClose(): void {
+    for (const l of this.closeListeners) l()
+  }
+
+  emitError(event: unknown): void {
+    for (const l of this.errorListeners) l(event)
+  }
+}
+
+function mockConnector(socket: MockSocket): {
+  connect: WebSocketConnector
+  calls: Array<{ url: string; headers: Record<string, string> }>
+} {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = []
+  const connect: WebSocketConnector = async (url, headers) => {
+    calls.push({ url, headers })
+    return socket
+  }
+  return { connect, calls }
+}
+
+async function asyncFrom<T>(items: T[]): Promise<AsyncIterable<T>> {
+  return (async function* () {
+    for (const item of items) yield item
+  })()
+}
+
+async function collect<T>(stream: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = []
+  for await (const item of stream) out.push(item)
+  return out
+}
+
+/** Build an ASR JSON server-response frame the way the wire encodes it. */
+function sttServerFrame(body: unknown, flags = MessageFlag.PositiveSequence): Uint8Array {
+  const payload = encoder.encode(JSON.stringify(body))
+  return buildSttRequestFrame({
+    messageType: MessageType.FullServerResponse,
+    flags,
+    serialization: Serialization.Json,
+    sequence: 1,
+    payload,
+  })
+}
+
+/** Build a TTS server event frame (audio or lifecycle). */
+function ttsServerFrame(event: number, payload: Uint8Array, sessionId = 's'): Uint8Array {
+  return buildTtsEventFrame({ event, sessionId, payload })
+}
+
+// --- Auth header assembly ---------------------------------------------------
+
+describe('buildAuthHeaders', () => {
+  it('maps credentials onto the X-Api-* handshake headers + Upgrade', () => {
+    const headers = buildAuthHeaders(
+      { appId: 'app-1', accessToken: 'tok-2', resourceId: 'volc.bigasr.sauc.duration' },
+      'conn-3'
+    )
+    // v3 token-header auth: app key + access key + resource id + per-connection
+    // connect id. No signature header, no secret key.
+    expect(headers).toEqual({
+      Upgrade: 'websocket',
+      'X-Api-App-Key': 'app-1',
+      'X-Api-Access-Key': 'tok-2',
+      'X-Api-Resource-Id': 'volc.bigasr.sauc.duration',
+      'X-Api-Connect-Id': 'conn-3',
+    })
+  })
+
+  it('never leaks credentials into a logged value: only the documented keys exist', () => {
+    const headers = buildAuthHeaders({ appId: 'a', accessToken: 'secret', resourceId: 'r' }, 'q')
+    // Guard against an accidental extra field carrying credentials elsewhere.
+    expect(Object.keys(headers).sort()).toEqual([
+      'Upgrade',
+      'X-Api-Access-Key',
+      'X-Api-App-Key',
+      'X-Api-Connect-Id',
+      'X-Api-Resource-Id',
+    ])
+  })
+})
+
+// --- ASR frame build + parse round-trip -------------------------------------
+
+describe('STT frame codec', () => {
+  it('encodes the 4-byte protocol header (version 1, header size 1)', () => {
+    const frame = buildSttConfigFrame({
+      uid: 'u',
+      format: 'pcm',
+      sampleRate: 16000,
+      model: 'bigmodel',
+    })
+    expect(frame[0]).toBe(0x11)
+    // byte1 = (FullClientRequest << 4) | PositiveSequence
+    expect(frame[1]).toBe((MessageType.FullClientRequest << 4) | MessageFlag.PositiveSequence)
+    // byte2 = (JSON << 4) | None
+    expect(frame[2]).toBe((Serialization.Json << 4) | Compression.None)
+    expect(frame[3]).toBe(0x00)
+  })
+
+  it('places a 4-byte big-endian sequence between header and payload size', () => {
+    const payload = encoder.encode('xy')
+    const frame = buildSttRequestFrame({
+      messageType: MessageType.AudioOnlyClient,
+      flags: MessageFlag.PositiveSequence,
+      serialization: Serialization.None,
+      sequence: 7,
+      payload,
+    })
+    const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength)
+    expect(view.getInt32(4, false)).toBe(7) // sequence
+    expect(view.getInt32(8, false)).toBe(2) // payload size
+    expect(decoder.decode(frame.subarray(12))).toBe('xy')
+  })
+
+  it('config frame round-trips through parseFrame with the documented JSON shape', () => {
+    const frame = buildSttConfigFrame({
+      uid: 'user-9',
+      format: 'pcm',
+      sampleRate: 24000,
+      model: 'bigmodel',
+    })
+    const parsed = parseFrame(frame)
+    expect(parsed.messageType).toBe(MessageType.FullClientRequest)
+    expect(parsed.sequence).toBe(1)
+    expect(parsed.serialization).toBe(Serialization.Json)
+    const body = JSON.parse(decoder.decode(parsed.payload))
+    expect(body).toEqual({
+      user: { uid: 'user-9' },
+      audio: { format: 'pcm', rate: 24000, bits: 16, channel: 1 },
+      request: { model_name: 'bigmodel', enable_punc: true, enable_itn: true },
+    })
+  })
+
+  it('flags the final audio packet with a negative sequence + NegativeWithSequence', () => {
+    const last = buildSttAudioFrame(encoder.encode('aud'), 5, true)
+    const parsed = parseFrame(last)
+    expect(parsed.messageType).toBe(MessageType.AudioOnlyClient)
+    expect(parsed.flags).toBe(MessageFlag.NegativeWithSequence)
+    expect(parsed.sequence).toBe(-5)
+    expect(decoder.decode(parsed.payload)).toBe('aud')
+  })
+
+  it('non-final audio packet keeps a positive sequence', () => {
+    const mid = buildSttAudioFrame(encoder.encode('aud'), 3, false)
+    const parsed = parseFrame(mid)
+    expect(parsed.flags).toBe(MessageFlag.PositiveSequence)
+    expect(parsed.sequence).toBe(3)
+  })
+})
+
+// --- ASR server-response mapping --------------------------------------------
+
+describe('parseSttResponse', () => {
+  it('maps a non-definite utterance to a non-final transcript chunk', () => {
+    const chunk = parseSttResponse(
+      parseFrame(sttServerFrame({ result: { text: '你好', utterances: [{ definite: false }] } }))
+    )
+    expect(chunk).toEqual({ text: '你好', isFinal: false })
+  })
+
+  it('marks the chunk final when any utterance is definite', () => {
+    const chunk = parseSttResponse(
+      parseFrame(
+        sttServerFrame({
+          result: { text: '你好世界', utterances: [{ definite: false }, { definite: true }] },
+        })
+      )
+    )
+    expect(chunk).toEqual({ text: '你好世界', isFinal: true })
+  })
+
+  it('treats a missing utterances array as not-final', () => {
+    const chunk = parseSttResponse(parseFrame(sttServerFrame({ result: { text: 'hi' } })))
+    expect(chunk).toEqual({ text: 'hi', isFinal: false })
+  })
+
+  it('returns undefined for an empty / textless ack frame', () => {
+    const ack = buildSttRequestFrame({
+      messageType: MessageType.FullServerResponse,
+      flags: MessageFlag.PositiveSequence,
+      serialization: Serialization.Json,
+      sequence: 1,
+      payload: encoder.encode(JSON.stringify({ result: {} })),
+    })
+    expect(parseSttResponse(parseFrame(ack))).toBeUndefined()
+  })
+
+  it('throws on an error-type server frame', () => {
+    const errFrame = buildSttRequestFrame({
+      messageType: MessageType.ErrorResponse,
+      flags: MessageFlag.PositiveSequence,
+      serialization: Serialization.Json,
+      sequence: 1,
+      payload: encoder.encode('bad credentials'),
+    })
+    expect(() => parseSttResponse(parseFrame(errFrame))).toThrowError(/Volcengine ASR error/)
+  })
+})
+
+// --- TTS event frame build + parse round-trip -------------------------------
+
+describe('TTS event frame codec', () => {
+  it('encodes the WithEvent flag and the event / sessionId / payload layout', () => {
+    const frame = buildTtsEventFrame({
+      event: TtsEvent.StartSession,
+      sessionId: 'sess-1',
+      payload: encoder.encode('{}'),
+    })
+    expect(frame[0]).toBe(0x11)
+    expect(frame[1]).toBe((MessageType.FullClientRequest << 4) | MessageFlag.WithEvent)
+
+    const parsed = parseFrame(frame)
+    expect(parsed.event).toBe(TtsEvent.StartSession)
+    expect(parsed.sessionId).toBe('sess-1')
+    expect(decoder.decode(parsed.payload)).toBe('{}')
+  })
+
+  it('StartConnection / FinishConnection carry an empty session id', () => {
+    for (const frame of [buildTtsStartConnectionFrame(), buildTtsFinishConnectionFrame()]) {
+      const parsed = parseFrame(frame)
+      expect(parsed.sessionId).toBe('')
+    }
+    expect(parseFrame(buildTtsStartConnectionFrame()).event).toBe(TtsEvent.StartConnection)
+    expect(parseFrame(buildTtsFinishConnectionFrame()).event).toBe(TtsEvent.FinishConnection)
+  })
+
+  it('StartSession payload carries speaker + audio params', () => {
+    const parsed = parseFrame(
+      buildTtsStartSessionFrame({ sessionId: 's', speaker: 'voice-x', sampleRate: 24000 })
+    )
+    const body = JSON.parse(decoder.decode(parsed.payload))
+    expect(body.event).toBe(TtsEvent.StartSession)
+    expect(body.req_params.speaker).toBe('voice-x')
+    expect(body.req_params.audio_params).toEqual({ format: 'pcm', sample_rate: 24000 })
+  })
+
+  it('TaskRequest payload carries the text chunk', () => {
+    const parsed = parseFrame(
+      buildTtsTaskRequestFrame({ sessionId: 's', text: '念这句', speaker: 'voice-x' })
+    )
+    const body = JSON.parse(decoder.decode(parsed.payload))
+    expect(body.event).toBe(TtsEvent.TaskRequest)
+    expect(body.req_params.text).toBe('念这句')
+  })
+
+  it('FinishSession round-trips the session id', () => {
+    const parsed = parseFrame(buildTtsFinishSessionFrame('sess-z'))
+    expect(parsed.event).toBe(TtsEvent.FinishSession)
+    expect(parsed.sessionId).toBe('sess-z')
+  })
+})
+
+// --- parseFrame guards ------------------------------------------------------
+
+describe('parseFrame guards', () => {
+  it('throws on a frame shorter than the 4-byte header', () => {
+    expect(() => parseFrame(new Uint8Array([0x11, 0x10]))).toThrowError(/4-byte header/)
+  })
+
+  it('accepts an ArrayBuffer payload as well as a Uint8Array', () => {
+    const frame = buildTtsStartConnectionFrame()
+    const viaArrayBuffer = parseFrame(frame.buffer.slice(0))
+    expect(viaArrayBuffer.event).toBe(TtsEvent.StartConnection)
+  })
+})
+
+// --- Streaming logic: transcribe (mock WS) ----------------------------------
+
+describe('createVolcengineSpeechProvider.stt.transcribe', () => {
+  it('sends config then audio frames and maps server responses to transcript chunks', async () => {
+    const socket = new MockSocket()
+    const { connect, calls } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({
+      appId: 'a',
+      accessToken: 't',
+      connect,
+    })
+
+    const audio = await asyncFrom([encoder.encode('f1'), encoder.encode('f2')])
+    const stream = stt.transcribe(audio)
+
+    // Drive the consumer in the background, then feed server responses.
+    const collected = (async () => {
+      const out = []
+      for await (const chunk of stream) {
+        out.push(chunk)
+        if (chunk.isFinal) break
+      }
+      return out
+    })()
+
+    // Let the pump send its frames before we emit responses.
+    await new Promise((r) => setTimeout(r, 0))
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '你', utterances: [{ definite: false }] } })
+    )
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '你好', utterances: [{ definite: true }] } })
+    )
+
+    const chunks = await collected
+    expect(chunks).toEqual([
+      { text: '你', isFinal: false },
+      { text: '你好', isFinal: true },
+    ])
+
+    // Connected to the ASR endpoint with the ASR resource id.
+    expect(calls[0].url).toContain('/sauc/bigmodel')
+    expect(calls[0].headers['X-Api-Resource-Id']).toBe('volc.bigasr.sauc.duration')
+
+    // First outbound frame is the JSON config (FullClientRequest); the last is
+    // the negative-sequence final audio packet.
+    const first = parseFrame(socket.sent[0])
+    expect(first.messageType).toBe(MessageType.FullClientRequest)
+    const last = parseFrame(socket.sent[socket.sent.length - 1])
+    expect(last.messageType).toBe(MessageType.AudioOnlyClient)
+    expect(last.flags).toBe(MessageFlag.NegativeWithSequence)
+    expect(last.sequence).toBeLessThan(0)
+  })
+
+  it('propagates a server error frame as a thrown error', async () => {
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const stream = stt.transcribe(await asyncFrom([encoder.encode('f')]))
+    const consumed = collect(stream)
+
+    await new Promise((r) => setTimeout(r, 0))
+    const errFrame = buildSttRequestFrame({
+      messageType: MessageType.ErrorResponse,
+      flags: MessageFlag.PositiveSequence,
+      serialization: Serialization.Json,
+      sequence: 1,
+      payload: encoder.encode('auth failed'),
+    })
+    socket.emitMessage(errFrame)
+
+    await expect(consumed).rejects.toThrow(/Volcengine ASR error/)
+  })
+})
+
+// --- Streaming logic: synthesize (mock WS) ----------------------------------
+
+describe('createVolcengineSpeechProvider.tts.synthesize', () => {
+  it('drives the event sequence and maps TTSResponse frames to audio chunks', async () => {
+    const socket = new MockSocket()
+    const { connect, calls } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const text = await asyncFrom(['句一', '句二'])
+    const stream = tts.synthesize(text)
+    const collected = collect(stream)
+
+    await new Promise((r) => setTimeout(r, 0))
+    // Read the session id the adapter assigned (from a session-scoped frame).
+    const startSession = socket.sent
+      .map((b) => parseFrame(b))
+      .find((f) => f.event === TtsEvent.StartSession)
+    const sessionId = startSession?.sessionId ?? 's'
+
+    socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('AUDIO1'), sessionId))
+    socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('AUDIO2'), sessionId))
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
+
+    const chunks = await collected
+    expect(chunks.slice(0, 2)).toEqual([
+      { audio: encoder.encode('AUDIO1'), done: false },
+      { audio: encoder.encode('AUDIO2'), done: false },
+    ])
+    const final = chunks[chunks.length - 1]
+    expect(final.done).toBe(true)
+
+    // Connected to the TTS endpoint with the TTS resource id.
+    expect(calls[0].url).toContain('/tts/bidirection')
+    expect(calls[0].headers['X-Api-Resource-Id']).toBe('volc.service_type.10029')
+
+    // The outbound event sequence is StartConnection -> StartSession ->
+    // TaskRequest(x2) -> FinishSession -> FinishConnection.
+    const events = socket.sent.map((b) => parseFrame(b).event)
+    expect(events).toEqual([
+      TtsEvent.StartConnection,
+      TtsEvent.StartSession,
+      TtsEvent.TaskRequest,
+      TtsEvent.TaskRequest,
+      TtsEvent.FinishSession,
+      TtsEvent.FinishConnection,
+    ])
+  })
+
+  it('surfaces a SessionFailed event as a thrown error', async () => {
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const stream = tts.synthesize(await asyncFrom(['x']))
+    const consumed = collect(stream)
+
+    await new Promise((r) => setTimeout(r, 0))
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionFailed, encoder.encode('quota exceeded')))
+
+    await expect(consumed).rejects.toThrow(/Volcengine TTS session failed/)
+  })
+
+  it('skips empty text pieces (no TaskRequest emitted for them)', async () => {
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const stream = tts.synthesize(await asyncFrom(['', 'real', '']))
+    const collected = collect(stream)
+
+    await new Promise((r) => setTimeout(r, 0))
+    const startSession = socket.sent
+      .map((b) => parseFrame(b))
+      .find((f) => f.event === TtsEvent.StartSession)
+    socket.emitMessage(
+      ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), startSession?.sessionId ?? 's')
+    )
+
+    await collected
+    const taskRequests = socket.sent
+      .map((b) => parseFrame(b))
+      .filter((f) => f.event === TtsEvent.TaskRequest)
+    expect(taskRequests).toHaveLength(1)
+    expect(JSON.parse(decoder.decode(taskRequests[0].payload)).req_params.text).toBe('real')
+  })
+
+  it('shares one provider instance across the STT and TTS slots', () => {
+    const provider = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't' })
+    expect(typeof provider.stt.transcribe).toBe('function')
+    expect(typeof provider.tts.synthesize).toBe('function')
+  })
+})

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -826,6 +826,13 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       )
       const socket = await connect(STT_URL, headers)
       const queue = new AsyncQueue<SttTranscriptChunk>()
+      // Tracks whether a final/definite transcript arrived — the ASR normal
+      // completion signal. A socket close is only a clean end-of-stream once this
+      // is set; a close BEFORE it (handshake-period failure, mid-stream network
+      // drop) is a premature close that must fail the queue, so a turn does not
+      // proceed with an empty/incomplete transcript. Mirrors the TTS layer's
+      // SessionFinished gate.
+      let finalReached = false
 
       socket.addEventListener('message', (event) => {
         try {
@@ -841,6 +848,7 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
           // the final transcript is never dropped. Also close the ASR socket as
           // the normal end-of-stream path (idempotent; mirrors the TTS layer).
           if (chunk.isFinal) {
+            finalReached = true
             queue.close()
             socket.close()
           }
@@ -848,7 +856,19 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
           queue.fail(err)
         }
       })
-      socket.addEventListener('close', () => queue.close())
+      // Distinguish a normal-completion close from a premature one. After a
+      // final/definite transcript the close is the expected end-of-stream ->
+      // close the queue normally. Before it (handshake race / mid-stream drop)
+      // the close is premature: fail the queue so the consumer
+      // (`collectFinalTranscript`) throws and the turn fails loud, rather than
+      // continuing with an empty/incomplete transcript.
+      socket.addEventListener('close', () => {
+        if (finalReached) {
+          queue.close()
+        } else {
+          queue.fail(new Error('Volcengine ASR socket closed before a final transcript'))
+        }
+      })
       socket.addEventListener('error', (err) => queue.fail(err))
 
       // Pump audio in the background so we can yield transcripts as they arrive.
@@ -894,6 +914,12 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       const socket = await connect(TTS_URL, headers)
       const queue = new AsyncQueue<TtsAudioChunk>()
       const handshake = new TtsHandshake()
+      // Tracks whether the session reached its normal completion (SessionFinished,
+      // event 152). A socket close is only a clean end-of-stream once this is set;
+      // a close BEFORE it (handshake-period failure, mid-stream network drop) is a
+      // premature close that must fail the queue, so a turn with text but missing
+      // TTS audio fails loudly instead of settling silently without audio.
+      let sessionFinished = false
 
       socket.addEventListener('message', (event) => {
         try {
@@ -913,6 +939,10 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
           if (frame.event === TtsEvent.TtsResponse && frame.payload.length > 0) {
             queue.push({ audio: copyBytes(frame.payload), done: false })
           } else if (frame.event === TtsEvent.SessionFinished) {
+            // Normal completion: push the final done frame, mark the session
+            // finished so a subsequent socket close is the clean end-of-stream,
+            // and end iteration.
+            sessionFinished = true
             queue.push({ audio: new Uint8Array(0), done: true })
             queue.close()
           } else if (frame.event === TtsEvent.SessionFailed) {
@@ -927,9 +957,21 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       })
       // A socket close before the handshake completes must reject the pending
       // gates so the pump fails loudly rather than awaiting a frame forever.
+      // `abort` is harmless once the gates have all settled (no-op on a settled
+      // gate), so it runs unconditionally on every close.
       socket.addEventListener('close', () => {
         handshake.abort(new Error('Volcengine TTS socket closed before session completed'))
-        queue.close()
+        // Distinguish a normal-completion close from a premature one. After
+        // SessionFinished (152) the close is the expected end-of-stream -> close
+        // the queue normally. Before it (handshake race / mid-stream drop) the
+        // close is premature: fail the queue so the consumer (`runTurn`'s TTS
+        // extraction) throws and the provider call fails loud, rather than the
+        // turn silently settling with text but no/partial audio.
+        if (sessionFinished) {
+          queue.close()
+        } else {
+          queue.fail(new Error('Volcengine TTS socket closed before session finished'))
+        }
       })
       socket.addEventListener('error', (err) => {
         handshake.abort(err)

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -77,6 +77,15 @@ export interface VolcengineSpeechOptions {
   ttsResourceId?: string
   /** ASR model name in the config request (`request.model_name`). */
   sttModel?: string
+  /**
+   * TTS model id, threaded into the Doubao TTS 2.0 `StartSession` `req_params`
+   * as `model` when set. The bidirectional TTS 2.0 protocol primarily binds the
+   * model via the endpoint resource id (`X-Api-Resource-Id`); this carries the
+   * resolved config model so a model switch in `provider-config` reaches the wire
+   * rather than being a silent no-op. Omitted when unset (the field is simply not
+   * sent), preserving the documented default request shape.
+   */
+  ttsModel?: string
   /** TTS speaker / voice type (`req_params.speaker`). */
   ttsSpeaker?: string
   /** Audio sample rate in Hz used on both the ASR input and TTS output. */
@@ -369,23 +378,36 @@ export function buildTtsFinishConnectionFrame(): Uint8Array {
   })
 }
 
-/** Build the TTS StartSession frame carrying the synthesis parameters. */
+/**
+ * Build the TTS StartSession frame carrying the synthesis parameters. `model` is
+ * threaded into `req_params` only when provided (the resolved config model), so
+ * the default request shape is unchanged when no model is configured.
+ */
 export function buildTtsStartSessionFrame(args: {
   sessionId: string
   speaker: string
   sampleRate: number
+  model?: string
 }): Uint8Array {
+  const reqParams: {
+    speaker: string
+    audio_params: { format: string; sample_rate: number }
+    model?: string
+  } = {
+    speaker: args.speaker,
+    audio_params: {
+      format: 'pcm',
+      sample_rate: args.sampleRate,
+    },
+  }
+  if (args.model !== undefined && args.model !== '') {
+    reqParams.model = args.model
+  }
   const payload = textEncoder.encode(
     JSON.stringify({
       event: TtsEvent.StartSession,
       namespace: 'BidirectionalTTS',
-      req_params: {
-        speaker: args.speaker,
-        audio_params: {
-          format: 'pcm',
-          sample_rate: args.sampleRate,
-        },
-      },
+      req_params: reqParams,
     })
   )
   return buildTtsEventFrame({
@@ -747,6 +769,7 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
   const sttResourceId = opts.sttResourceId ?? DEFAULT_STT_RESOURCE_ID
   const ttsResourceId = opts.ttsResourceId ?? DEFAULT_TTS_RESOURCE_ID
   const sttModel = opts.sttModel ?? DEFAULT_STT_MODEL
+  const ttsModel = opts.ttsModel
   const ttsSpeaker = opts.ttsSpeaker ?? DEFAULT_TTS_SPEAKER
   const sampleRate = opts.sampleRate ?? DEFAULT_SAMPLE_RATE
 
@@ -883,7 +906,14 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         socket.send(asArrayBuffer(buildTtsStartConnectionFrame()))
         await handshake.connectionStarted
         socket.send(
-          asArrayBuffer(buildTtsStartSessionFrame({ sessionId, speaker: ttsSpeaker, sampleRate }))
+          asArrayBuffer(
+            buildTtsStartSessionFrame({
+              sessionId,
+              speaker: ttsSpeaker,
+              sampleRate,
+              model: ttsModel,
+            })
+          )
         )
         await handshake.sessionStarted
         for await (const piece of text) {

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -1,0 +1,732 @@
+/**
+ * Volcengine (火山引擎) speech adapter — the shared platform voice layer.
+ *
+ * One adapter backs BOTH the STT and TTS provider interfaces (see
+ * `providers/types.ts`), because the L2 spec models voice as a single shared
+ * platform layer rather than one speech vendor per LLM provider.
+ *
+ *  - STT: Volcengine big-model streaming ASR over its self-owned binary
+ *    WebSocket protocol (`wss://openspeech.bytedance.com/api/v3/sauc/bigmodel`,
+ *    resource `volc.bigasr.sauc.duration`). The first frame is a JSON
+ *    full-client config request; subsequent frames are raw audio. Server
+ *    responses carry a JSON transcript whose `utterances[].definite` marks a
+ *    stabilized segment.
+ *  - TTS: Doubao TTS 2.0 bidirectional streaming over the event-based binary
+ *    protocol (`wss://openspeech.bytedance.com/api/v3/tts/bidirection`,
+ *    resource `volc.service_type.10029`). The client drives an event sequence
+ *    (StartConnection -> StartSession -> TaskRequest* -> FinishSession ->
+ *    FinishConnection); the server streams `TTSResponse` (event 352) audio
+ *    frames.
+ *
+ * Protocol references (consulted 2026-06):
+ *  - ASR binary protocol + sequence flags + auth headers:
+ *    https://www.volcengine.com/docs/6561/1354869
+ *  - TTS 2.0 bidirectional event protocol:
+ *    https://www.volcengine.com/docs/6561/1329505
+ *
+ * Cloudflare Workers runtime note: these v3 endpoints authenticate entirely via
+ * custom request headers (`X-Api-App-Key` / `X-Api-Access-Key` /
+ * `X-Api-Resource-Id` + a per-connection `X-Api-Connect-Id` UUID) — pure
+ * token-header auth, no HMAC signature and no secret key (the secret-key
+ * signature scheme is the legacy v1/v2 console-auth path this adapter does not
+ * use). The bare `new WebSocket(url)` constructor cannot set request headers in
+ * Workers, so the connection is opened with
+ * `fetch(url, { headers: { Upgrade: 'websocket', ... } })` and the socket is
+ * taken from `response.webSocket` + `.accept()`. Credentials come only from
+ * server-side env and are never sent to the client.
+ *
+ * The wire codec (frame build / frame parse / auth header assembly) is factored
+ * into the pure functions below so it is unit-testable without a live network;
+ * real Volcengine connectivity under the Workers runtime is a deploy-time
+ * open question (see the package README / task open questions).
+ */
+
+import type { AudioChunk } from '../contract'
+import type { SttProvider, SttTranscriptChunk, TtsAudioChunk, TtsProvider } from './types'
+
+// --- Public options ---
+
+/**
+ * Credentials + tuning for the Volcengine speech adapter. All credentials are
+ * server-side env values; never hard-code them and never forward them to a
+ * browser client.
+ */
+export interface VolcengineSpeechOptions {
+  /** Volcengine app id, sent as the `X-Api-App-Key` header. */
+  appId: string
+  /** Volcengine access token, sent as the `X-Api-Access-Key` header. */
+  accessToken: string
+  /**
+   * Resource id for the ASR endpoint (`X-Api-Resource-Id`). Defaults to
+   * `volc.bigasr.sauc.duration` (duration-billed big-model ASR).
+   */
+  sttResourceId?: string
+  /**
+   * Resource id for the TTS endpoint (`X-Api-Resource-Id`). Defaults to
+   * `volc.service_type.10029` (Doubao TTS 2.0 bidirectional streaming).
+   */
+  ttsResourceId?: string
+  /** ASR model name in the config request (`request.model_name`). */
+  sttModel?: string
+  /** TTS speaker / voice type (`req_params.speaker`). */
+  ttsSpeaker?: string
+  /** Audio sample rate in Hz used on both the ASR input and TTS output. */
+  sampleRate?: number
+  /**
+   * WebSocket connector seam. Defaults to the Cloudflare Workers
+   * `fetch(..., { headers: { Upgrade: 'websocket' } })` upgrade pattern. Tests
+   * inject a mock here to drive the streaming logic without a live network.
+   */
+  connect?: WebSocketConnector
+}
+
+/**
+ * Minimal structural view of a WebSocket the adapter drives. Matches the shape
+ * of both the Workers runtime socket and the `MessageEvent`-style mock used in
+ * tests; intentionally narrower than the DOM `WebSocket` lib type so the codec
+ * stays runtime-agnostic.
+ */
+export interface AdapterSocket {
+  send(data: ArrayBuffer | ArrayBufferView): void
+  close(code?: number, reason?: string): void
+  addEventListener(type: 'message', listener: (event: { data: unknown }) => void): void
+  addEventListener(type: 'close', listener: () => void): void
+  addEventListener(type: 'error', listener: (event: unknown) => void): void
+}
+
+/** Opens an authenticated WebSocket to `url` with the given request headers. */
+export type WebSocketConnector = (
+  url: string,
+  headers: Record<string, string>
+) => Promise<AdapterSocket>
+
+// --- Endpoints + protocol constants ---
+
+const STT_URL = 'wss://openspeech.bytedance.com/api/v3/sauc/bigmodel'
+const TTS_URL = 'wss://openspeech.bytedance.com/api/v3/tts/bidirection'
+const DEFAULT_STT_RESOURCE_ID = 'volc.bigasr.sauc.duration'
+const DEFAULT_TTS_RESOURCE_ID = 'volc.service_type.10029'
+const DEFAULT_STT_MODEL = 'bigmodel'
+const DEFAULT_TTS_SPEAKER = 'zh_female_cancan_mars_bigtts'
+const DEFAULT_SAMPLE_RATE = 16000
+
+/** byte0: (protocol version 0b0001 << 4) | (header size 0b0001 = 4 bytes). */
+const PROTOCOL_HEADER_BYTE0 = 0x11
+
+/** Message types (high nibble of byte 1). */
+export const MessageType = {
+  FullClientRequest: 0b0001,
+  AudioOnlyClient: 0b0010,
+  FullServerResponse: 0b1001,
+  AudioOnlyServer: 0b1011,
+  ErrorResponse: 0b1111,
+} as const
+
+/** Message-type-specific flags (low nibble of byte 1). */
+export const MessageFlag = {
+  NoSequence: 0b0000,
+  PositiveSequence: 0b0001,
+  LastNoSequence: 0b0010,
+  NegativeWithSequence: 0b0011,
+  /** TTS event-protocol marker: the frame carries an event int + session id. */
+  WithEvent: 0b0100,
+} as const
+
+/** Serialization method (high nibble of byte 2). */
+export const Serialization = {
+  None: 0b0000,
+  Json: 0b0001,
+} as const
+
+/** Compression method (low nibble of byte 2). No gzip — keeps the codec pure. */
+export const Compression = {
+  None: 0b0000,
+  Gzip: 0b0001,
+} as const
+
+/** TTS 2.0 bidirectional event codes. */
+export const TtsEvent = {
+  StartConnection: 1,
+  FinishConnection: 2,
+  ConnectionStarted: 50,
+  ConnectionFailed: 51,
+  StartSession: 100,
+  FinishSession: 102,
+  SessionStarted: 150,
+  SessionFinished: 152,
+  SessionFailed: 153,
+  TaskRequest: 200,
+  SentenceStart: 350,
+  SentenceEnd: 351,
+  TtsResponse: 352,
+} as const
+
+// --- Pure codec: frame build / parse / auth headers ---
+
+/** Parsed view of a Volcengine binary frame. */
+export interface ParsedFrame {
+  messageType: number
+  flags: number
+  serialization: number
+  compression: number
+  /** Sequence number, when the flags indicate one is present (ASR). */
+  sequence?: number
+  /** Event code, when the WithEvent flag is set (TTS). */
+  event?: number
+  /** Session id, when present on an event frame (TTS). */
+  sessionId?: string
+  /** Raw payload bytes (after any size field). */
+  payload: Uint8Array
+}
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+/**
+ * Assemble the WebSocket-handshake auth headers. Both the v3 big-model ASR and
+ * the Doubao TTS 2.0 endpoints authenticate via the same `X-Api-*` header set;
+ * `resourceId` selects the endpoint. `Upgrade: websocket` is required so the
+ * Workers `fetch` performs the upgrade (the bare `WebSocket` constructor cannot
+ * carry these custom headers).
+ *
+ * The v3 streaming endpoints use pure token-header auth — no HMAC signature, no
+ * secret key. The four headers are: `X-Api-App-Key` (app id), `X-Api-Access-Key`
+ * (access token), `X-Api-Resource-Id` (endpoint selector), and `X-Api-Connect-Id`
+ * (a per-connection UUID for handshake-level connection tracing — NOT the
+ * business `X-Api-Request-Id`, which is the per-request id used by the HTTP/
+ * recording-file APIs, not by this WS handshake).
+ */
+export function buildAuthHeaders(
+  opts: { appId: string; accessToken: string; resourceId: string },
+  connectId: string
+): Record<string, string> {
+  return {
+    Upgrade: 'websocket',
+    'X-Api-App-Key': opts.appId,
+    'X-Api-Access-Key': opts.accessToken,
+    'X-Api-Resource-Id': opts.resourceId,
+    'X-Api-Connect-Id': connectId,
+  }
+}
+
+function buildHeader(
+  messageType: number,
+  flags: number,
+  serialization: number,
+  compression: number
+): Uint8Array {
+  return new Uint8Array([
+    PROTOCOL_HEADER_BYTE0,
+    (messageType << 4) | flags,
+    (serialization << 4) | compression,
+    0x00,
+  ])
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.length, 0)
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const part of parts) {
+    out.set(part, offset)
+    offset += part.length
+  }
+  return out
+}
+
+/** Encode a signed 32-bit big-endian integer (used for sequence + sizes). */
+function int32BE(value: number): Uint8Array {
+  const buf = new Uint8Array(4)
+  new DataView(buf.buffer).setInt32(0, value, false)
+  return buf
+}
+
+/**
+ * Build an ASR client frame: `[header][seq?][payloadSize][payload]`.
+ *
+ * The first config request is a JSON full-client request with a positive
+ * sequence; audio frames are raw audio-only requests. The final audio frame
+ * carries a negative sequence with the `NegativeWithSequence` flag so the
+ * server knows the stream is complete.
+ */
+export function buildSttRequestFrame(args: {
+  messageType: number
+  flags: number
+  serialization: number
+  sequence?: number
+  payload: Uint8Array
+}): Uint8Array {
+  const header = buildHeader(args.messageType, args.flags, args.serialization, Compression.None)
+  const parts: Uint8Array[] = [header]
+  if (args.sequence !== undefined) {
+    parts.push(int32BE(args.sequence))
+  }
+  parts.push(int32BE(args.payload.length))
+  parts.push(args.payload)
+  return concatBytes(parts)
+}
+
+/** Build the ASR full-client config request frame (sequence 1). */
+export function buildSttConfigFrame(config: {
+  uid: string
+  format: string
+  sampleRate: number
+  model: string
+}): Uint8Array {
+  const payload = textEncoder.encode(
+    JSON.stringify({
+      user: { uid: config.uid },
+      audio: {
+        format: config.format,
+        rate: config.sampleRate,
+        bits: 16,
+        channel: 1,
+      },
+      request: {
+        model_name: config.model,
+        enable_punc: true,
+        enable_itn: true,
+      },
+    })
+  )
+  return buildSttRequestFrame({
+    messageType: MessageType.FullClientRequest,
+    flags: MessageFlag.PositiveSequence,
+    serialization: Serialization.Json,
+    sequence: 1,
+    payload,
+  })
+}
+
+/** Build one ASR audio frame; `isLast` flags the final (negative) packet. */
+export function buildSttAudioFrame(
+  audio: Uint8Array,
+  sequence: number,
+  isLast: boolean
+): Uint8Array {
+  return buildSttRequestFrame({
+    messageType: MessageType.AudioOnlyClient,
+    flags: isLast ? MessageFlag.NegativeWithSequence : MessageFlag.PositiveSequence,
+    serialization: Serialization.None,
+    sequence: isLast ? -sequence : sequence,
+    payload: audio,
+  })
+}
+
+/**
+ * Build a TTS event frame: `[header][event][sessionIdSize][sessionId?][payloadSize][payload]`.
+ *
+ * Connection-scoped events (StartConnection / FinishConnection) carry an empty
+ * session id; session-scoped events (StartSession / TaskRequest /
+ * FinishSession) carry the session id assigned by the client.
+ */
+export function buildTtsEventFrame(args: {
+  event: number
+  sessionId: string
+  payload: Uint8Array
+}): Uint8Array {
+  const header = buildHeader(
+    MessageType.FullClientRequest,
+    MessageFlag.WithEvent,
+    Serialization.Json,
+    Compression.None
+  )
+  const sessionIdBytes = textEncoder.encode(args.sessionId)
+  return concatBytes([
+    header,
+    int32BE(args.event),
+    int32BE(sessionIdBytes.length),
+    sessionIdBytes,
+    int32BE(args.payload.length),
+    args.payload,
+  ])
+}
+
+/** Build the TTS StartConnection frame (no session, empty JSON payload). */
+export function buildTtsStartConnectionFrame(): Uint8Array {
+  return buildTtsEventFrame({
+    event: TtsEvent.StartConnection,
+    sessionId: '',
+    payload: textEncoder.encode('{}'),
+  })
+}
+
+/** Build the TTS FinishConnection frame. */
+export function buildTtsFinishConnectionFrame(): Uint8Array {
+  return buildTtsEventFrame({
+    event: TtsEvent.FinishConnection,
+    sessionId: '',
+    payload: textEncoder.encode('{}'),
+  })
+}
+
+/** Build the TTS StartSession frame carrying the synthesis parameters. */
+export function buildTtsStartSessionFrame(args: {
+  sessionId: string
+  speaker: string
+  sampleRate: number
+}): Uint8Array {
+  const payload = textEncoder.encode(
+    JSON.stringify({
+      event: TtsEvent.StartSession,
+      namespace: 'BidirectionalTTS',
+      req_params: {
+        speaker: args.speaker,
+        audio_params: {
+          format: 'pcm',
+          sample_rate: args.sampleRate,
+        },
+      },
+    })
+  )
+  return buildTtsEventFrame({
+    event: TtsEvent.StartSession,
+    sessionId: args.sessionId,
+    payload,
+  })
+}
+
+/** Build a TTS TaskRequest frame feeding one text chunk into the session. */
+export function buildTtsTaskRequestFrame(args: {
+  sessionId: string
+  text: string
+  speaker: string
+}): Uint8Array {
+  const payload = textEncoder.encode(
+    JSON.stringify({
+      event: TtsEvent.TaskRequest,
+      namespace: 'BidirectionalTTS',
+      req_params: {
+        text: args.text,
+        speaker: args.speaker,
+      },
+    })
+  )
+  return buildTtsEventFrame({
+    event: TtsEvent.TaskRequest,
+    sessionId: args.sessionId,
+    payload,
+  })
+}
+
+/** Build the TTS FinishSession frame closing the synthesis session. */
+export function buildTtsFinishSessionFrame(sessionId: string): Uint8Array {
+  return buildTtsEventFrame({
+    event: TtsEvent.FinishSession,
+    sessionId,
+    payload: textEncoder.encode('{}'),
+  })
+}
+
+/** Coerce any inbound WS message payload to a `Uint8Array` view. */
+function toBytes(data: unknown): Uint8Array {
+  if (data instanceof Uint8Array) return data
+  if (data instanceof ArrayBuffer) return new Uint8Array(data)
+  if (ArrayBuffer.isView(data)) {
+    const view = data as ArrayBufferView
+    return new Uint8Array(view.buffer, view.byteOffset, view.byteLength)
+  }
+  if (typeof data === 'string') return textEncoder.encode(data)
+  throw new TypeError('unsupported WebSocket message payload')
+}
+
+/**
+ * Parse a Volcengine binary frame. Handles both shapes: the ASR
+ * sequence-carrying frame and the TTS event frame (WithEvent flag). The two
+ * are disambiguated by the flags nibble, exactly as the wire encodes them.
+ */
+export function parseFrame(data: unknown): ParsedFrame {
+  const bytes = toBytes(data)
+  if (bytes.length < 4) {
+    throw new RangeError('frame shorter than 4-byte header')
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const messageType = bytes[1] >> 4
+  const flags = bytes[1] & 0x0f
+  const serialization = bytes[2] >> 4
+  const compression = bytes[2] & 0x0f
+
+  let offset = 4
+  const frame: ParsedFrame = {
+    messageType,
+    flags,
+    serialization,
+    compression,
+    payload: new Uint8Array(0),
+  }
+
+  if ((flags & MessageFlag.WithEvent) === MessageFlag.WithEvent) {
+    // TTS event frame: [event][sessionIdSize][sessionId][payloadSize][payload].
+    frame.event = view.getInt32(offset, false)
+    offset += 4
+    const sessionIdSize = view.getInt32(offset, false)
+    offset += 4
+    frame.sessionId = textDecoder.decode(bytes.subarray(offset, offset + sessionIdSize))
+    offset += sessionIdSize
+  } else if (flags === MessageFlag.PositiveSequence || flags === MessageFlag.NegativeWithSequence) {
+    // ASR sequence-carrying frame: [sequence][payloadSize][payload].
+    frame.sequence = view.getInt32(offset, false)
+    offset += 4
+  }
+
+  const payloadSize = view.getInt32(offset, false)
+  offset += 4
+  frame.payload = bytes.subarray(offset, offset + payloadSize)
+  return frame
+}
+
+/**
+ * Map a parsed ASR server-response frame to a transcript chunk. Returns
+ * `undefined` for frames with no transcript text (e.g. an empty ack). A
+ * segment is final when any utterance reports `definite: true`.
+ */
+export function parseSttResponse(frame: ParsedFrame): SttTranscriptChunk | undefined {
+  if (frame.messageType === MessageType.ErrorResponse) {
+    throw new Error(`Volcengine ASR error: ${textDecoder.decode(frame.payload)}`)
+  }
+  if (frame.serialization !== Serialization.Json || frame.payload.length === 0) {
+    return undefined
+  }
+  const body = JSON.parse(textDecoder.decode(frame.payload)) as {
+    result?: {
+      text?: string
+      utterances?: Array<{ definite?: boolean }>
+    }
+  }
+  const result = body.result
+  if (!result || typeof result.text !== 'string') {
+    return undefined
+  }
+  const isFinal = (result.utterances ?? []).some((u) => u.definite === true)
+  return { text: result.text, isFinal }
+}
+
+// --- Default Workers connector ---
+
+/**
+ * Open an authenticated outbound WebSocket from a Cloudflare Worker. Uses the
+ * `fetch` + `Upgrade: websocket` pattern because the bare `WebSocket`
+ * constructor cannot attach the `X-Api-*` auth headers in the Workers runtime.
+ */
+const defaultConnect: WebSocketConnector = async (url, headers) => {
+  const response = await fetch(url, { headers })
+  // Cloudflare's fetch exposes the negotiated socket on the response.
+  const socket = (response as unknown as { webSocket?: AdapterSocket & { accept(): void } })
+    .webSocket
+  if (!socket) {
+    throw new Error('Volcengine WebSocket upgrade failed: no webSocket on response')
+  }
+  socket.accept()
+  return socket
+}
+
+// --- Streaming glue: an async queue bridging WS events to async iteration ---
+
+/**
+ * Minimal single-consumer async queue. Inbound WS messages are pushed in via
+ * `push`; the consumer pulls them with `for await`. `close` ends iteration,
+ * `fail` rejects the pending pull.
+ */
+class AsyncQueue<T> {
+  private values: T[] = []
+  private resolvers: Array<(r: IteratorResult<T>) => void> = []
+  private rejecters: Array<(e: unknown) => void> = []
+  private closed = false
+  private error: unknown
+
+  push(value: T): void {
+    if (this.closed) return
+    const resolve = this.resolvers.shift()
+    if (resolve) {
+      this.rejecters.shift()
+      resolve({ value, done: false })
+    } else {
+      this.values.push(value)
+    }
+  }
+
+  close(): void {
+    this.closed = true
+    while (this.resolvers.length > 0) {
+      this.rejecters.shift()
+      this.resolvers.shift()?.({ value: undefined, done: true })
+    }
+  }
+
+  fail(error: unknown): void {
+    this.error = error
+    this.closed = true
+    while (this.rejecters.length > 0) {
+      this.resolvers.shift()
+      this.rejecters.shift()?.(error)
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<T> {
+    while (true) {
+      if (this.values.length > 0) {
+        yield this.values.shift() as T
+        continue
+      }
+      if (this.error !== undefined) throw this.error
+      if (this.closed) return
+      const next = await new Promise<IteratorResult<T>>((resolve, reject) => {
+        this.resolvers.push(resolve)
+        this.rejecters.push(reject)
+      })
+      if (next.done) return
+      yield next.value
+    }
+  }
+}
+
+// --- Provider factory ---
+
+/**
+ * Build the Volcengine speech provider pair. The returned object satisfies both
+ * `SttProvider` and `TtsProvider`; the platform wires the same instance into
+ * both layer slots (the voice layer is shared, per the L2 spec).
+ */
+export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
+  stt: SttProvider
+  tts: TtsProvider
+} {
+  const connect = opts.connect ?? defaultConnect
+  const sttResourceId = opts.sttResourceId ?? DEFAULT_STT_RESOURCE_ID
+  const ttsResourceId = opts.ttsResourceId ?? DEFAULT_TTS_RESOURCE_ID
+  const sttModel = opts.sttModel ?? DEFAULT_STT_MODEL
+  const ttsSpeaker = opts.ttsSpeaker ?? DEFAULT_TTS_SPEAKER
+  const sampleRate = opts.sampleRate ?? DEFAULT_SAMPLE_RATE
+
+  const stt: SttProvider = {
+    async *transcribe(audio: AsyncIterable<AudioChunk>): AsyncIterable<SttTranscriptChunk> {
+      const connectId = randomId()
+      const headers = buildAuthHeaders(
+        { appId: opts.appId, accessToken: opts.accessToken, resourceId: sttResourceId },
+        connectId
+      )
+      const socket = await connect(STT_URL, headers)
+      const queue = new AsyncQueue<SttTranscriptChunk>()
+
+      socket.addEventListener('message', (event) => {
+        try {
+          const frame = parseFrame(event.data)
+          const chunk = parseSttResponse(frame)
+          if (chunk) queue.push(chunk)
+        } catch (err) {
+          queue.fail(err)
+        }
+      })
+      socket.addEventListener('close', () => queue.close())
+      socket.addEventListener('error', (err) => queue.fail(err))
+
+      // Pump audio in the background so we can yield transcripts as they arrive.
+      const pump = (async () => {
+        socket.send(
+          asArrayBuffer(
+            buildSttConfigFrame({
+              uid: connectId,
+              format: 'pcm',
+              sampleRate,
+              model: sttModel,
+            })
+          )
+        )
+        let seq = 1
+        let pending: Uint8Array | undefined
+        for await (const frame of audio) {
+          if (pending !== undefined) {
+            seq += 1
+            socket.send(asArrayBuffer(buildSttAudioFrame(pending, seq, false)))
+          }
+          pending = frame
+        }
+        // Flag the final audio packet with a negative sequence.
+        seq += 1
+        const last = pending ?? new Uint8Array(0)
+        socket.send(asArrayBuffer(buildSttAudioFrame(last, seq, true)))
+      })()
+      pump.catch((err) => queue.fail(err))
+
+      yield* queue
+    },
+  }
+
+  const tts: TtsProvider = {
+    async *synthesize(text: AsyncIterable<string>): AsyncIterable<TtsAudioChunk> {
+      const connectId = randomId()
+      const sessionId = randomId()
+      const headers = buildAuthHeaders(
+        { appId: opts.appId, accessToken: opts.accessToken, resourceId: ttsResourceId },
+        connectId
+      )
+      const socket = await connect(TTS_URL, headers)
+      const queue = new AsyncQueue<TtsAudioChunk>()
+
+      socket.addEventListener('message', (event) => {
+        try {
+          const frame = parseFrame(event.data)
+          if (frame.messageType === MessageType.ErrorResponse) {
+            queue.fail(new Error(`Volcengine TTS error: ${decodeUtf8(frame.payload)}`))
+            return
+          }
+          if (frame.event === TtsEvent.TtsResponse && frame.payload.length > 0) {
+            queue.push({ audio: copyBytes(frame.payload), done: false })
+          } else if (frame.event === TtsEvent.SessionFinished) {
+            queue.push({ audio: new Uint8Array(0), done: true })
+            queue.close()
+          } else if (frame.event === TtsEvent.SessionFailed) {
+            queue.fail(new Error(`Volcengine TTS session failed: ${decodeUtf8(frame.payload)}`))
+          }
+        } catch (err) {
+          queue.fail(err)
+        }
+      })
+      socket.addEventListener('close', () => queue.close())
+      socket.addEventListener('error', (err) => queue.fail(err))
+
+      const pump = (async () => {
+        socket.send(asArrayBuffer(buildTtsStartConnectionFrame()))
+        socket.send(
+          asArrayBuffer(buildTtsStartSessionFrame({ sessionId, speaker: ttsSpeaker, sampleRate }))
+        )
+        for await (const piece of text) {
+          if (piece.length === 0) continue
+          socket.send(
+            asArrayBuffer(buildTtsTaskRequestFrame({ sessionId, text: piece, speaker: ttsSpeaker }))
+          )
+        }
+        socket.send(asArrayBuffer(buildTtsFinishSessionFrame(sessionId)))
+        socket.send(asArrayBuffer(buildTtsFinishConnectionFrame()))
+      })()
+      pump.catch((err) => queue.fail(err))
+
+      yield* queue
+    },
+  }
+
+  return { stt, tts }
+}
+
+// --- Small helpers ---
+
+function asArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  // Copy into a standalone ArrayBuffer so the WS send sees exact frame bounds.
+  const copy = new Uint8Array(bytes.length)
+  copy.set(bytes)
+  return copy.buffer
+}
+
+function copyBytes(bytes: Uint8Array): Uint8Array {
+  const out = new Uint8Array(bytes.length)
+  out.set(bytes)
+  return out
+}
+
+function decodeUtf8(bytes: Uint8Array): string {
+  return textDecoder.decode(bytes)
+}
+
+function randomId(): string {
+  return crypto.randomUUID()
+}

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -439,26 +439,43 @@ export function buildTtsFinishSessionFrame(sessionId: string): Uint8Array {
  *
  * This pure gate makes that timing explicit and unit-testable without a live
  * socket: the message listener feeds inbound server events via `handleEvent`,
- * and the pump `await`s `connectionStarted` / `sessionStarted` before advancing.
- * A `ConnectionFailed` / `SessionFailed` event rejects the matching gate so the
- * pump fails loudly instead of hanging.
+ * and the pump `await`s `connectionStarted` / `sessionStarted` before advancing,
+ * then `sessionFinished` before closing the connection. A `ConnectionFailed` /
+ * `SessionFailed` event rejects the matching gate so the pump fails loudly
+ * instead of hanging.
  *
- * It only sequences the handshake (connection + session acceptance). Audio
- * (`TtsResponse`) and session completion (`SessionFinished`) stay in the
- * provider's message listener, which owns the audio queue.
+ * It sequences both ends of the handshake symmetrically: the connection +
+ * session acceptance gates open the turn, and the `sessionFinished` gate closes
+ * it. `SessionStarted` (150) resolves the start gate; `SessionFinished` (152)
+ * resolves the finish gate — gating the client's `FinishConnection` until the
+ * server has streamed every remaining `TTSResponse` frame and acknowledged the
+ * session is complete, so closing the socket never truncates the tail audio.
+ * The audio queue itself (pushing `TTSResponse` frames + the final `done` chunk
+ * on `SessionFinished`) stays in the provider's message listener.
  */
 export class TtsHandshake {
   /** Resolves when the server has accepted the connection (event 50). */
   readonly connectionStarted: Promise<void>
   /** Resolves when the server has accepted the session (event 150). */
   readonly sessionStarted: Promise<void>
+  /**
+   * Resolves when the server has finished the session (event 152) — i.e. every
+   * remaining `TTSResponse` audio frame has been delivered. The pump awaits this
+   * before sending `FinishConnection`, so closing the connection never truncates
+   * the tail audio. Symmetric to the start-side `connectionStarted` /
+   * `sessionStarted` gates.
+   */
+  readonly sessionFinished: Promise<void>
 
   private resolveConnection!: () => void
   private rejectConnection!: (err: unknown) => void
   private resolveSession!: () => void
   private rejectSession!: (err: unknown) => void
+  private resolveSessionFinished!: () => void
+  private rejectSessionFinished!: (err: unknown) => void
   private connectionSettled = false
   private sessionSettled = false
+  private sessionFinishedSettled = false
 
   constructor() {
     this.connectionStarted = new Promise<void>((resolve, reject) => {
@@ -469,17 +486,26 @@ export class TtsHandshake {
       this.resolveSession = resolve
       this.rejectSession = reject
     })
+    this.sessionFinished = new Promise<void>((resolve, reject) => {
+      this.resolveSessionFinished = resolve
+      this.rejectSessionFinished = reject
+    })
     // A rejected gate the pump has not awaited yet would surface as an unhandled
     // rejection; attach an inert catch so the rejection is delivered only to the
     // awaiting pump, never to the process.
     this.connectionStarted.catch(() => {})
     this.sessionStarted.catch(() => {})
+    this.sessionFinished.catch(() => {})
   }
 
   /**
    * Advance the handshake from one inbound server event. Returns `true` if the
    * event was a handshake-control event this gate consumed (so the caller can
-   * skip further handling), `false` for any other event (audio, completion).
+   * skip further handling), `false` for any other event (audio).
+   *
+   * `SessionFinished` (152) is special: it resolves the finish gate but returns
+   * `false`, because the provider's listener still owns pushing the final `done`
+   * chunk + closing the audio queue on that same event.
    */
   handleEvent(event: number | undefined, describe: () => string): boolean {
     switch (event) {
@@ -492,6 +518,9 @@ export class TtsHandshake {
       case TtsEvent.SessionStarted:
         this.settleSession()
         return true
+      case TtsEvent.SessionFinished:
+        this.settleSessionFinished()
+        return false
       default:
         return false
     }
@@ -501,6 +530,7 @@ export class TtsHandshake {
   abort(err: unknown): void {
     this.failConnection(err)
     this.failSession(err)
+    this.failSessionFinished(err)
   }
 
   private settleConnection(): void {
@@ -525,6 +555,18 @@ export class TtsHandshake {
     if (this.sessionSettled) return
     this.sessionSettled = true
     this.rejectSession(err)
+  }
+
+  private settleSessionFinished(): void {
+    if (this.sessionFinishedSettled) return
+    this.sessionFinishedSettled = true
+    this.resolveSessionFinished()
+  }
+
+  private failSessionFinished(err: unknown): void {
+    if (this.sessionFinishedSettled) return
+    this.sessionFinishedSettled = true
+    this.rejectSessionFinished(err)
   }
 }
 
@@ -827,11 +869,16 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         queue.fail(err)
       })
 
-      // Event-driven handshake: each client frame waits for the server to accept
-      // the previous step before being sent. StartConnection -> (await
-      // ConnectionStarted) -> StartSession -> (await SessionStarted) ->
-      // TaskRequest(s) -> FinishSession -> FinishConnection. The server then
-      // streams TTSResponse audio + SessionFinished, handled by the listener.
+      // Event-driven handshake, server-gated on both ends. Each client frame
+      // waits for the server to accept the previous step before being sent:
+      // StartConnection -> (await ConnectionStarted) -> StartSession -> (await
+      // SessionStarted) -> TaskRequest(s) -> FinishSession -> (await
+      // SessionFinished) -> FinishConnection. After FinishSession the server
+      // streams the remaining TTSResponse audio frames and then SessionFinished;
+      // gating FinishConnection on SessionFinished (rather than firing it
+      // immediately after FinishSession) lets the listener drain that tail audio
+      // before the connection closes, so the last synthesized frames are never
+      // truncated. This mirrors the start-side gating symmetrically.
       const pump = (async () => {
         socket.send(asArrayBuffer(buildTtsStartConnectionFrame()))
         await handshake.connectionStarted
@@ -846,6 +893,7 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
           )
         }
         socket.send(asArrayBuffer(buildTtsFinishSessionFrame(sessionId)))
+        await handshake.sessionFinished
         socket.send(asArrayBuffer(buildTtsFinishConnectionFrame()))
       })()
       pump.catch((err) => queue.fail(err))

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -681,12 +681,34 @@ export function parseSttResponse(frame: ParsedFrame): SttTranscriptChunk | undef
 // --- Default Workers connector ---
 
 /**
+ * Rewrite a WebSocket URL scheme to its HTTP equivalent for the `fetch`-upgrade
+ * path: `wss:` -> `https:`, `ws:` -> `http:`. The endpoint constants stay
+ * `wss://` (the adapter's outward contract is WebSocket), but the Cloudflare
+ * Workers custom-header upgrade pattern requires an `http(s)://` URL handed to
+ * `fetch`: `ws:`/`wss:` are reserved for the `new WebSocket()` constructor,
+ * which cannot carry the `X-Api-*` auth headers. With the
+ * `fetch_refuses_unknown_protocols` runtime behavior a `wss://` URL is no longer
+ * silently coerced to HTTP, so passing it straight to `fetch` fails the upgrade
+ * before any turn starts. Only the leading scheme is touched — host, path, and
+ * query are untouched. (Cloudflare docs: workers/examples/websockets +
+ * configuration/compatibility-flags#fetch-refuses-unknown-protocols.)
+ */
+function toFetchUpgradeUrl(url: string): string {
+  if (url.startsWith('wss:')) return `https:${url.slice('wss:'.length)}`
+  if (url.startsWith('ws:')) return `http:${url.slice('ws:'.length)}`
+  return url
+}
+
+/**
  * Open an authenticated outbound WebSocket from a Cloudflare Worker. Uses the
  * `fetch` + `Upgrade: websocket` pattern because the bare `WebSocket`
  * constructor cannot attach the `X-Api-*` auth headers in the Workers runtime.
+ * The `wss://` endpoint constant is rewritten to `https://` via
+ * `toFetchUpgradeUrl` before `fetch`, as the Workers upgrade path requires an
+ * `http(s)://` URL (see that helper).
  */
 export const defaultConnect: WebSocketConnector = async (url, headers) => {
-  const response = await fetch(url, { headers })
+  const response = await fetch(toFetchUpgradeUrl(url), { headers })
   // Cloudflare's fetch exposes the negotiated socket on the response.
   const socket = (
     response as unknown as {

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -905,7 +905,18 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       socket.addEventListener('error', (err) => queue.fail(err))
 
       // Pump audio in the background so we can yield transcripts as they arrive.
+      //
+      // `cancelled` is set by the generator's `finally` when the consumer calls
+      // `return()` (turn early-exit — e.g. `collectFinalTranscript` breaks early,
+      // or the turn aborts). The pump checks it before every send and stops pushing
+      // audio at once, rather than continuing to drive the ASR session the consumer
+      // abandoned. The inbound audio source is drained through an explicit iterator
+      // so the `finally` can `return()` it, terminating the pump's `for await` and
+      // releasing the upstream audio generator too.
+      let cancelled = false
+      const audioIterator = audio[Symbol.asyncIterator]()
       const pump = (async () => {
+        if (cancelled) return
         socket.send(
           asArrayBuffer(
             buildSttConfigFrame({
@@ -918,13 +929,17 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         )
         let seq = 1
         let pending: Uint8Array | undefined
-        for await (const frame of audio) {
+        for (;;) {
+          const next = await audioIterator.next()
+          if (next.done) break
+          if (cancelled) return
           if (pending !== undefined) {
             seq += 1
             socket.send(asArrayBuffer(buildSttAudioFrame(pending, seq, false)))
           }
-          pending = frame
+          pending = next.value
         }
+        if (cancelled) return
         // Flag the final audio packet with a negative sequence.
         seq += 1
         const last = pending ?? new Uint8Array(0)
@@ -932,7 +947,28 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       })()
       pump.catch((err) => queue.fail(err))
 
-      yield* queue
+      try {
+        yield* queue
+      } finally {
+        // Runs on every exit path: normal completion (a definite transcript closed
+        // the queue), a provider error (the queue was failed), and — the
+        // resource-leak fix — consumer cancellation via `transcribe`'s iterator
+        // `return()` when the turn exits early. On the cancellation path the queue
+        // is still open and the pump may be parked pulling the next audio frame, so
+        // without this the outbound Volcengine ASR socket would leak and audio keep
+        // streaming. Cleanup is idempotent so it never disturbs the already-settled
+        // normal / error paths:
+        //  - `cancelled` short-circuits any further pump sends;
+        //  - `audioIterator.return()` ends the pump's `for await` and releases the
+        //    upstream audio generator;
+        //  - `queue.close()` is idempotent on an already-closed/failed queue;
+        //  - `socket.close()` deterministically releases the outbound connection
+        //    (idempotent; the normal path already closes it on a final transcript).
+        cancelled = true
+        await audioIterator.return?.(undefined)
+        queue.close()
+        socket.close()
+      }
     },
   }
 
@@ -1021,9 +1057,19 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       // immediately after FinishSession) lets the listener drain that tail audio
       // before the connection closes, so the last synthesized frames are never
       // truncated. This mirrors the start-side gating symmetrically.
+      //
+      // `cancelled` is set by the generator's `finally` when the consumer calls
+      // `return()` (turn early-exit). The pump checks it before every send so a
+      // cancellation that lands mid-send-sequence stops issuing frames at once,
+      // rather than continuing to drive (and bill) a session the consumer has
+      // abandoned. The awaited gates are rejected by the same `finally` via
+      // `handshake.abort`, so a pump parked on a gate unblocks instead of hanging.
+      let cancelled = false
       const pump = (async () => {
+        if (cancelled) return
         socket.send(asArrayBuffer(buildTtsStartConnectionFrame()))
         await handshake.connectionStarted
+        if (cancelled) return
         socket.send(
           asArrayBuffer(
             buildTtsStartSessionFrame({
@@ -1036,18 +1082,42 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         )
         await handshake.sessionStarted
         for await (const piece of text) {
+          if (cancelled) return
           if (piece.length === 0) continue
           socket.send(
             asArrayBuffer(buildTtsTaskRequestFrame({ sessionId, text: piece, speaker: ttsSpeaker }))
           )
         }
+        if (cancelled) return
         socket.send(asArrayBuffer(buildTtsFinishSessionFrame(sessionId)))
         await handshake.sessionFinished
+        if (cancelled) return
         socket.send(asArrayBuffer(buildTtsFinishConnectionFrame()))
       })()
       pump.catch((err) => queue.fail(err))
 
-      yield* queue
+      try {
+        yield* queue
+      } finally {
+        // Runs on every exit path: normal completion (SessionFinished closed the
+        // queue), a provider error (the queue was failed), and — the resource-leak
+        // fix — consumer cancellation via `ttsIterator.return()` when the turn
+        // exits early (owner `end`, socket close, STT/LLM failure). On the
+        // cancellation path the queue is still open and the pump may be parked on a
+        // handshake gate or sending TaskRequests, so without this the outbound
+        // Volcengine TTS socket would leak and the session keep billing. Cleanup is
+        // idempotent so it never disturbs the already-settled normal / error paths:
+        //  - `cancelled` short-circuits any further pump sends;
+        //  - `handshake.abort` rejects only NOT-yet-settled gates (no-op once the
+        //    handshake completed normally), unblocking a parked pump;
+        //  - `queue.close()` is idempotent on an already-closed/failed queue;
+        //  - `socket.close()` deterministically releases the outbound connection
+        //    (idempotent; the normal path relies on the server closing it).
+        cancelled = true
+        handshake.abort(new Error('Volcengine TTS synthesize cancelled'))
+        queue.close()
+        socket.close()
+      }
     },
   }
 

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -41,8 +41,11 @@
  * use). The bare `new WebSocket(url)` constructor cannot set request headers in
  * Workers, so the connection is opened with
  * `fetch(url, { headers: { Upgrade: 'websocket', ... } })` and the socket is
- * taken from `response.webSocket` + `.accept()`. Credentials come only from
- * server-side env and are never sent to the client.
+ * taken from `response.webSocket`, set to `binaryType = 'arraybuffer'`, and then
+ * `.accept()`ed — so inbound ASR/TTS binary frames arrive as `ArrayBuffer` (what
+ * the synchronous `toBytes` codec needs) rather than the post-2026 `Blob`
+ * default. Credentials come only from server-side env and are never sent to the
+ * client.
  *
  * The wire codec (frame build / frame parse / auth header assembly) is factored
  * into the pure functions below so it is unit-testable without a live network;
@@ -682,14 +685,29 @@ export function parseSttResponse(frame: ParsedFrame): SttTranscriptChunk | undef
  * `fetch` + `Upgrade: websocket` pattern because the bare `WebSocket`
  * constructor cannot attach the `X-Api-*` auth headers in the Workers runtime.
  */
-const defaultConnect: WebSocketConnector = async (url, headers) => {
+export const defaultConnect: WebSocketConnector = async (url, headers) => {
   const response = await fetch(url, { headers })
   // Cloudflare's fetch exposes the negotiated socket on the response.
-  const socket = (response as unknown as { webSocket?: AdapterSocket & { accept(): void } })
-    .webSocket
+  const socket = (
+    response as unknown as {
+      webSocket?: AdapterSocket & { accept(): void; binaryType: 'blob' | 'arraybuffer' }
+    }
+  ).webSocket
   if (!socket) {
     throw new Error('Volcengine WebSocket upgrade failed: no webSocket on response')
   }
+  // Opt back into ArrayBuffer delivery BEFORE accepting. With this Worker's
+  // `compatibility_date` (2026-06-08) the `websocket_standard_binary_type`
+  // default delivers inbound binary WS frames as `Blob`. The ASR/TTS message
+  // listeners parse every frame synchronously via `parseFrame` -> `toBytes`,
+  // which accepts ArrayBuffer / typed-array views / strings but NOT a `Blob`
+  // (a Blob can only be read async via `blob.arrayBuffer()`). A Blob would hit
+  // `toBytes`'s `unsupported WebSocket message payload` throw and fail the turn.
+  // Setting `binaryType` keeps the synchronous codec path correct. MUST precede
+  // `accept()` — the runtime only honors it before the socket is accepted.
+  // (Cloudflare docs: runtime-apis/websockets#binary-messages.) Applies to BOTH
+  // outbound connections (ASR + TTS) since both open through this one connector.
+  socket.binaryType = 'arraybuffer'
   socket.accept()
   return socket
 }

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -612,7 +612,19 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         try {
           const frame = parseFrame(event.data)
           const chunk = parseSttResponse(frame)
-          if (chunk) queue.push(chunk)
+          if (!chunk) return
+          queue.push(chunk)
+          // A final/definite transcript is the normal completion signal: end the
+          // iteration here instead of waiting for a separate WS `close`. Without
+          // this, `collectFinalTranscript` (which drains `transcribe` to iterator
+          // end) would hang the whole turn whenever the server keeps the socket
+          // open after the definite result. Push the chunk first, then close, so
+          // the final transcript is never dropped. Also close the ASR socket as
+          // the normal end-of-stream path (idempotent; mirrors the TTS layer).
+          if (chunk.isFinal) {
+            queue.close()
+            socket.close()
+          }
         } catch (err) {
           queue.fail(err)
         }

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -10,13 +10,22 @@
  *    resource `volc.bigasr.sauc.duration`). The first frame is a JSON
  *    full-client config request; subsequent frames are raw audio. Server
  *    responses carry a JSON transcript whose `utterances[].definite` marks a
- *    stabilized segment.
+ *    stabilized segment. This ASR protocol is *client-push-first by design*:
+ *    the documented flow is "send full-client request, then stream audio packets
+ *    (~100-200ms each)"; there is NO connection/session-accepted handshake event
+ *    the client must wait for before sending audio (unlike the TTS layer below).
+ *    So sending config-then-audio without a server "ready" gate is correct here,
+ *    not optimistic — the server returns transcripts asynchronously as audio
+ *    flows.
  *  - TTS: Doubao TTS 2.0 bidirectional streaming over the event-based binary
  *    protocol (`wss://openspeech.bytedance.com/api/v3/tts/bidirection`,
- *    resource `volc.service_type.10029`). The client drives an event sequence
- *    (StartConnection -> StartSession -> TaskRequest* -> FinishSession ->
- *    FinishConnection); the server streams `TTSResponse` (event 352) audio
- *    frames.
+ *    resource `volc.service_type.10029`). This protocol is *stateful and
+ *    server-gated*: the client must wait for the server to accept each step
+ *    before advancing — StartConnection -> (await ConnectionStarted, event 50)
+ *    -> StartSession -> (await SessionStarted, event 150) -> TaskRequest* ->
+ *    FinishSession -> FinishConnection; the server then streams `TTSResponse`
+ *    (event 352) audio frames + `SessionFinished` (event 152). The handshake
+ *    gates live in `TtsHandshake` so the timing is unit-testable with a mock WS.
  *
  * Protocol references (consulted 2026-06):
  *  - ASR binary protocol + sequence flags + auth headers:
@@ -418,6 +427,107 @@ export function buildTtsFinishSessionFrame(sessionId: string): Uint8Array {
   })
 }
 
+// --- TTS handshake state machine (event-driven, server-gated) ---
+
+/**
+ * The Doubao TTS 2.0 bidirectional protocol is **stateful**: the server accepts
+ * the connection and the session in two distinct steps, and each must be
+ * acknowledged before the next client frame is legal. Sending `StartSession`
+ * before the server's `ConnectionStarted`, or `TaskRequest` before its
+ * `SessionStarted`, races the server — early frames are rejected/ignored and the
+ * turn yields no audio.
+ *
+ * This pure gate makes that timing explicit and unit-testable without a live
+ * socket: the message listener feeds inbound server events via `handleEvent`,
+ * and the pump `await`s `connectionStarted` / `sessionStarted` before advancing.
+ * A `ConnectionFailed` / `SessionFailed` event rejects the matching gate so the
+ * pump fails loudly instead of hanging.
+ *
+ * It only sequences the handshake (connection + session acceptance). Audio
+ * (`TtsResponse`) and session completion (`SessionFinished`) stay in the
+ * provider's message listener, which owns the audio queue.
+ */
+export class TtsHandshake {
+  /** Resolves when the server has accepted the connection (event 50). */
+  readonly connectionStarted: Promise<void>
+  /** Resolves when the server has accepted the session (event 150). */
+  readonly sessionStarted: Promise<void>
+
+  private resolveConnection!: () => void
+  private rejectConnection!: (err: unknown) => void
+  private resolveSession!: () => void
+  private rejectSession!: (err: unknown) => void
+  private connectionSettled = false
+  private sessionSettled = false
+
+  constructor() {
+    this.connectionStarted = new Promise<void>((resolve, reject) => {
+      this.resolveConnection = resolve
+      this.rejectConnection = reject
+    })
+    this.sessionStarted = new Promise<void>((resolve, reject) => {
+      this.resolveSession = resolve
+      this.rejectSession = reject
+    })
+    // A rejected gate the pump has not awaited yet would surface as an unhandled
+    // rejection; attach an inert catch so the rejection is delivered only to the
+    // awaiting pump, never to the process.
+    this.connectionStarted.catch(() => {})
+    this.sessionStarted.catch(() => {})
+  }
+
+  /**
+   * Advance the handshake from one inbound server event. Returns `true` if the
+   * event was a handshake-control event this gate consumed (so the caller can
+   * skip further handling), `false` for any other event (audio, completion).
+   */
+  handleEvent(event: number | undefined, describe: () => string): boolean {
+    switch (event) {
+      case TtsEvent.ConnectionStarted:
+        this.settleConnection()
+        return true
+      case TtsEvent.ConnectionFailed:
+        this.failConnection(new Error(`Volcengine TTS connection failed: ${describe()}`))
+        return true
+      case TtsEvent.SessionStarted:
+        this.settleSession()
+        return true
+      default:
+        return false
+    }
+  }
+
+  /** Reject any not-yet-settled gate (e.g. on a socket close before handshake). */
+  abort(err: unknown): void {
+    this.failConnection(err)
+    this.failSession(err)
+  }
+
+  private settleConnection(): void {
+    if (this.connectionSettled) return
+    this.connectionSettled = true
+    this.resolveConnection()
+  }
+
+  private failConnection(err: unknown): void {
+    if (this.connectionSettled) return
+    this.connectionSettled = true
+    this.rejectConnection(err)
+  }
+
+  private settleSession(): void {
+    if (this.sessionSettled) return
+    this.sessionSettled = true
+    this.resolveSession()
+  }
+
+  private failSession(err: unknown): void {
+    if (this.sessionSettled) return
+    this.sessionSettled = true
+    this.rejectSession(err)
+  }
+}
+
 /** Coerce any inbound WS message payload to a `Uint8Array` view. */
 function toBytes(data: unknown): Uint8Array {
   if (data instanceof Uint8Array) return data
@@ -674,12 +784,21 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       )
       const socket = await connect(TTS_URL, headers)
       const queue = new AsyncQueue<TtsAudioChunk>()
+      const handshake = new TtsHandshake()
 
       socket.addEventListener('message', (event) => {
         try {
           const frame = parseFrame(event.data)
           if (frame.messageType === MessageType.ErrorResponse) {
-            queue.fail(new Error(`Volcengine TTS error: ${decodeUtf8(frame.payload)}`))
+            const err = new Error(`Volcengine TTS error: ${decodeUtf8(frame.payload)}`)
+            handshake.abort(err)
+            queue.fail(err)
+            return
+          }
+          // Drive the connection/session-acceptance gates from server events; a
+          // handshake-control event advances the gate and needs no further
+          // handling here.
+          if (handshake.handleEvent(frame.event, () => decodeUtf8(frame.payload))) {
             return
           }
           if (frame.event === TtsEvent.TtsResponse && frame.payload.length > 0) {
@@ -688,20 +807,38 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
             queue.push({ audio: new Uint8Array(0), done: true })
             queue.close()
           } else if (frame.event === TtsEvent.SessionFailed) {
-            queue.fail(new Error(`Volcengine TTS session failed: ${decodeUtf8(frame.payload)}`))
+            const err = new Error(`Volcengine TTS session failed: ${decodeUtf8(frame.payload)}`)
+            handshake.abort(err)
+            queue.fail(err)
           }
         } catch (err) {
+          handshake.abort(err)
           queue.fail(err)
         }
       })
-      socket.addEventListener('close', () => queue.close())
-      socket.addEventListener('error', (err) => queue.fail(err))
+      // A socket close before the handshake completes must reject the pending
+      // gates so the pump fails loudly rather than awaiting a frame forever.
+      socket.addEventListener('close', () => {
+        handshake.abort(new Error('Volcengine TTS socket closed before session completed'))
+        queue.close()
+      })
+      socket.addEventListener('error', (err) => {
+        handshake.abort(err)
+        queue.fail(err)
+      })
 
+      // Event-driven handshake: each client frame waits for the server to accept
+      // the previous step before being sent. StartConnection -> (await
+      // ConnectionStarted) -> StartSession -> (await SessionStarted) ->
+      // TaskRequest(s) -> FinishSession -> FinishConnection. The server then
+      // streams TTSResponse audio + SessionFinished, handled by the listener.
       const pump = (async () => {
         socket.send(asArrayBuffer(buildTtsStartConnectionFrame()))
+        await handshake.connectionStarted
         socket.send(
           asArrayBuffer(buildTtsStartSessionFrame({ sessionId, speaker: ttsSpeaker, sampleRate }))
         )
+        await handshake.sessionStarted
         for await (const piece of text) {
           if (piece.length === 0) continue
           socket.send(

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -273,6 +273,30 @@ function int32BE(value: number): Uint8Array {
  * sequence; audio frames are raw audio-only requests. The final audio frame
  * carries a negative sequence with the `NegativeWithSequence` flag so the
  * server knows the stream is complete.
+ *
+ * Request-frame flag basis (verified against production clients, 2026-06):
+ * the `/api/v3/sauc/bigmodel` streaming ASR server accepts two equivalent
+ * client dialects — one that omits sequence numbers (audio frames flagged
+ * `NoSequence` 0b0000) and one that carries them (config + audio flagged
+ * `PositiveSequence` 0b0001, the final audio frame flagged
+ * `NegativeWithSequence` 0b0011 with a negative sequence). This adapter
+ * implements the SEQUENCE-CARRYING dialect consistently across the config,
+ * audio, and final frames. `0b0001`/`0b0011` are legitimate client-request
+ * flags (positive / negative sequence), NOT server-response-only markers — the
+ * server's frame parser keys "sequence present" off `flags & 0x01` and "last
+ * package" off `flags & 0x02` symmetrically for requests and responses. The
+ * config frame is sent as `FullClientRequest` + `PositiveSequence` + sequence=1,
+ * which matches Volcengine's own first-party client exactly.
+ * Ground truth:
+ *  - volcengine/ai-app-lab arkitect/core/component/asr/asr_client.py
+ *    (first-party, Apache-licensed): config frame =
+ *    `generate_header(message_type_specific_flags=POS_SEQUENCE)` +
+ *    `generate_before_payload(sequence=1)`.
+ *  - thundersoft-td/mcp-server-speech src/.../asr_ws.py (sequence-carrying
+ *    dialect): config = POS_SEQUENCE + seq; audio non-last = POS_SEQUENCE + seq;
+ *    audio last = NEG_WITH_SEQUENCE + negative seq; with the constant comments
+ *    `POS_SEQUENCE = 0b0001  # Positive sequence number` and
+ *    `NEG_WITH_SEQUENCE = 0b0011  # Negative sequence number (end data frame)`.
  */
 export function buildSttRequestFrame(args: {
   messageType: number

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -81,16 +81,22 @@ export interface VolcengineSpeechOptions {
   /** ASR model name in the config request (`request.model_name`). */
   sttModel?: string
   /**
-   * TTS model id, set as the Doubao TTS 2.0 `StartSession` `req_params.model`
-   * when provided. `req_params.model` is a real (optional) request field on the
-   * bidirectional protocol; its legal wire value is the model-family token
-   * `seed-tts-2.0` (NOT the product alias `doubao-tts-2.0`), and it must agree
-   * with the paired endpoint resource id (`X-Api-Resource-Id`, default
-   * `volc.service_type.10029`). Carrying the resolved config model here makes a
-   * `provider-config` model switch reach the wire instead of being a silent
-   * no-op. Omitted when unset (the field is simply not sent) — a Doubao TTS 2.0
-   * session can be driven by the resource id alone, with `req_params.model` left
-   * out — so unset preserves the default request shape.
+   * TTS model id, attached as the Doubao TTS 2.0 `StartSession`
+   * `req_params.model` ONLY when it is a non-empty concrete value. By default the
+   * field is OMITTED: the TTS model is bound by the paired endpoint resource id
+   * (`X-Api-Resource-Id`, default `volc.service_type.10029`), exactly as
+   * Volcengine's own first-party speech clients drive it (they omit
+   * `req_params.model` and let the resource id select the model). Both `undefined`
+   * and `''` mean "omit" — `''` is the `provider-config` sentinel for "use the
+   * resource-id default model", so the default request shape carries no model
+   * token. The factory threads the resolved config model here (F-K), so once the
+   * concrete wire token is confirmed at deploy time (`seed-tts-2.0-standard` /
+   * `-expressive` are the candidate concrete `req_params.model` values; the
+   * model-FAMILY id `seed-tts-2.0` and the resource id are NOT the in-payload
+   * model value), setting a non-empty `model` in `provider-config` reaches the
+   * wire through this same passthrough. Until then nothing is guessed onto the
+   * wire — sending a wrong token risks server rejection, sending none is the safe
+   * default.
    */
   ttsModel?: string
   /** TTS speaker / voice type (`req_params.speaker`). */
@@ -411,8 +417,11 @@ export function buildTtsFinishConnectionFrame(): Uint8Array {
 
 /**
  * Build the TTS StartSession frame carrying the synthesis parameters. `model` is
- * threaded into `req_params` only when provided (the resolved config model), so
- * the default request shape is unchanged when no model is configured.
+ * threaded into `req_params` only when it is a non-empty concrete value; both an
+ * absent `model` and an empty-string `model` (the `provider-config` "use the
+ * resource-id default model" sentinel) omit `req_params.model` entirely, so the
+ * default request shape carries no model token and the resource id selects the
+ * model — matching Volcengine's first-party clients.
  */
 export function buildTtsStartSessionFrame(args: {
   sessionId: string

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -81,12 +81,16 @@ export interface VolcengineSpeechOptions {
   /** ASR model name in the config request (`request.model_name`). */
   sttModel?: string
   /**
-   * TTS model id, threaded into the Doubao TTS 2.0 `StartSession` `req_params`
-   * as `model` when set. The bidirectional TTS 2.0 protocol primarily binds the
-   * model via the endpoint resource id (`X-Api-Resource-Id`); this carries the
-   * resolved config model so a model switch in `provider-config` reaches the wire
-   * rather than being a silent no-op. Omitted when unset (the field is simply not
-   * sent), preserving the documented default request shape.
+   * TTS model id, set as the Doubao TTS 2.0 `StartSession` `req_params.model`
+   * when provided. `req_params.model` is a real (optional) request field on the
+   * bidirectional protocol; its legal wire value is the model-family token
+   * `seed-tts-2.0` (NOT the product alias `doubao-tts-2.0`), and it must agree
+   * with the paired endpoint resource id (`X-Api-Resource-Id`, default
+   * `volc.service_type.10029`). Carrying the resolved config model here makes a
+   * `provider-config` model switch reach the wire instead of being a silent
+   * no-op. Omitted when unset (the field is simply not sent) — a Doubao TTS 2.0
+   * session can be driven by the resource id alone, with `req_params.model` left
+   * out — so unset preserves the default request shape.
    */
   ttsModel?: string
   /** TTS speaker / voice type (`req_params.speaker`). */

--- a/packages/platform-ai/src/session-assembly.test.ts
+++ b/packages/platform-ai/src/session-assembly.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+import { assembleSession } from './session-assembly'
+import { assertSocketOwnsBoundSession, SocketIdentityRegistry } from './auth-seam'
+import type { ManualData } from './contract'
+import type { ProviderEnv } from './providers/factory'
+
+/**
+ * Regression tests for the partial-publish atomicity defect in
+ * `VoiceSessionDO.createSession`.
+ *
+ * The defect: the old `createSession` published `this.userId` BEFORE the
+ * fallible `createProviders` step. `boundIdentity()` derives the session's
+ * ownership binding solely from `this.userId`, so the attack chain was:
+ *  1. `create` for a real-provider game (e.g. `demo` → DeepSeek + Volcengine)
+ *     with a secret missing → `createProviders` throws AFTER `userId` was set;
+ *  2. the DO now reports a bound, owned session with NO `state`/`providers`;
+ *  3. binary frames from a socket authenticated as that user pass the
+ *     ownership gate, lazily create the audio bridge, and enqueue leaked
+ *     pre-create audio;
+ *  4. the next SUCCESSFUL `create` does not reset `this.audio`, so the stale
+ *     bridge — leaked frames included — survives into the new session's first
+ *     turn.
+ *
+ * The fix extracts every fallible setup step into the pure `assembleSession`
+ * (locals only, complete-bundle-or-throw); the DO publishes the bundle in one
+ * uninterrupted synchronous block. The DO class itself imports
+ * `cloudflare:workers` and cannot be instantiated in the Node test
+ * environment, so — exactly as `session-identity.test.ts` does — these tests
+ * exercise the extracted pure pieces and model the DO's publish + observer
+ * shape around them.
+ */
+
+const MANUAL: ManualData = { version: 'test-v1', sections: { intro: 'sample section' } }
+
+describe('assembleSession — all-or-nothing session construction', () => {
+  it('throws on an unregistered gameId and returns no bundle', () => {
+    expect(() => assembleSession('no-such-game', 'user-A', MANUAL, undefined, {})).toThrow(
+      /no configuration registered/
+    )
+  })
+
+  it('throws when the selected real LLM provider is missing its secret', () => {
+    // `demo` selects the real DeepSeek LLM; an env without DEEPSEEK_API_KEY is
+    // exactly the missing-secret deploy misconfiguration of the attack chain.
+    expect(() => assembleSession('demo', 'user-A', MANUAL, undefined, {})).toThrow(
+      /DEEPSEEK_API_KEY/
+    )
+  })
+
+  it('throws when the selected real speech provider is missing its secret', () => {
+    // The LLM credential is present, so the throw comes from the LATER
+    // Volcengine step — the deepest fallible point. Under the old code the
+    // user id had long been published by the time this threw.
+    const env: ProviderEnv = { DEEPSEEK_API_KEY: 'test-key' }
+    expect(() => assembleSession('demo', 'user-A', MANUAL, undefined, env)).toThrow(/VOLC_APP_ID/)
+  })
+
+  it('returns the complete publishable bundle when every step succeeds', () => {
+    // `demo-mock` wires the deterministic mock providers — no credentials.
+    const assembled = assembleSession('demo-mock', 'user-A', MANUAL, undefined, {})
+
+    expect(assembled.userId).toBe('user-A')
+    expect(assembled.providers.stt).toBeDefined()
+    expect(assembled.providers.llm).toBeDefined()
+    expect(assembled.providers.tts).toBeDefined()
+    expect(assembled.state.config.gameId).toBe('demo-mock')
+    expect(assembled.state.manualData).toBe(MANUAL)
+    // Omitted game state defaults to the empty injection selection.
+    expect(assembled.state.gameState).toEqual({ relevantSections: [] })
+    expect(assembled.state.history).toEqual([])
+    expect(assembled.state.turnCount).toBe(0)
+    expect(assembled.state.usage).toEqual({
+      llmInputTokens: 0,
+      llmOutputTokens: 0,
+      sttInputSeconds: 0,
+      ttsOutputSeconds: 0,
+    })
+  })
+
+  it('threads an explicit gameState through to the assembled state', () => {
+    const gameState = { relevantSections: ['wires', 'button'] }
+    const assembled = assembleSession('demo-mock', 'user-A', MANUAL, gameState, {})
+
+    expect(assembled.state.gameState).toEqual(gameState)
+  })
+})
+
+describe('failed create publishes nothing — no half-bound session, no leaked audio', () => {
+  /** A stand-in socket — only reference identity matters to the registry. */
+  type FakeSocket = { id: string }
+  const socketA: FakeSocket = { id: 'socketA' }
+
+  /**
+   * Models the DO around the real extracted pieces: the session fields +
+   * `boundIdentity()` (binding derived solely from `userId`), `createSession`'s
+   * assemble-then-publish, and `onSocketMessage`'s binary branch (per-socket
+   * ownership gate, then lazy bridge + push) — the exact observer chain the
+   * half-bound state used to fool.
+   */
+  function makeDo() {
+    const DO_ID = 'do-session-1'
+    let userId: string | undefined
+    const reg = new SocketIdentityRegistry<FakeSocket>()
+    reg.bind(socketA, 'user-A')
+    let bridge: Uint8Array[] | undefined
+
+    // Mirrors VoiceSessionDO.createSession: assemble into a local, then publish.
+    function createSession(gameId: string, env: ProviderEnv): void {
+      const assembled = assembleSession(gameId, 'user-A', MANUAL, undefined, env)
+      userId = assembled.userId
+    }
+
+    // Mirrors VoiceSessionDO.boundIdentity.
+    const boundIdentity = () => ({
+      boundSessionId: userId === undefined ? undefined : DO_ID,
+      boundUserId: userId,
+    })
+
+    // Mirrors onSocketMessage's binary branch: gate, then lazy-create + push.
+    function feedBinaryFrame(socket: FakeSocket, frame: Uint8Array): void {
+      assertSocketOwnsBoundSession(reg, socket, boundIdentity())
+      if (bridge === undefined) bridge = []
+      bridge.push(frame)
+    }
+
+    return { createSession, boundIdentity, feedBinaryFrame, bridgeFrames: () => bridge }
+  }
+
+  it('a create that fails on a missing provider secret leaves the DO unbound', () => {
+    const { createSession, boundIdentity } = makeDo()
+
+    // The real-provider create aborts inside createProviders (missing secret).
+    expect(() => createSession('demo', {})).toThrow(/DEEPSEEK_API_KEY/)
+
+    // The old code would now report a bound, owned session (userId published
+    // before the throw). The fix publishes nothing: still entirely absent.
+    expect(boundIdentity()).toEqual({ boundSessionId: undefined, boundUserId: undefined })
+  })
+
+  it('binary frames after the failed create are rejected — no leaked bridge', () => {
+    const { createSession, feedBinaryFrame, bridgeFrames } = makeDo()
+
+    expect(() => createSession('demo', {})).toThrow(/DEEPSEEK_API_KEY/)
+
+    // Attack step 3: the same authenticated user pushes audio into the
+    // failed-create window. With no binding published, the ownership gate
+    // fails loud ("before createSession") and no bridge is ever created.
+    expect(() => feedBinaryFrame(socketA, new Uint8Array([9, 9, 9]))).toThrow(
+      /before createSession/
+    )
+    expect(bridgeFrames()).toBeUndefined()
+  })
+
+  it('the next successful create starts with a clean bridge — no frames from the failed window', () => {
+    const { createSession, boundIdentity, feedBinaryFrame, bridgeFrames } = makeDo()
+
+    // Failed-create window: nothing binds, the leaked frame is rejected.
+    expect(() => createSession('demo', {})).toThrow(/DEEPSEEK_API_KEY/)
+    expect(() => feedBinaryFrame(socketA, new Uint8Array([0xff]))).toThrow(/before createSession/)
+
+    // Attack step 4's precondition is gone: when the retry succeeds (mock
+    // providers, no credentials), the session starts with NO inherited audio —
+    // only frames pushed after the successful create reach the bridge.
+    createSession('demo-mock', {})
+    expect(boundIdentity()).toEqual({ boundSessionId: 'do-session-1', boundUserId: 'user-A' })
+
+    const ownFrame = new Uint8Array([1, 2, 3])
+    feedBinaryFrame(socketA, ownFrame)
+    expect(bridgeFrames()).toEqual([ownFrame])
+  })
+})

--- a/packages/platform-ai/src/session-assembly.ts
+++ b/packages/platform-ai/src/session-assembly.ts
@@ -1,0 +1,56 @@
+/**
+ * Session assembly — the FALLIBLE half of `VoiceSessionDO.createSession`,
+ * extracted pure so the all-or-nothing property is unit-testable in Node
+ * (the DO class imports `cloudflare:workers` and cannot be instantiated in
+ * the test environment — see `session-identity.test.ts`).
+ *
+ * Both setup steps can throw:
+ *  - `resolveConfig` on an unregistered `gameId` (loud-fail, no default game);
+ *  - `createProviders` when a selected REAL provider is missing its secret
+ *    (e.g. `deepseek` without `DEEPSEEK_API_KEY`, `volcengine` without
+ *    `VOLC_APP_ID`/`VOLC_ACCESS_KEY`).
+ *
+ * This function runs every fallible step into locals and returns the complete
+ * bundle only when ALL of them succeeded — it never partially constructs. The
+ * DO then publishes the bundle to its instance fields in one uninterrupted
+ * synchronous block, so observers keyed off `boundIdentity()` only ever see a
+ * session that is fully constructed or entirely absent, never half-bound.
+ */
+
+import type { ManualData } from './contract'
+import type { GameState } from './manual-injection'
+import { resolveConfig } from './provider-config'
+import { createProviders, type ProviderEnv } from './providers/factory'
+import type { SessionState, TurnProviders } from './turn-pipeline'
+
+/** Everything `createSession` publishes, assembled atomically or not at all. */
+export interface AssembledSession {
+  userId: string
+  providers: TurnProviders
+  state: SessionState
+}
+
+/**
+ * Run all fallible session-setup steps; return the full publishable bundle or
+ * throw. Pure (no instance state touched): a throw leaves no residue, so a
+ * failed create cannot bind a user, wire providers, or seed state.
+ */
+export function assembleSession(
+  gameId: string,
+  userId: string,
+  manualData: ManualData,
+  gameState: GameState | undefined,
+  env: ProviderEnv
+): AssembledSession {
+  const config = resolveConfig(gameId)
+  const providers = createProviders(config, env)
+  const state: SessionState = {
+    config,
+    manualData,
+    gameState: gameState ?? { relevantSections: [] },
+    history: [],
+    turnCount: 0,
+    usage: { llmInputTokens: 0, llmOutputTokens: 0, sttInputSeconds: 0, ttsOutputSeconds: 0 },
+  }
+  return { userId, providers, state }
+}

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -146,6 +146,26 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
   /** Audio bridge for the in-flight turn, if any. */
   private audio: AudioBridge | undefined
   /**
+   * Turn in-flight guard. A voice turn is a single serial round; a DO event can
+   * interleave across the many `await`s inside one turn (STT/LLM/TTS all await),
+   * so a second `turn` message arriving mid-flight would start a second
+   * `onAiResponse`/`runTurn` over the SAME `state`/`providers`/socket — racing
+   * the shared `history`/`usage` and interleaving two response streams on one
+   * socket. This flag is `true` for exactly the window one turn is running; a
+   * second `turn` while set is rejected (fail-loud), and it is cleared in the
+   * turn loop's `finally` so success / failure / cancel all release it (an
+   * exception can never wedge the guard shut).
+   */
+  private turnInFlight = false
+  /**
+   * The in-flight turn's async iterator, held so a mid-turn `end` (or the
+   * owner's socket close) can cancel it cleanly: closing the audio bridge
+   * terminates STT, and `return()` on this iterator runs `runTurn`'s `finally`
+   * (closes the sentence queue, returns the live LLM/TTS iterators) so no
+   * provider stream is left dangling. `undefined` when no turn is running.
+   */
+  private activeTurn: AsyncIterator<AiResponseChunk> | undefined
+  /**
    * Authenticated user id per accepted socket, forwarded by the Worker from the
    * validated handshake (`X-Session-User-Id`). This is the authoritative
    * identity bound at upgrade — the client-supplied control message is NOT
@@ -231,6 +251,14 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
     const ownsSession = socketOwnsBoundSession(this.socketIdentities, ws, this.boundIdentity())
     this.socketIdentities.release(ws)
     if (!ownsSession) return
+    // Owner gone: cancel any in-flight turn so its LLM/TTS streams are returned
+    // (`runTurn`'s `finally`) rather than left dangling, then close + clear the
+    // next-turn bridge. The turn loop's `finally` (which clears `turnInFlight`
+    // and `activeTurn`) runs when the `return()` settles. `cancelActiveTurn` is
+    // total and idempotent — a no-op when no turn is running. Fire-and-forget
+    // here because `onSocketClose` is a sync (total) close handler; the cancel's
+    // cleanup is best-effort on a socket that is already gone.
+    void this.cancelActiveTurn()
     this.audio?.close()
     this.audio = undefined
   }
@@ -316,6 +344,32 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
   }
 
   /**
+   * Send a structured, non-fatal error signal on a socket WITHOUT closing it.
+   * Used for reject-the-message-not-the-connection cases (an overlapping `turn`,
+   * a re-`create`) where a 1008 close would also truncate a turn streaming on
+   * the same socket. Distinct from the listener's 1008 close, which is reserved
+   * for ownership / protocol violations that must terminate the socket.
+   */
+  private sendError(ws: WebSocket, code: string, message: string): void {
+    ws.send(JSON.stringify({ type: 'error', code, message }))
+  }
+
+  /**
+   * Cleanly cancel the in-flight turn, if any. Closing the audio bridge (done by
+   * the caller) terminates the STT step; here we `return()` the held turn
+   * iterator, which resumes `runTurn` at its suspension point and runs its
+   * `finally` (closes the sentence queue, returns the live LLM/TTS iterators) so
+   * no provider stream is left dangling. The turn loop's own `finally` then
+   * clears `turnInFlight`/`activeTurn`. Total and idempotent: a no-op when no
+   * turn is running, and `return()` on an already-finished iterator is harmless.
+   */
+  private async cancelActiveTurn(): Promise<void> {
+    const turn = this.activeTurn
+    if (turn === undefined) return
+    await turn.return?.(undefined)
+  }
+
+  /**
    * Reject cross-session / cross-user access. Delegates to the pure
    * `assertSessionOwnership` predicate (the L2 ownership invariant —
    * `onPlayerAudio` / `onAiResponse` / `endSession` verify ownership).
@@ -354,6 +408,16 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
           ws.close(1008, 'no authenticated identity')
           return
         }
+        // A session is already live on this DO. Re-`create` would silently
+        // re-initialize `state`/`providers`/`userId` — blowing away an in-flight
+        // turn's state and the bound owner. Reject (the session is active)
+        // rather than reset. Fail-loud via an explicit signal on THIS socket so
+        // a concurrently streaming turn on the same socket is not truncated (a
+        // 1008 close would kill it); the owner's session is left intact.
+        if (this.state) {
+          this.sendError(ws, 'already_created', 'session already created')
+          return
+        }
         // Bind the AUTH-validated user id, NOT any id the client claims.
         const sessionId = this.createSession(
           msg.gameId,
@@ -369,41 +433,80 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
           ws.close(1008, 'turn before create')
           return
         }
+        // Turn in-flight guard: voice turns are serial. A second `turn` while
+        // one is running (owner double-click / retry) would start a second
+        // `runTurn` over the shared `state`/`providers` and interleave two
+        // response streams on this one socket — DO events interleave across the
+        // turn's STT/LLM/TTS `await`s. Reject the overlap with an explicit
+        // signal on THIS socket (NOT a 1008 close — the first turn is streaming
+        // on the same socket and a close would truncate it). No second
+        // `onAiResponse`/`runTurn` is started; the live turn is untouched.
+        if (this.turnInFlight) {
+          this.sendError(ws, 'turn_in_flight', 'a turn is already in progress')
+          return
+        }
         // Stream the AI response chunks back. Text rides as JSON; audio is
         // base64-encoded so the whole turn stays on the JSON text channel and
         // the binary frame direction remains player-audio-only. Ownership is
         // checked against THIS socket's user, so a second client on the same DO
         // cannot drive the first user's session.
         const sessionId = this.ctx.id.toString()
-        for await (const chunk of this.onAiResponse(sessionId, socketUserId)) {
-          if (chunk.kind === 'audio' && chunk.audio) {
-            ws.send(
-              JSON.stringify({
-                type: 'chunk',
-                kind: 'audio',
-                audio: base64FromBytes(chunk.audio),
-                done: chunk.done,
-              })
-            )
-          } else {
-            ws.send(
-              JSON.stringify({
-                type: 'chunk',
-                kind: 'text',
-                text: chunk.text ?? '',
-                done: chunk.done,
-              })
-            )
+        // Hold the iterator explicitly so a mid-turn `end` / owner close can
+        // cancel it via `return()`. Mark in-flight BEFORE the first `await`
+        // (synchronous up to here) so an interleaved second `turn` sees the
+        // guard set. The `finally` clears the guard + iterator on every exit
+        // (normal end, provider error, or cancellation) so the next turn can run.
+        const turn = this.onAiResponse(sessionId, socketUserId)[Symbol.asyncIterator]()
+        this.activeTurn = turn
+        this.turnInFlight = true
+        try {
+          for (;;) {
+            const next = await turn.next()
+            if (next.done) break
+            const chunk = next.value
+            if (chunk.kind === 'audio' && chunk.audio) {
+              ws.send(
+                JSON.stringify({
+                  type: 'chunk',
+                  kind: 'audio',
+                  audio: base64FromBytes(chunk.audio),
+                  done: chunk.done,
+                })
+              )
+            } else {
+              ws.send(
+                JSON.stringify({
+                  type: 'chunk',
+                  kind: 'text',
+                  text: chunk.text ?? '',
+                  done: chunk.done,
+                })
+              )
+            }
           }
+        } finally {
+          this.turnInFlight = false
+          this.activeTurn = undefined
         }
         return
       }
       case 'end': {
-        // `endSession` validates ownership against THIS socket's user, so an
-        // `end` from a different user on the same DO is rejected (throws) rather
-        // than tearing down the owner's session.
         if (this.state && socketUserId) {
+          // `endSession` re-validates ownership (a non-owner `end` throws before
+          // any teardown — the throw closes THAT socket with 1008 via the
+          // listener, so a non-owner cannot end / cancel the owner's turn),
+          // closes the audio bridge (the NEXT turn's bridge, which buffered any
+          // frames that arrived during this turn — the in-flight turn already
+          // detached + closed its own bridge at `onAiResponse` start, so its STT
+          // has already terminated), and returns the summary. The in-flight turn
+          // is then cleanly canceled: `cancelActiveTurn` `return()`s its iterator
+          // so `runTurn`'s `finally` runs — closing the sentence queue and
+          // returning the live LLM/TTS iterators, leaving no provider stream
+          // dangling. A turn canceled mid-flight never reached `runTurn`'s settle
+          // step, so it did not increment `turnCount` — the summary counts only
+          // fully-completed turns.
           const summary = this.endSession(this.ctx.id.toString(), socketUserId)
+          await this.cancelActiveTurn()
           ws.send(JSON.stringify({ type: 'summary', summary }))
         }
         ws.close(1000, 'session ended')

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -1,0 +1,324 @@
+/**
+ * `VoiceSessionDO` — the Durable Object that carries one voice session.
+ *
+ * It is a thin shell over the testable orchestration in `turn-pipeline.ts`:
+ *   - It holds the session state (gameId/userId binding, conversation history,
+ *     game state, usage counters) created in `createSession`.
+ *   - It implements the four-method contract semantics
+ *     (`createSession` / `onPlayerAudio` / `onAiResponse` / `endSession`),
+ *     enforcing `sessionId <-> userId` ownership on every operation.
+ *   - It drives `runTurn` over the WebSocket: inbound binary frames are player
+ *     audio; outbound `AiResponseChunk`s are serialized back to the player.
+ *
+ * The orchestration logic itself lives in `runTurn` (pure, provider-mocked
+ * unit tests); this class is the DO/WS adapter around it. WebSocket Hibernation
+ * is used so an idle session does not pin a live isolate: `ctx.acceptWebSocket`
+ * registers the socket and `webSocketMessage` / `webSocketClose` are the
+ * rehydration callbacks. API verified against `@cloudflare/workers-types`
+ * 4.20260608.1 (`DurableObject` base from `cloudflare:workers`;
+ * `DurableObjectState.acceptWebSocket` / `getWebSockets`).
+ */
+
+import { DurableObject } from 'cloudflare:workers'
+import type { AiResponseChunk, AudioChunk, ManualData, SessionSummary } from './contract'
+import type { GameState } from './manual-injection'
+import { resolveConfig } from './provider-config'
+import { createProviders, type ProviderEnv } from './providers/factory'
+import { runTurn, type SessionState, type TurnProviders } from './turn-pipeline'
+import { assertSessionOwnership } from './auth-seam'
+
+/** Env bindings visible to the DO (provider creds + the AUTH KV, unused here). */
+export type SessionDoEnv = ProviderEnv & Record<string, unknown>
+
+/** The DO accepts a single session-control message kind plus binary audio. */
+interface CreateSessionMessage {
+  type: 'create'
+  gameId: string
+  manualData: ManualData
+  gameState?: GameState
+}
+
+/**
+ * Run one turn: close the current audio bridge so STT terminates, drive
+ * `runTurn`, and stream the resulting `AiResponseChunk`s back to the client.
+ * The player pushes binary audio frames, then sends this control message to
+ * signal "that's my utterance, respond now".
+ */
+interface TurnMessage {
+  type: 'turn'
+}
+
+interface EndSessionMessage {
+  type: 'end'
+}
+
+type ControlMessage = CreateSessionMessage | TurnMessage | EndSessionMessage
+
+/**
+ * Base64-encode raw bytes for JSON transport of an audio frame. Uses the
+ * Workers-runtime global `btoa` over a latin1 string built byte-by-byte (the
+ * frames are small per-sentence TTS chunks, so this stays cheap).
+ */
+function base64FromBytes(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+/**
+ * Async audio bridge: binary WS frames are pushed in; `runTurn`'s STT step
+ * pulls them via `for await`. One bridge backs one in-flight turn; `end` closes
+ * it so the STT stream terminates.
+ */
+class AudioBridge {
+  private buffer: AudioChunk[] = []
+  private resolvers: Array<(r: IteratorResult<AudioChunk>) => void> = []
+  private closed = false
+
+  push(chunk: AudioChunk): void {
+    if (this.closed) return
+    const resolve = this.resolvers.shift()
+    if (resolve) {
+      resolve({ value: chunk, done: false })
+    } else {
+      this.buffer.push(chunk)
+    }
+  }
+
+  close(): void {
+    this.closed = true
+    while (this.resolvers.length > 0) {
+      this.resolvers.shift()?.({ value: undefined, done: true })
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<AudioChunk> {
+    for (;;) {
+      if (this.buffer.length > 0) {
+        yield this.buffer.shift() as AudioChunk
+        continue
+      }
+      if (this.closed) return
+      const next = await new Promise<IteratorResult<AudioChunk>>((resolve) => {
+        this.resolvers.push(resolve)
+      })
+      if (next.done) return
+      yield next.value
+    }
+  }
+}
+
+export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
+  /** Session state, set on `create`; `undefined` until then. */
+  private state: SessionState | undefined
+  /** Bound user id, set on `create`; ownership checks compare against it. */
+  private userId: string | undefined
+  /** Wired providers for the session. */
+  private providers: TurnProviders | undefined
+  /** Audio bridge for the in-flight turn, if any. */
+  private audio: AudioBridge | undefined
+  /**
+   * Authenticated user id forwarded by the Worker from the validated handshake
+   * (`X-Session-User-Id`). This is the authoritative identity bound at
+   * `createSession` — the client-supplied control message is NOT trusted for it.
+   */
+  private authUserId: string | undefined
+
+  /**
+   * WS upgrade entry. The Worker forwards the (already auth-validated) upgrade
+   * request here, carrying the resolved user id in `X-Session-User-Id`. We
+   * capture that id as the authoritative session identity, accept the client
+   * side via Hibernation, and hand the server side back in the 101 response.
+   */
+  override async fetch(request: Request): Promise<Response> {
+    if (request.headers.get('Upgrade') !== 'websocket') {
+      return new Response('expected websocket upgrade', { status: 426 })
+    }
+    const forwardedUserId = request.headers.get('X-Session-User-Id')
+    if (!forwardedUserId) {
+      return new Response('missing authenticated identity', { status: 401 })
+    }
+    this.authUserId = forwardedUserId
+    const pair = new WebSocketPair()
+    const client = pair[0]
+    const server = pair[1]
+    this.ctx.acceptWebSocket(server)
+    return new Response(null, { status: 101, webSocket: client })
+  }
+
+  /** Inbound WS frame: a JSON control message (string) or an audio frame (binary). */
+  override async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    if (typeof message === 'string') {
+      await this.handleControl(ws, JSON.parse(message) as ControlMessage)
+      return
+    }
+    // Binary frame: player audio for the in-flight (or next) turn.
+    const bridge = this.ensureAudioBridge()
+    bridge.push(new Uint8Array(message))
+  }
+
+  /** Socket closed: tear the in-flight turn's audio stream down. */
+  override async webSocketClose(): Promise<void> {
+    this.audio?.close()
+    this.audio = undefined
+  }
+
+  // --- Four-method contract semantics ---
+
+  /**
+   * Create the session: bind the (already-authenticated) `userId`, resolve the
+   * game's provider/prompt config, wire the providers, and initialize state.
+   * Returns the DO id string as the opaque `SessionId`.
+   */
+  createSession(
+    gameId: string,
+    userId: string,
+    manualData: ManualData,
+    gameState?: GameState
+  ): string {
+    const config = resolveConfig(gameId)
+    this.userId = userId
+    this.providers = createProviders(config, this.env)
+    this.state = {
+      config,
+      manualData,
+      gameState: gameState ?? { relevantSections: [] },
+      history: [],
+      turnCount: 0,
+      usage: { llmInputTokens: 0, llmOutputTokens: 0, sttInputSeconds: 0, ttsOutputSeconds: 0 },
+    }
+    return this.ctx.id.toString()
+  }
+
+  /**
+   * Feed one player audio frame. Validates `sessionId <-> userId` ownership,
+   * then pushes the frame onto the in-flight turn's audio bridge.
+   */
+  onPlayerAudio(sessionId: string, userId: string, audioChunk: AudioChunk): void {
+    this.assertOwner(sessionId, userId)
+    this.ensureAudioBridge().push(audioChunk)
+  }
+
+  /**
+   * Run a turn over the current audio and yield the AI response stream.
+   * Validates ownership, then delegates to `runTurn`. The caller is expected to
+   * have finished pushing the turn's audio (or to close the bridge) so STT can
+   * terminate.
+   */
+  async *onAiResponse(sessionId: string, userId: string): AsyncIterable<AiResponseChunk> {
+    this.assertOwner(sessionId, userId)
+    if (!this.state || !this.providers) {
+      throw new Error('session-do: onAiResponse before createSession')
+    }
+    const bridge = this.ensureAudioBridge()
+    bridge.close()
+    this.audio = undefined
+    yield* runTurn(this.providers, this.state, bridge)
+  }
+
+  /**
+   * End the session: validate ownership, settle, and return the summary with
+   * the turn count and usage mount point.
+   */
+  endSession(sessionId: string, userId: string): SessionSummary {
+    this.assertOwner(sessionId, userId)
+    if (!this.state) {
+      throw new Error('session-do: endSession before createSession')
+    }
+    this.audio?.close()
+    this.audio = undefined
+    return {
+      sessionId,
+      gameId: this.state.config.gameId,
+      userId,
+      turnCount: this.state.turnCount,
+      usage: { ...this.state.usage },
+    }
+  }
+
+  // --- Internals ---
+
+  private ensureAudioBridge(): AudioBridge {
+    if (this.audio === undefined) this.audio = new AudioBridge()
+    return this.audio
+  }
+
+  /**
+   * Reject cross-session / cross-user access. Delegates to the pure
+   * `assertSessionOwnership` predicate (the L2 ownership invariant —
+   * `onPlayerAudio` / `onAiResponse` / `endSession` verify ownership).
+   */
+  private assertOwner(sessionId: string, userId: string): void {
+    assertSessionOwnership(
+      {
+        boundSessionId: this.userId === undefined ? undefined : this.ctx.id.toString(),
+        boundUserId: this.userId,
+      },
+      sessionId,
+      userId
+    )
+  }
+
+  /** WS control-message dispatch driving the four-method semantics. */
+  private async handleControl(ws: WebSocket, msg: ControlMessage): Promise<void> {
+    switch (msg.type) {
+      case 'create': {
+        if (!this.authUserId) {
+          ws.close(1008, 'no authenticated identity')
+          return
+        }
+        // Bind the AUTH-validated user id, NOT any id the client claims.
+        const sessionId = this.createSession(
+          msg.gameId,
+          this.authUserId,
+          msg.manualData,
+          msg.gameState
+        )
+        ws.send(JSON.stringify({ type: 'created', sessionId }))
+        return
+      }
+      case 'turn': {
+        if (!this.state || !this.userId) {
+          ws.close(1008, 'turn before create')
+          return
+        }
+        // Stream the AI response chunks back. Text rides as JSON; audio is
+        // base64-encoded so the whole turn stays on the JSON text channel and
+        // the binary frame direction remains player-audio-only.
+        const sessionId = this.ctx.id.toString()
+        for await (const chunk of this.onAiResponse(sessionId, this.userId)) {
+          if (chunk.kind === 'audio' && chunk.audio) {
+            ws.send(
+              JSON.stringify({
+                type: 'chunk',
+                kind: 'audio',
+                audio: base64FromBytes(chunk.audio),
+                done: chunk.done,
+              })
+            )
+          } else {
+            ws.send(
+              JSON.stringify({
+                type: 'chunk',
+                kind: 'text',
+                text: chunk.text ?? '',
+                done: chunk.done,
+              })
+            )
+          }
+        }
+        return
+      }
+      case 'end': {
+        if (this.state && this.userId) {
+          const summary = this.endSession(this.ctx.id.toString(), this.userId)
+          ws.send(JSON.stringify({ type: 'summary', summary }))
+        }
+        ws.close(1000, 'session ended')
+        return
+      }
+    }
+  }
+}

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -498,15 +498,28 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
           // closes the audio bridge (the NEXT turn's bridge, which buffered any
           // frames that arrived during this turn — the in-flight turn already
           // detached + closed its own bridge at `onAiResponse` start, so its STT
-          // has already terminated), and returns the summary. The in-flight turn
-          // is then cleanly canceled: `cancelActiveTurn` `return()`s its iterator
-          // so `runTurn`'s `finally` runs — closing the sentence queue and
-          // returning the live LLM/TTS iterators, leaving no provider stream
-          // dangling. A turn canceled mid-flight never reached `runTurn`'s settle
-          // step, so it did not increment `turnCount` — the summary counts only
-          // fully-completed turns.
+          // has already terminated), and returns the summary.
           const summary = this.endSession(this.ctx.id.toString(), socketUserId)
-          await this.cancelActiveTurn()
+          // Cancel the in-flight turn FIRE-AND-FORGET, then summarize + close
+          // immediately — do NOT await the cancel. `AsyncIterator.return()` cannot
+          // interrupt a provider `await` already pending inside the generator (an
+          // STT/LLM/TTS promise that is slow or stuck): the generator only reaches
+          // its `finally` once that promise settles. Awaiting the cancel here would
+          // make `end` hang for as long as the provider is stuck — leaving the
+          // owner unable to end the session and the socket open. So we initiate the
+          // best-effort cancel (`return()` + bridge close already done by
+          // `endSession`) and proceed without blocking on it. The background cancel
+          // still completes when the provider promise eventually settles: at that
+          // point `runTurn`'s `finally` closes the sentence queue + returns the live
+          // LLM/TTS iterators (no stream leaks), and the turn loop's own `finally`
+          // clears `turnInFlight`/`activeTurn` — so the in-flight guard is released
+          // by the same path as before, just not synchronously with `end`. A turn
+          // canceled mid-flight never reaches `runTurn`'s settle step, so it never
+          // increments `turnCount` — the summary counts only fully-completed turns.
+          // Truly abortable cancellation (an AbortSignal threaded through `runTurn`
+          // into each adapter to interrupt a stuck fetch/WS) is a separate followup,
+          // not this fix.
+          void this.cancelActiveTurn()
           ws.send(JSON.stringify({ type: 'summary', summary }))
         }
         ws.close(1000, 'session ended')

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -265,15 +265,27 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
     this.socketIdentities.release(ws)
     if (!ownsSession) return
     // Owner gone: cancel any in-flight turn so its LLM/TTS streams are returned
-    // (`runTurn`'s `finally`) rather than left dangling, then close + clear the
-    // next-turn bridge. The turn loop's `finally` (which clears `turnInFlight`
-    // and `activeTurn`) runs when the `return()` settles. `cancelActiveTurn` is
-    // total and idempotent — a no-op when no turn is running. Fire-and-forget
-    // here because `onSocketClose` is a sync (total) close handler; the cancel's
-    // cleanup is best-effort on a socket that is already gone.
+    // (`runTurn`'s `finally`) rather than left dangling, then close the next-turn
+    // bridge and clear the bound session. The turn loop's `finally` (which clears
+    // `turnInFlight` and `activeTurn`) runs when the `return()` settles.
+    // `cancelActiveTurn` is total and idempotent — a no-op when no turn is
+    // running. Fire-and-forget here because `onSocketClose` is a sync (total)
+    // close handler; the cancel's cleanup is best-effort on a socket that is
+    // already gone.
+    //
+    // `cancelActiveTurn` MUST run BEFORE `clearSession` (it captures the live
+    // `activeTurn` synchronously — see `clearSession`). The owner's socket
+    // closing — whether via `end` (which already cleared the session, so this
+    // owner branch is not reached: `boundIdentity` is empty and `ownsSession` is
+    // false) or via an abrupt drop with no `end` — terminates the session, so
+    // we clear ALL session-level state, not just the bridge. Otherwise the
+    // abrupt-drop path leaves `state`/`userId`/`providers` bound on this resident
+    // DO: a later same-name reconnect authenticated as the same user could then
+    // `turn` with no fresh `create` and run a provider turn on the dropped
+    // session. Clearing makes that reconnect open a clean new session via
+    // `create` and reject a create-less `turn` ("turn before create").
     void this.cancelActiveTurn()
-    this.audio?.close()
-    this.audio = undefined
+    this.clearSession()
   }
 
   // --- Four-method contract semantics ---
@@ -354,6 +366,44 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
   private ensureAudioBridge(): AudioBridge {
     if (this.audio === undefined) this.audio = new AudioBridge()
     return this.audio
+  }
+
+  /**
+   * Reset every session-level mutable field back to the "no active session"
+   * initial state. Called by the `end` path after the summary is produced (and
+   * after a mid-turn cancel has been INITIATED) so the ended session leaves no
+   * residue on this resident DO instance.
+   *
+   * Without this, the DO keeps `state`/`userId`/`providers` bound after `end`
+   * (no hibernation — the instance is resident for the worker's lifetime). The
+   * next client reconnecting to the same-named DO would then (a) be wrongly
+   * rejected with `already_created` on `create` (the session is over, a fresh
+   * one should open) and (b) — worse — a `turn` with no new `create` would pass
+   * `assertOwner` against the stale binding and run a provider turn on an
+   * already-ended session. Clearing the binding makes a post-`end` `turn` fail
+   * "turn before create" and a post-`end` `create` open a clean new session.
+   *
+   * Coordination with the fire-and-forget cancel (`end` does NOT await the
+   * cancel — see the `end` branch): the caller MUST initiate
+   * `cancelActiveTurn()` BEFORE calling this, because that helper captures the
+   * live `activeTurn` synchronously; once captured, clearing the field here is
+   * safe (the captured iterator drives the background `return()` independently).
+   * The background cancel only runs `runTurn`'s `finally` (closes the sentence
+   * queue, returns the live LLM/TTS iterators) and the turn loop's own `finally`
+   * (which re-clears `turnInFlight`/`activeTurn` to their initial values — an
+   * idempotent no-op after this reset, never a revival): a canceled turn never
+   * reaches `runTurn`'s settle step, so it never writes back to the (now
+   * undefined) `state`. There is no read-after-clear that could NPE: the only
+   * post-clear toucher is the turn loop `finally`, which only assigns the same
+   * initial values these fields already hold.
+   */
+  private clearSession(): void {
+    this.state = undefined
+    this.userId = undefined
+    this.providers = undefined
+    this.audio = undefined
+    this.turnInFlight = false
+    this.activeTurn = undefined
   }
 
   /**
@@ -533,6 +583,15 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
           // into each adapter to interrupt a stuck fetch/WS) is a separate followup,
           // not this fix.
           void this.cancelActiveTurn()
+          // Clear the bound session state so the ended session leaves no residue
+          // on this resident DO. MUST follow the cancel: `cancelActiveTurn`
+          // captures the live `activeTurn` synchronously above, so clearing the
+          // field now does not strand the in-flight turn's cleanup. After this,
+          // a later same-name reconnect's `create` opens a clean new session
+          // (no false `already_created`) and a `turn` without a fresh `create`
+          // is rejected ("turn before create") instead of running a provider
+          // turn on the just-ended session. See `clearSession`.
+          this.clearSession()
           ws.send(JSON.stringify({ type: 'summary', summary }))
         }
         ws.close(1000, 'session ended')

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -13,9 +13,11 @@
  * The orchestration logic itself lives in `runTurn` (pure, provider-mocked
  * unit tests); this class is the DO/WS adapter around it.
  *
- * Hibernation is deliberately NOT used. The DO accepts the socket with a plain
- * `server.accept()` and listens via `addEventListener('message'|'close')`, so it
- * stays resident for the session's lifetime and the in-memory session state
+ * Hibernation is deliberately NOT used. The DO sets `binaryType = 'arraybuffer'`
+ * then accepts the socket with a plain `server.accept()` and listens via
+ * `addEventListener('message'|'close')`, so it stays resident for the session's
+ * lifetime, binary audio frames arrive as `ArrayBuffer` (not the post-2026
+ * `Blob` default), and the in-memory session state
  * (`state` / `providers`) is always valid between `create` and a later `turn`.
  * The WebSocket Hibernation API (`ctx.acceptWebSocket` + the `webSocketMessage`
  * rehydration callback) would drop that in-memory state on an idle-eviction
@@ -194,6 +196,17 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
     const client = pair[0]
     const server = pair[1]
 
+    // Opt this socket back into ArrayBuffer delivery for binary frames BEFORE
+    // accepting it. With this Worker's `compatibility_date` (2026-06-08) the
+    // `websocket_standard_binary_type` default delivers binary WS messages as
+    // `Blob`, but `onSocketMessage` consumes player audio frames synchronously
+    // as `ArrayBuffer` (`new Uint8Array(data)`). A `Blob` would slip past the
+    // `typeof data === 'string'` branch and be wrapped into an empty/garbage
+    // `Uint8Array`, corrupting every audio frame. Setting `binaryType` keeps the
+    // existing synchronous, ArrayBuffer-typed handler correct. MUST precede
+    // `accept()` — the runtime only honors it before the socket is accepted.
+    // (Cloudflare docs: runtime-apis/websockets#binary-messages.)
+    server.binaryType = 'arraybuffer'
     // Plain accept keeps the DO resident for the session (no hibernation), so
     // the in-memory session state survives between turns.
     server.accept()

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -59,8 +59,8 @@
 import { DurableObject } from 'cloudflare:workers'
 import type { AiResponseChunk, AudioChunk, ManualData, SessionSummary } from './contract'
 import type { GameState } from './manual-injection'
-import { resolveConfig } from './provider-config'
-import { createProviders, type ProviderEnv } from './providers/factory'
+import type { ProviderEnv } from './providers/factory'
+import { assembleSession } from './session-assembly'
 import { runTurn, type SessionState, type TurnProviders } from './turn-pipeline'
 import {
   assertSessionOwnership,
@@ -357,6 +357,20 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
    * Create the session: bind the (already-authenticated) `userId`, resolve the
    * game's provider/prompt config, wire the providers, and initialize state.
    * Returns the DO id string as the opaque `SessionId`.
+   *
+   * Publish-after-success (all-or-nothing): every fallible setup step —
+   * `resolveConfig` (unregistered game) and `createProviders` (a selected real
+   * provider missing its secret) — runs inside `assembleSession` into LOCALS
+   * first. Only once the whole bundle exists are `userId`/`providers`/`state`
+   * assigned, in one synchronous block with no `await` and no throw between the
+   * first and last publish. `boundIdentity()` derives the session's ownership
+   * binding solely from `this.userId`, so observers only ever see a session
+   * that is fully constructed or entirely absent — never half-bound. The prior
+   * interleaving (`this.userId = userId` BEFORE `createProviders`) let a failed
+   * create leave the DO bound to a user with NO `state`/`providers`: that
+   * user's binary frames then passed the ownership gate, lazily created an
+   * audio bridge, and the leaked pre-create frames survived into the next
+   * SUCCESSFUL session's first turn (create does not reset `this.audio`).
    */
   createSession(
     gameId: string,
@@ -364,17 +378,11 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
     manualData: ManualData,
     gameState?: GameState
   ): string {
-    const config = resolveConfig(gameId)
-    this.userId = userId
-    this.providers = createProviders(config, this.env)
-    this.state = {
-      config,
-      manualData,
-      gameState: gameState ?? { relevantSections: [] },
-      history: [],
-      turnCount: 0,
-      usage: { llmInputTokens: 0, llmOutputTokens: 0, sttInputSeconds: 0, ttsOutputSeconds: 0 },
-    }
+    const assembled = assembleSession(gameId, userId, manualData, gameState, this.env)
+    // Atomic publish — nothing below this line can throw or await.
+    this.userId = assembled.userId
+    this.providers = assembled.providers
+    this.state = assembled.state
     return this.ctx.id.toString()
   }
 

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -40,6 +40,20 @@
  * the owner's next `turn` would transcribe (forging the owner's utterance). So
  * the per-operation ownership invariant (L2 §Mechanism Variant 3) holds per
  * socket across every inbound frame, not just control messages.
+ *
+ * Two ownership grains coexist, split by what the operation does:
+ *  - DRIVE operations (`turn`, binary audio) are gated on the owner USER id: the
+ *    operating socket's authenticated user must equal the bound owner. They run a
+ *    turn / feed audio; they never clear the session.
+ *  - TEARDOWN operations (`end`, owner socket close) are gated on the owner
+ *    SOCKET reference — the exact socket recorded at `createSession`
+ *    (`ownerSocket` / `socketIsBoundSessionOwner`). A user-id grain is too coarse
+ *    here: the SAME user's second socket (a duplicate tab / reconnect) shares the
+ *    owner's user id, so a user-id gate would let that duplicate's `end` or close
+ *    `clearSession()` the still-active original session and truncate its turn.
+ *    Pinning teardown to the creator socket means only the socket that opened the
+ *    session can end it; every other socket's `end`/close (same user or not)
+ *    touches nothing but its own per-socket binding.
  */
 
 import { DurableObject } from 'cloudflare:workers'
@@ -51,7 +65,7 @@ import { runTurn, type SessionState, type TurnProviders } from './turn-pipeline'
 import {
   assertSessionOwnership,
   assertSocketOwnsBoundSession,
-  socketOwnsBoundSession,
+  socketIsBoundSessionOwner,
   SocketIdentityRegistry,
 } from './auth-seam'
 
@@ -205,6 +219,19 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
    * separate identities and cannot overwrite each other.
    */
   private readonly socketIdentities = new SocketIdentityRegistry<WebSocket>()
+  /**
+   * The exact socket that created/bound the session (recorded in `createSession`),
+   * or `undefined` when no session is bound. This is the OWNER socket: only its
+   * close tears the session down (`onSocketClose`).
+   *
+   * Tracking the owner by socket reference — not by user id — is what stops a
+   * same-user duplicate socket (a second tab / a reconnect to the same
+   * `/ai-ws/{sessionName}` DO) from clearing the still-active original session
+   * when that duplicate socket closes. A user-id match would mark the duplicate
+   * as an owner; the recorded-socket identity does not. Cleared in
+   * `clearSession` so a torn-down session leaves no stale owner reference.
+   */
+  private ownerSocket: WebSocket | undefined
 
   /**
    * WS upgrade entry. The Worker forwards the (already auth-validated) upgrade
@@ -280,18 +307,24 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
   /**
    * Socket closed. Always release THIS socket's identity binding (so the
    * registry never leaks). Tear down the shared audio bridge / in-flight turn
-   * ONLY when the closing socket owns the bound session — the same per-socket
-   * ownership gate the control and binary paths enforce.
+   * ONLY when the closing socket is the OWNER socket — the exact socket that
+   * created the session (`socketIsBoundSessionOwner`).
    *
    * Without this gate the close path is the one un-gated mutation of shared
-   * session state: a second authenticated client on the same `/ai-ws/{name}` DO
-   * (which only needs to know the session name) connecting and then disconnecting
-   * would close the owner's bridge and truncate the owner's in-flight turn. A
-   * non-owner close must touch nothing but its own binding. Ownership is checked
-   * with the non-throwing predicate because a close handler must be total.
+   * session state. Two clients can reach this DO and trigger a wrongful teardown:
+   *  - a DIFFERENT user's socket on the same `/ai-ws/{name}` DO — already blocked
+   *    by the prior user-id gate; and
+   *  - the SAME user's SECOND socket (a duplicate tab / a reconnect) — NOT blocked
+   *    by a user-id gate, because its user id equals the owner's. Its close would
+   *    have cleared the still-active original session and truncated the owner's
+   *    in-flight turn. Gating on the owner SOCKET reference (not the user id)
+   *    closes that path: only the creator socket's close tears down; every other
+   *    socket's close (same user or not) releases just its own binding.
+   * Ownership is checked with the total (non-throwing) predicate because a close
+   * handler must never throw.
    */
   private onSocketClose(ws: WebSocket): void {
-    const ownsSession = socketOwnsBoundSession(this.socketIdentities, ws, this.boundIdentity())
+    const ownsSession = socketIsBoundSessionOwner(ws, this.ownerSocket, this.boundIdentity())
     this.socketIdentities.release(ws)
     if (!ownsSession) return
     // Owner gone: cancel any in-flight turn so its LLM/TTS streams are returned
@@ -443,6 +476,7 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
     this.audio = undefined
     this.turnInFlight = false
     this.activeTurn = undefined
+    this.ownerSocket = undefined
   }
 
   /**
@@ -527,6 +561,11 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
           msg.manualData,
           msg.gameState
         )
+        // Record THIS socket as the session owner. Only this exact socket's close
+        // tears the session down (`onSocketClose`); a same-user duplicate socket's
+        // close must not. Set after a successful create so a rejected create
+        // (`already_created`) never repoints the owner.
+        this.ownerSocket = ws
         ws.send(JSON.stringify({ type: 'created', sessionId }))
         return
       }
@@ -610,7 +649,22 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
       }
       case 'end': {
         if (this.state && socketUserId) {
-          // `endSession` re-validates ownership (a non-owner `end` throws before
+          // Owner-socket gate on the teardown side (F-W self-consistency): `end`
+          // is the other path — besides owner-close — that `clearSession()`s the
+          // bound session. `endSession`'s `assertOwner` only checks the USER id,
+          // so a SAME-user duplicate socket (a second tab / reconnect) would pass
+          // it and tear down the still-active original session. Gate teardown on
+          // the owner SOCKET reference (mirroring `onSocketClose`): a non-owner
+          // socket's `end` — even same user — is rejected fail-loud (1008 close of
+          // THAT socket, consistent with the cross-user `assertOwner` throw path)
+          // and never reaches teardown, so the owner's session/turn survive.
+          // (`turn` and binary stay user-id-gated: they DRIVE the session, they do
+          // not tear it down — see `assertOwner` / `assertSocketOwner`.)
+          if (!socketIsBoundSessionOwner(ws, this.ownerSocket, this.boundIdentity())) {
+            ws.close(1008, 'end from non-owner socket')
+            return
+          }
+          // `endSession` re-validates ownership (a cross-user `end` throws before
           // any teardown — the throw closes THAT socket with 1008 via the
           // listener, so a non-owner cannot end / cancel the owner's turn),
           // closes the audio bridge (the NEXT turn's bridge, which buffered any

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -11,12 +11,28 @@
  *     audio; outbound `AiResponseChunk`s are serialized back to the player.
  *
  * The orchestration logic itself lives in `runTurn` (pure, provider-mocked
- * unit tests); this class is the DO/WS adapter around it. WebSocket Hibernation
- * is used so an idle session does not pin a live isolate: `ctx.acceptWebSocket`
- * registers the socket and `webSocketMessage` / `webSocketClose` are the
- * rehydration callbacks. API verified against `@cloudflare/workers-types`
- * 4.20260608.1 (`DurableObject` base from `cloudflare:workers`;
- * `DurableObjectState.acceptWebSocket` / `getWebSockets`).
+ * unit tests); this class is the DO/WS adapter around it.
+ *
+ * Hibernation is deliberately NOT used. The DO accepts the socket with a plain
+ * `server.accept()` and listens via `addEventListener('message'|'close')`, so it
+ * stays resident for the session's lifetime and the in-memory session state
+ * (`state` / `providers`) is always valid between `create` and a later `turn`.
+ * The WebSocket Hibernation API (`ctx.acceptWebSocket` + the `webSocketMessage`
+ * rehydration callback) would drop that in-memory state on an idle-eviction
+ * between turns — rejecting the next message as "turn before create" and losing
+ * history. Turn-based voice sessions have short idle windows, so the hibernation
+ * cost saving does not justify persisting + rehydrating session state per
+ * message (L2 §Open Questions — "WebSocket Hibernation 是否启用"). API verified
+ * against `@cloudflare/workers-types` 4.20260608.1 (`DurableObject` base from
+ * `cloudflare:workers`; `WebSocket.accept` / `addEventListener`).
+ *
+ * The authenticated user id forwarded by the Worker is bound PER ACCEPTED SOCKET
+ * (via `SocketIdentityRegistry`), not in a shared instance field: two
+ * already-authenticated clients can connect to the same-named DO (one instance),
+ * and a shared field would let the later upgrade overwrite the earlier client's
+ * identity — letting socket B drive `create`/`reset` under socket A's user. Each
+ * control message resolves the id of the exact socket it arrived on, so the
+ * per-operation ownership invariant (L2 §Mechanism Variant 3) holds per socket.
  */
 
 import { DurableObject } from 'cloudflare:workers'
@@ -25,7 +41,7 @@ import type { GameState } from './manual-injection'
 import { resolveConfig } from './provider-config'
 import { createProviders, type ProviderEnv } from './providers/factory'
 import { runTurn, type SessionState, type TurnProviders } from './turn-pipeline'
-import { assertSessionOwnership } from './auth-seam'
+import { assertSessionOwnership, SocketIdentityRegistry } from './auth-seam'
 
 /** Env bindings visible to the DO (provider creds + the AUTH KV, unused here). */
 export type SessionDoEnv = ProviderEnv & Record<string, unknown>
@@ -120,17 +136,21 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
   /** Audio bridge for the in-flight turn, if any. */
   private audio: AudioBridge | undefined
   /**
-   * Authenticated user id forwarded by the Worker from the validated handshake
-   * (`X-Session-User-Id`). This is the authoritative identity bound at
-   * `createSession` — the client-supplied control message is NOT trusted for it.
+   * Authenticated user id per accepted socket, forwarded by the Worker from the
+   * validated handshake (`X-Session-User-Id`). This is the authoritative
+   * identity bound at upgrade — the client-supplied control message is NOT
+   * trusted for it. Keyed by socket so two clients on the same DO instance keep
+   * separate identities and cannot overwrite each other.
    */
-  private authUserId: string | undefined
+  private readonly socketIdentities = new SocketIdentityRegistry<WebSocket>()
 
   /**
    * WS upgrade entry. The Worker forwards the (already auth-validated) upgrade
-   * request here, carrying the resolved user id in `X-Session-User-Id`. We
-   * capture that id as the authoritative session identity, accept the client
-   * side via Hibernation, and hand the server side back in the 101 response.
+   * request here, carrying the resolved user id in `X-Session-User-Id`. We bind
+   * that id to THIS accepted socket (so a second client on the same DO cannot
+   * overwrite it), accept the server side with a plain `accept()` (no
+   * hibernation — see the file header), wire its message/close listeners, and
+   * hand the client side back in the 101 response.
    */
   override async fetch(request: Request): Promise<Response> {
     if (request.headers.get('Upgrade') !== 'websocket') {
@@ -140,27 +160,46 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
     if (!forwardedUserId) {
       return new Response('missing authenticated identity', { status: 401 })
     }
-    this.authUserId = forwardedUserId
     const pair = new WebSocketPair()
     const client = pair[0]
     const server = pair[1]
-    this.ctx.acceptWebSocket(server)
+
+    // Plain accept keeps the DO resident for the session (no hibernation), so
+    // the in-memory session state survives between turns.
+    server.accept()
+    // Bind the authenticated identity to this specific socket.
+    this.socketIdentities.bind(server, forwardedUserId)
+
+    server.addEventListener('message', (event) => {
+      this.onSocketMessage(server, event.data as string | ArrayBuffer).catch((err: unknown) => {
+        // Fail loud: an ownership violation or a malformed control message ends
+        // this socket with a policy-violation close rather than leaking an
+        // unhandled rejection. Other sockets on the DO are unaffected.
+        const reason = err instanceof Error ? err.message : 'message handling failed'
+        server.close(1008, reason.slice(0, 123))
+      })
+    })
+    server.addEventListener('close', () => {
+      this.onSocketClose(server)
+    })
+
     return new Response(null, { status: 101, webSocket: client })
   }
 
   /** Inbound WS frame: a JSON control message (string) or an audio frame (binary). */
-  override async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
-    if (typeof message === 'string') {
-      await this.handleControl(ws, JSON.parse(message) as ControlMessage)
+  private async onSocketMessage(ws: WebSocket, data: string | ArrayBuffer): Promise<void> {
+    if (typeof data === 'string') {
+      await this.handleControl(ws, JSON.parse(data) as ControlMessage)
       return
     }
     // Binary frame: player audio for the in-flight (or next) turn.
     const bridge = this.ensureAudioBridge()
-    bridge.push(new Uint8Array(message))
+    bridge.push(new Uint8Array(data))
   }
 
-  /** Socket closed: tear the in-flight turn's audio stream down. */
-  override async webSocketClose(): Promise<void> {
+  /** Socket closed: drop its identity binding and tear the audio stream down. */
+  private onSocketClose(ws: WebSocket): void {
+    this.socketIdentities.release(ws)
     this.audio?.close()
     this.audio = undefined
   }
@@ -263,16 +302,19 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
 
   /** WS control-message dispatch driving the four-method semantics. */
   private async handleControl(ws: WebSocket, msg: ControlMessage): Promise<void> {
+    // The operating user is THIS socket's authenticated identity, resolved per
+    // message — never a shared field a later upgrade could have overwritten.
+    const socketUserId = this.socketIdentities.resolve(ws)
     switch (msg.type) {
       case 'create': {
-        if (!this.authUserId) {
+        if (!socketUserId) {
           ws.close(1008, 'no authenticated identity')
           return
         }
         // Bind the AUTH-validated user id, NOT any id the client claims.
         const sessionId = this.createSession(
           msg.gameId,
-          this.authUserId,
+          socketUserId,
           msg.manualData,
           msg.gameState
         )
@@ -280,15 +322,17 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
         return
       }
       case 'turn': {
-        if (!this.state || !this.userId) {
+        if (!this.state || !socketUserId) {
           ws.close(1008, 'turn before create')
           return
         }
         // Stream the AI response chunks back. Text rides as JSON; audio is
         // base64-encoded so the whole turn stays on the JSON text channel and
-        // the binary frame direction remains player-audio-only.
+        // the binary frame direction remains player-audio-only. Ownership is
+        // checked against THIS socket's user, so a second client on the same DO
+        // cannot drive the first user's session.
         const sessionId = this.ctx.id.toString()
-        for await (const chunk of this.onAiResponse(sessionId, this.userId)) {
+        for await (const chunk of this.onAiResponse(sessionId, socketUserId)) {
           if (chunk.kind === 'audio' && chunk.audio) {
             ws.send(
               JSON.stringify({
@@ -312,8 +356,11 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
         return
       }
       case 'end': {
-        if (this.state && this.userId) {
-          const summary = this.endSession(this.ctx.id.toString(), this.userId)
+        // `endSession` validates ownership against THIS socket's user, so an
+        // `end` from a different user on the same DO is rejected (throws) rather
+        // than tearing down the owner's session.
+        if (this.state && socketUserId) {
+          const summary = this.endSession(this.ctx.id.toString(), socketUserId)
           ws.send(JSON.stringify({ type: 'summary', summary }))
         }
         ws.close(1000, 'session ended')

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -49,6 +49,7 @@ import { runTurn, type SessionState, type TurnProviders } from './turn-pipeline'
 import {
   assertSessionOwnership,
   assertSocketOwnsBoundSession,
+  socketOwnsBoundSession,
   SocketIdentityRegistry,
 } from './auth-seam'
 
@@ -213,9 +214,23 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
     bridge.push(new Uint8Array(data))
   }
 
-  /** Socket closed: drop its identity binding and tear the audio stream down. */
+  /**
+   * Socket closed. Always release THIS socket's identity binding (so the
+   * registry never leaks). Tear down the shared audio bridge / in-flight turn
+   * ONLY when the closing socket owns the bound session — the same per-socket
+   * ownership gate the control and binary paths enforce.
+   *
+   * Without this gate the close path is the one un-gated mutation of shared
+   * session state: a second authenticated client on the same `/ai-ws/{name}` DO
+   * (which only needs to know the session name) connecting and then disconnecting
+   * would close the owner's bridge and truncate the owner's in-flight turn. A
+   * non-owner close must touch nothing but its own binding. Ownership is checked
+   * with the non-throwing predicate because a close handler must be total.
+   */
   private onSocketClose(ws: WebSocket): void {
+    const ownsSession = socketOwnsBoundSession(this.socketIdentities, ws, this.boundIdentity())
     this.socketIdentities.release(ws)
+    if (!ownsSession) return
     this.audio?.close()
     this.audio = undefined
   }

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -30,9 +30,14 @@
  * (via `SocketIdentityRegistry`), not in a shared instance field: two
  * already-authenticated clients can connect to the same-named DO (one instance),
  * and a shared field would let the later upgrade overwrite the earlier client's
- * identity — letting socket B drive `create`/`reset` under socket A's user. Each
- * control message resolves the id of the exact socket it arrived on, so the
- * per-operation ownership invariant (L2 §Mechanism Variant 3) holds per socket.
+ * identity — letting socket B drive `create`/`reset` under socket A's user. Both
+ * inbound paths resolve the id of the exact socket a frame arrived on and verify
+ * it owns the bound session: control messages (create/turn/end) and binary audio
+ * frames alike. The binary path must gate too — otherwise a second authenticated
+ * socket on the same DO could push audio onto the owner's shared bridge, which
+ * the owner's next `turn` would transcribe (forging the owner's utterance). So
+ * the per-operation ownership invariant (L2 §Mechanism Variant 3) holds per
+ * socket across every inbound frame, not just control messages.
  */
 
 import { DurableObject } from 'cloudflare:workers'
@@ -41,7 +46,11 @@ import type { GameState } from './manual-injection'
 import { resolveConfig } from './provider-config'
 import { createProviders, type ProviderEnv } from './providers/factory'
 import { runTurn, type SessionState, type TurnProviders } from './turn-pipeline'
-import { assertSessionOwnership, SocketIdentityRegistry } from './auth-seam'
+import {
+  assertSessionOwnership,
+  assertSocketOwnsBoundSession,
+  SocketIdentityRegistry,
+} from './auth-seam'
 
 /** Env bindings visible to the DO (provider creds + the AUTH KV, unused here). */
 export type SessionDoEnv = ProviderEnv & Record<string, unknown>
@@ -192,7 +201,14 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
       await this.handleControl(ws, JSON.parse(data) as ControlMessage)
       return
     }
-    // Binary frame: player audio for the in-flight (or next) turn.
+    // Binary frame: player audio. Gate it through the SAME per-socket ownership
+    // predicate the control path uses — a binary frame must come from the socket
+    // whose user owns the bound session. Without this, a second authenticated
+    // socket on the same DO could push frames the owner's next `turn` transcribes,
+    // forging the owner's utterance. The throw on a non-owner frame propagates to
+    // the message listener's `.catch`, which closes THAT socket with 1008 (fail
+    // loud, control-path-consistent) — the owner's bridge is never touched.
+    this.assertSocketOwner(ws)
     const bridge = this.ensureAudioBridge()
     bridge.push(new Uint8Array(data))
   }
@@ -290,14 +306,26 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
    * `onPlayerAudio` / `onAiResponse` / `endSession` verify ownership).
    */
   private assertOwner(sessionId: string, userId: string): void {
-    assertSessionOwnership(
-      {
-        boundSessionId: this.userId === undefined ? undefined : this.ctx.id.toString(),
-        boundUserId: this.userId,
-      },
-      sessionId,
-      userId
-    )
+    assertSessionOwnership(this.boundIdentity(), sessionId, userId)
+  }
+
+  /**
+   * Assert THIS socket's authenticated user owns the bound session, using the
+   * shared ownership predicate. Drives the binary audio path so it carries the
+   * same per-socket ownership guarantee as the control path. Throws (fail loud)
+   * on a non-owner / unauthenticated / pre-create frame; the caller's listener
+   * turns the throw into a 1008 close of this socket.
+   */
+  private assertSocketOwner(ws: WebSocket): void {
+    assertSocketOwnsBoundSession(this.socketIdentities, ws, this.boundIdentity())
+  }
+
+  /** The DO's bound identity in the `{ boundSessionId, boundUserId }` shape. */
+  private boundIdentity(): { boundSessionId: string | undefined; boundUserId: string | undefined } {
+    return {
+      boundSessionId: this.userId === undefined ? undefined : this.ctx.id.toString(),
+      boundUserId: this.userId,
+    }
   }
 
   /** WS control-message dispatch driving the four-method semantics. */

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -168,6 +168,36 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
    */
   private activeTurn: AsyncIterator<AiResponseChunk> | undefined
   /**
+   * Monotonic session-generation counter — the epoch guard that keeps a stale
+   * turn-loop `finally` from clobbering a NEWER session's shared `turnInFlight`/
+   * `activeTurn`.
+   *
+   * The race it closes: `end`/owner-close fire-and-forget a mid-turn cancel
+   * (`cancelActiveTurn` is NOT awaited — a provider promise may still be
+   * pending) and then `clearSession()` makes the same-named DO immediately
+   * reusable. The canceled turn's loop `finally` still runs LATER, when its
+   * iterator finally settles. If a client reconnects in that window — `create`s
+   * a fresh session and starts a NEW turn (setting fresh `turnInFlight`/
+   * `activeTurn`) — an UNCONDITIONAL clear in the stale `finally` would
+   * (1) reopen the overlap guard (the new session becomes attackable by an
+   * overlapping `turn`) and (2) null out the new `activeTurn` so the new turn
+   * can no longer be canceled by `end`. Root cause: cleanup wrote shared fields
+   * across the "old turn generation" / "new session generation" boundary.
+   *
+   * Mechanism: every turn captures its own generation (`myEpoch`) the instant it
+   * becomes active. Both the turn loop `finally` and `clearSession`'s reset only
+   * touch the shared fields while the current epoch still matches the captured
+   * one. `clearSession` (end / owner-close) bumps the epoch, advancing the
+   * generation, so a stale `finally` comparing an old `myEpoch` is a no-op and
+   * never reaches the new session's state. A new `create` does not need to bump:
+   * `clearSession` already advanced the epoch at the prior session's end, and
+   * `create` does not start a turn (no `myEpoch` is captured until the first
+   * `turn`). Normal single-session flow is unchanged — the epoch only advances on
+   * teardown, so a turn that completes within its own live session always finds
+   * its epoch current and clears as before.
+   */
+  private turnEpoch = 0
+  /**
    * Authenticated user id per accepted socket, forwarded by the Worker from the
    * validated handshake (`X-Session-User-Id`). This is the authoritative
    * identity bound at upgrade — the client-supplied control message is NOT
@@ -389,15 +419,24 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
    * live `activeTurn` synchronously; once captured, clearing the field here is
    * safe (the captured iterator drives the background `return()` independently).
    * The background cancel only runs `runTurn`'s `finally` (closes the sentence
-   * queue, returns the live LLM/TTS iterators) and the turn loop's own `finally`
-   * (which re-clears `turnInFlight`/`activeTurn` to their initial values — an
-   * idempotent no-op after this reset, never a revival): a canceled turn never
-   * reaches `runTurn`'s settle step, so it never writes back to the (now
-   * undefined) `state`. There is no read-after-clear that could NPE: the only
-   * post-clear toucher is the turn loop `finally`, which only assigns the same
-   * initial values these fields already hold.
+   * queue, returns the live LLM/TTS iterators) and the turn loop's own `finally`.
+   * A canceled turn never reaches `runTurn`'s settle step, so it never writes
+   * back to the (now undefined) `state`.
+   *
+   * Epoch advance — the cross-generation guard: bumping `turnEpoch` here
+   * advances the session generation, so the just-canceled (or any still-draining)
+   * turn's loop `finally`, which captured the OLD epoch, no longer matches and
+   * becomes a no-op. Without this, that stale `finally` settling AFTER a client
+   * reconnected + started a NEW turn would null out the NEW session's
+   * `turnInFlight`/`activeTurn` — reopening the overlap guard and stranding the
+   * new turn (uncancelable by `end`). The current-generation `turnInFlight`/
+   * `activeTurn` reset below still clears the ended session's own state; the
+   * epoch bump only fences off the stale generation's late callback. Bump BEFORE
+   * the field reset so any `finally` that interleaves already sees the advanced
+   * epoch.
    */
   private clearSession(): void {
+    this.turnEpoch += 1
     this.state = undefined
     this.userId = undefined
     this.providers = undefined
@@ -517,9 +556,16 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
         // Hold the iterator explicitly so a mid-turn `end` / owner close can
         // cancel it via `return()`. Mark in-flight BEFORE the first `await`
         // (synchronous up to here) so an interleaved second `turn` sees the
-        // guard set. The `finally` clears the guard + iterator on every exit
-        // (normal end, provider error, or cancellation) so the next turn can run.
+        // guard set. Capture THIS turn's generation (`myEpoch`) at the same
+        // synchronous point the shared fields are set, so the `finally` can tell
+        // "still my session" from "a newer session reused this DO after my
+        // session was torn down". The `finally` clears the guard + iterator on
+        // every exit (normal end, provider error, or cancellation) so the next
+        // turn can run — but ONLY while this turn is still the live generation
+        // (see `turnEpoch`): a stale `finally` whose session was already ended/
+        // dropped must not null out a newer session's `turnInFlight`/`activeTurn`.
         const turn = this.onAiResponse(sessionId, socketUserId)[Symbol.asyncIterator]()
+        const myEpoch = this.turnEpoch
         this.activeTurn = turn
         this.turnInFlight = true
         try {
@@ -548,8 +594,17 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
             }
           }
         } finally {
-          this.turnInFlight = false
-          this.activeTurn = undefined
+          // Epoch guard: only release the guard + iterator if THIS turn is still
+          // the live generation. If `clearSession` (end / owner-close) already
+          // bumped the epoch and a newer session is running on this resident DO,
+          // `this.turnEpoch !== myEpoch` and we leave the new session's
+          // `turnInFlight`/`activeTurn` untouched — the stale `finally` is a
+          // no-op. In the normal single-session path the epoch is unchanged, so
+          // this clears exactly as before.
+          if (this.turnEpoch === myEpoch) {
+            this.turnInFlight = false
+            this.activeTurn = undefined
+          }
         }
         return
       }
@@ -574,11 +629,16 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
           // `endSession`) and proceed without blocking on it. The background cancel
           // still completes when the provider promise eventually settles: at that
           // point `runTurn`'s `finally` closes the sentence queue + returns the live
-          // LLM/TTS iterators (no stream leaks), and the turn loop's own `finally`
-          // clears `turnInFlight`/`activeTurn` — so the in-flight guard is released
-          // by the same path as before, just not synchronously with `end`. A turn
-          // canceled mid-flight never reaches `runTurn`'s settle step, so it never
-          // increments `turnCount` — the summary counts only fully-completed turns.
+          // LLM/TTS iterators (no stream leaks). The in-flight guard itself is
+          // released synchronously by the `clearSession` below (which resets
+          // `turnInFlight`/`activeTurn` for this ended generation); the late turn
+          // loop `finally` is then EPOCH-FENCED — `clearSession` bumped the epoch,
+          // so the stale `finally` finds `turnEpoch !== myEpoch` and is a no-op,
+          // never touching a session that may have already been re-`create`d on
+          // this resident DO (the cross-generation race this fix closes; see
+          // `turnEpoch` + `clearSession`). A turn canceled mid-flight never reaches
+          // `runTurn`'s settle step, so it never increments `turnCount` — the
+          // summary counts only fully-completed turns.
           // Truly abortable cancellation (an AbortSignal threaded through `runTurn`
           // into each adapter to interrupt a stuck fetch/WS) is a separate followup,
           // not this fix.

--- a/packages/platform-ai/src/session-end-cleanup.test.ts
+++ b/packages/platform-ai/src/session-end-cleanup.test.ts
@@ -105,13 +105,22 @@ interface OutboundMessage {
   [k: string]: unknown
 }
 
+/** A stand-in socket — only reference identity matters to the owner-socket gate. */
+type FakeWs = { id: string }
+/** The socket that opens the session in tests that don't pass one explicitly. */
+const OWNER: FakeWs = { id: 'owner-socket' }
+
 /**
  * Mirrors `VoiceSessionDO.handleControl` for `create` / `turn` / `end` plus the
  * owner branch of `onSocketClose` and the `clearSession` reset. It holds the
  * same session-level fields the real DO clears (`state` / `userId` /
- * `providers` / `turnInFlight` / `activeTurn` / `bridge`). The single owner
- * socket is implicit (ownership isolation is covered in
- * `session-identity.test.ts`); here we isolate the post-end cleanup contract.
+ * `providers` / `turnInFlight` / `activeTurn` / `bridge` / `ownerSocket`).
+ *
+ * Teardown grain (F-W): `end` and owner-close are gated on the OWNER SOCKET
+ * reference recorded at `create` (`ownerSocket` / mirrors
+ * `socketIsBoundSessionOwner`), not the user id — so a same-user duplicate
+ * socket cannot tear the original session down. Tests that don't care about the
+ * multi-socket shape omit the socket arg and operate as the `OWNER` socket.
  */
 class FakeSessionDo {
   state: { history: string[]; turnCount: number } | undefined
@@ -120,6 +129,7 @@ class FakeSessionDo {
   turnInFlight = false
   activeTurn: AsyncIterator<AiResponseChunk> | undefined
   bridge: SharedBridge | undefined
+  ownerSocket: FakeWs | undefined
   /** Unblock-the-STT-await hook (the real `this.audio.close()` analogue). */
   onBridgeClose: (() => void) | undefined
   readonly sent: OutboundMessage[] = []
@@ -130,11 +140,23 @@ class FakeSessionDo {
     this.sent.push(msg)
   }
 
+  /** Mirrors `socketIsBoundSessionOwner`: a session is bound AND `ws` is the owner socket. */
+  private isOwnerSocket(ws: FakeWs): boolean {
+    if (this.state === undefined || this.userId === undefined) return false
+    if (this.ownerSocket === undefined) return false
+    return ws === this.ownerSocket
+  }
+
   /**
    * Mirrors the `create` branch: reject a re-create while a session is live,
-   * otherwise bind the session/user/providers. Returns whether a session opened.
+   * otherwise bind the session/user/providers AND record the owner socket.
+   * Returns whether a session opened.
    */
-  create(userId: string, initialState: { history: string[]; turnCount: number }): boolean {
+  create(
+    userId: string,
+    initialState: { history: string[]; turnCount: number },
+    ws: FakeWs = OWNER
+  ): boolean {
     if (this.state) {
       this.send({ type: 'error', code: 'already_created', message: 'session already created' })
       return false
@@ -142,6 +164,7 @@ class FakeSessionDo {
     this.state = initialState
     this.userId = userId
     this.providers = {}
+    this.ownerSocket = ws
     this.send({ type: 'created' })
     return true
   }
@@ -178,19 +201,27 @@ class FakeSessionDo {
   }
 
   /**
-   * Mirrors the post-fix `end` branch: close the bridge (next-turn bridge), then
-   * cancel any in-flight turn FIRE-AND-FORGET (no await), CLEAR the bound session
-   * state, and summarize. `clearSession` MUST follow the cancel so the cancel
-   * captures the live `activeTurn` before it is reset. A no-session `end` is a
-   * no-op (mirrors the `if (this.state && socketUserId)` guard).
+   * Mirrors the post-fix `end` branch: a no-session `end` is a no-op (the
+   * `if (this.state && socketUserId)` guard); a non-owner-SOCKET `end` is rejected
+   * fail-loud (the F-W owner-socket teardown gate) and tears nothing down; only
+   * the owner socket's `end` closes the bridge, cancels any in-flight turn
+   * FIRE-AND-FORGET (no await), CLEARs the bound session, and summarizes.
+   * `clearSession` MUST follow the cancel so the cancel captures the live
+   * `activeTurn` before it is reset. Returns whether teardown ran.
    */
-  end(): void {
-    if (!this.state || !this.userId) return
+  end(ws: FakeWs = OWNER): boolean {
+    if (!this.state || !this.userId) return false
+    if (!this.isOwnerSocket(ws)) {
+      // Same-user duplicate (or any non-owner) socket: reject, do NOT tear down.
+      this.send({ type: 'closed', code: 1008, reason: 'end from non-owner socket' })
+      return false
+    }
     const turnCount = this.state.turnCount
     this.closeBridge()
     void this.cancelActiveTurn()
     this.clearSession()
     this.send({ type: 'summary', turnCount })
+    return true
   }
 
   /**
@@ -229,6 +260,7 @@ class FakeSessionDo {
     this.bridge = undefined
     this.turnInFlight = false
     this.activeTurn = undefined
+    this.ownerSocket = undefined
   }
 }
 
@@ -430,5 +462,99 @@ describe('owner abrupt close — clears the session like end (P2 audit)', () => 
     const opened = do_.create('user-A', { history: [], turnCount: 0 })
     expect(opened).toBe(true)
     expect(do_.state).toEqual({ history: [], turnCount: 0 })
+  })
+})
+
+// --- F-W: `end` from a same-user NON-OWNER socket must not tear down ----------
+//
+// `end` is the second teardown trigger (besides owner-close) — it `clearSession`s
+// the bound session. `endSession`'s `assertOwner` only checks the user id, so a
+// SAME-user second socket (duplicate tab / reconnect) would pass it and tear down
+// the still-active original session. The fix gates `end` teardown on the owner
+// SOCKET reference: a non-owner socket's `end` (even same user) is rejected
+// fail-loud and tears nothing down; the owner's session/turn survive, and the
+// owner's own `end` still ends the session normally afterwards.
+
+describe('end teardown gate — only the owner socket can end the session (F-W)', () => {
+  const DUP: FakeWs = { id: 'same-user-second-socket' }
+
+  it('a same-user duplicate socket’s end is rejected and clears nothing', () => {
+    const do_ = new FakeSessionDo(() => {
+      throw new Error('no turn in this test')
+    })
+    do_.create('user-A', { history: ['live'], turnCount: 2 }) // owner = OWNER socket
+    do_.bridge = { closed: false }
+
+    // A second socket for the SAME user (user-A) sends `end`. Owner-socket gate
+    // rejects it; no summary, no teardown.
+    const tore = do_.end(DUP)
+
+    expect(tore).toBe(false)
+    expect(do_.sent).toContainEqual({
+      type: 'closed',
+      code: 1008,
+      reason: 'end from non-owner socket',
+    })
+    expect(do_.sent).not.toContainEqual({ type: 'summary', turnCount: 2 })
+    // The original session is fully intact — state, owner, bridge all untouched.
+    expect(do_.state).toEqual({ history: ['live'], turnCount: 2 })
+    expect(do_.userId).toBe('user-A')
+    expect(do_.ownerSocket).toBe(OWNER)
+    expect(do_.bridge?.closed).toBe(false)
+  })
+
+  it('after a duplicate socket’s rejected end, the OWNER socket can still end normally', () => {
+    const do_ = new FakeSessionDo(() => {
+      throw new Error('no turn in this test')
+    })
+    do_.create('user-A', { history: [], turnCount: 1 })
+    do_.bridge = { closed: false }
+
+    // Duplicate's end bounces.
+    expect(do_.end(DUP)).toBe(false)
+    expect(do_.state).toBeDefined()
+
+    // The real owner socket ends: now the session tears down and summarizes.
+    const tore = do_.end(OWNER)
+    expect(tore).toBe(true)
+    expect(do_.sent).toContainEqual({ type: 'summary', turnCount: 1 })
+    expect(do_.state).toBeUndefined()
+    expect(do_.ownerSocket).toBeUndefined()
+  })
+
+  it('a same-user duplicate socket’s end does not cancel the owner’s in-flight turn', async () => {
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    const bridge: SharedBridge = { closed: false }
+    const ctrl = makeControllableTurn(sharedState, bridge, [
+      textChunk('partial'),
+      textChunk('', true),
+    ])
+    const do_ = new FakeSessionDo(() => {
+      do_.onBridgeClose = ctrl.cancel
+      return ctrl.generator
+    })
+    do_.create('user-A', sharedState) // owner = OWNER socket
+    do_.bridge = bridge
+
+    const turning = do_.turn()
+    await tick()
+    ctrl.releaseNext()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+
+    // Same-user duplicate socket fires `end` mid-turn: rejected, the in-flight
+    // turn keeps running and is NOT canceled.
+    expect(do_.end(DUP)).toBe(false)
+    expect(do_.turnInFlight).toBe(true)
+    expect(ctrl.cleanedUp()).toBe(false)
+
+    // The owner's own turn still completes (and is still cancelable by the OWNER's
+    // `end`, which here lets it settle by releasing the remaining chunk first).
+    ctrl.releaseNext()
+    await tick()
+    ctrl.releaseNext()
+    await turning
+    expect(ctrl.settled()).toBe(true)
+    expect(sharedState.turnCount).toBe(1)
   })
 })

--- a/packages/platform-ai/src/session-end-cleanup.test.ts
+++ b/packages/platform-ai/src/session-end-cleanup.test.ts
@@ -1,0 +1,434 @@
+import { describe, expect, it } from 'vitest'
+import type { AiResponseChunk } from './contract'
+
+/**
+ * Regression tests for post-`end` (and post-owner-close) session-state cleanup
+ * (the P2 from PR #156 review). `VoiceSessionDO` imports `cloudflare:workers`
+ * and cannot be instantiated in the Node test environment, so — exactly as the
+ * per-socket identity, `runTurn`, and turn-guard mechanisms are tested via
+ * faithful stand-ins (see `session-identity.test.ts`, `turn-pipeline.test.ts`,
+ * `session-turn-guard.test.ts`) — these tests model the DO's control-dispatch
+ * logic with a stand-in (`FakeSessionDo`) that mirrors the real fields
+ * (`state` / `userId` / `providers` / `turnInFlight` / `activeTurn` / `audio`)
+ * and the real `handleControl` `end` / `create` / `turn` branches plus the
+ * `clearSession` reset one-for-one.
+ *
+ * The defect's shape: after the owner sends `end` and gets the summary, the DO
+ * kept `state` / `userId` / `providers` bound on the resident (non-hibernating)
+ * instance. A later client reconnecting to the SAME-named DO (which only needs
+ * the session name) and authenticating as the same user could then:
+ *   (a) be wrongly rejected with `already_created` on `create` — the session is
+ *       over, a fresh one should open; and worse
+ *   (b) send a `turn` with NO new `create`, pass the stale ownership guard, and
+ *       run a provider turn on the already-ended session.
+ * The fix clears the bound session state at `end` (and at an owner abrupt
+ * close), coordinated with the existing fire-and-forget mid-turn cancel.
+ */
+
+// --- a controllable turn generator -------------------------------------------
+
+/**
+ * Mirror of `session-turn-guard.test.ts`'s controllable turn: an async
+ * generator that suspends at a per-chunk gate (a real turn parked at an
+ * STT/LLM/TTS `await`), records whether its `finally` ran (the clean-cancel
+ * signal) and whether it reached its settle step, and mutates a shared `state`
+ * so a turn that wrongly ran on an ended session would be observable.
+ */
+interface TurnState {
+  history: string[]
+  turnCount: number
+}
+
+interface SharedBridge {
+  closed: boolean
+}
+
+function makeControllableTurn(
+  state: TurnState,
+  bridge: SharedBridge,
+  chunks: AiResponseChunk[]
+): {
+  generator: AsyncGenerator<AiResponseChunk>
+  releaseNext: () => void
+  cancel: () => void
+  cleanedUp: () => boolean
+  settled: () => boolean
+} {
+  let cleaned = false
+  let didSettle = false
+  let canceled = false
+  let gate: (() => void) | undefined
+  const waitGate = (): Promise<void> =>
+    new Promise<void>((resolve) => {
+      gate = resolve
+    })
+  const wake = (): void => {
+    const g = gate
+    gate = undefined
+    g?.()
+  }
+
+  async function* gen(): AsyncGenerator<AiResponseChunk> {
+    try {
+      for (const chunk of chunks) {
+        await waitGate()
+        if (canceled) break
+        if (chunk.kind === 'text' && chunk.text) state.history.push(chunk.text)
+        yield chunk
+      }
+      if (!canceled) {
+        didSettle = true
+        state.turnCount += 1
+      }
+    } finally {
+      cleaned = true
+      bridge.closed = true
+    }
+  }
+
+  return {
+    generator: gen(),
+    releaseNext: wake,
+    cancel: () => {
+      canceled = true
+      wake()
+    },
+    cleanedUp: () => cleaned,
+    settled: () => didSettle,
+  }
+}
+
+// --- a faithful DO control-dispatch stand-in ---------------------------------
+
+interface OutboundMessage {
+  type: string
+  [k: string]: unknown
+}
+
+/**
+ * Mirrors `VoiceSessionDO.handleControl` for `create` / `turn` / `end` plus the
+ * owner branch of `onSocketClose` and the `clearSession` reset. It holds the
+ * same session-level fields the real DO clears (`state` / `userId` /
+ * `providers` / `turnInFlight` / `activeTurn` / `bridge`). The single owner
+ * socket is implicit (ownership isolation is covered in
+ * `session-identity.test.ts`); here we isolate the post-end cleanup contract.
+ */
+class FakeSessionDo {
+  state: { history: string[]; turnCount: number } | undefined
+  userId: string | undefined
+  providers: object | undefined
+  turnInFlight = false
+  activeTurn: AsyncIterator<AiResponseChunk> | undefined
+  bridge: SharedBridge | undefined
+  /** Unblock-the-STT-await hook (the real `this.audio.close()` analogue). */
+  onBridgeClose: (() => void) | undefined
+  readonly sent: OutboundMessage[] = []
+
+  constructor(private readonly turnFactory: () => AsyncGenerator<AiResponseChunk>) {}
+
+  private send(msg: OutboundMessage): void {
+    this.sent.push(msg)
+  }
+
+  /**
+   * Mirrors the `create` branch: reject a re-create while a session is live,
+   * otherwise bind the session/user/providers. Returns whether a session opened.
+   */
+  create(userId: string, initialState: { history: string[]; turnCount: number }): boolean {
+    if (this.state) {
+      this.send({ type: 'error', code: 'already_created', message: 'session already created' })
+      return false
+    }
+    this.state = initialState
+    this.userId = userId
+    this.providers = {}
+    this.send({ type: 'created' })
+    return true
+  }
+
+  /**
+   * Mirrors the `turn` branch: `turn before create` if no session (no
+   * provider turn starts), the in-flight guard, then drive the loop and clear
+   * the guard in `finally`. Returns the loop promise so a test can interleave.
+   */
+  async turn(): Promise<void> {
+    if (!this.state || !this.userId) {
+      this.send({ type: 'error', code: 'turn_before_create', message: 'turn before create' })
+      return
+    }
+    if (this.turnInFlight) {
+      this.send({ type: 'error', code: 'turn_in_flight', message: 'a turn is already in progress' })
+      return
+    }
+    const turn = this.turnFactory()[Symbol.asyncIterator]()
+    this.activeTurn = turn
+    this.turnInFlight = true
+    try {
+      for (;;) {
+        const next = await turn.next()
+        if (next.done) break
+        const chunk = next.value
+        this.send({ type: 'chunk', kind: chunk.kind, done: chunk.done, text: chunk.text })
+      }
+    } finally {
+      this.turnInFlight = false
+      this.activeTurn = undefined
+      this.onBridgeClose = undefined
+    }
+  }
+
+  /**
+   * Mirrors the post-fix `end` branch: close the bridge (next-turn bridge), then
+   * cancel any in-flight turn FIRE-AND-FORGET (no await), CLEAR the bound session
+   * state, and summarize. `clearSession` MUST follow the cancel so the cancel
+   * captures the live `activeTurn` before it is reset. A no-session `end` is a
+   * no-op (mirrors the `if (this.state && socketUserId)` guard).
+   */
+  end(): void {
+    if (!this.state || !this.userId) return
+    const turnCount = this.state.turnCount
+    this.closeBridge()
+    void this.cancelActiveTurn()
+    this.clearSession()
+    this.send({ type: 'summary', turnCount })
+  }
+
+  /**
+   * Mirrors `onSocketClose` owner branch (post-fix): cancel in-flight turn, then
+   * clear the whole bound session (not just the bridge) so an abrupt owner drop
+   * with no `end` leaves no resumable residue.
+   */
+  async ownerClose(): Promise<void> {
+    this.closeBridge()
+    const turn = this.activeTurn
+    this.clearSession()
+    if (turn !== undefined) await turn.return?.(undefined)
+  }
+
+  /** Mirrors `this.audio.close()`: unblock the STT await, mark the bridge closed. */
+  private closeBridge(): void {
+    this.onBridgeClose?.()
+    if (this.bridge) this.bridge.closed = true
+  }
+
+  /**
+   * Mirrors `cancelActiveTurn`: capture the live iterator synchronously, then
+   * `return()` it. Captured BEFORE `clearSession` resets `activeTurn`.
+   */
+  private async cancelActiveTurn(): Promise<void> {
+    const turn = this.activeTurn
+    if (turn === undefined) return
+    await turn.return?.(undefined)
+  }
+
+  /** Mirrors `clearSession`: reset every session-level field to its initial value. */
+  private clearSession(): void {
+    this.state = undefined
+    this.userId = undefined
+    this.providers = undefined
+    this.bridge = undefined
+    this.turnInFlight = false
+    this.activeTurn = undefined
+  }
+}
+
+// --- helpers -----------------------------------------------------------------
+
+const textChunk = (text: string, done = false): AiResponseChunk => ({ kind: 'text', text, done })
+
+const tick = (): Promise<void> => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+// --- post-end: a create-less turn is rejected --------------------------------
+
+describe('post-end cleanup — a turn after end is rejected, no provider turn (P2)', () => {
+  it('rejects a turn after end with no new create; the turn factory is never called', async () => {
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    let turnsStarted = 0
+    const do_ = new FakeSessionDo(() => {
+      turnsStarted += 1
+      throw new Error('a provider turn must not start after end')
+    })
+    do_.create('user-A', sharedState)
+    do_.bridge = { closed: false }
+
+    // Owner ends the session: summary out, state cleared.
+    do_.end()
+    expect(do_.sent).toContainEqual({ type: 'summary', turnCount: 0 })
+    expect(do_.state).toBeUndefined()
+    expect(do_.userId).toBeUndefined()
+    expect(do_.providers).toBeUndefined()
+
+    // A `turn` arrives on the same DO with NO fresh `create` (a reconnect, or a
+    // late frame). It is rejected as "turn before create" — no provider turn.
+    await do_.turn()
+
+    expect(turnsStarted).toBe(0)
+    expect(do_.sent).toContainEqual({
+      type: 'error',
+      code: 'turn_before_create',
+      message: 'turn before create',
+    })
+    // The ended session's state was never resurrected by the rejected turn.
+    expect(do_.state).toBeUndefined()
+    expect(sharedState.turnCount).toBe(0)
+  })
+})
+
+// --- post-end: a same-name create opens a clean new session ------------------
+
+describe('post-end cleanup — a create after end opens a fresh session (P2)', () => {
+  it('does not reject the post-end create with already_created; binds a new session', () => {
+    const firstState = { history: ['old-turn'], turnCount: 3 }
+    const do_ = new FakeSessionDo(() => {
+      throw new Error('no turn in this test')
+    })
+    do_.create('user-A', firstState)
+    do_.bridge = { closed: false }
+
+    do_.end()
+    expect(do_.state).toBeUndefined()
+
+    // Same user reconnects to the same-named DO and creates again. With the stale
+    // state cleared, this is NOT rejected as already_created — a clean new
+    // session opens, unbound from the previous run's history.
+    const opened = do_.create('user-A', { history: [], turnCount: 0 })
+
+    expect(opened).toBe(true)
+    expect(do_.sent).not.toContainEqual({
+      type: 'error',
+      code: 'already_created',
+      message: 'session already created',
+    })
+    expect(do_.state).toEqual({ history: [], turnCount: 0 })
+    // The new session does NOT carry the ended run's history.
+    expect(do_.state?.history).toEqual([])
+  })
+
+  it('still rejects a genuine re-create WHILE a session is live (unchanged behaviour)', () => {
+    const do_ = new FakeSessionDo(() => {
+      throw new Error('no turn in this test')
+    })
+    do_.create('user-A', { history: [], turnCount: 0 })
+
+    // No `end` happened — the session is still live, so a second create is the
+    // already_created case the prior fix established. Cleanup must not weaken it.
+    const opened = do_.create('user-A', { history: [], turnCount: 0 })
+
+    expect(opened).toBe(false)
+    expect(do_.sent).toContainEqual({
+      type: 'error',
+      code: 'already_created',
+      message: 'session already created',
+    })
+  })
+})
+
+// --- post-end with an in-flight turn: cancel + clear, no resurrection ---------
+
+describe('post-end cleanup — end mid-turn cancels, clears, and the background settle is clean (P2 + F-J)', () => {
+  it('fire-and-forget cancels the in-flight turn, clears state, and the late settle does not revive the session', async () => {
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    const bridge: SharedBridge = { closed: false }
+    const ctrl = makeControllableTurn(sharedState, bridge, [
+      textChunk('partial'),
+      textChunk('', true),
+    ])
+    const do_ = new FakeSessionDo(() => {
+      do_.onBridgeClose = ctrl.cancel
+      return ctrl.generator
+    })
+    do_.create('user-A', sharedState)
+    do_.bridge = bridge
+
+    const turning = do_.turn()
+    await tick()
+    ctrl.releaseNext()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+    expect(ctrl.settled()).toBe(false)
+
+    // `end` arrives mid-turn: summary lands synchronously and the session state
+    // is cleared immediately — BEFORE the background cancel's `finally` runs.
+    do_.end()
+    expect(do_.sent).toContainEqual({ type: 'summary', turnCount: 0 })
+    expect(do_.state).toBeUndefined()
+    expect(do_.userId).toBeUndefined()
+    expect(do_.providers).toBeUndefined()
+    expect(bridge.closed).toBe(true)
+
+    // The background cancel then settles (the controllable turn unblocks on the
+    // bridge-close analogue) and the turn drains to completion WITHOUT error.
+    await turning
+
+    // The turn's `finally` ran (streams returned, queue closed); the bridge is
+    // closed (STT terminated). The canceled turn never reached settle, so it did
+    // not count — and, critically, the late settle did NOT re-bind the session.
+    expect(ctrl.cleanedUp()).toBe(true)
+    expect(ctrl.settled()).toBe(false)
+    expect(sharedState.turnCount).toBe(0)
+    expect(do_.state).toBeUndefined()
+    expect(do_.turnInFlight).toBe(false)
+    expect(do_.activeTurn).toBeUndefined()
+
+    // And a post-end turn on the cleared DO is rejected — the ended session
+    // cannot be driven even though a turn was mid-flight when `end` arrived.
+    await do_.turn()
+    expect(do_.sent).toContainEqual({
+      type: 'error',
+      code: 'turn_before_create',
+      message: 'turn before create',
+    })
+  })
+})
+
+// --- owner abrupt close (no end): same residue, same cleanup -----------------
+
+describe('owner abrupt close — clears the session like end (P2 audit)', () => {
+  it('an owner socket drop with no end clears state so a reconnect cannot drive the old session', async () => {
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    const bridge: SharedBridge = { closed: false }
+    let turnsStarted = 0
+    const ctrl = makeControllableTurn(sharedState, bridge, [textChunk('x'), textChunk('', true)])
+    const do_ = new FakeSessionDo(() => {
+      turnsStarted += 1
+      do_.onBridgeClose = ctrl.cancel
+      return ctrl.generator
+    })
+    do_.create('user-A', sharedState)
+    do_.bridge = bridge
+
+    const turning = do_.turn()
+    await tick()
+    ctrl.releaseNext()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+
+    // Owner's socket drops WITHOUT sending `end` (network drop / tab close).
+    await do_.ownerClose()
+    await turning
+
+    // The in-flight turn was cleanly canceled (streams returned, no settle) and
+    // the whole session is cleared — not just the bridge.
+    expect(ctrl.cleanedUp()).toBe(true)
+    expect(ctrl.settled()).toBe(false)
+    expect(do_.state).toBeUndefined()
+    expect(do_.userId).toBeUndefined()
+    expect(do_.providers).toBeUndefined()
+    expect(do_.turnInFlight).toBe(false)
+    expect(do_.activeTurn).toBeUndefined()
+
+    // A reconnect's create-less turn is rejected (no provider turn runs).
+    await do_.turn()
+    expect(turnsStarted).toBe(1)
+    expect(do_.sent).toContainEqual({
+      type: 'error',
+      code: 'turn_before_create',
+      message: 'turn before create',
+    })
+
+    // And a reconnect `create` opens a fresh session (not already_created).
+    const opened = do_.create('user-A', { history: [], turnCount: 0 })
+    expect(opened).toBe(true)
+    expect(do_.state).toEqual({ history: [], turnCount: 0 })
+  })
+})

--- a/packages/platform-ai/src/session-epoch-guard.test.ts
+++ b/packages/platform-ai/src/session-epoch-guard.test.ts
@@ -1,0 +1,501 @@
+import { describe, expect, it } from 'vitest'
+import type { AiResponseChunk } from './contract'
+
+/**
+ * Regression tests for the session-generation EPOCH guard (the P2 from PR #156
+ * review, raised by the prior `clearSession` fix). `VoiceSessionDO` imports
+ * `cloudflare:workers` and cannot be instantiated in the Node test environment,
+ * so — exactly as the per-socket identity, `runTurn`, turn-guard, and end-cleanup
+ * mechanisms are tested via faithful stand-ins (see `session-identity.test.ts`,
+ * `turn-pipeline.test.ts`, `session-turn-guard.test.ts`,
+ * `session-end-cleanup.test.ts`) — these tests model the DO's control-dispatch
+ * logic with a stand-in (`FakeSessionDo`) that mirrors the real fields
+ * (`state` / `userId` / `providers` / `turnInFlight` / `activeTurn` / `bridge` /
+ * `turnEpoch`) and the real `handleControl` `end` / `create` / `turn` branches
+ * plus the `clearSession` reset and the EPOCH-GUARDED turn-loop `finally`
+ * one-for-one.
+ *
+ * The defect's shape (cross-generation clobber): on `end` / owner-close mid-turn,
+ * the DO fire-and-forgets the cancel (a provider promise may still be pending) and
+ * `clearSession()` makes the same-named DO immediately reusable. The canceled
+ * turn's loop `finally` still runs LATER, when its iterator finally settles. If a
+ * client reconnects in that window — `create`s a fresh session and starts a NEW
+ * turn (setting fresh `turnInFlight`/`activeTurn`) — an UNCONDITIONAL clear in the
+ * stale `finally` would (1) reopen the overlap guard so the new session is again
+ * attackable by an overlapping `turn`, and (2) null out the new `activeTurn` so
+ * the new turn can no longer be canceled by `end`. Root cause: cleanup wrote
+ * shared fields across the "old turn generation" / "new session generation"
+ * boundary.
+ *
+ * The fix gives each turn its own generation (`myEpoch`, captured the instant the
+ * turn becomes active). `clearSession` bumps `turnEpoch`, advancing the
+ * generation; the turn-loop `finally` only clears the shared fields while
+ * `this.turnEpoch === myEpoch`, so a stale `finally` from an ended generation is a
+ * no-op and never touches the new session. These tests reproduce the
+ * cross-generation interleave deterministically by deferring the stale turn's
+ * `finally` until AFTER the new session is created and a new turn is running.
+ */
+
+// --- a controllable turn whose `finally` settles on demand -------------------
+
+/**
+ * A stand-in for `runTurn` whose cleanup (`finally`) can be deferred to an
+ * explicit moment, so a test can interleave a brand-new session/turn between the
+ * `end`/cancel and the stale turn's late `finally` — exactly the cross-generation
+ * window the P2 lives in.
+ *
+ * `next()` parks at a per-chunk gate (a real turn at an STT/LLM/TTS `await`).
+ * `return()` (the DO's cancel) does not finish until a deferred `settleReturn()`
+ * is called — modelling the real "`return()` cannot run the `finally` until the
+ * pending provider promise settles". When it does settle, the generator runs its
+ * `finally` (mirrors `runTurn` closing the queue + returning the live iterators).
+ */
+function makeDeferredTurn(chunks: AiResponseChunk[]): {
+  generator: AsyncGenerator<AiResponseChunk>
+  /** Advance one chunk: resolve the gate so the parked turn yields its next. */
+  releaseNext: () => void
+  /** Settle the deferred `return()` so the generator unwinds and runs `finally`. */
+  settleReturn: () => void
+  /** True once the generator's `finally` ran. */
+  cleanedUp: () => boolean
+  /** True once the generator reached its settle step (turn fully completed). */
+  settled: () => boolean
+} {
+  let cleaned = false
+  let didSettle = false
+  let canceled = false
+  let returnSettled = false
+  let chunkGate: (() => void) | undefined
+  let returnGate: (() => void) | undefined
+
+  const waitChunk = (): Promise<void> =>
+    new Promise<void>((resolve) => {
+      chunkGate = resolve
+    })
+  const wakeChunk = (): void => {
+    const g = chunkGate
+    chunkGate = undefined
+    g?.()
+  }
+  // Latched: if `settleReturn` already fired before the generator parks at the
+  // return gate, the wait resolves immediately rather than blocking forever.
+  const waitReturn = (): Promise<void> =>
+    new Promise<void>((resolve) => {
+      if (returnSettled) {
+        resolve()
+        return
+      }
+      returnGate = resolve
+    })
+  const wakeReturn = (): void => {
+    returnSettled = true
+    const g = returnGate
+    returnGate = undefined
+    g?.()
+  }
+
+  async function* gen(): AsyncGenerator<AiResponseChunk> {
+    try {
+      for (const chunk of chunks) {
+        await waitChunk()
+        if (canceled) break
+        yield chunk
+      }
+      if (!canceled) didSettle = true
+    } finally {
+      // Cancel path: the `return()` is held here until the test settles it,
+      // modelling the late provider-promise settle that finally lets the
+      // generator's cleanup run. The normal-completion path skips the wait.
+      if (canceled) await waitReturn()
+      cleaned = true
+    }
+  }
+
+  return {
+    generator: gen(),
+    releaseNext: wakeChunk,
+    settleReturn: () => {
+      canceled = true
+      // Wake the parked chunk gate so the loop observes cancellation and falls
+      // into `finally`, then release the `finally`'s return gate.
+      wakeChunk()
+      wakeReturn()
+    },
+    cleanedUp: () => cleaned,
+    settled: () => didSettle,
+  }
+}
+
+// --- a faithful DO control-dispatch stand-in (with the epoch guard) ----------
+
+interface OutboundMessage {
+  type: string
+  [k: string]: unknown
+}
+
+interface SharedBridge {
+  closed: boolean
+}
+
+/**
+ * Mirrors `VoiceSessionDO.handleControl` for `create` / `turn` / `end` plus the
+ * owner branch of `onSocketClose`, the `clearSession` reset (which bumps
+ * `turnEpoch`), and the EPOCH-GUARDED turn-loop `finally`. It holds the same
+ * session-level fields the real DO has, including `turnEpoch`. The single owner
+ * socket is implicit (ownership isolation is covered in `session-identity.test.ts`).
+ */
+class FakeSessionDo {
+  state: { history: string[]; turnCount: number } | undefined
+  userId: string | undefined
+  providers: object | undefined
+  turnInFlight = false
+  activeTurn: AsyncIterator<AiResponseChunk> | undefined
+  bridge: SharedBridge | undefined
+  /** Monotonic session generation — the epoch guard (mirrors `turnEpoch`). */
+  turnEpoch = 0
+  readonly sent: OutboundMessage[] = []
+
+  /** Per-call turn supplier so distinct sessions get distinct turn generators. */
+  constructor(private turnFactory: () => AsyncGenerator<AiResponseChunk>) {}
+
+  setTurnFactory(factory: () => AsyncGenerator<AiResponseChunk>): void {
+    this.turnFactory = factory
+  }
+
+  private send(msg: OutboundMessage): void {
+    this.sent.push(msg)
+  }
+
+  /** Mirrors the `create` branch: reject a re-create while a session is live. */
+  create(userId: string, initialState: { history: string[]; turnCount: number }): boolean {
+    if (this.state) {
+      this.send({ type: 'error', code: 'already_created', message: 'session already created' })
+      return false
+    }
+    this.state = initialState
+    this.userId = userId
+    this.providers = {}
+    this.send({ type: 'created' })
+    return true
+  }
+
+  /**
+   * Mirrors the post-fix `turn` branch: guard, hold the iterator, capture
+   * `myEpoch` at the same synchronous point the shared fields are set, drive the
+   * loop, and clear the guard in `finally` ONLY while this turn is still the live
+   * generation (`this.turnEpoch === myEpoch`). Returns the loop promise so a test
+   * can interleave other messages while it is in flight.
+   */
+  async turn(): Promise<void> {
+    if (!this.state || !this.userId) {
+      this.send({ type: 'error', code: 'turn_before_create', message: 'turn before create' })
+      return
+    }
+    if (this.turnInFlight) {
+      this.send({ type: 'error', code: 'turn_in_flight', message: 'a turn is already in progress' })
+      return
+    }
+    const turn = this.turnFactory()[Symbol.asyncIterator]()
+    const myEpoch = this.turnEpoch
+    this.activeTurn = turn
+    this.turnInFlight = true
+    try {
+      for (;;) {
+        const next = await turn.next()
+        if (next.done) break
+        const chunk = next.value
+        this.send({ type: 'chunk', kind: chunk.kind, done: chunk.done, text: chunk.text })
+      }
+    } finally {
+      // Epoch guard: only release if THIS turn is still the live generation.
+      if (this.turnEpoch === myEpoch) {
+        this.turnInFlight = false
+        this.activeTurn = undefined
+      }
+    }
+  }
+
+  /**
+   * Mirrors the post-fix `end` branch: close the bridge, cancel the in-flight
+   * turn FIRE-AND-FORGET (no await), CLEAR the bound session (bumping the epoch),
+   * and summarize. A no-session `end` is a no-op.
+   */
+  end(): void {
+    if (!this.state || !this.userId) return
+    const turnCount = this.state.turnCount
+    this.closeBridge()
+    void this.cancelActiveTurn()
+    this.clearSession()
+    this.send({ type: 'summary', turnCount })
+  }
+
+  /** Mirrors `onSocketClose` owner branch (post-fix): cancel, then clear (epoch bump). */
+  ownerClose(): void {
+    this.closeBridge()
+    void this.cancelActiveTurn()
+    this.clearSession()
+  }
+
+  private closeBridge(): void {
+    if (this.bridge) this.bridge.closed = true
+  }
+
+  /** Mirrors `cancelActiveTurn`: capture the live iterator synchronously, then `return()`. */
+  private async cancelActiveTurn(): Promise<void> {
+    const turn = this.activeTurn
+    if (turn === undefined) return
+    await turn.return?.(undefined)
+  }
+
+  /** Mirrors `clearSession`: bump the epoch FIRST, then reset every session field. */
+  private clearSession(): void {
+    this.turnEpoch += 1
+    this.state = undefined
+    this.userId = undefined
+    this.providers = undefined
+    this.bridge = undefined
+    this.turnInFlight = false
+    this.activeTurn = undefined
+  }
+}
+
+// --- helpers -----------------------------------------------------------------
+
+const textChunk = (text: string, done = false): AiResponseChunk => ({ kind: 'text', text, done })
+
+const tick = (): Promise<void> => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+// --- the cross-generation race: stale finally must NOT clobber the new session --
+
+describe('epoch guard — a stale turn finally does not clobber a new session (P2)', () => {
+  it('end mid-turn → reconnect create + new turn → stale finally settles late and is a no-op', async () => {
+    // Generation 1: an owner session with a turn parked mid-flight at a provider
+    // await (the cancel cannot settle until we say so).
+    const gen1 = makeDeferredTurn([textChunk('g1-partial'), textChunk('', true)])
+    const do_ = new FakeSessionDo(() => gen1.generator)
+    do_.create('user-A', { history: [], turnCount: 0 })
+    do_.bridge = { closed: false }
+
+    const turning1 = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+    expect(do_.activeTurn).toBe(gen1.generator)
+    const epoch1 = do_.turnEpoch
+
+    // Owner ends mid-turn: fire-and-forget cancel, clearSession bumps the epoch.
+    // The gen-1 turn loop's `finally` has NOT run yet (its `return()` is parked
+    // on the deferred provider settle).
+    do_.end()
+    expect(do_.sent).toContainEqual({ type: 'summary', turnCount: 0 })
+    expect(do_.state).toBeUndefined()
+    expect(do_.turnEpoch).toBe(epoch1 + 1)
+    expect(gen1.cleanedUp()).toBe(false)
+
+    // A client reconnects to the SAME-named DO and opens a fresh session, then
+    // starts a NEW turn. This is generation 2: fresh turnInFlight/activeTurn.
+    const gen2 = makeDeferredTurn([textChunk('g2-partial'), textChunk('', true)])
+    do_.setTurnFactory(() => gen2.generator)
+    expect(do_.create('user-B', { history: [], turnCount: 0 })).toBe(true)
+    do_.bridge = { closed: false }
+    const turning2 = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+    expect(do_.activeTurn).toBe(gen2.generator)
+    const epoch2 = do_.turnEpoch
+
+    // NOW the gen-1 turn's deferred `return()` finally settles and its `finally`
+    // runs — LATE, after gen 2 is live. The epoch guard must make it a no-op.
+    gen1.settleReturn()
+    await turning1
+    expect(gen1.cleanedUp()).toBe(true)
+    expect(gen1.settled()).toBe(false)
+
+    // (1) The new session's overlap guard is STILL set — the stale finally did
+    // not reopen it.
+    expect(do_.turnInFlight).toBe(true)
+    // (2) The new session's activeTurn is STILL the gen-2 iterator — the stale
+    // finally did not null it out (so gen 2 stays cancelable by end).
+    expect(do_.activeTurn).toBe(gen2.generator)
+    expect(do_.turnEpoch).toBe(epoch2)
+
+    // (3) Overlap guard still rejects an overlapping turn ON THE NEW SESSION.
+    await do_.turn()
+    expect(do_.sent).toContainEqual({
+      type: 'error',
+      code: 'turn_in_flight',
+      message: 'a turn is already in progress',
+    })
+
+    // (4) The new turn is still cancelable by end — its activeTurn survived, so
+    // end can drive its return() and clear the (gen-2) session.
+    do_.end()
+    expect(do_.state).toBeUndefined()
+    expect(do_.sent.filter((m) => m.type === 'summary')).toHaveLength(2)
+
+    // Drain gen 2's deferred cleanup so nothing is left pending.
+    gen2.settleReturn()
+    await turning2
+    expect(gen2.cleanedUp()).toBe(true)
+  })
+
+  it('owner abrupt close mid-turn → reconnect + new turn → stale finally is a no-op', async () => {
+    const gen1 = makeDeferredTurn([textChunk('g1'), textChunk('', true)])
+    const do_ = new FakeSessionDo(() => gen1.generator)
+    do_.create('user-A', { history: [], turnCount: 0 })
+    do_.bridge = { closed: false }
+
+    const turning1 = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+
+    // Owner socket drops WITHOUT `end`: cancel fire-and-forget + clearSession
+    // (epoch bump). gen-1 finally still parked.
+    do_.ownerClose()
+    expect(do_.state).toBeUndefined()
+    expect(gen1.cleanedUp()).toBe(false)
+
+    // Reconnect: fresh session + new turn (generation 2).
+    const gen2 = makeDeferredTurn([textChunk('g2'), textChunk('', true)])
+    do_.setTurnFactory(() => gen2.generator)
+    expect(do_.create('user-A', { history: [], turnCount: 0 })).toBe(true)
+    do_.bridge = { closed: false }
+    const turning2 = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+    expect(do_.activeTurn).toBe(gen2.generator)
+
+    // gen-1's late `finally` runs after gen 2 is live: must be a no-op.
+    gen1.settleReturn()
+    await turning1
+
+    expect(do_.turnInFlight).toBe(true)
+    expect(do_.activeTurn).toBe(gen2.generator)
+    await do_.turn()
+    expect(do_.sent).toContainEqual({
+      type: 'error',
+      code: 'turn_in_flight',
+      message: 'a turn is already in progress',
+    })
+
+    // cleanup
+    gen2.settleReturn()
+    await turning2
+    expect(gen2.cleanedUp()).toBe(true)
+  })
+})
+
+// --- normal single-session flow must not regress -----------------------------
+
+describe('epoch guard — normal single-session flow is unchanged (no interleave)', () => {
+  it('a turn that completes within its own live session clears the guard as before', async () => {
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    const controls: ReturnType<typeof makeDeferredTurn>[] = []
+    const do_ = new FakeSessionDo(() => {
+      const ctrl = makeDeferredTurn([textChunk('hi'), textChunk('', true)])
+      controls.push(ctrl)
+      return ctrl.generator
+    })
+    do_.create('user-A', sharedState)
+    do_.bridge = { closed: false }
+    const startEpoch = do_.turnEpoch
+
+    const t1 = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+    // Drive both chunks to normal completion — no end, no interleave.
+    controls[0].releaseNext()
+    await tick()
+    controls[0].releaseNext()
+    await t1
+
+    // Normal completion: the epoch never advanced, so the (current-generation)
+    // finally cleared the guard exactly as before.
+    expect(controls[0].settled()).toBe(true)
+    expect(controls[0].cleanedUp()).toBe(true)
+    expect(do_.turnInFlight).toBe(false)
+    expect(do_.activeTurn).toBeUndefined()
+    expect(do_.turnEpoch).toBe(startEpoch)
+
+    // A subsequent turn in the SAME session runs normally (guard was released).
+    const t2 = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+    expect(controls).toHaveLength(2)
+    controls[1].releaseNext()
+    await tick()
+    controls[1].releaseNext()
+    await t2
+    expect(do_.turnInFlight).toBe(false)
+    expect(do_.turnEpoch).toBe(startEpoch)
+  })
+
+  it('overlap guard still rejects an overlapping turn within one live session', async () => {
+    let turnsStarted = 0
+    const controls: ReturnType<typeof makeDeferredTurn>[] = []
+    const do_ = new FakeSessionDo(() => {
+      turnsStarted += 1
+      const ctrl = makeDeferredTurn([textChunk('A'), textChunk('', true)])
+      controls.push(ctrl)
+      return ctrl.generator
+    })
+    do_.create('user-A', { history: [], turnCount: 0 })
+    do_.bridge = { closed: false }
+
+    const firstTurn = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+    expect(turnsStarted).toBe(1)
+
+    // Overlapping turn while the first is parked: rejected, no second turn starts.
+    await do_.turn()
+    expect(turnsStarted).toBe(1)
+    expect(do_.sent).toContainEqual({
+      type: 'error',
+      code: 'turn_in_flight',
+      message: 'a turn is already in progress',
+    })
+
+    // cleanup — drive the first turn to completion.
+    controls[0].releaseNext()
+    await tick()
+    controls[0].releaseNext()
+    await firstTurn
+    expect(do_.turnInFlight).toBe(false)
+  })
+
+  it('end with no interleave still cancels + clears (single-session end path intact)', async () => {
+    const gen1 = makeDeferredTurn([textChunk('partial'), textChunk('', true)])
+    const do_ = new FakeSessionDo(() => gen1.generator)
+    do_.create('user-A', { history: [], turnCount: 0 })
+    do_.bridge = { closed: false }
+
+    const turning = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+
+    // End mid-turn, NO reconnect: summary out, state cleared, epoch bumped.
+    do_.end()
+    expect(do_.sent).toContainEqual({ type: 'summary', turnCount: 0 })
+    expect(do_.state).toBeUndefined()
+    expect(do_.turnInFlight).toBe(false)
+    expect(do_.activeTurn).toBeUndefined()
+
+    // The stale finally settles late with no new session present: still a no-op,
+    // and the already-cleared fields stay cleared (no revival).
+    gen1.settleReturn()
+    await turning
+    expect(gen1.cleanedUp()).toBe(true)
+    expect(gen1.settled()).toBe(false)
+    expect(do_.state).toBeUndefined()
+    expect(do_.turnInFlight).toBe(false)
+    expect(do_.activeTurn).toBeUndefined()
+
+    // A post-end create-less turn is still rejected (cleanup contract intact).
+    await do_.turn()
+    expect(do_.sent).toContainEqual({
+      type: 'error',
+      code: 'turn_before_create',
+      message: 'turn before create',
+    })
+  })
+})

--- a/packages/platform-ai/src/session-identity.test.ts
+++ b/packages/platform-ai/src/session-identity.test.ts
@@ -315,3 +315,57 @@ describe('non-hibernation invariant — session state stays valid between turns 
     expect(resident.state?.gameId).toBe('bombsquad')
   })
 })
+
+describe('binary frame delivery type — arraybuffer is required for audio fidelity (F-M)', () => {
+  /**
+   * Models `VoiceSessionDO.onSocketMessage`'s string-vs-binary dispatch. The DO
+   * accepts its `WebSocketPair` server with `binaryType = 'arraybuffer'` set
+   * BEFORE `accept()`, so player audio frames arrive as `ArrayBuffer` and the
+   * synchronous handler's `new Uint8Array(data)` reconstructs the exact bytes.
+   *
+   * Under this Worker's `compatibility_date` (2026-06-08) the runtime default
+   * (`websocket_standard_binary_type`) instead delivers binary frames as `Blob`.
+   * A `Blob` is neither a string nor an `ArrayBuffer`: it would fall through to
+   * the binary branch and be cast to `ArrayBuffer`, and `new Uint8Array(blob)`
+   * yields an empty/garbage view — corrupting every audio frame. These tests pin
+   * the contract the binaryType opt-in guarantees.
+   */
+  const AUDIO_BYTES = new Uint8Array([0x10, 0x20, 0x30, 0x40])
+
+  /** Mirrors onSocketMessage's dispatch: string → control, else binary audio. */
+  function dispatch(data: string | ArrayBuffer): { kind: 'control' | 'audio'; frame?: Uint8Array } {
+    if (typeof data === 'string') {
+      return { kind: 'control' }
+    }
+    // Binary branch: the handler treats `data` as an ArrayBuffer (the fix's
+    // guarantee) and wraps it synchronously — exactly `new Uint8Array(data)`.
+    return { kind: 'audio', frame: new Uint8Array(data) }
+  }
+
+  it('reconstructs the exact audio bytes from an ArrayBuffer binary frame', () => {
+    // What binaryType='arraybuffer' delivers: event.data is an ArrayBuffer.
+    const arrayBuffer = AUDIO_BYTES.slice().buffer
+    const result = dispatch(arrayBuffer)
+
+    expect(result.kind).toBe('audio')
+    expect(result.frame).toEqual(AUDIO_BYTES)
+  })
+
+  it('routes string frames to the control path, never the binary branch', () => {
+    expect(dispatch(JSON.stringify({ type: 'turn' })).kind).toBe('control')
+  })
+
+  it('a Blob default (no binaryType opt-in) would corrupt the frame — why the fix is needed', () => {
+    // Reproduce the un-fixed 2026 default: a Blob payload. It is not a string, so
+    // it reaches the binary branch; `new Uint8Array(blob)` does NOT read the
+    // blob's bytes — it produces a zero-length view (or throws), losing the audio.
+    const blob = new Blob([AUDIO_BYTES])
+    // The blob slips past the text guard (it is not a string).
+    expect(typeof (blob as unknown) === 'string').toBe(false)
+    // Synchronously wrapping it the way the handler does yields NOT the 4 audio
+    // bytes — proving the synchronous ArrayBuffer-typed path breaks on a Blob and
+    // the binaryType='arraybuffer' opt-in (set before accept) is load-bearing.
+    const wrapped = new Uint8Array(blob as unknown as ArrayBuffer)
+    expect(Array.from(wrapped)).not.toEqual(Array.from(AUDIO_BYTES))
+  })
+})

--- a/packages/platform-ai/src/session-identity.test.ts
+++ b/packages/platform-ai/src/session-identity.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   assertSessionOwnership,
   assertSocketOwnsBoundSession,
-  socketOwnsBoundSession,
+  socketIsBoundSessionOwner,
   SocketIdentityRegistry,
 } from './auth-seam'
 
@@ -185,30 +185,40 @@ describe('binary audio path — non-owner frames cannot pollute the owner bridge
   })
 })
 
-describe('socket close — only the owner’s close tears down the shared bridge (F-E)', () => {
+describe('socket close — only the OWNER SOCKET’s close tears down the shared bridge (F-E / F-W)', () => {
   // Model VoiceSessionDO.onSocketClose: it ALWAYS releases the closing socket's
   // identity binding, but tears down the shared audio bridge / in-flight turn
-  // ONLY when the closing socket owns the bound session. The bug was an
-  // UNCONDITIONAL teardown: a non-owner client connecting to the same
-  // `/ai-ws/{name}` DO and then disconnecting closed the owner's bridge and
-  // truncated the owner's in-flight turn. The control/binary paths were already
-  // owner-gated; the close path bypassed the gate.
+  // ONLY when the closing socket IS THE OWNER SOCKET — the exact socket recorded
+  // at `createSession`. Two earlier-and-now defects:
+  //  - F-E: an UNCONDITIONAL teardown let any close tear the owner's bridge down.
+  //  - F-W: a USER-ID-keyed gate (`socketUserId === boundUserId`) still let the
+  //    SAME user's SECOND socket (a duplicate tab / reconnect) tear down on close,
+  //    because its user id equals the owner's. The fix keys teardown on the owner
+  //    SOCKET reference, so a same-user duplicate socket's close touches nothing
+  //    but its own binding.
   const SESSION_ID = 'do-session-1'
+
+  // socketA2 is a SECOND socket for the SAME user as socketA — the F-W shape.
+  const socketA2: FakeSocket = { id: 'socketA2' }
 
   function makeDo() {
     const reg = new SocketIdentityRegistry<FakeSocket>()
-    // socket A created the session → bound owner is user-A.
+    // socket A created the session → it is the OWNER SOCKET, owner user is user-A.
     reg.bind(socketA, 'user-A')
+    // socketA2: SAME user (user-A), different socket — a duplicate tab / reconnect.
+    reg.bind(socketA2, 'user-A')
+    // socketB: a different user entirely.
     reg.bind(socketB, 'user-B')
     const ownerBound = { boundSessionId: SESSION_ID, boundUserId: 'user-A' }
+    const ownerSocket: FakeSocket = socketA
     // `bridge` stands in for the DO's `this.audio`: a live object = an in-flight
     // turn, `undefined` = torn down.
     let bridge: { closed: boolean } | undefined = { closed: false }
 
-    // Mirrors VoiceSessionDO.onSocketClose: gate teardown on ownership, always
-    // release the closing socket's own binding.
+    // Mirrors VoiceSessionDO.onSocketClose: gate teardown on OWNER-SOCKET identity,
+    // always release the closing socket's own binding.
     function closeSocket(socket: FakeSocket): void {
-      const ownsSession = socketOwnsBoundSession(reg, socket, ownerBound)
+      const ownsSession = socketIsBoundSessionOwner(socket, ownerSocket, ownerBound)
       reg.release(socket)
       if (!ownsSession) return
       if (bridge) bridge.closed = true
@@ -223,10 +233,10 @@ describe('socket close — only the owner’s close tears down the shared bridge
     }
   }
 
-  it('a non-owner close leaves the owner bridge / turn untouched', () => {
+  it('a different-user close leaves the owner bridge / turn untouched (F-E)', () => {
     const { closeSocket, reg, bridgeIsLive } = makeDo()
 
-    // Non-owner socket B (user-B) connected and now disconnects.
+    // Different-user socket B connected and now disconnects.
     closeSocket(socketB)
 
     // The owner's in-flight turn survives: the bridge is still live.
@@ -236,7 +246,22 @@ describe('socket close — only the owner’s close tears down the shared bridge
     expect(reg.resolve(socketA)).toBe('user-A')
   })
 
-  it('the owner’s own close tears the bridge down normally', () => {
+  it('a SAME-USER duplicate socket’s close leaves the owner session untouched (F-W)', () => {
+    const { closeSocket, reg, bridgeIsLive } = makeDo()
+
+    // socketA2 is a second tab / reconnect for user-A — the SAME user as the owner.
+    // A user-id-keyed gate would have wrongly treated it as the owner and torn the
+    // session down. The owner-socket gate does not: its close releases only its own
+    // binding, and the owner's still-active session/turn survive.
+    closeSocket(socketA2)
+
+    expect(bridgeIsLive()).toBe(true)
+    expect(reg.resolve(socketA2)).toBeUndefined()
+    // The real owner socket and its binding are untouched.
+    expect(reg.resolve(socketA)).toBe('user-A')
+  })
+
+  it('the owner socket’s own close tears the bridge down normally', () => {
     const { closeSocket, reg, bridgeIsLive, bridgeClosed } = makeDo()
 
     closeSocket(socketA)
@@ -247,14 +272,17 @@ describe('socket close — only the owner’s close tears down the shared bridge
     expect(reg.resolve(socketA)).toBeUndefined()
   })
 
-  it('a non-owner close then the owner close still tears down exactly once', () => {
+  it('non-owner closes (other user + same-user duplicate) then the owner close tears down exactly once', () => {
     const { closeSocket, bridgeIsLive } = makeDo()
 
-    // Attacker connects + disconnects first: bridge must survive.
+    // Both a different user AND a same-user duplicate disconnect first: bridge must
+    // survive every non-owner close.
     closeSocket(socketB)
     expect(bridgeIsLive()).toBe(true)
+    closeSocket(socketA2)
+    expect(bridgeIsLive()).toBe(true)
 
-    // Owner finally disconnects: now teardown happens.
+    // Owner socket finally disconnects: now teardown happens.
     closeSocket(socketA)
     expect(bridgeIsLive()).toBe(false)
   })
@@ -265,27 +293,28 @@ describe('socket close — only the owner’s close tears down the shared bridge
 
     closeSocket(unbound)
 
-    // No bound identity → not the owner → bridge untouched.
+    // Not the owner socket → bridge untouched.
     expect(bridgeIsLive()).toBe(true)
   })
 
-  it('socketOwnsBoundSession is false before any session is created', () => {
-    const reg = new SocketIdentityRegistry<FakeSocket>()
-    reg.bind(socketA, 'user-A')
+  it('socketIsBoundSessionOwner is false before any session is created', () => {
     const preCreate = { boundSessionId: undefined, boundUserId: undefined }
 
-    // Pre-create close must not tear down a (nonexistent) bridge.
-    expect(socketOwnsBoundSession(reg, socketA, preCreate)).toBe(false)
+    // Pre-create close must not tear down a (nonexistent) bridge — and there is no
+    // owner socket recorded yet either.
+    expect(socketIsBoundSessionOwner(socketA, undefined, preCreate)).toBe(false)
+    expect(socketIsBoundSessionOwner(socketA, socketA, preCreate)).toBe(false)
   })
 
-  it('socketOwnsBoundSession is true only for the owning socket', () => {
-    const reg = new SocketIdentityRegistry<FakeSocket>()
-    reg.bind(socketA, 'user-A')
-    reg.bind(socketB, 'user-B')
+  it('socketIsBoundSessionOwner is true only for the exact owner socket', () => {
     const ownerBound = { boundSessionId: SESSION_ID, boundUserId: 'user-A' }
 
-    expect(socketOwnsBoundSession(reg, socketA, ownerBound)).toBe(true)
-    expect(socketOwnsBoundSession(reg, socketB, ownerBound)).toBe(false)
+    // Only the recorded owner socket matches — not a same-user duplicate, not a
+    // different user, not when no owner socket is recorded.
+    expect(socketIsBoundSessionOwner(socketA, socketA, ownerBound)).toBe(true)
+    expect(socketIsBoundSessionOwner(socketA2, socketA, ownerBound)).toBe(false)
+    expect(socketIsBoundSessionOwner(socketB, socketA, ownerBound)).toBe(false)
+    expect(socketIsBoundSessionOwner(socketA, undefined, ownerBound)).toBe(false)
   })
 })
 

--- a/packages/platform-ai/src/session-identity.test.ts
+++ b/packages/platform-ai/src/session-identity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   assertSessionOwnership,
   assertSocketOwnsBoundSession,
+  socketOwnsBoundSession,
   SocketIdentityRegistry,
 } from './auth-seam'
 
@@ -181,6 +182,110 @@ describe('binary audio path — non-owner frames cannot pollute the owner bridge
     const ownerBound = { boundSessionId: SESSION_ID, boundUserId: 'user-A' }
 
     expect(assertSocketOwnsBoundSession(reg, socketA, ownerBound)).toBe('user-A')
+  })
+})
+
+describe('socket close — only the owner’s close tears down the shared bridge (F-E)', () => {
+  // Model VoiceSessionDO.onSocketClose: it ALWAYS releases the closing socket's
+  // identity binding, but tears down the shared audio bridge / in-flight turn
+  // ONLY when the closing socket owns the bound session. The bug was an
+  // UNCONDITIONAL teardown: a non-owner client connecting to the same
+  // `/ai-ws/{name}` DO and then disconnecting closed the owner's bridge and
+  // truncated the owner's in-flight turn. The control/binary paths were already
+  // owner-gated; the close path bypassed the gate.
+  const SESSION_ID = 'do-session-1'
+
+  function makeDo() {
+    const reg = new SocketIdentityRegistry<FakeSocket>()
+    // socket A created the session → bound owner is user-A.
+    reg.bind(socketA, 'user-A')
+    reg.bind(socketB, 'user-B')
+    const ownerBound = { boundSessionId: SESSION_ID, boundUserId: 'user-A' }
+    // `bridge` stands in for the DO's `this.audio`: a live object = an in-flight
+    // turn, `undefined` = torn down.
+    let bridge: { closed: boolean } | undefined = { closed: false }
+
+    // Mirrors VoiceSessionDO.onSocketClose: gate teardown on ownership, always
+    // release the closing socket's own binding.
+    function closeSocket(socket: FakeSocket): void {
+      const ownsSession = socketOwnsBoundSession(reg, socket, ownerBound)
+      reg.release(socket)
+      if (!ownsSession) return
+      if (bridge) bridge.closed = true
+      bridge = undefined
+    }
+
+    return {
+      reg,
+      closeSocket,
+      bridgeIsLive: () => bridge !== undefined,
+      bridgeClosed: () => bridge?.closed ?? true,
+    }
+  }
+
+  it('a non-owner close leaves the owner bridge / turn untouched', () => {
+    const { closeSocket, reg, bridgeIsLive } = makeDo()
+
+    // Non-owner socket B (user-B) connected and now disconnects.
+    closeSocket(socketB)
+
+    // The owner's in-flight turn survives: the bridge is still live.
+    expect(bridgeIsLive()).toBe(true)
+    // Only socket B's own identity binding was released.
+    expect(reg.resolve(socketB)).toBeUndefined()
+    expect(reg.resolve(socketA)).toBe('user-A')
+  })
+
+  it('the owner’s own close tears the bridge down normally', () => {
+    const { closeSocket, reg, bridgeIsLive, bridgeClosed } = makeDo()
+
+    closeSocket(socketA)
+
+    // Owner teardown: bridge closed and cleared, owner binding released.
+    expect(bridgeClosed()).toBe(true)
+    expect(bridgeIsLive()).toBe(false)
+    expect(reg.resolve(socketA)).toBeUndefined()
+  })
+
+  it('a non-owner close then the owner close still tears down exactly once', () => {
+    const { closeSocket, bridgeIsLive } = makeDo()
+
+    // Attacker connects + disconnects first: bridge must survive.
+    closeSocket(socketB)
+    expect(bridgeIsLive()).toBe(true)
+
+    // Owner finally disconnects: now teardown happens.
+    closeSocket(socketA)
+    expect(bridgeIsLive()).toBe(false)
+  })
+
+  it('a close from an unbound socket tears down nothing', () => {
+    const { closeSocket, bridgeIsLive } = makeDo()
+    const unbound: FakeSocket = { id: 'never-bound' }
+
+    closeSocket(unbound)
+
+    // No bound identity → not the owner → bridge untouched.
+    expect(bridgeIsLive()).toBe(true)
+  })
+
+  it('socketOwnsBoundSession is false before any session is created', () => {
+    const reg = new SocketIdentityRegistry<FakeSocket>()
+    reg.bind(socketA, 'user-A')
+    const preCreate = { boundSessionId: undefined, boundUserId: undefined }
+
+    // Pre-create close must not tear down a (nonexistent) bridge.
+    expect(socketOwnsBoundSession(reg, socketA, preCreate)).toBe(false)
+  })
+
+  it('socketOwnsBoundSession is true only for the owning socket', () => {
+    const reg = new SocketIdentityRegistry<FakeSocket>()
+    reg.bind(socketA, 'user-A')
+    reg.bind(socketB, 'user-B')
+    const ownerBound = { boundSessionId: SESSION_ID, boundUserId: 'user-A' }
+
+    expect(socketOwnsBoundSession(reg, socketA, ownerBound)).toBe(true)
+    expect(socketOwnsBoundSession(reg, socketB, ownerBound)).toBe(false)
   })
 })
 

--- a/packages/platform-ai/src/session-identity.test.ts
+++ b/packages/platform-ai/src/session-identity.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { assertSessionOwnership, SocketIdentityRegistry } from './auth-seam'
+import {
+  assertSessionOwnership,
+  assertSocketOwnsBoundSession,
+  SocketIdentityRegistry,
+} from './auth-seam'
 
 /**
  * Regression tests for the per-socket session-identity mechanism that
@@ -85,6 +89,98 @@ describe('per-socket ownership — two users on one DO stay isolated (F-B)', () 
     // The crux of the fix: even after socket B connected (and would have
     // overwritten a shared field), socket A still resolves to user-A.
     expect(reg.resolve(socketA)).toBe('user-A')
+  })
+})
+
+describe('binary audio path — non-owner frames cannot pollute the owner bridge (F-B)', () => {
+  // Model the DO's binary branch: the owner's audio bridge is a shared sink. A
+  // binary frame is only pushed AFTER the per-socket ownership gate passes —
+  // exactly the order `onSocketMessage` runs (`assertSocketOwner(ws)` then
+  // `bridge.push`). The bug was the binary branch pushing UNCONDITIONALLY, so a
+  // second authenticated socket on the same DO could inject frames the owner's
+  // next turn would transcribe.
+  const SESSION_ID = 'do-session-1'
+
+  function makeDo() {
+    const reg = new SocketIdentityRegistry<FakeSocket>()
+    // socket A created the session → bound owner is user-A.
+    reg.bind(socketA, 'user-A')
+    reg.bind(socketB, 'user-B')
+    const ownerBound = { boundSessionId: SESSION_ID, boundUserId: 'user-A' }
+    const audioBridge: Uint8Array[] = []
+
+    // Mirrors VoiceSessionDO.onSocketMessage's binary branch: gate, then push.
+    function feedBinaryFrame(socket: FakeSocket, frame: Uint8Array): void {
+      assertSocketOwnsBoundSession(reg, socket, ownerBound)
+      audioBridge.push(frame)
+    }
+
+    return { audioBridge, feedBinaryFrame }
+  }
+
+  it('queues the owner socket’s binary frame onto the bridge', () => {
+    const { audioBridge, feedBinaryFrame } = makeDo()
+    const frame = new Uint8Array([1, 2, 3])
+
+    feedBinaryFrame(socketA, frame)
+
+    expect(audioBridge).toEqual([frame])
+  })
+
+  it('rejects a non-owner socket’s binary frame and never touches the owner bridge', () => {
+    const { audioBridge, feedBinaryFrame } = makeDo()
+
+    // Socket B (user-B) knows the session name and is authenticated, but does NOT
+    // own the session → its binary frame is rejected before reaching the bridge.
+    expect(() => feedBinaryFrame(socketB, new Uint8Array([9, 9, 9]))).toThrow(/does not own/)
+
+    // The owner's bridge stays empty — the owner's next turn transcribes only the
+    // owner's own audio, not the attacker's injected frame.
+    expect(audioBridge).toEqual([])
+  })
+
+  it('does not let an attacker frame interleave with the owner’s real audio', () => {
+    const { audioBridge, feedBinaryFrame } = makeDo()
+    const ownerFrame1 = new Uint8Array([1])
+    const ownerFrame2 = new Uint8Array([2])
+
+    feedBinaryFrame(socketA, ownerFrame1)
+    expect(() => feedBinaryFrame(socketB, new Uint8Array([0xff]))).toThrow(/does not own/)
+    feedBinaryFrame(socketA, ownerFrame2)
+
+    // Only the owner's two frames are present, in order — the attacker's frame
+    // never wedged itself into the middle of the owner's utterance.
+    expect(audioBridge).toEqual([ownerFrame1, ownerFrame2])
+  })
+
+  it('rejects a binary frame from a socket with no bound identity', () => {
+    const { audioBridge, feedBinaryFrame } = makeDo()
+    const unboundSocket: FakeSocket = { id: 'never-bound' }
+
+    expect(() => feedBinaryFrame(unboundSocket, new Uint8Array([7]))).toThrow(
+      /no authenticated identity/
+    )
+    expect(audioBridge).toEqual([])
+  })
+
+  it('rejects a binary frame that arrives before any session is created', () => {
+    // Pre-create: the DO has no bound owner/session yet. A binary frame must not
+    // silently create or feed a bridge — it fails loud like the control path.
+    const reg = new SocketIdentityRegistry<FakeSocket>()
+    reg.bind(socketA, 'user-A')
+    const preCreateBound = { boundSessionId: undefined, boundUserId: undefined }
+
+    expect(() => assertSocketOwnsBoundSession(reg, socketA, preCreateBound)).toThrow(
+      /before createSession/
+    )
+  })
+
+  it('returns the verified operating user id on a successful ownership check', () => {
+    const reg = new SocketIdentityRegistry<FakeSocket>()
+    reg.bind(socketA, 'user-A')
+    const ownerBound = { boundSessionId: SESSION_ID, boundUserId: 'user-A' }
+
+    expect(assertSocketOwnsBoundSession(reg, socketA, ownerBound)).toBe('user-A')
   })
 })
 

--- a/packages/platform-ai/src/session-identity.test.ts
+++ b/packages/platform-ai/src/session-identity.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { assertSessionOwnership, SocketIdentityRegistry } from './auth-seam'
+
+/**
+ * Regression tests for the per-socket session-identity mechanism that
+ * `VoiceSessionDO` is a thin shell over (L2 §Mechanism Variant 3, step 3).
+ *
+ * The DO class itself imports `cloudflare:workers` and cannot be instantiated in
+ * the Node test environment, so — exactly as `assertSessionOwnership` and
+ * `runTurn` are tested — these tests exercise the extracted pure pieces:
+ *  - `SocketIdentityRegistry`: binds the handshake-forwarded user id to the
+ *    specific accepted socket (F-B), so a second client on the same DO instance
+ *    cannot overwrite the first client's identity.
+ *  - `assertSessionOwnership`: the per-operation ownership check the DO runs with
+ *    THIS socket's resolved user id as the operating user.
+ *
+ * Together they reproduce the defect's attack shape: two authenticated clients
+ * connect to the same-named DO (one instance, one session owner bound at
+ * `create`), and the second client must NOT be able to drive the first user's
+ * session.
+ */
+
+/** A stand-in socket — only reference identity matters to the registry. */
+type FakeSocket = { id: string }
+
+const socketA: FakeSocket = { id: 'socketA' }
+const socketB: FakeSocket = { id: 'socketB' }
+
+describe('SocketIdentityRegistry — per-socket identity binding (F-B)', () => {
+  it('resolves each socket to its own bound user id', () => {
+    const reg = new SocketIdentityRegistry<FakeSocket>()
+    reg.bind(socketA, 'user-A')
+    reg.bind(socketB, 'user-B')
+
+    // The later bind does NOT overwrite the earlier socket's identity — the bug
+    // was a single shared field that the second upgrade clobbered.
+    expect(reg.resolve(socketA)).toBe('user-A')
+    expect(reg.resolve(socketB)).toBe('user-B')
+    expect(reg.size).toBe(2)
+  })
+
+  it('returns undefined for a socket that was never bound', () => {
+    const reg = new SocketIdentityRegistry<FakeSocket>()
+    expect(reg.resolve(socketA)).toBeUndefined()
+  })
+
+  it('releases a socket binding on close without affecting others', () => {
+    const reg = new SocketIdentityRegistry<FakeSocket>()
+    reg.bind(socketA, 'user-A')
+    reg.bind(socketB, 'user-B')
+
+    reg.release(socketA)
+    expect(reg.resolve(socketA)).toBeUndefined()
+    expect(reg.resolve(socketB)).toBe('user-B')
+    expect(reg.size).toBe(1)
+  })
+})
+
+describe('per-socket ownership — two users on one DO stay isolated (F-B)', () => {
+  // Model the DO: socket A (user-A) created the session, so the DO's bound owner
+  // is user-A and the session id is fixed.
+  const SESSION_ID = 'do-session-1'
+  const reg = new SocketIdentityRegistry<FakeSocket>()
+  reg.bind(socketA, 'user-A')
+  reg.bind(socketB, 'user-B')
+  const ownerBound = { boundSessionId: SESSION_ID, boundUserId: 'user-A' }
+
+  it('lets the owning socket operate on its own session', () => {
+    // The DO uses THIS socket's resolved user as the operating user.
+    const operatingUser = reg.resolve(socketA) as string
+    expect(() => assertSessionOwnership(ownerBound, SESSION_ID, operatingUser)).not.toThrow()
+  })
+
+  it('rejects a second authenticated user driving the first user’s session', () => {
+    // Socket B sends create/turn/end on the SAME DO. Its per-socket identity is
+    // user-B, which does not own the session bound to user-A → rejected.
+    const operatingUser = reg.resolve(socketB) as string
+    expect(operatingUser).toBe('user-B')
+    expect(() => assertSessionOwnership(ownerBound, SESSION_ID, operatingUser)).toThrow(
+      /does not own/
+    )
+  })
+
+  it('binding socket B does not change the user resolved for socket A', () => {
+    // The crux of the fix: even after socket B connected (and would have
+    // overwritten a shared field), socket A still resolves to user-A.
+    expect(reg.resolve(socketA)).toBe('user-A')
+  })
+})
+
+describe('non-hibernation invariant — session state stays valid between turns (F-C)', () => {
+  /**
+   * With hibernation dropped (`server.accept()` instead of `ctx.acceptWebSocket`)
+   * the DO stays resident for the session, so the in-memory state created at
+   * `create` is still present when a later `turn` arrives. We model that
+   * persistence with a plain object the "DO" holds across operations: a `create`
+   * sets it; a subsequent `turn` reads it back (it is never reset to undefined
+   * by an eviction). This documents the chosen (b) approach and guards against a
+   * regression to per-message state that an idle hibernation would have lost.
+   */
+  it('state set at create is readable by a later turn (resident DO)', () => {
+    // A tiny stand-in for the DO: it holds session state across operations.
+    const resident: { state?: { gameId: string } } = {}
+
+    // create
+    resident.state = { gameId: 'bombsquad' }
+
+    // No hibernation/eviction happens between operations, so state survives.
+    // (Under the old hibernation path, an idle eviction here would reset the
+    // instance fields to undefined and the turn below would see no session.)
+
+    // turn — reads the state created earlier
+    expect(resident.state).toBeDefined()
+    expect(resident.state?.gameId).toBe('bombsquad')
+  })
+})

--- a/packages/platform-ai/src/session-turn-guard.test.ts
+++ b/packages/platform-ai/src/session-turn-guard.test.ts
@@ -196,11 +196,18 @@ class FakeSessionDo {
     }
   }
 
-  /** Mirrors the `end` branch: close the bridge, cancel the in-flight turn, summarize. */
-  async end(): Promise<void> {
+  /**
+   * Mirrors the `end` branch: close the bridge, then cancel the in-flight turn
+   * FIRE-AND-FORGET (no await) and summarize + return immediately. Awaiting the
+   * cancel would make `end` hang whenever the turn is parked at a provider await
+   * that never settles (`return()` cannot interrupt a pending await). The
+   * background cancel still completes when that await eventually settles, running
+   * the turn's `finally` and clearing the guard via the turn loop's own `finally`.
+   */
+  end(): void {
     if (!this.state) return
     this.closeBridge()
-    await this.cancelActiveTurn()
+    void this.cancelActiveTurn()
     this.send({ type: 'summary', turnCount: this.state.turnCount })
   }
 
@@ -374,8 +381,15 @@ describe('end during a turn — clean cancellation (matrix: end)', () => {
     expect(do_.turnInFlight).toBe(true)
     expect(ctrl.settled()).toBe(false)
 
-    // `end` arrives mid-turn: clean cancel.
-    await do_.end()
+    // `end` arrives mid-turn: fire-and-forget cancel, immediate summary. The
+    // summary lands synchronously, BEFORE the turn's `finally` (the cancel runs
+    // in the background) — proving `end` does not block on the cancel.
+    do_.end()
+    expect(do_.sent).toContainEqual({ type: 'summary', turnCount: 0 })
+    expect(bridge.closed).toBe(true)
+
+    // The background cancel then settles (the controllable turn unblocks on the
+    // bridge-close analogue), and the turn drains to completion.
     await turning
 
     // The turn's `finally` ran (LLM/TTS streams returned, queue closed) and the
@@ -385,7 +399,7 @@ describe('end during a turn — clean cancellation (matrix: end)', () => {
     // The canceled turn never reached settle, so it did not count.
     expect(ctrl.settled()).toBe(false)
     expect(sharedState.turnCount).toBe(0)
-    // Guard cleared after cancellation.
+    // Guard cleared after the background cancellation completes.
     expect(do_.turnInFlight).toBe(false)
     expect(do_.activeTurn).toBeUndefined()
     // A summary was still emitted, reflecting only completed turns.
@@ -400,8 +414,73 @@ describe('end during a turn — clean cancellation (matrix: end)', () => {
     do_.create(sharedState)
     do_.bridge = { closed: false }
 
-    await expect(do_.end()).resolves.toBeUndefined()
+    do_.end()
     expect(do_.sent).toContainEqual({ type: 'summary', turnCount: 0 })
+  })
+
+  it('does not hang when the in-flight turn is parked at a never-settling provider await (F-J)', async () => {
+    // F-J: `AsyncIterator.return()` cannot interrupt a provider `await` already
+    // pending inside the generator — the generator reaches its `finally` only when
+    // that promise settles. A stuck STT/LLM/TTS provider (a fetch/WS that never
+    // resolves) is modelled here by a turn parked at a promise NOTHING resolves —
+    // closing the bridge does NOT unblock it (unlike the controllable turn above).
+    // If `end` awaited the cancel it would hang forever; the fix makes `end`
+    // fire-and-forget, so it must summarize + close promptly regardless.
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    let finallyRan = false
+    let stuckReturnAwaited = false
+
+    // A turn generator that parks at a never-settling await on its first `next()`.
+    // `return()` on it queues a completion but cannot run the `finally` until the
+    // pending await settles — which never happens here.
+    async function* stuckTurn(): AsyncGenerator<AiResponseChunk> {
+      try {
+        await new Promise<void>(() => {
+          // Intentionally never resolves: models a stuck provider promise.
+        })
+        yield textChunk('unreachable')
+      } finally {
+        finallyRan = true
+      }
+    }
+
+    const do_ = new FakeSessionDo(() => stuckTurn())
+    do_.create(sharedState)
+    do_.bridge = { closed: false }
+    // Wrap the active turn's `return()` so we can confirm the cancel was initiated
+    // (fire-and-forget) yet never settles — exactly the hang `end` must not await.
+    const turning = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+    const realReturn = do_.activeTurn?.return?.bind(do_.activeTurn)
+    if (do_.activeTurn && realReturn) {
+      do_.activeTurn.return = (value?: unknown) => {
+        stuckReturnAwaited = true
+        return realReturn(value)
+      }
+    }
+
+    // `end` must resolve PROMPTLY even though the turn's cancel can never settle.
+    // Race it against a timer; `end()` returning + the summary landing must win.
+    const ended = (async () => {
+      do_.end()
+      return 'ended' as const
+    })()
+    const timed = new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 200))
+    const outcome = await Promise.race([ended, timed])
+
+    expect(outcome).toBe('ended')
+    // Summary emitted + cancel initiated, but the stuck turn's `finally` did NOT
+    // run (the provider await is still pending) — proving `end` never blocked on it.
+    expect(do_.sent).toContainEqual({ type: 'summary', turnCount: 0 })
+    expect(stuckReturnAwaited).toBe(true)
+    expect(finallyRan).toBe(false)
+    // The bridge was still closed synchronously by `end` (best-effort teardown).
+    expect(do_.bridge?.closed).toBe(true)
+
+    // `turning` stays pending forever (the stuck provider never settles); do not
+    // await it. The test asserts only that `end` itself did not hang.
+    void turning
   })
 })
 

--- a/packages/platform-ai/src/session-turn-guard.test.ts
+++ b/packages/platform-ai/src/session-turn-guard.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it } from 'vitest'
+import type { AiResponseChunk } from './contract'
+
+/**
+ * Regression tests for the turn in-flight guard and the DO cross-await reentrancy
+ * matrix (the P1 from PR #156 review). `VoiceSessionDO` imports
+ * `cloudflare:workers` and cannot be instantiated in the Node test environment, so
+ * — exactly as the per-socket identity and `runTurn` mechanisms are tested via
+ * their extracted pieces (see `session-identity.test.ts`, `turn-pipeline.test.ts`)
+ * — these tests model the DO's control-dispatch logic with a faithful stand-in
+ * (`FakeSessionDo`) that mirrors the real fields (`state` / `turnInFlight` /
+ * `activeTurn` / `audio`) and the real `handleControl` branches one-for-one.
+ *
+ * The defect's shape: a DO event can interleave across the many `await`s inside
+ * one turn (STT/LLM/TTS all await), so a second `turn` message arriving mid-flight
+ * would start a SECOND `runTurn` over the SAME `state`/`providers`/socket — racing
+ * shared `history`/`usage` and interleaving two response streams on one socket.
+ * The guard rejects the overlap; `end` / owner-close cleanly cancel an in-flight
+ * turn. These tests reproduce the interleave deterministically with a controllable
+ * async turn generator.
+ */
+
+// --- a controllable turn generator -------------------------------------------
+
+/**
+ * A stand-in for `runTurn`: an async generator that suspends at a per-chunk gate
+ * (modelling a real turn parked at an STT/LLM/TTS `await`), then yields a chunk.
+ * While parked at the gate the DO is free to process an interleaved control
+ * message — exactly the cross-await interleave the P1 is about. It records whether
+ * its `finally` ran (the clean-cancel signal) and mutates a shared `state` so a
+ * second concurrent turn would be observable as state corruption.
+ *
+ * Cancellation mirrors the real pipeline: the DO drives cancel as "close the
+ * bridge (which unblocks the STT `await`) THEN `return()`". Here `cancel()`
+ * resolves the pending gate (the bridge-close analogue) before the DO's
+ * `return()`, so the generator unblocks, observes the return-completion, and runs
+ * its `finally` — never hanging on a permanently-pending await.
+ */
+interface TurnState {
+  /** Mirrors `SessionState.history` — a second concurrent turn would race this. */
+  history: string[]
+  /** Mirrors `SessionState.turnCount` — only a fully-completed turn increments it. */
+  turnCount: number
+}
+
+interface SharedBridge {
+  closed: boolean
+}
+
+function makeControllableTurn(
+  state: TurnState,
+  bridge: SharedBridge,
+  chunks: AiResponseChunk[]
+): {
+  generator: AsyncGenerator<AiResponseChunk>
+  /** Resolve the pending gate so the generator advances to its next yield. */
+  releaseNext: () => void
+  /** Bridge-close analogue: unblock any pending gate so `return()` can unwind. */
+  cancel: () => void
+  /** True once the generator's `finally` ran (normal completion OR cancellation). */
+  cleanedUp: () => boolean
+  /** True once the generator reached its settle step (turn fully completed). */
+  settled: () => boolean
+} {
+  let cleaned = false
+  let didSettle = false
+  let canceled = false
+  let gate: (() => void) | undefined
+  const waitGate = (): Promise<void> =>
+    new Promise<void>((resolve) => {
+      gate = resolve
+    })
+  const wake = (): void => {
+    const g = gate
+    gate = undefined
+    g?.()
+  }
+
+  async function* gen(): AsyncGenerator<AiResponseChunk> {
+    try {
+      for (const chunk of chunks) {
+        // Park at the gate — a real turn is suspended at an STT/LLM/TTS await
+        // here, which is exactly when the DO would process an interleaved event.
+        await waitGate()
+        // Bridge-close analogue: once the bridge is closed (cancel), the STT
+        // step yields no more input, so the turn stops producing — it exits the
+        // loop and lets the `finally` unwind (no further chunks, no settle).
+        if (canceled) break
+        // Mutate shared state as a real turn does; a second concurrent turn
+        // racing this is the corruption the guard prevents.
+        if (chunk.kind === 'text' && chunk.text) state.history.push(chunk.text)
+        yield chunk
+      }
+      // Settle step (mirrors runTurn's tail): only reached on normal completion.
+      if (!canceled) {
+        didSettle = true
+        state.turnCount += 1
+      }
+    } finally {
+      // Runs on normal completion AND on an upstream `return()` (cancellation):
+      // mirrors runTurn closing the sentence queue + returning the LLM/TTS
+      // iterators. Closing the bridge here stands in for STT termination.
+      cleaned = true
+      bridge.closed = true
+    }
+  }
+
+  return {
+    generator: gen(),
+    // Advance one chunk: resolve the gate so the parked turn yields its next.
+    releaseNext: wake,
+    // Bridge-close analogue: flag cancellation, then wake the parked gate so the
+    // turn observes it, stops producing, and unwinds (the DO's `return()` then
+    // settles cleanly without the turn re-parking).
+    cancel: () => {
+      canceled = true
+      wake()
+    },
+    cleanedUp: () => cleaned,
+    settled: () => didSettle,
+  }
+}
+
+// --- a faithful DO control-dispatch stand-in ---------------------------------
+
+interface OutboundMessage {
+  type: string
+  [k: string]: unknown
+}
+
+/**
+ * Mirrors `VoiceSessionDO.handleControl` for the three control messages, holding
+ * the same fields and running the same guard / cancel logic. `turnFactory`
+ * supplies the controllable turn generator in place of `onAiResponse`. The single
+ * owner socket is implicit (ownership is covered in `session-identity.test.ts`);
+ * here we isolate the reentrancy matrix.
+ */
+class FakeSessionDo {
+  state: { history: string[]; turnCount: number } | undefined
+  turnInFlight = false
+  activeTurn: AsyncIterator<AiResponseChunk> | undefined
+  bridge: SharedBridge | undefined
+  /**
+   * Unblock-the-STT-await hook for the in-flight turn — the test wires it to the
+   * controllable turn's `cancel()`. Mirrors the real `this.audio.close()`:
+   * closing the bridge resolves the STT step's pending `await` so a subsequent
+   * `return()` can unwind the parked generator (an async generator's `return()`
+   * cannot interrupt a still-pending `await`). Reset to `undefined` between turns.
+   */
+  onBridgeClose: (() => void) | undefined
+  readonly sent: OutboundMessage[] = []
+
+  constructor(private readonly turnFactory: () => AsyncGenerator<AiResponseChunk>) {}
+
+  private send(msg: OutboundMessage): void {
+    this.sent.push(msg)
+  }
+
+  create(initialState: { history: string[]; turnCount: number }): void {
+    // Mirrors the `create` branch: reject a re-create while a session is live.
+    if (this.state) {
+      this.send({ type: 'error', code: 'already_created', message: 'session already created' })
+      return
+    }
+    this.state = initialState
+  }
+
+  /**
+   * Mirrors the `turn` branch: guard, hold the iterator, mark in-flight BEFORE the
+   * first await, drive the loop, clear the guard in `finally`. Returns the loop
+   * promise so a test can interleave other messages while it is in flight.
+   */
+  async turn(): Promise<void> {
+    if (!this.state) {
+      this.send({ type: 'error', code: 'turn_before_create', message: 'turn before create' })
+      return
+    }
+    if (this.turnInFlight) {
+      this.send({ type: 'error', code: 'turn_in_flight', message: 'a turn is already in progress' })
+      return
+    }
+    const turn = this.turnFactory()[Symbol.asyncIterator]()
+    this.activeTurn = turn
+    this.turnInFlight = true
+    try {
+      for (;;) {
+        const next = await turn.next()
+        if (next.done) break
+        const chunk = next.value
+        this.send({ type: 'chunk', kind: chunk.kind, done: chunk.done, text: chunk.text })
+      }
+    } finally {
+      this.turnInFlight = false
+      this.activeTurn = undefined
+      this.onBridgeClose = undefined
+    }
+  }
+
+  /** Mirrors the `end` branch: close the bridge, cancel the in-flight turn, summarize. */
+  async end(): Promise<void> {
+    if (!this.state) return
+    this.closeBridge()
+    await this.cancelActiveTurn()
+    this.send({ type: 'summary', turnCount: this.state.turnCount })
+  }
+
+  /** Mirrors `onSocketClose` owner branch: cancel in-flight turn + close bridge. */
+  async ownerClose(): Promise<void> {
+    this.closeBridge()
+    await this.cancelActiveTurn()
+  }
+
+  /** Mirrors `this.audio.close()`: unblock the STT await, mark the bridge closed. */
+  private closeBridge(): void {
+    this.onBridgeClose?.()
+    if (this.bridge) this.bridge.closed = true
+  }
+
+  private async cancelActiveTurn(): Promise<void> {
+    const turn = this.activeTurn
+    if (turn === undefined) return
+    await turn.return?.(undefined)
+  }
+}
+
+// --- helpers -----------------------------------------------------------------
+
+const textChunk = (text: string, done = false): AiResponseChunk => ({ kind: 'text', text, done })
+
+/** Let microtasks drain so an awaiting loop advances to its next suspension. */
+const tick = (): Promise<void> => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+// --- the in-flight turn guard ------------------------------------------------
+
+describe('turn in-flight guard — overlapping turn is rejected (P1)', () => {
+  it('rejects a second turn while the first is in flight; no second runTurn starts', async () => {
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    const bridge: SharedBridge = { closed: false }
+    let turnsStarted = 0
+    const controls: ReturnType<typeof makeControllableTurn>[] = []
+
+    const do_ = new FakeSessionDo(() => {
+      turnsStarted += 1
+      const ctrl = makeControllableTurn(sharedState, bridge, [textChunk('A'), textChunk('', true)])
+      controls.push(ctrl)
+      do_.onBridgeClose = ctrl.cancel
+      return ctrl.generator
+    })
+    do_.create(sharedState)
+    do_.bridge = bridge
+
+    // First turn starts and parks at its first await (real turn mid-STT/LLM).
+    const firstTurn = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+    expect(turnsStarted).toBe(1)
+
+    // Owner double-clicks: a second `turn` arrives while the first is parked.
+    await do_.turn()
+
+    // Rejected with an explicit signal — NOT a second runTurn, NOT a socket close.
+    expect(turnsStarted).toBe(1)
+    expect(do_.sent).toContainEqual({
+      type: 'error',
+      code: 'turn_in_flight',
+      message: 'a turn is already in progress',
+    })
+    // The shared state is untouched by the rejected turn.
+    expect(sharedState.history).toEqual([])
+
+    // Drive the first turn to completion (two chunks → two gate releases).
+    controls[0].releaseNext()
+    await tick()
+    controls[0].releaseNext()
+    await firstTurn
+
+    // First turn settled normally: one turn counted, no concurrent pollution.
+    expect(controls[0].settled()).toBe(true)
+    expect(sharedState.turnCount).toBe(1)
+    expect(sharedState.history).toEqual(['A'])
+    // Guard cleared so the next turn can run.
+    expect(do_.turnInFlight).toBe(false)
+    expect(do_.activeTurn).toBeUndefined()
+  })
+
+  it('clears the guard after a turn so a subsequent turn runs normally', async () => {
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    const bridge: SharedBridge = { closed: false }
+    const controls: ReturnType<typeof makeControllableTurn>[] = []
+    const do_ = new FakeSessionDo(() => {
+      const ctrl = makeControllableTurn(sharedState, bridge, [textChunk('', true)])
+      controls.push(ctrl)
+      do_.onBridgeClose = ctrl.cancel
+      return ctrl.generator
+    })
+    do_.create(sharedState)
+    do_.bridge = bridge
+
+    const t1 = do_.turn()
+    await tick()
+    controls[0].releaseNext()
+    await t1
+    expect(do_.turnInFlight).toBe(false)
+
+    // A fresh turn after the first completes is accepted (a real second runTurn).
+    const t2 = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+    expect(controls).toHaveLength(2)
+    controls[1].releaseNext()
+    await t2
+    expect(sharedState.turnCount).toBe(2)
+  })
+
+  it('clears the guard even when the turn throws (exception cannot wedge it shut)', async () => {
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    const bridge: SharedBridge = { closed: false }
+
+    // A turn generator that rejects on its first `next()` (provider error) before
+    // producing any chunk — models a provider that throws at the STT/LLM step. It
+    // intentionally never yields, hence the scoped rule suppression.
+    // eslint-disable-next-line require-yield
+    async function* throwingTurn(): AsyncGenerator<AiResponseChunk> {
+      throw new Error('provider boom')
+    }
+    const do_ = new FakeSessionDo(() => throwingTurn())
+    do_.create(sharedState)
+    do_.bridge = bridge
+
+    await expect(do_.turn()).rejects.toThrow('provider boom')
+
+    // The guard is released despite the throw, so the session is not wedged.
+    expect(do_.turnInFlight).toBe(false)
+    expect(do_.activeTurn).toBeUndefined()
+
+    // A subsequent turn is accepted (not blocked by a stuck guard).
+    const recoveredCtrl = makeControllableTurn(sharedState, bridge, [textChunk('', true)])
+    const recovered = new FakeSessionDo(() => {
+      recovered.onBridgeClose = recoveredCtrl.cancel
+      return recoveredCtrl.generator
+    })
+    recovered.create(sharedState)
+    const t = recovered.turn()
+    await tick()
+    expect(recovered.turnInFlight).toBe(true)
+    // (cleanup) drive the parked turn to completion so nothing is left pending.
+    recoveredCtrl.releaseNext()
+    await t
+  })
+})
+
+// --- end during a turn cleanly cancels ---------------------------------------
+
+describe('end during a turn — clean cancellation (matrix: end)', () => {
+  it('cancels the in-flight turn: bridge closed, streams returned, no settle', async () => {
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    const bridge: SharedBridge = { closed: false }
+    const ctrl = makeControllableTurn(sharedState, bridge, [
+      textChunk('partial'),
+      textChunk('', true),
+    ])
+    const do_ = new FakeSessionDo(() => {
+      do_.onBridgeClose = ctrl.cancel
+      return ctrl.generator
+    })
+    do_.create(sharedState)
+    do_.bridge = bridge
+
+    const turning = do_.turn()
+    await tick()
+    // Let the first chunk through so the turn is genuinely mid-stream.
+    ctrl.releaseNext()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+    expect(ctrl.settled()).toBe(false)
+
+    // `end` arrives mid-turn: clean cancel.
+    await do_.end()
+    await turning
+
+    // The turn's `finally` ran (LLM/TTS streams returned, queue closed) and the
+    // bridge is closed (STT terminated) — nothing left dangling.
+    expect(ctrl.cleanedUp()).toBe(true)
+    expect(bridge.closed).toBe(true)
+    // The canceled turn never reached settle, so it did not count.
+    expect(ctrl.settled()).toBe(false)
+    expect(sharedState.turnCount).toBe(0)
+    // Guard cleared after cancellation.
+    expect(do_.turnInFlight).toBe(false)
+    expect(do_.activeTurn).toBeUndefined()
+    // A summary was still emitted, reflecting only completed turns.
+    expect(do_.sent).toContainEqual({ type: 'summary', turnCount: 0 })
+  })
+
+  it('end with no turn in flight is a no-op cancel and still summarizes', async () => {
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    const do_ = new FakeSessionDo(() => {
+      throw new Error('turn should not start')
+    })
+    do_.create(sharedState)
+    do_.bridge = { closed: false }
+
+    await expect(do_.end()).resolves.toBeUndefined()
+    expect(do_.sent).toContainEqual({ type: 'summary', turnCount: 0 })
+  })
+})
+
+// --- create during a turn is rejected ----------------------------------------
+
+describe('create during a turn — rejected, session stays active (matrix: create)', () => {
+  it('rejects a re-create and does not reset the in-flight session state', async () => {
+    const sharedState = { history: ['established'], turnCount: 1 }
+    const bridge: SharedBridge = { closed: false }
+    const ctrl = makeControllableTurn(sharedState, bridge, [textChunk('', true)])
+    const do_ = new FakeSessionDo(() => ctrl.generator)
+    do_.create(sharedState)
+    do_.bridge = bridge
+
+    const turning = do_.turn()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+
+    // A second `create` arrives mid-turn.
+    do_.create({ history: [], turnCount: 0 })
+
+    // Rejected — the live session state is NOT clobbered.
+    expect(do_.sent).toContainEqual({
+      type: 'error',
+      code: 'already_created',
+      message: 'session already created',
+    })
+    expect(do_.state).toBe(sharedState)
+    expect(do_.state?.history).toEqual(['established'])
+
+    // (cleanup) finish the turn.
+    ctrl.releaseNext()
+    await turning
+  })
+})
+
+// --- owner socket close during a turn cancels --------------------------------
+
+describe('owner close during a turn — cancels cleanly (matrix: close)', () => {
+  it('owner close cancels the in-flight turn and closes the bridge', async () => {
+    const sharedState = { history: [] as string[], turnCount: 0 }
+    const bridge: SharedBridge = { closed: false }
+    const ctrl = makeControllableTurn(sharedState, bridge, [textChunk('x'), textChunk('', true)])
+    const do_ = new FakeSessionDo(() => {
+      do_.onBridgeClose = ctrl.cancel
+      return ctrl.generator
+    })
+    do_.create(sharedState)
+    do_.bridge = bridge
+
+    const turning = do_.turn()
+    await tick()
+    ctrl.releaseNext()
+    await tick()
+    expect(do_.turnInFlight).toBe(true)
+
+    await do_.ownerClose()
+    await turning
+
+    expect(ctrl.cleanedUp()).toBe(true)
+    expect(bridge.closed).toBe(true)
+    expect(ctrl.settled()).toBe(false)
+    expect(do_.turnInFlight).toBe(false)
+    expect(do_.activeTurn).toBeUndefined()
+  })
+})

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -89,9 +89,9 @@ function mockTts(received: string[]): TtsProvider {
 const resolvedConfig: ResolvedConfig = {
   gameId: 'demo',
   systemPromptConfig: { role: 'guide', ruleTemplate: ['rule one'] },
-  llm: { provider: 'deepseek', model: 'deepseek-v4-flash', fallback: [] },
-  stt: { provider: 'volcengine', model: 'bigmodel', fallback: [] },
-  tts: { provider: 'volcengine', model: 'doubao', fallback: [] },
+  llm: { provider: 'deepseek', model: 'deepseek-v4-flash' },
+  stt: { provider: 'volcengine', model: 'bigmodel' },
+  tts: { provider: 'volcengine', model: 'doubao' },
 }
 
 const manualData: ManualData = { version: 'v1', sections: { intro: { text: 'hi' } } }

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it } from 'vitest'
+import { runTurn, splitSentences, type SessionState, type TurnProviders } from './turn-pipeline'
+import type { AiResponseChunk, AudioChunk, ManualData } from './contract'
+import type {
+  LlmCompletionChunk,
+  LlmCompletionRequest,
+  LlmProvider,
+  SttProvider,
+  SttTranscriptChunk,
+  TtsAudioChunk,
+  TtsProvider,
+} from './providers/types'
+import type { ResolvedConfig } from './provider-config'
+
+// --- helpers -------------------------------------------------------------
+
+async function* fromArray<T>(items: T[]): AsyncIterable<T> {
+  for (const item of items) yield item
+}
+
+async function collect(stream: AsyncIterable<AiResponseChunk>): Promise<AiResponseChunk[]> {
+  const out: AiResponseChunk[] = []
+  for await (const chunk of stream) out.push(chunk)
+  return out
+}
+
+/** STT mock: ignores audio, replays a fixed transcript sequence. */
+function mockStt(transcripts: SttTranscriptChunk[]): SttProvider {
+  return {
+    async *transcribe(audio: AsyncIterable<AudioChunk>): AsyncIterable<SttTranscriptChunk> {
+      // Drain audio so the bridge closes cleanly, then emit transcripts.
+      for await (const _ of audio) void _
+      yield* fromArray(transcripts)
+    },
+  }
+}
+
+/** LLM mock: records the request, streams the given content deltas, then done. */
+function mockLlm(
+  deltas: string[],
+  opts: {
+    usage?: { inputTokens: number; outputTokens: number }
+    capture?: (r: LlmCompletionRequest) => void
+  } = {}
+): LlmProvider & { lastUsage?: { inputTokens: number; outputTokens: number } } {
+  const provider: LlmProvider & { lastUsage?: { inputTokens: number; outputTokens: number } } = {
+    async *streamCompletion(request: LlmCompletionRequest): AsyncIterable<LlmCompletionChunk> {
+      opts.capture?.(request)
+      for (const content of deltas) yield { content, done: false }
+      provider.lastUsage = opts.usage
+      yield { content: '', done: true }
+    },
+  }
+  return provider
+}
+
+/** LLM mock: streams the exact chunks given (incl. a content-bearing done chunk). */
+function rawLlm(chunks: LlmCompletionChunk[]): LlmProvider {
+  return {
+    async *streamCompletion(): AsyncIterable<LlmCompletionChunk> {
+      for (const chunk of chunks) yield chunk
+    },
+  }
+}
+
+/** LLM mock: yields one delta, then rejects — exercises the error cleanup path. */
+function rejectingLlm(message: string): LlmProvider {
+  return {
+    async *streamCompletion(): AsyncIterable<LlmCompletionChunk> {
+      yield { content: 'partial ', done: false }
+      throw new Error(message)
+    },
+  }
+}
+
+/** TTS mock: records the sentences it received, emits one audio frame each. */
+function mockTts(received: string[]): TtsProvider {
+  return {
+    async *synthesize(text: AsyncIterable<string>): AsyncIterable<TtsAudioChunk> {
+      for await (const sentence of text) {
+        received.push(sentence)
+        yield { audio: new Uint8Array([sentence.length]), done: false }
+      }
+      yield { audio: new Uint8Array(0), done: true }
+    },
+  }
+}
+
+const resolvedConfig: ResolvedConfig = {
+  gameId: 'demo',
+  systemPromptConfig: { role: 'guide', ruleTemplate: ['rule one'] },
+  llm: { provider: 'deepseek', model: 'deepseek-v4-flash', fallback: [] },
+  stt: { provider: 'volcengine', model: 'bigmodel', fallback: [] },
+  tts: { provider: 'volcengine', model: 'doubao', fallback: [] },
+}
+
+const manualData: ManualData = { version: 'v1', sections: { intro: { text: 'hi' } } }
+
+function freshState(): SessionState {
+  return {
+    config: resolvedConfig,
+    manualData,
+    gameState: { relevantSections: ['intro'] },
+    history: [],
+    turnCount: 0,
+    usage: { llmInputTokens: 0, llmOutputTokens: 0, sttInputSeconds: 0, ttsOutputSeconds: 0 },
+  }
+}
+
+function providers(stt: SttProvider, llm: LlmProvider, tts: TtsProvider): TurnProviders {
+  return { stt, llm, tts }
+}
+
+// --- splitSentences (pure) ----------------------------------------------
+
+describe('splitSentences', () => {
+  it('splits on ASCII and CJK terminal punctuation', () => {
+    const { sentences, remainder } = splitSentences('Hello. World! 你好。tail')
+    expect(sentences).toEqual(['Hello.', 'World!', '你好。'])
+    expect(remainder).toBe('tail')
+  })
+
+  it('keeps an unterminated fragment in the remainder', () => {
+    const { sentences, remainder } = splitSentences('no terminator yet')
+    expect(sentences).toEqual([])
+    expect(remainder).toBe('no terminator yet')
+  })
+})
+
+// --- runTurn orchestration ----------------------------------------------
+
+describe('runTurn', () => {
+  it('chains STT -> manual injection -> LLM -> TTS and emits ordered chunks', async () => {
+    const ttsReceived: string[] = []
+    let capturedRequest: LlmCompletionRequest | undefined
+    const turn = runTurn(
+      providers(
+        mockStt([{ text: 'I see a red wire.', isFinal: true }]),
+        mockLlm(['Cut the ', 'blue wire.'], { capture: (r) => (capturedRequest = r) }),
+        mockTts(ttsReceived)
+      ),
+      freshState(),
+      fromArray<AudioChunk>([new Uint8Array([1])])
+    )
+    const chunks = await collect(turn)
+
+    // The LLM saw: system message (role+rules+manual) + the player utterance.
+    expect(capturedRequest?.messages[0].role).toBe('system')
+    expect(capturedRequest?.messages[0].content).toContain('rule one')
+    expect(capturedRequest?.messages[0].content).toContain('intro')
+    const lastMessage = capturedRequest?.messages.at(-1)
+    expect(lastMessage).toEqual({ role: 'user', content: 'I see a red wire.' })
+
+    // TTS received the segmented sentence assembled from the LLM deltas.
+    expect(ttsReceived).toEqual(['Cut the blue wire.'])
+
+    // Text chunks arrive, audio chunks arrive, exactly one terminal done chunk.
+    const textChunks = chunks.filter((c) => c.kind === 'text' && !c.done)
+    const audioChunks = chunks.filter((c) => c.kind === 'audio')
+    expect(textChunks.map((c) => c.text)).toEqual(['Cut the ', 'blue wire.'])
+    expect(audioChunks.length).toBeGreaterThan(0)
+
+    const doneChunks = chunks.filter((c) => c.done)
+    expect(doneChunks).toHaveLength(1)
+    expect(doneChunks[0].done).toBe(true)
+    expect(chunks.at(-1)?.done).toBe(true)
+  })
+
+  it('takes the last isFinal transcript (cumulative ASR semantics)', async () => {
+    let capturedRequest: LlmCompletionRequest | undefined
+    const turn = runTurn(
+      providers(
+        // Cumulative full-text chunks: only the last isFinal is the utterance.
+        mockStt([
+          { text: 'I', isFinal: false },
+          { text: 'I see', isFinal: false },
+          { text: 'I see a red wire', isFinal: true },
+        ]),
+        mockLlm(['ok.'], { capture: (r) => (capturedRequest = r) }),
+        mockTts([])
+      ),
+      freshState(),
+      fromArray<AudioChunk>([new Uint8Array([1])])
+    )
+    await collect(turn)
+    expect(capturedRequest?.messages.at(-1)).toEqual({ role: 'user', content: 'I see a red wire' })
+  })
+
+  it('accumulates usage and history across a turn', async () => {
+    const state = freshState()
+    const turn = runTurn(
+      providers(
+        mockStt([{ text: 'hello.', isFinal: true }]),
+        mockLlm(['Hi there.'], { usage: { inputTokens: 42, outputTokens: 7 } }),
+        mockTts([])
+      ),
+      state,
+      fromArray<AudioChunk>([new Uint8Array([1])])
+    )
+    await collect(turn)
+
+    expect(state.turnCount).toBe(1)
+    expect(state.usage.llmInputTokens).toBe(42)
+    expect(state.usage.llmOutputTokens).toBe(7)
+    expect(state.history).toEqual([
+      { role: 'user', content: 'hello.' },
+      { role: 'assistant', content: 'Hi there.' },
+    ])
+  })
+
+  it('estimates non-zero STT/TTS audio seconds from the bytes that flowed', async () => {
+    // 32000 bytes = 1.0s under the PCM-16 mono 16kHz estimate. Feed exactly that
+    // many inbound audio bytes; the mock TTS emits a frame per sentence whose
+    // byte length is the sentence length (see mockTts), so TTS seconds are
+    // small-but-non-zero. The point of the assertion: neither stays 0 (the bug
+    // was a silent 0 even though audio flowed both ways).
+    const state = freshState()
+    const turn = runTurn(
+      providers(
+        mockStt([{ text: 'hi.', isFinal: true }]),
+        mockLlm(['One sentence here.']),
+        mockTts([])
+      ),
+      state,
+      fromArray<AudioChunk>([new Uint8Array(16000), new Uint8Array(16000)])
+    )
+    await collect(turn)
+
+    // 32000 inbound bytes -> exactly 1.0 STT second.
+    expect(state.usage.sttInputSeconds).toBeCloseTo(1.0, 5)
+    // TTS produced at least one audio frame, so its seconds estimate is > 0.
+    expect(state.usage.ttsOutputSeconds).toBeGreaterThan(0)
+  })
+
+  // Intent: single-session ROLLING-HISTORY context, not cross-session
+  // determinism. The pipeline mutates one `state`'s history, so within a session
+  // the prior turns precede the new utterance. (Byte-identical-context
+  // determinism is a separate property, covered for the pure injection step in
+  // manual-injection.test.ts; it does NOT hold across turns of one session,
+  // because each turn appends to history by design.)
+  it('threads prior rolling history into the next turn context (single session)', async () => {
+    const state = freshState()
+    state.history = [
+      { role: 'user', content: 'earlier question' },
+      { role: 'assistant', content: 'earlier answer' },
+    ]
+    let capturedRequest: LlmCompletionRequest | undefined
+    const turn = runTurn(
+      providers(
+        mockStt([{ text: 'next.', isFinal: true }]),
+        mockLlm(['reply.'], { capture: (r) => (capturedRequest = r) }),
+        mockTts([])
+      ),
+      state,
+      fromArray<AudioChunk>([new Uint8Array([1])])
+    )
+    await collect(turn)
+
+    // The assembled context is exactly: system, prior user, prior assistant, new
+    // user — the rolling history sits between the system message and this turn's
+    // utterance, in order.
+    expect(capturedRequest?.messages).toEqual([
+      { role: 'system', content: capturedRequest?.messages[0].content },
+      { role: 'user', content: 'earlier question' },
+      { role: 'assistant', content: 'earlier answer' },
+      { role: 'user', content: 'next.' },
+    ])
+  })
+
+  it('flushes an unterminated trailing sentence to TTS at stream end', async () => {
+    const ttsReceived: string[] = []
+    const turn = runTurn(
+      providers(
+        mockStt([{ text: 'q.', isFinal: true }]),
+        // No terminal punctuation: the whole text is one trailing fragment.
+        mockLlm(['just a fragment without punctuation']),
+        mockTts(ttsReceived)
+      ),
+      freshState(),
+      fromArray<AudioChunk>([new Uint8Array([1])])
+    )
+    await collect(turn)
+    expect(ttsReceived).toEqual(['just a fragment without punctuation'])
+  })
+
+  it('does not drop content carried on a done chunk (OpenAI finish-chunk tail)', async () => {
+    // OpenAI-compatible streams can place the tail text on the SAME chunk that
+    // sets done:true. That tail must still reach the text stream AND TTS.
+    const ttsReceived: string[] = []
+    const turn = runTurn(
+      providers(
+        mockStt([{ text: 'q.', isFinal: true }]),
+        rawLlm([
+          { content: 'Cut the ', done: false },
+          { content: 'tail.', done: true },
+        ]),
+        mockTts(ttsReceived)
+      ),
+      freshState(),
+      fromArray<AudioChunk>([new Uint8Array([1])])
+    )
+    const chunks = await collect(turn)
+
+    // The done-chunk tail is segmented into the final sentence and synthesized.
+    expect(ttsReceived).toEqual(['Cut the tail.'])
+    // It also surfaces as a text chunk (not the empty terminal one).
+    const textChunks = chunks.filter((c) => c.kind === 'text' && !c.done)
+    expect(textChunks.map((c) => c.text)).toEqual(['Cut the ', 'tail.'])
+  })
+
+  it('cleans up the TTS side when a provider rejects mid-turn', async () => {
+    // The LLM stream rejects after one delta. The turn must surface the error,
+    // and the cleanup path must close the sentence queue and return the active
+    // TTS iterator so nothing leaks or hangs.
+    let ttsClosed = false
+    const tts: TtsProvider = {
+      async *synthesize(text: AsyncIterable<string>): AsyncIterable<TtsAudioChunk> {
+        try {
+          for await (const sentence of text) {
+            void sentence
+            yield { audio: new Uint8Array(1), done: false }
+          }
+        } finally {
+          // Runs on normal completion OR on an upstream `return()` — the latter
+          // is what the pipeline's cleanup invokes on the error path.
+          ttsClosed = true
+        }
+      },
+    }
+    const turn = runTurn(
+      providers(mockStt([{ text: 'q.', isFinal: true }]), rejectingLlm('llm boom'), tts),
+      freshState(),
+      fromArray<AudioChunk>([new Uint8Array([1])])
+    )
+
+    await expect(collect(turn)).rejects.toThrow('llm boom')
+    expect(ttsClosed).toBe(true)
+  })
+})

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -1,0 +1,353 @@
+/**
+ * Turn-pipeline orchestration — the testable core of the voice session
+ * (L2 §Mechanism Variant 1).
+ *
+ * One player turn is a pipeline: player audio -> STT transcript -> deterministic
+ * manual injection + history -> LLM streaming text -> sentence segmentation ->
+ * TTS audio -> interleaved `AiResponseChunk` stream back to the player.
+ *
+ * The Durable Object that owns the WebSocket is a thin shell over `runTurn`:
+ * `runTurn` is a provider-injected async generator that takes the three
+ * providers, the mutable session state, and the inbound audio stream, and yields
+ * the ordered `AiResponseChunk` stream. It does no I/O of its own (only drives
+ * the injected providers) but it *does* mutate `state` (history, turnCount,
+ * usage) — it is I/O-free, not side-effect-free. Keeping the orchestration here
+ * (no WS, no DO, no clock) makes it unit-testable with three mocked providers.
+ *
+ * Volcengine ASR note: the current Volcengine ASR adapter returns the
+ * *cumulative* full transcript on each chunk (not an incremental delta). So the
+ * player's utterance for the turn is the text of the LAST `isFinal` chunk — we
+ * take the final cumulative text, not a concatenation of fragments.
+ */
+
+import type { AiResponseChunk, AudioChunk } from './contract'
+import type { ChatMessage, LlmProvider, SttProvider, TtsProvider } from './providers/types'
+import { assembleLlmContext, type GameState } from './manual-injection'
+import type { ResolvedConfig } from './provider-config'
+import type { ManualData } from './contract'
+
+/** Usage counters accumulated across a session (mirrors `SessionSummary.usage`). */
+export interface UsageCounters {
+  llmInputTokens: number
+  llmOutputTokens: number
+  sttInputSeconds: number
+  ttsOutputSeconds: number
+}
+
+/**
+ * Audio-duration estimation constant. Both the Volcengine ASR input and the
+ * Doubao TTS output are PCM 16-bit mono at 16 kHz (the adapter's
+ * `DEFAULT_SAMPLE_RATE`), i.e. 16000 samples/s * 2 bytes/sample = 32000 bytes/s.
+ *
+ * v1 estimate / metering mount point: the pipeline only sees opaque byte frames,
+ * so it derives seconds from byte length under this fixed-format assumption.
+ * Precise, per-provider sample-rate-aware accounting (and any non-PCM codec)
+ * lives in the downstream `add-usage-metering` task; this fills the counters
+ * with a real, non-zero estimate instead of silently reporting 0.
+ */
+const PCM16_MONO_16K_BYTES_PER_SECOND = 32000
+
+/** Estimate audio seconds from a raw PCM-frame byte count (see constant above). */
+function estimateAudioSeconds(byteLength: number): number {
+  return byteLength / PCM16_MONO_16K_BYTES_PER_SECOND
+}
+
+/**
+ * Mutable per-session state the pipeline reads and updates. Held by the DO;
+ * passed by reference into `runTurn` so a completed turn's history + usage carry
+ * into the next turn.
+ */
+export interface SessionState {
+  /** Resolved provider/prompt config for this session's game. */
+  config: ResolvedConfig
+  /** This run's manual payload (deterministic injection source). */
+  manualData: ManualData
+  /** Current game state driving manual-subset selection. */
+  gameState: GameState
+  /** Rolling conversation history (user/assistant turns), excluding system. */
+  history: ChatMessage[]
+  /** Number of completed player->AI turns. */
+  turnCount: number
+  /** Accumulated usage counters. */
+  usage: UsageCounters
+}
+
+/** The three wired providers a turn drives. */
+export interface TurnProviders {
+  stt: SttProvider
+  llm: LlmProvider
+  tts: TtsProvider
+}
+
+/**
+ * LLM provider instances may expose a `lastUsage` after a stream is drained
+ * (the DeepSeek adapter does). We read it structurally so the pipeline does not
+ * depend on the concrete adapter type.
+ */
+interface MaybeUsageProvider {
+  lastUsage?: { inputTokens: number; outputTokens: number }
+}
+
+/**
+ * Split a growing assistant text buffer into complete sentences plus a
+ * remainder. A sentence boundary is a CJK/ASCII terminal punctuation mark; the
+ * trailing unterminated fragment stays in the remainder until more text (or the
+ * stream end) completes it. Pure and total.
+ */
+export function splitSentences(buffer: string): { sentences: string[]; remainder: string } {
+  const sentences: string[] = []
+  let start = 0
+  for (let i = 0; i < buffer.length; i += 1) {
+    const ch = buffer[i]
+    if (ch === '.' || ch === '!' || ch === '?' || ch === '。' || ch === '！' || ch === '？') {
+      const sentence = buffer.slice(start, i + 1).trim()
+      if (sentence.length > 0) sentences.push(sentence)
+      start = i + 1
+    }
+  }
+  return { sentences, remainder: buffer.slice(start) }
+}
+
+/**
+ * Drain an STT transcript stream and return the player's utterance for the
+ * turn: the text of the last `isFinal` chunk (cumulative ASR semantics). If no
+ * `isFinal` chunk arrives, fall back to the last chunk's text (best effort), or
+ * empty string for an empty stream.
+ *
+ * Also reports `audioBytes`: the total byte length of the inbound audio frames
+ * the STT provider actually pulled, tapped via a counting passthrough. The
+ * caller turns this into the STT input-seconds usage estimate. The passthrough
+ * forwards every frame unchanged, so STT behaviour is unaffected.
+ */
+async function collectFinalTranscript(
+  stt: SttProvider,
+  audio: AsyncIterable<AudioChunk>
+): Promise<{ transcript: string; audioBytes: number }> {
+  let audioBytes = 0
+  const counted: AsyncIterable<AudioChunk> = {
+    async *[Symbol.asyncIterator]() {
+      for await (const frame of audio) {
+        audioBytes += frame.byteLength
+        yield frame
+      }
+    },
+  }
+
+  let lastFinal: string | undefined
+  let lastAny = ''
+  for await (const chunk of stt.transcribe(counted)) {
+    lastAny = chunk.text
+    if (chunk.isFinal) lastFinal = chunk.text
+  }
+  return { transcript: (lastFinal ?? lastAny).trim(), audioBytes }
+}
+
+/**
+ * A tiny single-producer/single-consumer async string queue. The LLM loop
+ * pushes complete sentences in; the TTS provider consumes them via `for await`.
+ * Decoupling them lets text chunks surface to the player as the LLM streams,
+ * while TTS synthesis runs concurrently.
+ */
+class SentenceQueue {
+  private buffer: string[] = []
+  private resolvers: Array<(r: IteratorResult<string>) => void> = []
+  private closed = false
+
+  push(sentence: string): void {
+    if (this.closed) return
+    const resolve = this.resolvers.shift()
+    if (resolve) {
+      resolve({ value: sentence, done: false })
+    } else {
+      this.buffer.push(sentence)
+    }
+  }
+
+  close(): void {
+    this.closed = true
+    while (this.resolvers.length > 0) {
+      this.resolvers.shift()?.({ value: undefined, done: true })
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<string> {
+    for (;;) {
+      if (this.buffer.length > 0) {
+        yield this.buffer.shift() as string
+        continue
+      }
+      if (this.closed) return
+      const next = await new Promise<IteratorResult<string>>((resolve) => {
+        this.resolvers.push(resolve)
+      })
+      if (next.done) return
+      yield next.value
+    }
+  }
+}
+
+/**
+ * Run one player turn end to end.
+ *
+ * Yields the turn's `AiResponseChunk`s in order: incremental `text` chunks as
+ * the LLM streams, `audio` chunks as TTS synthesizes the segmented sentences,
+ * and exactly one terminal chunk with `done: true`. Mutates `state` (history,
+ * turnCount, usage) as a side effect so the next turn sees this turn's context.
+ *
+ * I/O-free beyond driving the injected providers (it never touches the network,
+ * a clock, or a socket directly) — fully unit-testable with mocked STT/LLM/TTS.
+ */
+export async function* runTurn(
+  providers: TurnProviders,
+  state: SessionState,
+  audio: AsyncIterable<AudioChunk>
+): AsyncIterable<AiResponseChunk> {
+  // 1. STT: transcribe the player's audio; take the final cumulative transcript.
+  //    `audioBytes` is the inbound-frame byte total, turned into the STT
+  //    input-seconds usage estimate at turn settle.
+  const { transcript: playerText, audioBytes: sttAudioBytes } = await collectFinalTranscript(
+    providers.stt,
+    audio
+  )
+
+  // 2. Inject: deterministic system message (role + rules + manual subset),
+  //    then the rolling history, then this turn's player utterance.
+  const systemMessages = assembleLlmContext({
+    systemPromptConfig: state.config.systemPromptConfig,
+    manualData: state.manualData,
+    gameState: state.gameState,
+  })
+  const userMessage: ChatMessage = { role: 'user', content: playerText }
+  const messages: ChatMessage[] = [...systemMessages, ...state.history, userMessage]
+
+  // 3. LLM + 4. TTS run concurrently: the LLM loop segments text into sentences
+  //    and feeds a queue the TTS provider drains. We interleave text chunks
+  //    (as the LLM streams) with audio chunks (as TTS produces them).
+  const sentenceQueue = new SentenceQueue()
+  const ttsIterator = providers.tts.synthesize(sentenceQueue)[Symbol.asyncIterator]()
+
+  let assistantText = ''
+  let pending = ''
+  let ttsDone = false
+  let nextTtsPromise: Promise<IteratorResult<{ audio: Uint8Array; done: boolean }>> | undefined =
+    ttsIterator.next()
+
+  const llmStream = providers.llm
+    .streamCompletion({
+      model: state.config.llm.model,
+      messages,
+    })
+    [Symbol.asyncIterator]()
+
+  let llmDone = false
+  let nextLlmPromise: Promise<IteratorResult<{ content: string; done: boolean }>> | undefined =
+    llmStream.next()
+
+  // TTS output bytes tallied across the turn's synthesized frames, turned into
+  // the TTS output-seconds usage estimate at turn settle.
+  let ttsAudioBytes = 0
+
+  // Drive both streams until both are exhausted. Whichever resolves first
+  // produces the next chunk, so text and audio interleave in arrival order.
+  // A provider error (either stream's `next()` rejects) propagates out of the
+  // `Promise.race`; the `finally` below closes the sentence queue and returns
+  // the live iterators so neither leaks nor hangs.
+  try {
+    while (!llmDone || !ttsDone) {
+      const racers: Array<Promise<{ source: 'llm' | 'tts'; result: IteratorResult<unknown> }>> = []
+      if (nextLlmPromise) {
+        racers.push(nextLlmPromise.then((result) => ({ source: 'llm' as const, result })))
+      }
+      if (nextTtsPromise) {
+        racers.push(nextTtsPromise.then((result) => ({ source: 'tts' as const, result })))
+      }
+      if (racers.length === 0) break
+
+      const winner = await Promise.race(racers)
+
+      if (winner.source === 'llm') {
+        const result = winner.result as IteratorResult<{ content: string; done: boolean }>
+        if (result.done || result.value.done) {
+          // LLM stream finished. A finish chunk may still carry content (the
+          // OpenAI-compatible stream can place the tail text on the chunk that
+          // also sets `done: true`); append it BEFORE flushing + closing so the
+          // tail reaches both the text stream and TTS, never dropped.
+          llmDone = true
+          nextLlmPromise = undefined
+          if (!result.done && result.value.content.length > 0) {
+            const delta = result.value.content
+            assistantText += delta
+            pending += delta
+            yield { kind: 'text', text: delta, done: false }
+          }
+          const { sentences, remainder } = splitSentences(pending)
+          for (const sentence of sentences) sentenceQueue.push(sentence)
+          pending = remainder
+          const tail = pending.trim()
+          if (tail.length > 0) {
+            sentenceQueue.push(tail)
+            pending = ''
+          }
+          sentenceQueue.close()
+        } else {
+          const delta = result.value.content
+          if (delta.length > 0) {
+            assistantText += delta
+            pending += delta
+            yield { kind: 'text', text: delta, done: false }
+            const { sentences, remainder } = splitSentences(pending)
+            for (const sentence of sentences) sentenceQueue.push(sentence)
+            pending = remainder
+          }
+          nextLlmPromise = llmStream.next()
+        }
+      } else {
+        const result = winner.result as IteratorResult<{ audio: Uint8Array; done: boolean }>
+        if (result.done) {
+          ttsDone = true
+          nextTtsPromise = undefined
+        } else {
+          if (result.value.audio.length > 0) {
+            ttsAudioBytes += result.value.audio.byteLength
+            yield { kind: 'audio', audio: result.value.audio, done: false }
+          }
+          if (result.value.done) {
+            ttsDone = true
+            nextTtsPromise = undefined
+          } else {
+            nextTtsPromise = ttsIterator.next()
+          }
+        }
+      }
+    }
+  } finally {
+    // Cleanup on any exit path — normal completion or a provider error. The
+    // error path is "fail loud": the rejection from `Promise.race` propagates to
+    // the caller (no error chunk is fabricated); here we only release resources
+    // so a half-driven turn cannot leak the queue or a live iterator. `close()`
+    // is idempotent; `return()` on an async iterator that has no `return` is a
+    // no-op, so both are safe to call unconditionally.
+    sentenceQueue.close()
+    await ttsIterator.return?.(undefined)
+    await llmStream.return?.(undefined)
+  }
+
+  // 5. Settle turn state: record history, count, and usage; emit the terminal
+  //    chunk so the consumer can close out the turn.
+  state.history.push(userMessage)
+  state.history.push({ role: 'assistant', content: assistantText })
+  state.turnCount += 1
+
+  const usage = (providers.llm as MaybeUsageProvider).lastUsage
+  if (usage) {
+    state.usage.llmInputTokens += usage.inputTokens
+    state.usage.llmOutputTokens += usage.outputTokens
+  }
+  // Best-effort audio-duration metering (v1 estimate; see
+  // `estimateAudioSeconds`). Filled from the bytes that actually flowed this
+  // turn so `endSession` reports a real estimate, not a silent 0.
+  state.usage.sttInputSeconds += estimateAudioSeconds(sttAudioBytes)
+  state.usage.ttsOutputSeconds += estimateAudioSeconds(ttsAudioBytes)
+
+  yield { kind: 'text', text: '', done: true }
+}

--- a/packages/platform-ai/src/worker.ts
+++ b/packages/platform-ai/src/worker.ts
@@ -1,0 +1,79 @@
+/**
+ * Platform AI Worker entry (L2 §Mechanism Variant 3).
+ *
+ * Mounted same-origin at `claw.amio.fans/ai-ws/*` (see `wrangler.toml`) so the
+ * auth-session cookie rides along on the WebSocket upgrade. The Worker:
+ *   1. Accepts only `/ai-ws/*` WebSocket upgrades.
+ *   2. Runs the handshake-time auth seam (cookie -> session-reader -> userId);
+ *      an invalid/absent session is rejected at the handshake (401, no upgrade).
+ *   3. Routes to the per-session `VoiceSessionDO` and forwards the upgrade.
+ *
+ * The DO id is derived from the URL path segment after `/ai-ws/` (the opaque
+ * session name the client connects on); `idFromName` makes the same name route
+ * to the same DO. The resolved `userId` is forwarded so the DO can bind it.
+ *
+ * Cloudflare API verified against `@cloudflare/workers-types` 4.20260608.1:
+ * `DurableObjectNamespace.idFromName/get`, `DurableObjectStub.fetch`.
+ */
+
+import { VoiceSessionDO } from './session-do'
+import { resolveSessionReader, type AuthSeamEnv } from './auth-seam'
+import type { ProviderEnv } from './providers/factory'
+
+/** Worker env: the DO namespace binding + auth seam + provider creds. */
+export interface WorkerEnv extends AuthSeamEnv, ProviderEnv {
+  /** Durable Object namespace binding (`wrangler.toml` name `VOICE_SESSION`). */
+  VOICE_SESSION: DurableObjectNamespace
+}
+
+/** WS route prefix this Worker owns; pinned at L2 and must not drift. */
+const AI_WS_PREFIX = '/ai-ws/'
+
+/**
+ * Derive the DO session name from the request path. Everything after the
+ * `/ai-ws/` prefix is the opaque session name the client connects on. An empty
+ * name (a bare `/ai-ws/` connect) returns `null` -> 400.
+ */
+function sessionNameFromPath(pathname: string): string | null {
+  if (!pathname.startsWith(AI_WS_PREFIX)) return null
+  const name = pathname.slice(AI_WS_PREFIX.length)
+  return name.length > 0 ? name : null
+}
+
+export default {
+  async fetch(request: Request, env: WorkerEnv): Promise<Response> {
+    const url = new URL(request.url)
+
+    // Only the same-origin WS route is served by this Worker.
+    if (!url.pathname.startsWith(AI_WS_PREFIX)) {
+      return new Response('not found', { status: 404 })
+    }
+    if (request.headers.get('Upgrade') !== 'websocket') {
+      return new Response('expected websocket upgrade', { status: 426 })
+    }
+
+    // Handshake-time auth: cookie -> session-reader -> userId. Reject before
+    // any upgrade if there is no valid session.
+    const reader = resolveSessionReader(env)
+    const identity = await reader.resolve(request.headers.get('Cookie'))
+    if (identity === null) {
+      return new Response('unauthorized', { status: 401 })
+    }
+
+    const sessionName = sessionNameFromPath(url.pathname)
+    if (sessionName === null) {
+      return new Response('missing session name', { status: 400 })
+    }
+
+    // Route to the per-session DO and forward the upgrade. The resolved userId
+    // rides along in a header so the DO can bind ownership; this header is set
+    // server-side here, never trusted from the client.
+    const id = env.VOICE_SESSION.idFromName(sessionName)
+    const stub = env.VOICE_SESSION.get(id)
+    const forwarded = new Request(request)
+    forwarded.headers.set('X-Session-User-Id', identity.userId)
+    return stub.fetch(forwarded)
+  },
+}
+
+export { VoiceSessionDO }

--- a/packages/platform-ai/tsconfig.json
+++ b/packages/platform-ai/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"]
+}

--- a/packages/platform-ai/vitest.config.ts
+++ b/packages/platform-ai/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+// Standalone vitest config for the platform-ai package. Mirrors the api
+// package's approach — this package is a Cloudflare Worker (Durable Object +
+// WebSocket orchestration land in later rounds), not a Vite project, so we
+// depend on the vitest CLI only and run the pure-logic tests in the Node
+// environment with workers-types ambient declarations supplied by tsconfig.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+})

--- a/packages/platform-ai/wrangler.toml
+++ b/packages/platform-ai/wrangler.toml
@@ -1,0 +1,78 @@
+# Platform AI Interface — standalone Cloudflare Worker.
+#
+# This is the repo's first independent Worker deploy unit. It hosts the
+# Durable Object that carries the per-session WebSocket voice pipeline
+# (STT -> LLM -> TTS). The DO/WebSocket server implementation and the real
+# provider adapters land in later rounds (R2/R3); this file pins the
+# deploy-time bindings so those rounds have a stable contract.
+#
+# TOML syntax verified against the current Cloudflare docs (June 2026):
+#   - Durable Objects bindings + migrations:
+#     https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/
+#   - KV namespaces, routes, vars:
+#     https://developers.cloudflare.com/workers/wrangler/configuration/
+
+name = "platform-ai"
+main = "src/worker.ts"
+compatibility_date = "2026-06-08"
+
+# Worker runs only the server-side AI orchestration. The Node.js compat flag
+# is intentionally NOT set here — adapters target the standard Workers fetch /
+# WebSocket / streams APIs, decided in a later round if a provider SDK needs it.
+
+# --- Durable Object: per-session voice pipeline state holder ---
+# The DO owns one voice session's conversation history, current phase, and the
+# WebSocket long-connection. Single-point serialization keeps turns ordered.
+# Implementation deferred to R3; the binding + class name are pinned now.
+[[durable_objects.bindings]]
+name = "VOICE_SESSION"
+class_name = "VoiceSessionDO"
+
+# SQLite-backed DO storage (the recommended backend for new classes). The
+# migration tag is the ordered changelog of DO class lifecycle events.
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["VoiceSessionDO"]
+
+# --- AUTH KV: shared session keyspace owned by auth-session ---
+# The Worker self-binds the auth-session AUTH namespace and reuses the shared
+# session-reader during the WS upgrade handshake (read-only: cookie -> session
+# id -> session:<id>). The Worker never writes here. `id` is the production
+# namespace id, filled at deploy wiring time (placeholder until then).
+[[kv_namespaces]]
+binding = "AUTH"
+id = "PLACEHOLDER_AUTH_KV_NAMESPACE_ID"
+
+# --- Same-origin WS route on the canonical zone ---
+# Mounting under claw.amio.fans (same zone as the Platform SPA / /api/*) is the
+# structural prerequisite for the session cookie to ride along on the WS
+# upgrade — a path-prefix route on the existing zone, not a whole-domain custom
+# domain. The /ai-ws/* prefix is pinned at L2 and must not drift.
+[[routes]]
+pattern = "claw.amio.fans/ai-ws/*"
+zone_name = "amio.fans"
+
+# --- Plain-text vars ---
+[vars]
+# Dev-only auth bypass. When set (dev/preview), the WS handshake's
+# session-reader step is replaced by a fixed dev identity; the prod build
+# compiles this branch out. Mounting point / "validate-at-handshake, reject if
+# invalid" shape stays fixed — only the session lookup is stubbed.
+DEV_AUTH_BYPASS = "false"
+
+# --- Secrets (set via `wrangler secret put`, NEVER committed as plaintext) ---
+# Provider API keys and any system-prompt material live only server-side as
+# Cloudflare secrets. Set each with `wrangler secret put <NAME>`:
+#   DEEPSEEK_API_KEY   — DeepSeek (OpenAI-compatible) LLM key.
+#   VOLC_ACCESS_KEY    — Volcengine (火山) access key, sent as X-Api-Access-Key.
+#   VOLC_APP_ID        — Volcengine (火山) speech app id, sent as X-Api-App-Key.
+# These are referenced by the provider adapters; declared here only as
+# documentation so the deploy operator knows what to provision.
+#
+# No VOLC_SECRET_KEY: the v3 big-model endpoints this adapter targets —
+# streaming ASR (/api/v3/sauc/bigmodel) and Doubao TTS 2.0 bidirectional
+# (/api/v3/tts/bidirection) — authenticate purely via the X-Api-App-Key /
+# X-Api-Access-Key / X-Api-Resource-Id token headers. They do NOT use the legacy
+# `Authorization: HMAC256` signature scheme, so no secret key is needed. (The
+# secret-key signature path is the older console-auth method for the v1/v2
+# endpoints, which this adapter does not use.)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,18 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/platform-ai:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260608.1
+        version: 4.20260608.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/ui:
     devDependencies:
       '@testing-library/jest-dom':
@@ -1023,89 +1035,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1219,36 +1247,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -2303,24 +2337,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
## Summary

- Adds `@amiclaw/platform-ai`: a game-agnostic, vendor-swappable server-side AI interface for mode② (platform-integrated AI) — the shared prerequisite for downstream mode② game integrations.
- Route-one modular STT→LLM→TTS turn pipeline on a per-player Durable Object + WebSocket Worker; STT/LLM/TTS each config-swappable via `provider-config`. First adapters: DeepSeek v4 (OpenAI-compatible SSE, default LLM) + Volcengine (火山, default voice ASR + Doubao TTS 2.0).
- Deterministic manual injection (system prompt resolved server-side from `gameId`, never on the wire); same-origin `/ai-ws/*` handshake auth seam (dev stub, env-gated; the DO never trusts a client-claimed `userId`); provider keys and prompts stay server-side. Minimal demo harness runs the full speak→reply loop under `wrangler dev` with mock providers.

## Type of change

- [x] New feature

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

102 package tests + 588 workspace tests pass; typecheck / lint / format green; `wrangler deploy --dry-run` parses. The demo harness ran the full `create → turn → chunks → summary` loop end-to-end under `wrangler dev` with mock providers; client artifacts verified to carry **zero** provider keys / system prompts.

**Deploy-time verification (out of scope here, explicitly flagged):** real Volcengine / DeepSeek connectivity + auth from the Cloudflare edge, the `AUTH` KV namespace id, and the same-origin Worker route wiring are validated at deployment, not in unit tests.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (CHANGELOG + C4: `docs/architecture/arch-component-platform-ai-interface.md` + `architecture.md` — independent Worker + DO container, voice I/O = WebSocket gate)
- [x] Breaking changes documented if any (none — additive new package, not yet wired into any game)

🤖 Generated with [Claude Code](https://claude.com/claude-code)