### PR TITLE
feat(platform-ai): real per-user usage metering with USAGE KV persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Real usage metering for platform AI sessions** - Every platform-AI voice
+session now measures what it actually consumed instead of estimating.
+Speech-to-text seconds come from the speech provider's own duration report
+when available, with an exact byte-derived fallback when it is not (each
+record says which path produced it); text-to-speech seconds are converted
+exactly from the audio actually synthesized; LLM token counts stay
+provider-reported. When a session ends — whether closed normally or dropped —
+its totals are persisted once to a dedicated usage store, keyed by user and
+date, as the data foundation for fair quotas and billing on the paid path.
+Recording is fail-open: a storage hiccup is logged and never interrupts a
+player's session. Session ids are now independently minted UUIDs, so usage
+records can never collide across sessions.
+
 **Google sign-in** - You can now sign in with Google as well as by email magic
 link. The `/login` page shows a "用 Google 登录" button that takes you to Google's
 consent screen and back; signing in with Google lands you in the same account as

--- a/packages/platform-ai/src/index.ts
+++ b/packages/platform-ai/src/index.ts
@@ -30,6 +30,8 @@ export type {
   LlmUsage,
   LlmProvider,
   SttTranscriptChunk,
+  SttUsage,
+  SttUsageSource,
   SttProvider,
   TtsAudioChunk,
   TtsProvider,
@@ -54,7 +56,12 @@ export type { ProviderEnv, SessionProviders } from './providers/factory'
 export { createProviders } from './providers/factory'
 
 // Deterministic mock providers — no-credential demo / e2e harness backend.
-export type { MockLlmProvider, MockLlmProviderOptions } from './providers/mock'
+export type {
+  MockLlmProvider,
+  MockLlmProviderOptions,
+  MockSttProvider,
+  MockSttProviderOptions,
+} from './providers/mock'
 export {
   createMockLlmProvider,
   createMockSttProvider,
@@ -80,6 +87,9 @@ export {
 // Testable turn-pipeline orchestration (DO is a thin shell over this).
 export type { UsageCounters, SessionState, TurnProviders } from './turn-pipeline'
 export { runTurn, splitSentences } from './turn-pipeline'
+
+// Session-terminal usage metering flush (the DO is a thin shell over this).
+export type { UsageKvWriter, UsageRecord, SessionUsageSnapshot } from './usage-flush'
 
 // Durable Object class (named export required for the wrangler DO binding).
 export { VoiceSessionDO } from './session-do'

--- a/packages/platform-ai/src/providers/mock.test.ts
+++ b/packages/platform-ai/src/providers/mock.test.ts
@@ -39,6 +39,26 @@ describe('createMockSttProvider', () => {
     const chunks = await collect(stt.transcribe(audioFrames()))
     expect(chunks).toEqual([{ text: MOCK_TRANSCRIPT, isFinal: true }])
   })
+
+  it('exposes injected usage as lastUsage after the stream is drained', async () => {
+    // Controllable usage injection: tests drive the pipeline's structured STT
+    // metering path deterministically through the same lastUsage channel the
+    // Volcengine adapter uses.
+    const stt = createMockSttProvider({
+      usage: { durationMs: 1234, source: 'provider-reported' },
+    })
+    expect(stt.lastUsage).toBeUndefined()
+
+    await collect(stt.transcribe(audioFrames(new Uint8Array([1]))))
+
+    expect(stt.lastUsage).toEqual({ durationMs: 1234, source: 'provider-reported' })
+  })
+
+  it('exposes no usage by default — consumers fall back to byte derivation', async () => {
+    const stt = createMockSttProvider()
+    await collect(stt.transcribe(audioFrames(new Uint8Array([1]))))
+    expect(stt.lastUsage).toBeUndefined()
+  })
 })
 
 describe('createMockLlmProvider', () => {

--- a/packages/platform-ai/src/providers/mock.ts
+++ b/packages/platform-ai/src/providers/mock.ts
@@ -32,6 +32,7 @@ import type {
   LlmUsage,
   SttProvider,
   SttTranscriptChunk,
+  SttUsage,
   TtsAudioChunk,
   TtsProvider,
 } from './types'
@@ -114,23 +115,47 @@ export function createMockLlmProvider(options: MockLlmProviderOptions = {}): Moc
   return provider
 }
 
+/** Options for the mock STT provider. */
+export interface MockSttProviderOptions {
+  /**
+   * Fixed STT usage reported after each transcribe stream, so tests can drive
+   * the pipeline's structured STT metering path deterministically. When
+   * omitted, the mock exposes NO usage — the pipeline then exercises its
+   * byte-derived fallback path, matching the pre-metering behavior.
+   */
+  usage?: SttUsage
+}
+
+/**
+ * A mock STT provider. Mirrors the Volcengine adapter's shape (exposes an
+ * optional `lastUsage` the turn pipeline reads structurally) so it is a
+ * drop-in substitute on the STT slot.
+ */
+export interface MockSttProvider extends SttProvider {
+  /** STT usage from the most recently consumed transcribe stream. */
+  lastUsage?: SttUsage
+}
+
 /**
  * Create a deterministic mock STT provider. Drains the inbound audio stream
  * (so the audio bridge is consumed exactly like the real adapter) and yields a
  * single final transcript chunk carrying the fixed example utterance. An empty
  * audio stream still yields the fixed transcript so a turn always has text.
  */
-export function createMockSttProvider(): SttProvider {
-  return {
+export function createMockSttProvider(options: MockSttProviderOptions = {}): MockSttProvider {
+  const provider: MockSttProvider = {
     async *transcribe(audio: AsyncIterable<AudioChunk>): AsyncIterable<SttTranscriptChunk> {
+      provider.lastUsage = undefined
       // Consume the inbound frames so the bridge drains; the content is ignored
       // (deterministic transcript), but draining matches real-adapter behavior.
       for await (const _frame of audio) {
         // intentionally empty — frames are consumed, not inspected
       }
+      provider.lastUsage = options.usage
       yield { text: MOCK_TRANSCRIPT, isFinal: true }
     },
   }
+  return provider
 }
 
 /**

--- a/packages/platform-ai/src/providers/types.ts
+++ b/packages/platform-ai/src/providers/types.ts
@@ -91,6 +91,29 @@ export interface SttTranscriptChunk {
 }
 
 /**
+ * Where an STT duration measurement came from. `provider-reported` is the
+ * vendor's own duration report (Volcengine ASR `audio_info.duration`);
+ * `derived-from-bytes` is an exact byte-rate conversion of the audio that
+ * actually flowed (PCM16 mono at the configured sample rate). Every metering
+ * entry carries this annotation so downstream aggregation knows its precision.
+ */
+export type SttUsageSource = 'provider-reported' | 'derived-from-bytes'
+
+/**
+ * STT usage for one consumed transcribe stream (one ASR connection — the
+ * pipeline runs one per turn). Mirrors the LLM layer's `lastUsage` pattern:
+ * adapters expose it as an optional `lastUsage` field on the provider instance,
+ * which the turn pipeline reads structurally after the stream is drained (kept
+ * off the chunk stream so the transcript hot path stays text-only).
+ */
+export interface SttUsage {
+  /** Audio duration consumed by the connection, in milliseconds. */
+  durationMs: number
+  /** Provenance of the measurement — see {@link SttUsageSource}. */
+  source: SttUsageSource
+}
+
+/**
  * STT provider layer. The first adapter is Volcengine (火山) modular ASR over
  * its self-owned WebSocket protocol; that adapter is shared with TTS as the
  * platform voice layer.
@@ -100,6 +123,10 @@ export interface SttProvider {
    * Stream player audio frames in, yield transcription chunks out. The input
    * is an async stream of audio frames (the session WebSocket's inbound side);
    * the output is the transcript stream consumed by the LLM step.
+   *
+   * Adapters that can measure the consumed audio duration expose an optional
+   * `lastUsage?: SttUsage` field on the provider instance, populated after each
+   * stream is fully consumed (see {@link SttUsage}).
    */
   transcribe(audio: AsyncIterable<AudioChunk>): AsyncIterable<SttTranscriptChunk>
 }

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -17,6 +17,7 @@ import {
   MessageFlag,
   MessageType,
   parseFrame,
+  parseSttAudioDurationMs,
   parseSttResponse,
   Serialization,
   TtsEvent,
@@ -296,6 +297,45 @@ describe('parseSttResponse', () => {
       payload: encoder.encode(JSON.stringify({ result: {} })),
     })
     expect(parseSttResponse(parseFrame(ack))).toBeUndefined()
+  })
+
+  it('parses audio_info.duration alongside the transcript fields', () => {
+    // The example-JSON-only field (doc 6561/1354869): present -> the cumulative
+    // recognized duration in milliseconds.
+    const frame = parseFrame(
+      sttServerFrame({
+        result: { text: '你好', utterances: [{ definite: true }] },
+        audio_info: { duration: 3696 },
+      })
+    )
+    expect(parseSttAudioDurationMs(frame)).toBe(3696)
+    // The transcript parse is unaffected by the extra field.
+    expect(parseSttResponse(frame)).toEqual({ text: '你好', isFinal: true })
+  })
+
+  it('returns undefined duration when audio_info is absent or malformed (best-effort field)', () => {
+    // Absent entirely — the formal field table does not list audio_info, so an
+    // absent field is the documented-normal case, not an error.
+    expect(
+      parseSttAudioDurationMs(parseFrame(sttServerFrame({ result: { text: 'x' } })))
+    ).toBeUndefined()
+    // Present but non-numeric — ignored, never thrown.
+    expect(
+      parseSttAudioDurationMs(
+        parseFrame(sttServerFrame({ result: { text: 'x' }, audio_info: { duration: 'oops' } }))
+      )
+    ).toBeUndefined()
+    // Error frames are the transcript parser's job — the duration helper is total.
+    const errFrame = parseFrame(
+      buildSttRequestFrame({
+        messageType: MessageType.ErrorResponse,
+        flags: MessageFlag.PositiveSequence,
+        serialization: Serialization.Json,
+        sequence: 1,
+        payload: encoder.encode('boom'),
+      })
+    )
+    expect(parseSttAudioDurationMs(errFrame)).toBeUndefined()
   })
 
   it('throws on an error-type server frame', () => {
@@ -646,6 +686,83 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
 
     const chunks = await collected
     expect(chunks).toEqual([{ text: '你好', isFinal: true }])
+  })
+})
+
+describe('createVolcengineSpeechProvider.stt — per-connection usage metering', () => {
+  it('reports the LAST cumulative audio_info.duration, not the per-response sum (provider-reported)', async () => {
+    // The server's duration is CUMULATIVE per connection: each full response
+    // carries the total recognized so far. Two responses (1200ms then 3696ms)
+    // must settle as 3696 — summing them (4896) would double-count.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const drained = collect(stt.transcribe(await asyncFrom([encoder.encode('f1')])))
+    await tick()
+    socket.emitMessage(
+      sttServerFrame({
+        result: { text: '你', utterances: [{ definite: false }] },
+        audio_info: { duration: 1200 },
+      })
+    )
+    socket.emitMessage(
+      sttServerFrame({
+        result: { text: '你好', utterances: [{ definite: true }] },
+        audio_info: { duration: 3696 },
+      })
+    )
+    await drained
+
+    expect(stt.lastUsage).toEqual({ durationMs: 3696, source: 'provider-reported' })
+  })
+
+  it('falls back to exact bytes-sent conversion when no response carries audio_info (derived-from-bytes)', async () => {
+    // No audio_info anywhere (the formal field table does not promise it). The
+    // connection sent 8000 + 8000 = 16000 audio payload bytes; at the default
+    // PCM16 mono 16kHz byte rate (32000 B/s) that is exactly 500ms.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const drained = collect(
+      stt.transcribe(await asyncFrom([new Uint8Array(8000), new Uint8Array(8000)]))
+    )
+    await tick()
+    socket.emitMessage(sttServerFrame({ result: { text: '好', utterances: [{ definite: true }] } }))
+    await drained
+
+    expect(stt.lastUsage).toEqual({ durationMs: 500, source: 'derived-from-bytes' })
+  })
+
+  it('resets usage per connection — a later no-report stream does not inherit the prior duration', async () => {
+    // Connection 1 settles provider-reported; connection 2 gets no audio_info
+    // and must settle from ITS OWN bytes, not leak 9999 from the prior stream.
+    const socket1 = new MockSocket()
+    const sockets = [socket1, new MockSocket()]
+    let call = 0
+    const connect: WebSocketConnector = async () => sockets[call++]
+    const { stt } = createVolcengineSpeechProvider({ appId: 'a', accessToken: 't', connect })
+
+    const drained1 = collect(stt.transcribe(await asyncFrom([new Uint8Array(64000)])))
+    await tick()
+    socket1.emitMessage(
+      sttServerFrame({
+        result: { text: 'one', utterances: [{ definite: true }] },
+        audio_info: { duration: 9999 },
+      })
+    )
+    await drained1
+    expect(stt.lastUsage).toEqual({ durationMs: 9999, source: 'provider-reported' })
+
+    const drained2 = collect(stt.transcribe(await asyncFrom([new Uint8Array(32000)])))
+    await tick()
+    sockets[1].emitMessage(
+      sttServerFrame({ result: { text: 'two', utterances: [{ definite: true }] } })
+    )
+    await drained2
+
+    expect(stt.lastUsage).toEqual({ durationMs: 1000, source: 'derived-from-bytes' })
   })
 })
 

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -54,7 +54,7 @@
  */
 
 import type { AudioChunk } from '../contract'
-import type { SttProvider, SttTranscriptChunk, TtsAudioChunk, TtsProvider } from './types'
+import type { SttProvider, SttTranscriptChunk, SttUsage, TtsAudioChunk, TtsProvider } from './types'
 
 // --- Public options ---
 
@@ -715,6 +715,37 @@ export function parseSttResponse(frame: ParsedFrame): SttTranscriptChunk | undef
   return { text: result.text, isFinal }
 }
 
+/**
+ * Extract the cumulative recognized-audio duration (milliseconds) from a full
+ * ASR server response, when present.
+ *
+ * `audio_info.duration` appears in the documented example JSON of the v3
+ * big-model ASR response but NOT in its formal field table (doc 6561/1354869),
+ * so it is treated as best-effort by design: parse it when present
+ * (`provider-reported` metering) and fall back to an exact byte-rate conversion
+ * when absent (`derived-from-bytes`). Semantics are CUMULATIVE per connection —
+ * each response carries the total recognized duration so far, so the LAST
+ * value (never the sum across responses) is the connection's consumption.
+ *
+ * Pure and total: returns `undefined` for non-JSON frames, error frames,
+ * empty payloads, malformed JSON, or a missing/non-numeric field — it never
+ * throws (transcript-side errors are `parseSttResponse`'s job).
+ */
+export function parseSttAudioDurationMs(frame: ParsedFrame): number | undefined {
+  if (frame.messageType !== MessageType.FullServerResponse) return undefined
+  if (frame.serialization !== Serialization.Json || frame.payload.length === 0) return undefined
+  let body: { audio_info?: { duration?: unknown } }
+  try {
+    body = JSON.parse(textDecoder.decode(frame.payload)) as {
+      audio_info?: { duration?: unknown }
+    }
+  } catch {
+    return undefined
+  }
+  const duration = body.audio_info?.duration
+  return typeof duration === 'number' && Number.isFinite(duration) ? duration : undefined
+}
+
 // --- Default Workers connector ---
 
 /**
@@ -834,12 +865,25 @@ class AsyncQueue<T> {
 // --- Provider factory ---
 
 /**
+ * The Volcengine STT slot. Extends `SttProvider` with the optional `lastUsage`
+ * metering field (mirrors `DeepSeekLlmProvider.lastUsage`): after each
+ * transcribe stream is fully consumed, it carries the connection's audio
+ * duration — the server's cumulative `audio_info.duration` report when one
+ * arrived (`provider-reported`), else the exact byte-rate conversion of the
+ * audio actually sent (`derived-from-bytes`).
+ */
+export interface VolcengineSttProvider extends SttProvider {
+  /** STT usage from the most recently consumed transcribe stream. */
+  lastUsage?: SttUsage
+}
+
+/**
  * Build the Volcengine speech provider pair. The returned object satisfies both
  * `SttProvider` and `TtsProvider`; the platform wires the same instance into
  * both layer slots (the voice layer is shared, per the L2 spec).
  */
 export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
-  stt: SttProvider
+  stt: VolcengineSttProvider
   tts: TtsProvider
 } {
   const connect = opts.connect ?? defaultConnect
@@ -849,9 +893,15 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
   const ttsModel = opts.ttsModel
   const ttsSpeaker = opts.ttsSpeaker ?? DEFAULT_TTS_SPEAKER
   const sampleRate = opts.sampleRate ?? DEFAULT_SAMPLE_RATE
+  // PCM 16-bit mono: 2 bytes per sample. Exact byte rate for the
+  // `derived-from-bytes` fallback conversion below.
+  const bytesPerSecond = sampleRate * 2
 
-  const stt: SttProvider = {
+  const stt: VolcengineSttProvider = {
     async *transcribe(audio: AsyncIterable<AudioChunk>): AsyncIterable<SttTranscriptChunk> {
+      // Reset before consuming so a prior connection's usage cannot leak into
+      // this one (mirrors the DeepSeek `lastUsage` reset).
+      stt.lastUsage = undefined
       const connectId = randomId()
       const headers = buildAuthHeaders(
         { appId: opts.appId, accessToken: opts.accessToken, resourceId: sttResourceId },
@@ -866,10 +916,22 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       // proceed with an empty/incomplete transcript. Mirrors the TTS layer's
       // SessionFinished gate.
       let finalReached = false
+      // Per-connection metering state. `reportedDurationMs` follows the server's
+      // cumulative `audio_info.duration` — each response overwrites it, so it
+      // ends as the LAST response's value, the connection's total consumption
+      // (summing per response would double-count the cumulative figure).
+      // `sentAudioBytes` counts the audio payload bytes actually SENT on the
+      // wire (config frame excluded) — the exact-conversion fallback source. A
+      // cancelled pump stops sending and stops counting, so the fallback can
+      // only undercount, never over-meter.
+      let reportedDurationMs: number | undefined
+      let sentAudioBytes = 0
 
       socket.addEventListener('message', (event) => {
         try {
           const frame = parseFrame(event.data)
+          const duration = parseSttAudioDurationMs(frame)
+          if (duration !== undefined) reportedDurationMs = duration
           const chunk = parseSttResponse(frame)
           if (!chunk) return
           queue.push(chunk)
@@ -936,6 +998,7 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
           if (pending !== undefined) {
             seq += 1
             socket.send(asArrayBuffer(buildSttAudioFrame(pending, seq, false)))
+            sentAudioBytes += pending.byteLength
           }
           pending = next.value
         }
@@ -944,6 +1007,7 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         seq += 1
         const last = pending ?? new Uint8Array(0)
         socket.send(asArrayBuffer(buildSttAudioFrame(last, seq, true)))
+        sentAudioBytes += last.byteLength
       })()
       pump.catch((err) => queue.fail(err))
 
@@ -964,6 +1028,16 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         //  - `queue.close()` is idempotent on an already-closed/failed queue;
         //  - `socket.close()` deterministically releases the outbound connection
         //    (idempotent; the normal path already closes it on a final transcript).
+        //
+        // Usage settle (runs on every exit path, so even a failed/cancelled
+        // connection reports what it consumed): prefer the server's cumulative
+        // duration report when any response carried one (`provider-reported`),
+        // else convert the audio bytes actually sent at the exact PCM16 byte
+        // rate (`derived-from-bytes`).
+        stt.lastUsage =
+          reportedDurationMs !== undefined
+            ? { durationMs: reportedDurationMs, source: 'provider-reported' }
+            : { durationMs: (sentAudioBytes * 1000) / bytesPerSecond, source: 'derived-from-bytes' }
         cancelled = true
         await audioIterator.return?.(undefined)
         queue.close()

--- a/packages/platform-ai/src/session-assembly.test.ts
+++ b/packages/platform-ai/src/session-assembly.test.ts
@@ -75,6 +75,9 @@ describe('assembleSession — all-or-nothing session construction', () => {
       sttInputSeconds: 0,
       ttsOutputSeconds: 0,
     })
+    // STT metering annotation starts at the precision ceiling; the pipeline
+    // latches it to 'derived-from-bytes' on the first byte-derived turn.
+    expect(assembled.state.sttSource).toBe('provider-reported')
   })
 
   it('threads an explicit gameState through to the assembled state', () => {
@@ -82,6 +85,24 @@ describe('assembleSession — all-or-nothing session construction', () => {
     const assembled = assembleSession('demo-mock', 'user-A', MANUAL, gameState, {})
 
     expect(assembled.state.gameState).toEqual(gameState)
+  })
+
+  it('mints a fresh opaque UUID session id per assembly — never a DO-derived id', () => {
+    // The L2 spec forbids the bare DO id (and any "DO id + in-memory counter"
+    // composite) as the session id: the same-named resident DO hosts many
+    // logical sessions, and an eviction resets any counter — colliding the
+    // write-once `usage:{date}:{user_id}:{session_id}` metering keys. The mint
+    // happens in `assembleSession`, so the DO publishes the minted id and
+    // `createSession` returns it instead of `ctx.id`.
+    const a = assembleSession('demo-mock', 'user-A', MANUAL, undefined, {})
+    const b = assembleSession('demo-mock', 'user-A', MANUAL, undefined, {})
+
+    const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    expect(a.sessionId).toMatch(UUID_V4)
+    expect(b.sessionId).toMatch(UUID_V4)
+    // Two sessions on the same inputs (same DO, same user, same game) still get
+    // distinct ids — the property a DO-derived id cannot provide.
+    expect(a.sessionId).not.toBe(b.sessionId)
   })
 })
 

--- a/packages/platform-ai/src/session-assembly.ts
+++ b/packages/platform-ai/src/session-assembly.ts
@@ -25,6 +25,17 @@ import type { SessionState, TurnProviders } from './turn-pipeline'
 
 /** Everything `createSession` publishes, assembled atomically or not at all. */
 export interface AssembledSession {
+  /**
+   * Freshly minted opaque session id (`crypto.randomUUID()`), one per
+   * successful assembly. Deliberately NOT the Durable Object id (and not a
+   * "DO id + generation counter" composite): the same-named DO instance hosts
+   * many logical sessions over its lifetime — every reconnect/`create` after a
+   * `clearSession`, and any in-memory counter resets to zero on a DO
+   * eviction/restart — so a DO-derived id would collide across distinct
+   * sessions wherever the id must be globally unique (the per-session
+   * `usage:{date}:{user_id}:{session_id}` metering key).
+   */
+  sessionId: string
   userId: string
   providers: TurnProviders
   state: SessionState
@@ -32,8 +43,9 @@ export interface AssembledSession {
 
 /**
  * Run all fallible session-setup steps; return the full publishable bundle or
- * throw. Pure (no instance state touched): a throw leaves no residue, so a
- * failed create cannot bind a user, wire providers, or seed state.
+ * throw. Pure aside from the session-id mint (no instance state touched): a
+ * throw leaves no residue, so a failed create cannot bind a user, wire
+ * providers, or seed state.
  */
 export function assembleSession(
   gameId: string,
@@ -51,6 +63,9 @@ export function assembleSession(
     history: [],
     turnCount: 0,
     usage: { llmInputTokens: 0, llmOutputTokens: 0, sttInputSeconds: 0, ttsOutputSeconds: 0 },
+    // Latches to 'derived-from-bytes' on the first turn whose STT seconds did
+    // not come from the provider's own report (see `SessionState.sttSource`).
+    sttSource: 'provider-reported',
   }
-  return { userId, providers, state }
+  return { sessionId: crypto.randomUUID(), userId, providers, state }
 }

--- a/packages/platform-ai/src/session-do-usage-flush.test.ts
+++ b/packages/platform-ai/src/session-do-usage-flush.test.ts
@@ -1,0 +1,373 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Production-class tests for `VoiceSessionDO`'s session-terminal usage flush.
+ *
+ * The sibling `session-usage-flush.test.ts` covers the pure `usage-flush.ts`
+ * core plus a faithful `FakeSessionDo` MIRROR of the DO's terminal-path
+ * wiring. A mirror passing does not prove the real class still carries the
+ * wiring: a regression in `session-do.ts` (flush dropped from `endSession`,
+ * `ctx.waitUntil` replaced with a bare void, the `usageFlushed` guard removed)
+ * would leave the mirror green. These tests close that gap by instantiating
+ * the REAL `VoiceSessionDO` in Node:
+ *
+ *  - `cloudflare:workers` is mocked so the `DurableObject` base becomes a
+ *    plain ctx/env-stashing stub — the only base behavior the class relies on.
+ *  - `ctx` is a recording double exposing the one member the class uses
+ *    (`waitUntil`), plus an `id` to prove the usage key never uses the DO id.
+ *  - `env` carries a recording USAGE KV double; providers wire through the
+ *    real `assembleSession` -> `createProviders` path using the `demo-mock`
+ *    game (all three layers select the credential-free mock provider).
+ *  - The WS terminal paths (`end` control message, abrupt owner-socket close)
+ *    are driven through the real `fetch` upgrade entry with `WebSocketPair` /
+ *    `Response` globals stubbed to minimal doubles. The DO accepts sockets
+ *    with a plain `accept()` + `addEventListener` (no hibernation
+ *    attachments), so the socket double needs only those members. Node's own
+ *    `Response` rejects status 101, hence the stub.
+ */
+
+vi.mock('cloudflare:workers', () => {
+  /** Stand-in for the real base: stash `ctx` + `env` like `DurableObject`. */
+  class DurableObjectStub {
+    protected ctx: unknown
+    protected env: unknown
+
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx
+      this.env = env
+    }
+  }
+  return { DurableObject: DurableObjectStub }
+})
+
+import { VoiceSessionDO, type SessionDoEnv } from './session-do'
+import type { ManualData } from './contract'
+import type { UsageCounters } from './turn-pipeline'
+import type { UsageKvWriter } from './usage-flush'
+
+// --- doubles -------------------------------------------------------------------
+
+/** Recording KV double implementing the structural `put` slice. */
+class RecordingUsageKv implements UsageKvWriter {
+  readonly puts: Array<{ key: string; value: string }> = []
+
+  async put(key: string, value: string): Promise<void> {
+    this.puts.push({ key, value })
+  }
+}
+
+/** KV double whose every put rejects — the fail-open injection point. */
+class FailingUsageKv implements UsageKvWriter {
+  attempts = 0
+
+  async put(): Promise<void> {
+    this.attempts += 1
+    throw new Error('kv unavailable')
+  }
+}
+
+/**
+ * Recording `DurableObjectState` double — only the surface `VoiceSessionDO`
+ * actually touches: `waitUntil` (the flush's lifecycle registration seam) and
+ * an `id` distinct from any minted session UUID.
+ */
+class FakeDoCtx {
+  readonly registered: Promise<unknown>[] = []
+  /** Distinct from every minted session UUID — the usage key must never use it. */
+  readonly id = { toString: (): string => 'do-id-not-a-session-id' }
+
+  waitUntil(promise: Promise<unknown>): void {
+    this.registered.push(promise)
+  }
+}
+
+type MessageListener = (event: { data: string | ArrayBuffer }) => void
+type CloseListener = () => void
+
+/**
+ * Minimal server-socket double for the DO's non-hibernating WS usage surface:
+ * `binaryType` assignment, `accept()`, `addEventListener('message'|'close')`,
+ * `send`, `close`. Tests deliver frames with `receive()` and fire the close
+ * event with `disconnect()` — exactly what the runtime would do.
+ */
+class FakeWebSocket {
+  binaryType: string | undefined
+  accepted = false
+  readonly sent: string[] = []
+  readonly closes: Array<{ code?: number; reason?: string }> = []
+  private readonly messageListeners: MessageListener[] = []
+  private readonly closeListeners: CloseListener[] = []
+
+  accept(): void {
+    this.accepted = true
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closes.push({ code, reason })
+  }
+
+  addEventListener(type: string, listener: MessageListener | CloseListener): void {
+    if (type === 'message') this.messageListeners.push(listener as MessageListener)
+    if (type === 'close') this.closeListeners.push(listener as CloseListener)
+  }
+
+  /** Deliver one inbound frame (fires the 'message' listeners). */
+  receive(data: string | ArrayBuffer): void {
+    for (const listener of this.messageListeners) listener({ data })
+  }
+
+  /** Fire the 'close' event as the runtime would on disconnect. */
+  disconnect(): void {
+    for (const listener of this.closeListeners) listener()
+  }
+}
+
+/** Pairs created by the stubbed `WebSocketPair` global, newest last. */
+const createdPairs: Array<{ 0: FakeWebSocket; 1: FakeWebSocket }> = []
+
+class FakeWebSocketPair {
+  0 = new FakeWebSocket()
+  1 = new FakeWebSocket()
+
+  constructor() {
+    createdPairs.push(this)
+  }
+}
+
+/** Node's `Response` rejects status 101; the DO's WS upgrade needs this stub. */
+class FakeUpgradeResponse {
+  readonly status: number
+  readonly webSocket: unknown
+
+  constructor(_body: unknown, init?: { status?: number; webSocket?: unknown }) {
+    this.status = init?.status ?? 200
+    this.webSocket = init?.webSocket ?? null
+  }
+}
+
+vi.stubGlobal('WebSocketPair', FakeWebSocketPair)
+vi.stubGlobal('Response', FakeUpgradeResponse)
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+// --- harness -------------------------------------------------------------------
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+const ZERO_COUNTERS: UsageCounters = {
+  llmInputTokens: 0,
+  llmOutputTokens: 0,
+  sttInputSeconds: 0,
+  ttsOutputSeconds: 0,
+}
+
+const MANUAL: ManualData = {
+  version: 'manual-v1',
+  sections: { intro: 'The red ABORT button is a decoy.' },
+}
+
+/** Build a real `VoiceSessionDO` over the ctx double + the given USAGE binding. */
+function makeDo(usage?: UsageKvWriter): { doInstance: VoiceSessionDO; ctx: FakeDoCtx } {
+  const ctx = new FakeDoCtx()
+  const env = (usage === undefined ? {} : { USAGE: usage }) as SessionDoEnv
+  return {
+    doInstance: new VoiceSessionDO(ctx as unknown as DurableObjectState, env),
+    ctx,
+  }
+}
+
+/** Run the real `fetch` upgrade for an authenticated user; return the server socket. */
+async function openSocket(doInstance: VoiceSessionDO, userId: string): Promise<FakeWebSocket> {
+  const request = {
+    headers: {
+      get(name: string): string | null {
+        if (name === 'Upgrade') return 'websocket'
+        if (name === 'X-Session-User-Id') return userId
+        return null
+      },
+    },
+  } as unknown as Request
+  const response = await doInstance.fetch(request)
+  expect(response.status).toBe(101)
+  return createdPairs[createdPairs.length - 1][1]
+}
+
+/** Send the `create` control message over the socket; return the minted session id. */
+function createSessionOverWs(socket: FakeWebSocket): string {
+  socket.receive(JSON.stringify({ type: 'create', gameId: 'demo-mock', manualData: MANUAL }))
+  const created = JSON.parse(socket.sent[socket.sent.length - 1]) as {
+    type: string
+    sessionId: string
+  }
+  expect(created.type).toBe('created')
+  return created.sessionId
+}
+
+beforeEach(() => {
+  createdPairs.length = 0
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// --- direct contract path: endSession is the flush boundary ---------------------
+
+describe('real VoiceSessionDO — direct endSession flush', () => {
+  it('flushes one record via ctx.waitUntil, keyed usage:{date}:{userId}:{sessionId UUID}', async () => {
+    const kv = new RecordingUsageKv()
+    const { doInstance, ctx } = makeDo(kv)
+
+    const sessionId = doInstance.createSession('demo-mock', 'user-A', MANUAL)
+    // The session identity is a freshly minted UUID, never the DO id.
+    expect(sessionId).toMatch(UUID_RE)
+    expect(sessionId).not.toBe(ctx.id.toString())
+
+    const summary = doInstance.endSession(sessionId, 'user-A')
+    expect(summary.sessionId).toBe(sessionId)
+    expect(summary.turnCount).toBe(0)
+
+    // The flush promise is registered on the DO lifecycle, not bare-voided.
+    expect(ctx.registered).toHaveLength(1)
+    await Promise.all(ctx.registered)
+
+    expect(kv.puts).toHaveLength(1)
+    const utcDate = new Date().toISOString().slice(0, 10)
+    expect(kv.puts[0].key).toBe(`usage:${utcDate}:user-A:${sessionId}`)
+    const record = JSON.parse(kv.puts[0].value) as {
+      gameId: string
+      turnCount: number
+      usage: UsageCounters
+      sttSource: string
+    }
+    expect(record.gameId).toBe('demo-mock')
+    expect(record.turnCount).toBe(0)
+    expect(record.usage).toEqual(ZERO_COUNTERS)
+    expect(record.sttSource).toBe('provider-reported')
+  })
+
+  it('a repeated direct endSession stays guarded — one write, one registration', async () => {
+    const kv = new RecordingUsageKv()
+    const { doInstance, ctx } = makeDo(kv)
+    const sessionId = doInstance.createSession('demo-mock', 'user-A', MANUAL)
+
+    // `endSession` does not clear the session (teardown belongs to the WS
+    // branch / owner-close), so a second direct call passes the state checks;
+    // the real class's `usageFlushed` guard must absorb it.
+    doInstance.endSession(sessionId, 'user-A')
+    doInstance.endSession(sessionId, 'user-A')
+
+    expect(ctx.registered).toHaveLength(1)
+    await Promise.all(ctx.registered)
+    expect(kv.puts).toHaveLength(1)
+  })
+})
+
+// --- WS terminal paths: end branch + owner-socket close --------------------------
+
+describe('real VoiceSessionDO — WS terminal paths', () => {
+  it('an end message followed by the owner-socket close event writes once', async () => {
+    const kv = new RecordingUsageKv()
+    const { doInstance, ctx } = makeDo(kv)
+    const socket = await openSocket(doInstance, 'user-A')
+    const sessionId = createSessionOverWs(socket)
+
+    socket.receive(JSON.stringify({ type: 'end' }))
+    // The end branch answered with the summary and a clean 1000 close.
+    const last = JSON.parse(socket.sent[socket.sent.length - 1]) as { type: string }
+    expect(last.type).toBe('summary')
+    expect(socket.closes).toEqual([{ code: 1000, reason: 'session ended' }])
+    // The close event that follows in the runtime: `clearSession` already
+    // unbound the owner, so the close branch must not double-flush.
+    socket.disconnect()
+
+    expect(ctx.registered).toHaveLength(1)
+    await Promise.all(ctx.registered)
+    expect(kv.puts).toHaveLength(1)
+    expect(kv.puts[0].key).toContain(`:user-A:${sessionId}`)
+  })
+
+  it('an abrupt owner-socket close (no end) flushes exactly once via waitUntil', async () => {
+    const kv = new RecordingUsageKv()
+    const { doInstance, ctx } = makeDo(kv)
+    const socket = await openSocket(doInstance, 'user-A')
+    const sessionId = createSessionOverWs(socket)
+
+    // Abrupt drop: the socket closes without any `end` control message.
+    socket.disconnect()
+
+    expect(ctx.registered).toHaveLength(1)
+    await Promise.all(ctx.registered)
+    expect(kv.puts).toHaveLength(1)
+    expect(kv.puts[0].key).toContain(`:user-A:${sessionId}`)
+
+    // A second close event is a no-op — the session is already cleared.
+    socket.disconnect()
+    expect(ctx.registered).toHaveLength(1)
+    expect(kv.puts).toHaveLength(1)
+  })
+
+  it('a same-user duplicate socket close does not flush the still-live session', async () => {
+    const kv = new RecordingUsageKv()
+    const { doInstance, ctx } = makeDo(kv)
+    const owner = await openSocket(doInstance, 'user-A')
+    const sessionId = createSessionOverWs(owner)
+    // A second tab / reconnect for the SAME user on the same DO.
+    const duplicate = await openSocket(doInstance, 'user-A')
+
+    duplicate.disconnect()
+    expect(ctx.registered).toHaveLength(0)
+    expect(kv.puts).toHaveLength(0)
+
+    // The owner's close afterwards still flushes the one record.
+    owner.disconnect()
+    expect(ctx.registered).toHaveLength(1)
+    await Promise.all(ctx.registered)
+    expect(kv.puts).toHaveLength(1)
+    expect(kv.puts[0].key).toContain(`:user-A:${sessionId}`)
+  })
+})
+
+// --- fail-open: a broken or absent USAGE KV never reaches the player path --------
+
+describe('real VoiceSessionDO — fail-open', () => {
+  it('a failing USAGE.put logs, never throws, and the WS end path closes cleanly', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const kv = new FailingUsageKv()
+    const { doInstance, ctx } = makeDo(kv)
+    const socket = await openSocket(doInstance, 'user-A')
+    createSessionOverWs(socket)
+
+    socket.receive(JSON.stringify({ type: 'end' }))
+
+    // The session-close path is unaffected: summary sent, clean 1000 close (a
+    // throw would have surfaced as a 1008 policy close via the listener).
+    const last = JSON.parse(socket.sent[socket.sent.length - 1]) as { type: string }
+    expect(last.type).toBe('summary')
+    expect(socket.closes).toEqual([{ code: 1000, reason: 'session ended' }])
+
+    await Promise.all(ctx.registered)
+    expect(kv.attempts).toBe(1)
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect(String(errorSpy.mock.calls[0][0])).toContain('usage flush failed')
+  })
+
+  it('a missing USAGE binding skips silently and endSession still returns the summary', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { doInstance, ctx } = makeDo()
+
+    const sessionId = doInstance.createSession('demo-mock', 'user-A', MANUAL)
+    const summary = doInstance.endSession(sessionId, 'user-A')
+
+    expect(summary.gameId).toBe('demo-mock')
+    expect(ctx.registered).toHaveLength(1)
+    await Promise.all(ctx.registered)
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -62,6 +62,7 @@ import type { GameState } from './manual-injection'
 import type { ProviderEnv } from './providers/factory'
 import { assembleSession } from './session-assembly'
 import { runTurn, type SessionState, type TurnProviders } from './turn-pipeline'
+import { flushSessionUsage, type UsageKvWriter } from './usage-flush'
 import {
   assertSessionOwnership,
   assertSocketOwnsBoundSession,
@@ -69,8 +70,13 @@ import {
   SocketIdentityRegistry,
 } from './auth-seam'
 
-/** Env bindings visible to the DO (provider creds + the AUTH KV, unused here). */
-export type SessionDoEnv = ProviderEnv & Record<string, unknown>
+/**
+ * Env bindings visible to the DO: provider creds, the AUTH KV (unused here),
+ * and the optional USAGE KV the session-terminal metering flush writes to.
+ * `USAGE` is optional by design — a dev/demo deploy without the binding skips
+ * the flush fail-open (see `usage-flush.ts`).
+ */
+export type SessionDoEnv = ProviderEnv & { USAGE?: UsageKvWriter } & Record<string, unknown>
 
 /** The DO accepts a single session-control message kind plus binary audio. */
 interface CreateSessionMessage {
@@ -157,6 +163,22 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
   private state: SessionState | undefined
   /** Bound user id, set on `create`; ownership checks compare against it. */
   private userId: string | undefined
+  /**
+   * The bound session's opaque id — a UUID minted fresh per `createSession`
+   * (see `session-assembly.ts` for why it is NOT the DO id), `undefined` when
+   * no session is bound. Every ownership check, WS protocol message, and the
+   * usage-flush key carry this value, never `ctx.id`.
+   */
+  private sessionId: string | undefined
+  /**
+   * Whether THIS session's usage has been flushed to the USAGE KV. Set at
+   * `create` (false) and flipped by `flushUsage`, so the flush runs exactly
+   * once per session no matter how many terminal paths fire (`endSession` +
+   * owner-socket close). Generation-safe by construction: a new `create`
+   * starts a new session with a fresh `false`, so the guard never bleeds
+   * across the `clearSession` epoch boundary.
+   */
+  private usageFlushed = false
   /** Wired providers for the session. */
   private providers: TurnProviders | undefined
   /** Audio bridge for the in-flight turn, if any. */
@@ -347,7 +369,16 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
     // `turn` with no fresh `create` and run a provider turn on the dropped
     // session. Clearing makes that reconnect open a clean new session via
     // `create` and reject a create-less `turn` ("turn before create").
+    //
+    // Abrupt-drop is a session-TERMINAL path that never reaches `endSession`
+    // (the contract-level flush boundary), so it carries its own usage flush —
+    // between the cancel (a canceled turn never settles, so its partial usage
+    // is excluded: undercount-only) and the clear (the flush reads the live
+    // session fields). After an `end`, this branch is unreachable (see above),
+    // so the flush cannot double-fire across the two paths — and the
+    // `usageFlushed` guard backstops it regardless.
     void this.cancelActiveTurn()
+    this.flushUsage()
     this.clearSession()
   }
 
@@ -356,21 +387,24 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
   /**
    * Create the session: bind the (already-authenticated) `userId`, resolve the
    * game's provider/prompt config, wire the providers, and initialize state.
-   * Returns the DO id string as the opaque `SessionId`.
+   * Returns the freshly minted opaque `SessionId` — a per-session UUID from
+   * `assembleSession`, NOT the DO id (the resident DO hosts many logical
+   * sessions over its lifetime; see `AssembledSession.sessionId`).
    *
    * Publish-after-success (all-or-nothing): every fallible setup step —
    * `resolveConfig` (unregistered game) and `createProviders` (a selected real
    * provider missing its secret) — runs inside `assembleSession` into LOCALS
-   * first. Only once the whole bundle exists are `userId`/`providers`/`state`
-   * assigned, in one synchronous block with no `await` and no throw between the
-   * first and last publish. `boundIdentity()` derives the session's ownership
-   * binding solely from `this.userId`, so observers only ever see a session
-   * that is fully constructed or entirely absent — never half-bound. The prior
-   * interleaving (`this.userId = userId` BEFORE `createProviders`) let a failed
-   * create leave the DO bound to a user with NO `state`/`providers`: that
-   * user's binary frames then passed the ownership gate, lazily created an
-   * audio bridge, and the leaked pre-create frames survived into the next
-   * SUCCESSFUL session's first turn (create does not reset `this.audio`).
+   * first. Only once the whole bundle exists are
+   * `userId`/`sessionId`/`providers`/`state` assigned, in one synchronous block
+   * with no `await` and no throw between the first and last publish.
+   * `boundIdentity()` derives the session's ownership binding solely from these
+   * published fields, so observers only ever see a session that is fully
+   * constructed or entirely absent — never half-bound. The prior interleaving
+   * (`this.userId = userId` BEFORE `createProviders`) let a failed create leave
+   * the DO bound to a user with NO `state`/`providers`: that user's binary
+   * frames then passed the ownership gate, lazily created an audio bridge, and
+   * the leaked pre-create frames survived into the next SUCCESSFUL session's
+   * first turn (create does not reset `this.audio`).
    */
   createSession(
     gameId: string,
@@ -380,10 +414,12 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
   ): string {
     const assembled = assembleSession(gameId, userId, manualData, gameState, this.env)
     // Atomic publish — nothing below this line can throw or await.
+    this.sessionId = assembled.sessionId
     this.userId = assembled.userId
     this.providers = assembled.providers
     this.state = assembled.state
-    return this.ctx.id.toString()
+    this.usageFlushed = false
+    return assembled.sessionId
   }
 
   /**
@@ -413,8 +449,23 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
   }
 
   /**
-   * End the session: validate ownership, settle, and return the summary with
-   * the turn count and usage mount point.
+   * End the session: validate ownership, settle, flush the session's usage to
+   * the USAGE KV, and return the summary with the turn count and usage mount
+   * point.
+   *
+   * The flush lives HERE — in the contract method — because `endSession` is
+   * the single implementation boundary every `end`-shaped termination goes
+   * through: the WS `end` branch calls this method, and a direct consumer
+   * driving the four-method contract over the DO stub reaches it without any
+   * WS framing. Hanging the flush on the WS branch instead would let a direct
+   * contract call end a session unmetered. The owner-socket close path keeps
+   * its own `flushUsage()` — an abrupt drop never reaches `endSession` (see
+   * `onSocketClose`). State is still live at this point, so the flush
+   * naturally precedes any `clearSession` the caller performs. A mid-flight
+   * turn's partial usage stays excluded (undercount-only, per the locked
+   * metering stance): usage counters are written only when a turn settles,
+   * and no `await` separates this snapshot from the teardown that cancels
+   * the turn.
    */
   endSession(sessionId: string, userId: string): SessionSummary {
     this.assertOwner(sessionId, userId)
@@ -423,13 +474,15 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
     }
     this.audio?.close()
     this.audio = undefined
-    return {
+    const summary: SessionSummary = {
       sessionId,
       gameId: this.state.config.gameId,
       userId,
       turnCount: this.state.turnCount,
       usage: { ...this.state.usage },
     }
+    this.flushUsage()
+    return summary
   }
 
   // --- Internals ---
@@ -480,11 +533,55 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
     this.turnEpoch += 1
     this.state = undefined
     this.userId = undefined
+    this.sessionId = undefined
     this.providers = undefined
     this.audio = undefined
     this.turnInFlight = false
     this.activeTurn = undefined
     this.ownerSocket = undefined
+    this.usageFlushed = false
+  }
+
+  /**
+   * Flush the ended session's usage counters to the USAGE KV — exactly once
+   * per session, reached from the two terminal boundaries: the public
+   * `endSession` body (which the WS `end` branch goes through) and the
+   * owner-socket close path (an abrupt drop never reaches `endSession`).
+   * MUST run BEFORE `clearSession` (it reads the live session fields) and is
+   * idempotent against double-firing: the `usageFlushed` guard flips on the
+   * first call, and a fresh `create` resets it, so the guard can neither
+   * double-write one session nor suppress the next session's flush (the
+   * cross-generation misfire the `turnEpoch` comments warn about — this guard
+   * is per-session state reset at `create`, not a field that survives the
+   * generation boundary).
+   *
+   * The KV write runs in the background, registered on the DO lifecycle via
+   * `ctx.waitUntil` and never awaited here (fail-open): `flushSessionUsage`
+   * never rejects — an absent binding skips, a put failure logs — so a slow
+   * or failing KV can never block or delay session teardown / socket close,
+   * while the registration keeps the runtime from reclaiming an
+   * otherwise-idle DO before the pending put settles. The remaining loss
+   * window is only a termination that runs no callbacks at all (deploy
+   * eviction / crash / OOM) — the accepted undercount-only cost, per the
+   * locked L2 metering stance.
+   */
+  private flushUsage(): void {
+    const state = this.state
+    const sessionId = this.sessionId
+    const userId = this.userId
+    if (!state || sessionId === undefined || userId === undefined) return
+    if (this.usageFlushed) return
+    this.usageFlushed = true
+    this.ctx.waitUntil(
+      flushSessionUsage(this.env.USAGE, {
+        sessionId,
+        userId,
+        gameId: state.config.gameId,
+        turnCount: state.turnCount,
+        usage: { ...state.usage },
+        sttSource: state.sttSource,
+      })
+    )
   }
 
   /**
@@ -533,10 +630,14 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
     assertSocketOwnsBoundSession(this.socketIdentities, ws, this.boundIdentity())
   }
 
-  /** The DO's bound identity in the `{ boundSessionId, boundUserId }` shape. */
+  /**
+   * The DO's bound identity in the `{ boundSessionId, boundUserId }` shape.
+   * Both fields publish/clear together (`createSession` / `clearSession`), so
+   * the pair is always fully bound or fully absent.
+   */
   private boundIdentity(): { boundSessionId: string | undefined; boundUserId: string | undefined } {
     return {
-      boundSessionId: this.userId === undefined ? undefined : this.ctx.id.toString(),
+      boundSessionId: this.sessionId,
       boundUserId: this.userId,
     }
   }
@@ -578,7 +679,8 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
         return
       }
       case 'turn': {
-        if (!this.state || !socketUserId) {
+        const sessionId = this.sessionId
+        if (!this.state || !socketUserId || sessionId === undefined) {
           ws.close(1008, 'turn before create')
           return
         }
@@ -599,7 +701,7 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
         // the binary frame direction remains player-audio-only. Ownership is
         // checked against THIS socket's user, so a second client on the same DO
         // cannot drive the first user's session.
-        const sessionId = this.ctx.id.toString()
+        //
         // Hold the iterator explicitly so a mid-turn `end` / owner close can
         // cancel it via `return()`. Mark in-flight BEFORE the first `await`
         // (synchronous up to here) so an interleaved second `turn` sees the
@@ -656,7 +758,8 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
         return
       }
       case 'end': {
-        if (this.state && socketUserId) {
+        const sessionId = this.sessionId
+        if (this.state && socketUserId && sessionId !== undefined) {
           // Owner-socket gate on the teardown side (F-W self-consistency): `end`
           // is the other path — besides owner-close — that `clearSession()`s the
           // bound session. `endSession`'s `assertOwner` only checks the USER id,
@@ -678,8 +781,11 @@ export class VoiceSessionDO extends DurableObject<SessionDoEnv> {
           // closes the audio bridge (the NEXT turn's bridge, which buffered any
           // frames that arrived during this turn — the in-flight turn already
           // detached + closed its own bridge at `onAiResponse` start, so its STT
-          // has already terminated), and returns the summary.
-          const summary = this.endSession(this.ctx.id.toString(), socketUserId)
+          // has already terminated), flushes the session's usage to the USAGE
+          // KV (exactly once — the flush boundary lives in the contract method,
+          // not in this branch; see `endSession` / `flushUsage`), and returns
+          // the summary.
+          const summary = this.endSession(sessionId, socketUserId)
           // Cancel the in-flight turn FIRE-AND-FORGET, then summarize + close
           // immediately — do NOT await the cancel. `AsyncIterator.return()` cannot
           // interrupt a provider `await` already pending inside the generator (an

--- a/packages/platform-ai/src/session-usage-flush.test.ts
+++ b/packages/platform-ai/src/session-usage-flush.test.ts
@@ -1,0 +1,505 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildUsageRecord,
+  flushSessionUsage,
+  usageKeyFor,
+  type SessionUsageSnapshot,
+  type UsageKvWriter,
+} from './usage-flush'
+import type { UsageCounters } from './turn-pipeline'
+import type { SttUsageSource } from './providers/types'
+
+/**
+ * Tests for the session-terminal usage flush (P3 of the usage-metering task):
+ * the pure `usage-flush.ts` core directly, and the DO's exactly-once /
+ * all-terminal-paths flush wiring via a faithful stand-in. `VoiceSessionDO`
+ * imports `cloudflare:workers` and cannot be instantiated in the Node test
+ * environment, so — exactly as the per-socket identity, end-cleanup, and
+ * epoch-guard mechanisms are tested (see `session-identity.test.ts`,
+ * `session-end-cleanup.test.ts`, `session-epoch-guard.test.ts`) — the
+ * stand-in (`FakeSessionDo`) mirrors the real fields (`state` / `userId` /
+ * `sessionId` / `usageFlushed` / `ownerSocket`), the public `endSession`
+ * contract body (the flush boundary), the real `handleControl` `end` branch,
+ * `onSocketClose` owner branch, `flushUsage` (including its `ctx.waitUntil`
+ * registration), and `clearSession` one-for-one.
+ *
+ * The contract under test (L2 §Mechanism Variant 4):
+ *  - Every terminal path flushes: the public `endSession` contract method
+ *    (reached directly over the DO stub OR via the WS `end` branch) AND an
+ *    abrupt owner-socket close.
+ *  - Exactly once per session: end-then-close, double end, double close — one
+ *    write total, keyed `usage:{date}:{user_id}:{session_id}`.
+ *  - The background flush promise is registered on the DO lifecycle
+ *    (`ctx.waitUntil`), never bare-voided.
+ *  - The guard is per-session: a new `create` on the same resident DO resets
+ *    it, so session 2 flushes even though session 1 already did (the
+ *    cross-generation misfire the `turnEpoch` epoch guard warns about).
+ *  - FAIL-OPEN: a KV failure logs and is swallowed; an absent USAGE binding
+ *    skips silently. Session teardown is never blocked either way.
+ */
+
+// --- KV test doubles ----------------------------------------------------------
+
+/** Recording KV double implementing the structural `put` slice. */
+class FakeUsageKv implements UsageKvWriter {
+  readonly puts: Array<{ key: string; value: string }> = []
+
+  async put(key: string, value: string): Promise<void> {
+    this.puts.push({ key, value })
+  }
+}
+
+/** KV double whose every put rejects — the fail-open injection point. */
+class FailingUsageKv implements UsageKvWriter {
+  attempts = 0
+
+  async put(): Promise<void> {
+    this.attempts += 1
+    throw new Error('kv unavailable')
+  }
+}
+
+const COUNTERS: UsageCounters = {
+  llmInputTokens: 100,
+  llmOutputTokens: 50,
+  sttInputSeconds: 12.5,
+  ttsOutputSeconds: 8.25,
+}
+
+function snapshot(overrides: Partial<SessionUsageSnapshot> = {}): SessionUsageSnapshot {
+  return {
+    sessionId: 'session-uuid-1',
+    userId: 'user-A',
+    gameId: 'demo-mock',
+    turnCount: 3,
+    usage: { ...COUNTERS },
+    sttSource: 'provider-reported',
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// --- pure core: key + record + fail-open --------------------------------------
+
+describe('usageKeyFor', () => {
+  it('builds usage:{date}:{user_id}:{session_id} with the UTC date at flush time', () => {
+    // 23:30 UTC on the 11th is already the 12th in UTC+8 — the key must use
+    // UTC, not the local calendar.
+    const flushedAt = new Date('2026-06-11T23:30:00Z')
+    expect(usageKeyFor(flushedAt, 'user-A', 'session-uuid-1')).toBe(
+      'usage:2026-06-11:user-A:session-uuid-1'
+    )
+  })
+})
+
+describe('buildUsageRecord', () => {
+  it('carries the four counters, sttSource, gameId, turnCount, and the flush timestamp', () => {
+    const flushedAt = new Date('2026-06-11T08:00:00Z')
+    expect(buildUsageRecord(snapshot(), flushedAt)).toEqual({
+      gameId: 'demo-mock',
+      turnCount: 3,
+      usage: COUNTERS,
+      sttSource: 'provider-reported',
+      flushedAt: '2026-06-11T08:00:00.000Z',
+    })
+  })
+
+  it('copies the counters instead of aliasing the live session object', () => {
+    const snap = snapshot()
+    const record = buildUsageRecord(snap, new Date('2026-06-11T08:00:00Z'))
+    snap.usage.llmInputTokens = 999999
+    expect(record.usage.llmInputTokens).toBe(100)
+  })
+})
+
+describe('flushSessionUsage — fail-open', () => {
+  it('writes one record under the usage key', async () => {
+    const kv = new FakeUsageKv()
+    await flushSessionUsage(kv, snapshot(), new Date('2026-06-11T08:00:00Z'))
+
+    expect(kv.puts).toHaveLength(1)
+    expect(kv.puts[0].key).toBe('usage:2026-06-11:user-A:session-uuid-1')
+    expect(JSON.parse(kv.puts[0].value)).toEqual({
+      gameId: 'demo-mock',
+      turnCount: 3,
+      usage: COUNTERS,
+      sttSource: 'provider-reported',
+      flushedAt: '2026-06-11T08:00:00.000Z',
+    })
+  })
+
+  it('skips silently when the USAGE binding is absent (dev/demo deploys)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await expect(flushSessionUsage(undefined, snapshot())).resolves.toBeUndefined()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('logs and swallows a KV put failure — never rejects', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const kv = new FailingUsageKv()
+
+    await expect(flushSessionUsage(kv, snapshot())).resolves.toBeUndefined()
+
+    expect(kv.attempts).toBe(1)
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect(String(errorSpy.mock.calls[0][0])).toContain('usage flush failed for usage:')
+  })
+})
+
+// --- a faithful DO terminal-path stand-in --------------------------------------
+
+/** A stand-in socket — only reference identity matters to the owner-socket gate. */
+type FakeWs = { id: string }
+const OWNER: FakeWs = { id: 'owner-socket' }
+
+interface FakeState {
+  gameId: string
+  turnCount: number
+  usage: UsageCounters
+  sttSource: SttUsageSource
+}
+
+/**
+ * Records promises registered on the DO lifecycle — the `ctx.waitUntil`
+ * scheduling seam. Mirrors the one `DurableObjectState` member `flushUsage`
+ * uses, so tests can assert the flush promise was REGISTERED (kept alive by
+ * the runtime until it settles) rather than bare-voided.
+ */
+class FakeDoCtx {
+  readonly registered: Promise<unknown>[] = []
+
+  waitUntil(promise: Promise<unknown>): void {
+    this.registered.push(promise)
+  }
+}
+
+/**
+ * Mirrors `VoiceSessionDO`'s terminal-path wiring one-for-one: the session
+ * fields (`state` / `userId` / `sessionId` / `usageFlushed` / `ownerSocket`),
+ * `createSession`'s atomic publish (fresh minted id + `usageFlushed = false`),
+ * the public `endSession` contract body (summary -> flush — the contract-level
+ * flush boundary), the `end` branch (owner-socket gate -> `endSession` ->
+ * clear), the `onSocketClose` owner branch (gate -> flush -> clear),
+ * `flushUsage`'s guard + snapshot + `ctx.waitUntil`-registered
+ * `flushSessionUsage`, and `clearSession`'s reset. Turn-cancel mechanics are
+ * owned by `session-end-cleanup.test.ts` / `session-epoch-guard.test.ts` and
+ * elided here.
+ */
+class FakeSessionDo {
+  state: FakeState | undefined
+  userId: string | undefined
+  sessionId: string | undefined
+  ownerSocket: FakeWs | undefined
+  usageFlushed = false
+  /** The DO-lifecycle scheduling seam `flushUsage` registers its promise on. */
+  readonly ctx = new FakeDoCtx()
+
+  constructor(private readonly env: { USAGE?: UsageKvWriter }) {}
+
+  /** Mirrors `createSession` + the `create` control branch's owner record. */
+  create(userId: string, state: FakeState, ws: FakeWs = OWNER): boolean {
+    if (this.state) return false
+    // Atomic publish — mirrors the real field set, minted UUID included.
+    this.sessionId = crypto.randomUUID()
+    this.userId = userId
+    this.state = state
+    this.usageFlushed = false
+    this.ownerSocket = ws
+    return true
+  }
+
+  /** Mirrors `socketIsBoundSessionOwner` for the teardown gates. */
+  private isOwnerSocket(ws: FakeWs): boolean {
+    if (this.state === undefined || this.userId === undefined) return false
+    return this.ownerSocket !== undefined && ws === this.ownerSocket
+  }
+
+  /**
+   * Mirrors the public `endSession` contract body: settle the summary off the
+   * live state, then flush — the flush boundary lives HERE, not in the WS
+   * branch, so a direct contract call (no WS framing) is metered too. Like
+   * the real method, it does NOT clear the session; teardown belongs to the
+   * caller (`end` branch / owner-close).
+   */
+  endSession(): { turnCount: number } {
+    if (!this.state || !this.userId || this.sessionId === undefined) {
+      throw new Error('endSession before createSession')
+    }
+    const summary = { turnCount: this.state.turnCount }
+    this.flushUsage()
+    return summary
+  }
+
+  /** Mirrors the `end` control branch: gate -> `endSession` (flushes) -> clear. */
+  end(ws: FakeWs = OWNER): boolean {
+    if (!this.state || !this.userId || this.sessionId === undefined) return false
+    if (!this.isOwnerSocket(ws)) return false
+    this.endSession()
+    this.clearSession()
+    return true
+  }
+
+  /** Mirrors the `onSocketClose` owner branch: gate -> flush -> clear. */
+  socketClose(ws: FakeWs): void {
+    if (!this.isOwnerSocket(ws)) return
+    this.flushUsage()
+    this.clearSession()
+  }
+
+  /** Mirrors `VoiceSessionDO.flushUsage` one-for-one (incl. `ctx.waitUntil`). */
+  private flushUsage(): void {
+    const state = this.state
+    const sessionId = this.sessionId
+    const userId = this.userId
+    if (!state || sessionId === undefined || userId === undefined) return
+    if (this.usageFlushed) return
+    this.usageFlushed = true
+    this.ctx.waitUntil(
+      flushSessionUsage(this.env.USAGE, {
+        sessionId,
+        userId,
+        gameId: state.gameId,
+        turnCount: state.turnCount,
+        usage: { ...state.usage },
+        sttSource: state.sttSource,
+      })
+    )
+  }
+
+  /** Mirrors `clearSession`'s session-field reset (epoch/turn fields elided). */
+  private clearSession(): void {
+    this.state = undefined
+    this.userId = undefined
+    this.sessionId = undefined
+    this.ownerSocket = undefined
+    this.usageFlushed = false
+  }
+
+  /** Let the lifecycle-registered background flushes settle. */
+  async settle(): Promise<void> {
+    await Promise.all(this.ctx.registered)
+  }
+}
+
+function liveState(): FakeState {
+  return {
+    gameId: 'demo-mock',
+    turnCount: 2,
+    usage: { ...COUNTERS },
+    sttSource: 'derived-from-bytes',
+  }
+}
+
+describe('session-terminal flush — every terminal path flushes exactly once', () => {
+  it('a normal end flushes one record keyed by date/user/session', async () => {
+    const kv = new FakeUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+    do_.create('user-A', liveState())
+    const sessionId = do_.sessionId as string
+
+    expect(do_.end()).toBe(true)
+    await do_.settle()
+
+    expect(kv.puts).toHaveLength(1)
+    const utcDate = new Date().toISOString().slice(0, 10)
+    expect(kv.puts[0].key).toBe(`usage:${utcDate}:user-A:${sessionId}`)
+    const record = JSON.parse(kv.puts[0].value) as {
+      gameId: string
+      turnCount: number
+      usage: UsageCounters
+      sttSource: string
+    }
+    expect(record.gameId).toBe('demo-mock')
+    expect(record.turnCount).toBe(2)
+    expect(record.usage).toEqual(COUNTERS)
+    expect(record.sttSource).toBe('derived-from-bytes')
+    // The session is cleanly torn down after the flush.
+    expect(do_.state).toBeUndefined()
+    expect(do_.sessionId).toBeUndefined()
+  })
+
+  it('an abrupt owner-socket close (no end) flushes the same single record', async () => {
+    const kv = new FakeUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+    do_.create('user-A', liveState())
+    const sessionId = do_.sessionId as string
+
+    do_.socketClose(OWNER)
+    await do_.settle()
+
+    expect(kv.puts).toHaveLength(1)
+    expect(kv.puts[0].key).toContain(`:user-A:${sessionId}`)
+    expect(do_.state).toBeUndefined()
+  })
+
+  it('end followed by the owner socket close writes once, not twice', async () => {
+    // The real DO's close handler is unreachable after `end` (clearSession
+    // already unbound the owner), and the usageFlushed guard backstops it —
+    // either way: one write.
+    const kv = new FakeUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+    do_.create('user-A', liveState())
+
+    do_.end()
+    do_.socketClose(OWNER)
+    await do_.settle()
+
+    expect(kv.puts).toHaveLength(1)
+  })
+
+  it('a double end writes once', async () => {
+    const kv = new FakeUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+    do_.create('user-A', liveState())
+
+    do_.end()
+    do_.end()
+    await do_.settle()
+
+    expect(kv.puts).toHaveLength(1)
+  })
+
+  it('a non-owner socket close flushes nothing (the session is still live)', async () => {
+    const kv = new FakeUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+    do_.create('user-A', liveState())
+
+    do_.socketClose({ id: 'same-user-duplicate-tab' })
+    await do_.settle()
+
+    expect(kv.puts).toHaveLength(0)
+    expect(do_.state).toBeDefined()
+  })
+
+  it('the guard is per-session: a reconnect session on the same DO flushes its own record', async () => {
+    // Cross-generation correctness: session 1 ends (flushes, guard tripped),
+    // a new session opens on the SAME resident DO (create resets the guard),
+    // and its end must flush AGAIN — under its own minted id.
+    const kv = new FakeUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+
+    do_.create('user-A', liveState())
+    const firstId = do_.sessionId as string
+    do_.end()
+
+    do_.create('user-A', { ...liveState(), turnCount: 7 })
+    const secondId = do_.sessionId as string
+    do_.end()
+    await do_.settle()
+
+    expect(kv.puts).toHaveLength(2)
+    expect(firstId).not.toBe(secondId)
+    expect(kv.puts[0].key).toContain(firstId)
+    expect(kv.puts[1].key).toContain(secondId)
+    expect((JSON.parse(kv.puts[1].value) as { turnCount: number }).turnCount).toBe(7)
+  })
+})
+
+describe('public endSession contract — the flush boundary lives in the method body', () => {
+  it('a direct endSession call (no WS end message) flushes exactly once via the production mechanism', async () => {
+    // A consumer driving the four-method contract over the DO stub never sends
+    // a WS 'end' message — the flush must ride inside `endSession` itself, or
+    // that caller ends the session unmetered.
+    const kv = new FakeUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+    do_.create('user-A', liveState())
+    const sessionId = do_.sessionId as string
+
+    do_.endSession()
+    await do_.settle()
+
+    expect(kv.puts).toHaveLength(1)
+    expect(kv.puts[0].key).toContain(`:user-A:${sessionId}`)
+    expect((JSON.parse(kv.puts[0].value) as { turnCount: number }).turnCount).toBe(2)
+  })
+
+  it('a repeated direct endSession call stays guarded — still one write', async () => {
+    // `endSession` does not clear the session (teardown belongs to the WS
+    // branch / owner-close), so a second direct call passes the state checks;
+    // the per-session `usageFlushed` guard must absorb it.
+    const kv = new FakeUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+    do_.create('user-A', liveState())
+
+    do_.endSession()
+    do_.endSession()
+    await do_.settle()
+
+    expect(kv.puts).toHaveLength(1)
+  })
+
+  it('the WS end branch does not regress: an end message still flushes exactly once', async () => {
+    // The branch carries no flush of its own anymore — the single write rides
+    // inside the `endSession` call it makes.
+    const kv = new FakeUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+    do_.create('user-A', liveState())
+
+    expect(do_.end()).toBe(true)
+    await do_.settle()
+
+    expect(kv.puts).toHaveLength(1)
+  })
+})
+
+describe('flush scheduling — the write is registered on the DO lifecycle (ctx.waitUntil)', () => {
+  it('end registers exactly one flush promise via waitUntil instead of bare-voiding it', async () => {
+    const kv = new FakeUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+    do_.create('user-A', liveState())
+
+    do_.end()
+
+    // The promise is handed to the lifecycle seam synchronously at flush time,
+    // so the runtime keeps the DO alive until the background put settles.
+    expect(do_.ctx.registered).toHaveLength(1)
+    await do_.settle()
+    expect(kv.puts).toHaveLength(1)
+  })
+
+  it('the abrupt owner-close path registers its flush promise the same way', async () => {
+    const kv = new FakeUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+    do_.create('user-A', liveState())
+
+    do_.socketClose(OWNER)
+
+    expect(do_.ctx.registered).toHaveLength(1)
+    await do_.settle()
+    expect(kv.puts).toHaveLength(1)
+  })
+})
+
+describe('session-terminal flush — fail-open against the player path', () => {
+  it('a KV put failure still tears the session down cleanly and logs the error', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const kv = new FailingUsageKv()
+    const do_ = new FakeSessionDo({ USAGE: kv })
+    do_.create('user-A', liveState())
+
+    // end() must not throw — the failure stays inside the background flush.
+    expect(do_.end()).toBe(true)
+    await do_.settle()
+
+    expect(kv.attempts).toBe(1)
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    // Teardown completed despite the failed write.
+    expect(do_.state).toBeUndefined()
+    expect(do_.sessionId).toBeUndefined()
+  })
+
+  it('a missing USAGE binding skips the flush and the session still closes', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const do_ = new FakeSessionDo({})
+    do_.create('user-A', liveState())
+
+    expect(do_.end()).toBe(true)
+    await do_.settle()
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(do_.state).toBeUndefined()
+  })
+})

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -7,6 +7,7 @@ import type {
   LlmProvider,
   SttProvider,
   SttTranscriptChunk,
+  SttUsage,
   TtsAudioChunk,
   TtsProvider,
 } from './providers/types'
@@ -24,15 +25,25 @@ async function collect(stream: AsyncIterable<AiResponseChunk>): Promise<AiRespon
   return out
 }
 
-/** STT mock: ignores audio, replays a fixed transcript sequence. */
-function mockStt(transcripts: SttTranscriptChunk[]): SttProvider {
-  return {
+/**
+ * STT mock: ignores audio, replays a fixed transcript sequence. When `usage`
+ * is given, exposes it as `lastUsage` after the stream drains (the structured
+ * STT metering channel); without it, the pipeline's byte-tap fallback applies.
+ */
+function mockStt(
+  transcripts: SttTranscriptChunk[],
+  opts: { usage?: SttUsage } = {}
+): SttProvider & { lastUsage?: SttUsage } {
+  const provider: SttProvider & { lastUsage?: SttUsage } = {
     async *transcribe(audio: AsyncIterable<AudioChunk>): AsyncIterable<SttTranscriptChunk> {
+      provider.lastUsage = undefined
       // Drain audio so the bridge closes cleanly, then emit transcripts.
       for await (const _ of audio) void _
+      provider.lastUsage = opts.usage
       yield* fromArray(transcripts)
     },
   }
+  return provider
 }
 
 /** LLM mock: records the request, streams the given content deltas, then done. */
@@ -104,6 +115,7 @@ function freshState(): SessionState {
     history: [],
     turnCount: 0,
     usage: { llmInputTokens: 0, llmOutputTokens: 0, sttInputSeconds: 0, ttsOutputSeconds: 0 },
+    sttSource: 'provider-reported',
   }
 }
 
@@ -208,8 +220,8 @@ describe('runTurn', () => {
     ])
   })
 
-  it('estimates non-zero STT/TTS audio seconds from the bytes that flowed', async () => {
-    // 32000 bytes = 1.0s under the PCM-16 mono 16kHz estimate. Feed exactly that
+  it('derives non-zero STT/TTS audio seconds from the bytes that flowed (no adapter usage)', async () => {
+    // 32000 bytes = 1.0s at the PCM-16 mono 16kHz byte rate. Feed exactly that
     // many inbound audio bytes; the mock TTS emits a frame per sentence whose
     // byte length is the sentence length (see mockTts), so TTS seconds are
     // small-but-non-zero. The point of the assertion: neither stays 0 (the bug
@@ -228,8 +240,112 @@ describe('runTurn', () => {
 
     // 32000 inbound bytes -> exactly 1.0 STT second.
     expect(state.usage.sttInputSeconds).toBeCloseTo(1.0, 5)
-    // TTS produced at least one audio frame, so its seconds estimate is > 0.
+    // TTS produced at least one audio frame, so its seconds figure is > 0.
     expect(state.usage.ttsOutputSeconds).toBeGreaterThan(0)
+    // No structured STT usage was exposed -> the byte fallback ran and the
+    // session's STT metering annotation latched to byte-derived.
+    expect(state.sttSource).toBe('derived-from-bytes')
+  })
+
+  it('prefers the STT adapter usage report over the byte tap (provider-reported)', async () => {
+    // The adapter reports 2500ms via the structured channel; the pipeline's own
+    // byte tap saw 32000 bytes (= 1.0s). The provider value must win, and the
+    // session annotation must STAY provider-reported.
+    const state = freshState()
+    const turn = runTurn(
+      providers(
+        mockStt([{ text: 'hi.', isFinal: true }], {
+          usage: { durationMs: 2500, source: 'provider-reported' },
+        }),
+        mockLlm(['Ok.']),
+        mockTts([])
+      ),
+      state,
+      fromArray<AudioChunk>([new Uint8Array(32000)])
+    )
+    await collect(turn)
+
+    expect(state.usage.sttInputSeconds).toBeCloseTo(2.5, 9)
+    expect(state.sttSource).toBe('provider-reported')
+  })
+
+  it('an adapter-reported byte-derived usage still counts but downgrades the annotation', async () => {
+    // The adapter itself fell back to its byte-rate conversion (no
+    // audio_info.duration in any server response) and says so via the source
+    // tag. The duration is taken as-is; the session annotation downgrades.
+    const state = freshState()
+    const turn = runTurn(
+      providers(
+        mockStt([{ text: 'hi.', isFinal: true }], {
+          usage: { durationMs: 1500, source: 'derived-from-bytes' },
+        }),
+        mockLlm(['Ok.']),
+        mockTts([])
+      ),
+      state,
+      fromArray<AudioChunk>([new Uint8Array(1)])
+    )
+    await collect(turn)
+
+    expect(state.usage.sttInputSeconds).toBeCloseTo(1.5, 9)
+    expect(state.sttSource).toBe('derived-from-bytes')
+  })
+
+  it('one byte-derived turn latches the session annotation even after provider-reported turns', async () => {
+    // Turn 1 is provider-reported; turn 2 has no structured usage (byte
+    // fallback). The aggregate seconds add up and the annotation describes the
+    // precision FLOOR: once any turn is byte-derived, the session is.
+    const state = freshState()
+    await collect(
+      runTurn(
+        providers(
+          mockStt([{ text: 'one.', isFinal: true }], {
+            usage: { durationMs: 1000, source: 'provider-reported' },
+          }),
+          mockLlm(['First.']),
+          mockTts([])
+        ),
+        state,
+        fromArray<AudioChunk>([new Uint8Array(1)])
+      )
+    )
+    expect(state.sttSource).toBe('provider-reported')
+
+    await collect(
+      runTurn(
+        providers(mockStt([{ text: 'two.', isFinal: true }]), mockLlm(['Second.']), mockTts([])),
+        state,
+        fromArray<AudioChunk>([new Uint8Array(32000)])
+      )
+    )
+
+    expect(state.usage.sttInputSeconds).toBeCloseTo(2.0, 5)
+    expect(state.sttSource).toBe('derived-from-bytes')
+  })
+
+  it('converts TTS seconds exactly from the synthesized bytes', async () => {
+    // The TTS mock emits exactly the frames given: 48000 + 16000 bytes =
+    // 64000 bytes = exactly 2.0s at the PCM-16 mono 16kHz byte rate. This is
+    // the actual-product conversion, not an estimate: the tally is over the
+    // frames the turn really yielded.
+    const tts: TtsProvider = {
+      async *synthesize(text: AsyncIterable<string>): AsyncIterable<TtsAudioChunk> {
+        for await (const _ of text) void _
+        yield { audio: new Uint8Array(48000), done: false }
+        yield { audio: new Uint8Array(16000), done: false }
+        yield { audio: new Uint8Array(0), done: true }
+      },
+    }
+    const state = freshState()
+    await collect(
+      runTurn(
+        providers(mockStt([{ text: 'hi.', isFinal: true }]), mockLlm(['Reply here.']), tts),
+        state,
+        fromArray<AudioChunk>([new Uint8Array(1)])
+      )
+    )
+
+    expect(state.usage.ttsOutputSeconds).toBeCloseTo(2.0, 9)
   })
 
   // Intent: single-session ROLLING-HISTORY context, not cross-session

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -21,7 +21,14 @@
  */
 
 import type { AiResponseChunk, AudioChunk } from './contract'
-import type { ChatMessage, LlmProvider, SttProvider, TtsProvider } from './providers/types'
+import type {
+  ChatMessage,
+  LlmProvider,
+  SttProvider,
+  SttUsage,
+  SttUsageSource,
+  TtsProvider,
+} from './providers/types'
 import { assembleLlmContext, type GameState } from './manual-injection'
 import type { ResolvedConfig } from './provider-config'
 import type { ManualData } from './contract'
@@ -35,20 +42,21 @@ export interface UsageCounters {
 }
 
 /**
- * Audio-duration estimation constant. Both the Volcengine ASR input and the
- * Doubao TTS output are PCM 16-bit mono at 16 kHz (the adapter's
- * `DEFAULT_SAMPLE_RATE`), i.e. 16000 samples/s * 2 bytes/sample = 32000 bytes/s.
+ * Audio byte-rate constant. Both the Volcengine ASR input and the Doubao TTS
+ * output are PCM 16-bit mono at 16 kHz (the adapter's `DEFAULT_SAMPLE_RATE`),
+ * i.e. 16000 samples/s * 2 bytes/sample = 32000 bytes/s.
  *
- * v1 estimate / metering mount point: the pipeline only sees opaque byte frames,
- * so it derives seconds from byte length under this fixed-format assumption.
- * Precise, per-provider sample-rate-aware accounting (and any non-PCM codec)
- * lives in the downstream `add-usage-metering` task; this fills the counters
- * with a real, non-zero estimate instead of silently reporting 0.
+ * Under that fixed format the byte->seconds conversion is EXACT, not an
+ * estimate: the byte count of the actual audio that flowed divides precisely
+ * into its duration. For TTS this measures the actual synthesized product
+ * (every frame's bytes are tallied as they are yielded); for STT it is the
+ * fallback path when the adapter reports no structured usage of its own —
+ * metered seconds from this path carry the `derived-from-bytes` annotation.
  */
 const PCM16_MONO_16K_BYTES_PER_SECOND = 32000
 
-/** Estimate audio seconds from a raw PCM-frame byte count (see constant above). */
-function estimateAudioSeconds(byteLength: number): number {
+/** Convert a raw PCM-frame byte count to seconds (exact under the format above). */
+function audioSecondsFromBytes(byteLength: number): number {
   return byteLength / PCM16_MONO_16K_BYTES_PER_SECOND
 }
 
@@ -70,6 +78,15 @@ export interface SessionState {
   turnCount: number
   /** Accumulated usage counters. */
   usage: UsageCounters
+  /**
+   * Aggregate STT metering provenance across the session. Starts
+   * `provider-reported` and latches to `derived-from-bytes` as soon as ANY
+   * turn's STT seconds came from a byte-rate conversion rather than the
+   * provider's own report — the annotation describes the precision floor of
+   * the aggregated `sttInputSeconds`, so one fallback turn downgrades the
+   * whole session's annotation. Flushed alongside the counters at session end.
+   */
+  sttSource: SttUsageSource
 }
 
 /** The three wired providers a turn drives. */
@@ -86,6 +103,16 @@ export interface TurnProviders {
  */
 interface MaybeUsageProvider {
   lastUsage?: { inputTokens: number; outputTokens: number }
+}
+
+/**
+ * STT provider instances may expose a structured `lastUsage` after a transcribe
+ * stream is drained (the Volcengine adapter does; the mock does on request).
+ * Read structurally, mirroring the LLM `lastUsage` pattern, so the pipeline
+ * stays adapter-agnostic.
+ */
+interface MaybeSttUsageProvider {
+  lastUsage?: SttUsage
 }
 
 /**
@@ -116,8 +143,9 @@ export function splitSentences(buffer: string): { sentences: string[]; remainder
  *
  * Also reports `audioBytes`: the total byte length of the inbound audio frames
  * the STT provider actually pulled, tapped via a counting passthrough. The
- * caller turns this into the STT input-seconds usage estimate. The passthrough
- * forwards every frame unchanged, so STT behaviour is unaffected.
+ * caller uses this as the fallback STT metering path when the adapter exposes
+ * no structured usage of its own. The passthrough forwards every frame
+ * unchanged, so STT behaviour is unaffected.
  */
 async function collectFinalTranscript(
   stt: SttProvider,
@@ -203,8 +231,8 @@ export async function* runTurn(
   audio: AsyncIterable<AudioChunk>
 ): AsyncIterable<AiResponseChunk> {
   // 1. STT: transcribe the player's audio; take the final cumulative transcript.
-  //    `audioBytes` is the inbound-frame byte total, turned into the STT
-  //    input-seconds usage estimate at turn settle.
+  //    `audioBytes` is the inbound-frame byte total — the fallback STT metering
+  //    source at turn settle when the adapter reports no structured usage.
   const { transcript: playerText, audioBytes: sttAudioBytes } = await collectFinalTranscript(
     providers.stt,
     audio
@@ -243,8 +271,9 @@ export async function* runTurn(
   let nextLlmPromise: Promise<IteratorResult<{ content: string; done: boolean }>> | undefined =
     llmStream.next()
 
-  // TTS output bytes tallied across the turn's synthesized frames, turned into
-  // the TTS output-seconds usage estimate at turn settle.
+  // TTS output bytes tallied across the turn's synthesized frames — converted
+  // exactly into the TTS output-seconds usage at turn settle (the actual
+  // synthesized product, not an estimate).
   let ttsAudioBytes = 0
 
   // Drive both streams until both are exhausted. Whichever resolves first
@@ -343,11 +372,25 @@ export async function* runTurn(
     state.usage.llmInputTokens += usage.inputTokens
     state.usage.llmOutputTokens += usage.outputTokens
   }
-  // Best-effort audio-duration metering (v1 estimate; see
-  // `estimateAudioSeconds`). Filled from the bytes that actually flowed this
-  // turn so `endSession` reports a real estimate, not a silent 0.
-  state.usage.sttInputSeconds += estimateAudioSeconds(sttAudioBytes)
-  state.usage.ttsOutputSeconds += estimateAudioSeconds(ttsAudioBytes)
+  // STT seconds: prefer the adapter's structured usage report (the Volcengine
+  // adapter exposes the server's `audio_info.duration` when reported, or its
+  // own exact bytes->duration conversion when not). When the adapter exposes
+  // nothing at all, fall back to the pipeline's byte tap over the inbound
+  // frames the STT provider actually pulled — and latch the session's STT
+  // metering annotation to `derived-from-bytes` (see `SessionState.sttSource`).
+  const sttUsage = (providers.stt as MaybeSttUsageProvider).lastUsage
+  if (sttUsage) {
+    state.usage.sttInputSeconds += sttUsage.durationMs / 1000
+    if (sttUsage.source === 'derived-from-bytes') state.sttSource = 'derived-from-bytes'
+  } else {
+    state.usage.sttInputSeconds += audioSecondsFromBytes(sttAudioBytes)
+    state.sttSource = 'derived-from-bytes'
+  }
+  // TTS seconds: exact conversion of the actual synthesized product — the byte
+  // tally of every audio frame this turn yielded, under the adapters' fixed
+  // PCM16 mono 16 kHz output contract (the Volcengine TTS session requests
+  // exactly that format; the mock's placeholder bytes meter the same way).
+  state.usage.ttsOutputSeconds += audioSecondsFromBytes(ttsAudioBytes)
 
   yield { kind: 'text', text: '', done: true }
 }

--- a/packages/platform-ai/src/usage-flush.ts
+++ b/packages/platform-ai/src/usage-flush.ts
@@ -1,0 +1,97 @@
+/**
+ * Usage flush — persist one ended session's usage counters to the USAGE KV.
+ *
+ * This is the testable core of the DO's session-terminal metering flush
+ * (`VoiceSessionDO.flushUsage` is a thin shell over `flushSessionUsage`),
+ * extracted pure-ish so the key shape, record shape, and fail-open behavior
+ * are unit-testable in Node (the DO class imports `cloudflare:workers` and
+ * cannot be instantiated in the test environment).
+ *
+ * Storage contract (L2 §Mechanism Variant 4):
+ *  - One write-once record per session: key `usage:{date}:{user_id}:{session_id}`
+ *    where `date` is the UTC `YYYY-MM-DD` at flush time and `session_id` is the
+ *    session's freshly minted UUID (see `session-assembly.ts`) — globally
+ *    unique, so concurrent sessions never contend on a key and the read side
+ *    aggregates by `list({ prefix }) + sum`. No read-modify-write counters
+ *    (KV has no atomic increment; concurrent RMW loses updates).
+ *  - Billing-grade data: no TTL.
+ *  - FAIL-OPEN: a KV failure (or an absent binding in dev/demo) is logged and
+ *    swallowed — metering must never throw into, block, or delay session
+ *    teardown or the player-facing path. The accepted failure cost is
+ *    undercount-only (the platform absorbs it); nothing here can over-meter.
+ */
+
+import type { UsageCounters } from './turn-pipeline'
+import type { SttUsageSource } from './providers/types'
+
+/**
+ * Minimal structural view of the bound USAGE KV namespace — just the write the
+ * flush needs. Narrower than the full `KVNamespace` lib type so the flush stays
+ * testable with a plain object mock.
+ */
+export interface UsageKvWriter {
+  put(key: string, value: string): Promise<void>
+}
+
+/** Snapshot of one ended session's metering state, captured before teardown. */
+export interface SessionUsageSnapshot {
+  sessionId: string
+  userId: string
+  gameId: string
+  /** Completed player->AI turns (a turn canceled mid-flight never counts). */
+  turnCount: number
+  /** The session's accumulated usage counters. */
+  usage: UsageCounters
+  /** Aggregate STT metering provenance (see `SessionState.sttSource`). */
+  sttSource: SttUsageSource
+}
+
+/** JSON value stored under the usage key. Identity lives in the key. */
+export interface UsageRecord {
+  gameId: string
+  turnCount: number
+  usage: UsageCounters
+  sttSource: SttUsageSource
+  /** ISO 8601 flush timestamp — provenance for audits and late-write triage. */
+  flushedAt: string
+}
+
+/** Build the write-once usage key: `usage:{date}:{user_id}:{session_id}` (UTC date). */
+export function usageKeyFor(flushedAt: Date, userId: string, sessionId: string): string {
+  return `usage:${flushedAt.toISOString().slice(0, 10)}:${userId}:${sessionId}`
+}
+
+/** Build the stored JSON record from a session snapshot. */
+export function buildUsageRecord(snapshot: SessionUsageSnapshot, flushedAt: Date): UsageRecord {
+  return {
+    gameId: snapshot.gameId,
+    turnCount: snapshot.turnCount,
+    usage: { ...snapshot.usage },
+    sttSource: snapshot.sttSource,
+    flushedAt: flushedAt.toISOString(),
+  }
+}
+
+/**
+ * Persist one session's usage snapshot to the USAGE KV. Never rejects:
+ *  - `kv` undefined (dev/demo deploy without the binding) -> silent no-op;
+ *  - KV `put` failure -> `console.error` and swallow.
+ * The caller fires-and-forgets this from the session-terminal paths; the
+ * exactly-once guard lives with the caller's session state (the flush is
+ * called at most once per session), not here.
+ */
+export async function flushSessionUsage(
+  kv: UsageKvWriter | undefined,
+  snapshot: SessionUsageSnapshot,
+  now: Date = new Date()
+): Promise<void> {
+  if (kv === undefined) return
+  const key = usageKeyFor(now, snapshot.userId, snapshot.sessionId)
+  try {
+    await kv.put(key, JSON.stringify(buildUsageRecord(snapshot, now)))
+  } catch (err) {
+    // Fail-open: losing one metering record is an accepted undercount; failing
+    // the session-close path over it is not.
+    console.error(`platform-ai: usage flush failed for ${key}`, err)
+  }
+}

--- a/packages/platform-ai/wrangler.toml
+++ b/packages/platform-ai/wrangler.toml
@@ -43,6 +43,20 @@ new_sqlite_classes = ["VoiceSessionDO"]
 binding = "AUTH"
 id = "PLACEHOLDER_AUTH_KV_NAMESPACE_ID"
 
+# --- USAGE KV: per-session usage metering records ---
+# The session DO flushes ONE write-once record per ended voice session — key
+# `usage:{date}:{user_id}:{session_id}` (UTC date at flush time, session_id a
+# per-session UUID), value the session's usage counters (LLM tokens + STT/TTS
+# seconds + STT source annotation). Billing-grade data: no TTL. The write is
+# fail-open (a KV failure is logged, never blocks session close) and the
+# binding is OPTIONAL at runtime — a dev/demo config without it just skips the
+# flush. Dedicated namespace; do NOT reuse LEADERBOARD or AUTH. `id` is the
+# production namespace id, filled at deploy wiring time (placeholder until
+# then, same as AUTH above).
+[[kv_namespaces]]
+binding = "USAGE"
+id = "PLACEHOLDER_USAGE_KV_NAMESPACE_ID"
+
 # --- Same-origin WS route on the canonical zone ---
 # Mounting under claw.amio.fans (same zone as the Platform SPA / /api/*) is the
 # structural prerequisite for the session cookie to ride along on the WS


### PR DESCRIPTION
## Summary

- Replace estimated speech-seconds with real provider usage: Volcengine ASR `audio_info.duration` (cumulative; last full server response per connection) with a derived-from-bytes fallback and a per-record source tag; TTS seconds derived exactly from actual synthesized bytes; DeepSeek token path unchanged
- Persist per-session usage to a dedicated `USAGE` KV namespace on all DO terminal paths (contract `endSession` body + abnormal socket close), exactly once per logical session, registered via `ctx.waitUntil`, fail-open (KV failure only logs, never blocks teardown); key `usage:{date}:{user_id}:{session_id}`, write-once, no TTL
- Mint `session_id` as `crypto.randomUUID()` at `createSession` — never the bare DO id (DO reuse after `clearSession` would collide billing keys and silently overwrite records)
- Production-class DO test harness (`vi.mock('cloudflare:workers')`) driving the real `VoiceSessionDO` terminal paths; suite 766 → 804 tests

## Type of change

- [x] New feature

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Full-repo gates all green: `pnpm lint` / `pnpm format:check` / `pnpm typecheck` / `pnpm test:run` → 804/804 (platform-ai 245, api 145, ui 2, manual 71, game-yijing 21, platform 39, game-bombsquad 281). Manual smoke via `wrangler dev` (mock providers): create → 32000B audio turn → end; sessionId is UUID v4 (not DO id), summary reports exact usage; demo without USAGE binding fail-opens cleanly.

Cross-model verification: two codex review rounds during development (flush-boundary + runtime-lifetime findings fixed; closure confirmed; remaining test-boundary finding closed with the production-class harness).

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

Architecture SSOT updated (vault, via docs symlink): `docs/architecture/arch-component-platform-ai-interface.md` §Mechanism Variant 4 + `docs/architecture/architecture.md` (three-namespace KV). Deploy wiring for the real `USAGE` namespace id belongs to the `deploy-and-verify-platform-ai-worker` followup. `SessionSummary` wire shape unchanged (no client-visible metering detail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)