### PR TITLE
fix(platform-ai): demo records PCM16 16kHz audio instead of webm/opus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Platform-AI voice demo now records protocol-correct PCM16 16kHz audio** -
+Internal fix. The first-party voice-session demo harness used to capture
+microphone audio with `MediaRecorder` as webm/opus, which does not match the
+format the real speech-recognition adapter declares. The demo now captures PCM16
+16kHz mono — the exact wire format the adapter expects — via the Web Audio API,
+so the demo's audio layer is protocol-correct and reusable as-is by a
+real-provider verification harness. The deterministic mock round still completes
+unchanged. No player-facing behavior changes.
+
 **Platform-AI voice moved to the current Volcengine sign-in and the upgraded
 speech recognition model** - Internal fix. The voice partner's speech layer now
 authenticates with Volcengine's current console API key instead of the retired

--- a/packages/platform-ai/demo/README.md
+++ b/packages/platform-ai/demo/README.md
@@ -1,12 +1,25 @@
 # Platform AI — Voice Session Demo
 
 A minimal first-party harness that drives the whole `@amiclaw/platform-ai`
-pipeline (STT → LLM → TTS) over the same-origin `/ai-ws/*` WebSocket, with **no
-real provider credentials**.
+pipeline (STT → LLM → TTS) over the same-origin `/ai-ws/*` WebSocket. By default
+it runs against the deterministic **mock** providers (gameId `demo-mock`), so it
+needs **no real provider credentials**.
 
 It exists to prove the locked acceptance end to end: _speak → ASR → LLM (grounded
 in the injected manual) → TTS → see / hear a deterministic reply_, and to show
 the security invariant holds — the browser holds no key and no system prompt.
+
+## Audio format
+
+Player audio is captured as **PCM16 16kHz mono** — the exact wire format the real
+STT adapter expects (`../src/providers/volcengine.ts`: `format:'pcm', rate:16000,
+bits:16, channel:1`). Capture uses `AudioContext({ sampleRate: 16000 })` feeding a
+`ScriptProcessorNode`; each frame's Float32 samples are converted to Int16
+little-endian PCM (`floatTo16BitPCM` in `audio-pcm.js`, unit-tested in
+`audio-pcm.test.js`) and sent over the WS binary channel. Because the audio layer
+is now protocol-correct (no more `MediaRecorder` / webm-opus), this same capture
+path is reusable as-is by a real-provider / live-verification harness — only the
+server-side gameId and credentials would change.
 
 ## How it works
 

--- a/packages/platform-ai/demo/audio-pcm.js
+++ b/packages/platform-ai/demo/audio-pcm.js
@@ -1,0 +1,29 @@
+// Pure audio-format helpers for the voice-session demo.
+//
+// Side-effect-free ESM: no DOM / Web Audio access at module top level, so it is
+// safe to import from both the browser demo client (`demo.js`) and the vitest
+// unit test (`audio-pcm.test.js`).
+
+/**
+ * Convert mono Float32 PCM samples (range [-1, 1]) to 16-bit little-endian PCM.
+ *
+ * Each sample is clamped to [-1, 1], scaled to the signed 16-bit range
+ * (negative side uses 0x8000, positive side uses 0x7FFF), rounded to an integer,
+ * and written little-endian. The result is `samples.length * 2` bytes — the
+ * exact wire format the real STT adapter expects (`format:'pcm', bits:16`).
+ *
+ * @param {Float32Array} samples Mono Float32 samples in [-1, 1].
+ * @returns {ArrayBuffer} Int16 little-endian PCM, 2 bytes per sample.
+ */
+export function floatTo16BitPCM(samples) {
+  const buffer = new ArrayBuffer(samples.length * 2)
+  const view = new DataView(buffer)
+  for (let i = 0; i < samples.length; i += 1) {
+    let s = samples[i]
+    if (s > 1) s = 1
+    else if (s < -1) s = -1
+    const int = s < 0 ? Math.round(s * 0x8000) : Math.round(s * 0x7fff)
+    view.setInt16(i * 2, int, true)
+  }
+  return buffer
+}

--- a/packages/platform-ai/demo/audio-pcm.test.js
+++ b/packages/platform-ai/demo/audio-pcm.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { floatTo16BitPCM } from './audio-pcm.js'
+
+describe('floatTo16BitPCM', () => {
+  it('returns an ArrayBuffer of 2 bytes per sample', () => {
+    const out = floatTo16BitPCM(new Float32Array(8))
+    expect(out).toBeInstanceOf(ArrayBuffer)
+    expect(out.byteLength).toBe(8 * 2)
+  })
+
+  it('returns an empty buffer for an empty input', () => {
+    expect(floatTo16BitPCM(new Float32Array(0)).byteLength).toBe(0)
+  })
+
+  it('maps the boundary values exactly: 1.0 -> 0x7FFF, -1.0 -> -0x8000, 0 -> 0', () => {
+    const view = new DataView(floatTo16BitPCM(new Float32Array([1, -1, 0])))
+    expect(view.getInt16(0, true)).toBe(0x7fff)
+    expect(view.getInt16(2, true)).toBe(-0x8000)
+    expect(view.getInt16(4, true)).toBe(0)
+  })
+
+  it('clamps out-of-range samples into [-1, 1]', () => {
+    const view = new DataView(floatTo16BitPCM(new Float32Array([2, -2, 1.5, -3])))
+    expect(view.getInt16(0, true)).toBe(0x7fff)
+    expect(view.getInt16(2, true)).toBe(-0x8000)
+    expect(view.getInt16(4, true)).toBe(0x7fff)
+    expect(view.getInt16(6, true)).toBe(-0x8000)
+  })
+
+  it('writes samples little-endian (low byte first)', () => {
+    const bytes = new Uint8Array(floatTo16BitPCM(new Float32Array([1, -1])))
+    // 0x7FFF little-endian -> [0xFF, 0x7F]
+    expect(bytes[0]).toBe(0xff)
+    expect(bytes[1]).toBe(0x7f)
+    // -0x8000 (two's complement 0x8000) little-endian -> [0x00, 0x80]
+    expect(bytes[2]).toBe(0x00)
+    expect(bytes[3]).toBe(0x80)
+  })
+})

--- a/packages/platform-ai/demo/demo.js
+++ b/packages/platform-ai/demo/demo.js
@@ -4,6 +4,15 @@
 // WebSocket: create -> stream player audio frames -> `turn` -> render the AI's
 // streamed text + audio response.
 //
+// AUDIO FORMAT: player audio is captured as PCM16 16kHz mono — the exact wire
+// format the real STT adapter expects (`volcengine.ts`: format:'pcm', rate:16000,
+// bits:16, channel:1). Capture uses `AudioContext({ sampleRate: 16000 })` +
+// `ScriptProcessorNode`, converting Float32 samples to Int16 little-endian PCM
+// per frame (see `floatTo16BitPCM` in `./audio-pcm.js`). The server defaults to
+// the deterministic mock providers here (gameId `demo-mock`), but because the
+// audio layer is now protocol-correct, this capture path is reusable as-is by a
+// real-provider / live-verification harness.
+//
 // SECURITY INVARIANT (load-bearing): this client connects ONLY to the
 // same-origin Worker WebSocket. It holds NO provider API key and NO system
 // prompt. The gameId (`demo-mock`) is the only game material it sends; the
@@ -15,6 +24,8 @@
 // credentials. Note: the mock TTS frame is the UTF-8 bytes of the sentence (a
 // placeholder, not a real audio codec), so playback is best-effort — the point
 // of the demo is to show the text + audio chunks arriving end to end.
+
+import { floatTo16BitPCM } from './audio-pcm.js'
 
 const els = {
   connect: document.getElementById('connect'),
@@ -39,9 +50,13 @@ const MANUAL_DATA = {
 }
 const GAME_STATE = { relevantSections: ['button-module'] }
 
+const CAPTURE_SAMPLE_RATE = 16000
+
 let ws = null
 let mediaStream = null
-let mediaRecorder = null
+let audioCtx = null
+let sourceNode = null
+let procNode = null
 let currentAiTurn = null
 
 function setStatus(text) {
@@ -151,29 +166,48 @@ async function startSpeaking() {
   } catch {
     setStatus('Microphone permission denied — sending a silent frame instead.')
     // Even without a mic, the mock STT yields its fixed transcript, so the demo
-    // still completes a turn. Send one empty frame to stand in for audio.
-    ws.send(new Uint8Array([0]).buffer)
+    // still completes a turn. Send one empty PCM frame to stand in for audio.
+    ws.send(new ArrayBuffer(0))
     return
   }
-  mediaRecorder = new MediaRecorder(mediaStream)
-  mediaRecorder.addEventListener('dataavailable', async (event) => {
-    if (event.data.size > 0 && ws && ws.readyState === WebSocket.OPEN) {
-      const buf = await event.data.arrayBuffer()
-      ws.send(buf)
-    }
+  // Capture at 16kHz so the browser resamples the mic to the STT adapter's rate;
+  // no manual downsampling needed. ScriptProcessor is deprecated but universally
+  // supported and sufficient for this dev harness.
+  audioCtx = new AudioContext({ sampleRate: CAPTURE_SAMPLE_RATE })
+  sourceNode = audioCtx.createMediaStreamSource(mediaStream)
+  procNode = audioCtx.createScriptProcessor(4096, 1, 1)
+  procNode.addEventListener('audioprocess', (event) => {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+    // Mono Float32 samples @16kHz -> Int16 little-endian PCM frame.
+    const pcm = floatTo16BitPCM(event.inputBuffer.getChannelData(0))
+    ws.send(pcm)
   })
-  mediaRecorder.start(250) // emit a frame every 250ms
+  sourceNode.connect(procNode)
+  procNode.connect(audioCtx.destination)
   setStatus('Listening… release to send.')
 }
 
-function stopSpeaking() {
-  if (mediaRecorder && mediaRecorder.state !== 'inactive') {
-    mediaRecorder.stop()
+function teardownCapture() {
+  if (procNode) {
+    procNode.disconnect()
+    procNode = null
+  }
+  if (sourceNode) {
+    sourceNode.disconnect()
+    sourceNode = null
+  }
+  if (audioCtx) {
+    audioCtx.close()
+    audioCtx = null
   }
   if (mediaStream) {
     mediaStream.getTracks().forEach((t) => t.stop())
     mediaStream = null
   }
+}
+
+function stopSpeaking() {
+  teardownCapture()
   if (ws && ws.readyState === WebSocket.OPEN) {
     // Give the last audio frame a moment to flush, then request the AI turn.
     setStatus('Thinking…')


### PR DESCRIPTION
## Summary

- The first-party voice-session demo captured mic audio with `MediaRecorder` (webm/opus), which does not match the PCM16 16kHz mono format the real STT adapter declares (`volcengine.ts`: `format:'pcm', rate:16000, bits:16, channel:1`) — so the demo protocol was only correct for the mock provider.
- Replace the `MediaRecorder` path with `AudioContext({sampleRate:16000})` + `ScriptProcessorNode`, converting Float32 → Int16 little-endian PCM via a new pure helper `floatTo16BitPCM` (`demo/audio-pcm.js`), unit-tested in `demo/audio-pcm.test.js`.
- Demo stays mock-only by default (gameId unchanged), holds no key/prompt; its capture path is now reusable as-is by a real-provider verification harness. README + CHANGELOG updated.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Manual / verification: `pnpm -r run test:run` green (279 platform-ai tests incl. 5 new for `floatTo16BitPCM`); `typecheck` exit 0; eslint/prettier clean. Independent verifier traced the demo-mock turn end-to-end (server WS receive → mock STT) and confirmed the 0-byte mic-denied fallback frame still completes a turn — no regression. Live real-provider capture is out of scope (demo stays mock by default).

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

🤖 Generated with [Claude Code](https://claude.com/claude-code)