### PR TITLE
fix(platform-ai): bound LLM SSE inter-chunk gap so a stalled stream fails loud, not parks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Platform-AI voice turns can no longer hang when the LLM stream stalls
+mid-reply** - Internal reliability hardening. The AI's language model streams its
+answer back token by token; if it sent the first token and then went silent —
+the connection still open, but no further output and no error — the turn used to
+park until the platform's hard timeout, leaving the player with an AI that never
+finished speaking and a session that would not free up. The streaming layer now
+bounds the silent gap between tokens: if a stream that has already started goes
+quiet for too long, the turn fails cleanly and the session is freed instead of
+hanging. The guard resets on every token, so a legitimately long answer — even
+one with natural pauses — is never cut off; only a truly stuck stream is. No
+player-facing behavior changes beyond turns no longer hanging.
+
 **Platform-AI voice demo now records protocol-correct PCM16 16kHz audio** -
 Internal fix. The first-party voice-session demo harness used to capture
 microphone audio with `MediaRecorder` as webm/opus, which does not match the

--- a/packages/platform-ai/src/providers/deepseek.test.ts
+++ b/packages/platform-ai/src/providers/deepseek.test.ts
@@ -345,39 +345,141 @@ describe('createDeepSeekLlmProvider — connect timeout', () => {
     expect(init?.signal).toBeInstanceOf(AbortSignal)
   })
 
-  it('does NOT kill a slow-but-valid response that streams for a long time', async () => {
-    // The timeout bounds the CONNECT phase only: once `fetch` resolves with the
-    // response, the deadline is cleared and the streaming body is unbounded. Model
-    // a body whose deltas arrive across a long span (well past connectMs of fake
-    // time) — every delta must still be delivered, none killed by the timer.
-    vi.useFakeTimers()
-    try {
-      const encoder = new TextEncoder()
-      const slowStream = new ReadableStream<Uint8Array>({
-        async start(controller) {
-          controller.enqueue(encoder.encode(deltaLine('slow ')))
-          // A long pause AFTER the first byte — longer than every deadline. A
-          // whole-turn timeout would wrongly kill the stream here; a connect /
-          // first-response timeout must not.
-          await vi.advanceTimersByTimeAsync(TIMEOUTS.connectMs + TIMEOUTS.firstResponseMs + 5000)
-          controller.enqueue(encoder.encode(deltaLine('tail')))
-          controller.enqueue(encoder.encode('data: [DONE]\n'))
-          controller.close()
-        },
-      })
-      vi.stubGlobal(
-        'fetch',
-        vi.fn(async (_url: string, _init?: RequestInit) => new Response(slowStream))
-      )
-      const provider = createDeepSeekLlmProvider({ apiKey: 'sk-test' })
-      const chunks = await collect(provider.streamCompletion(baseRequest))
-      expect(chunks).toEqual([
-        { content: 'slow ', done: false },
-        { content: 'tail', done: false },
-        { content: '', done: true },
-      ])
-    } finally {
-      vi.useRealTimers()
+  it('does NOT kill a long but live stream — each inter-chunk gap stays under the idle window', async () => {
+    // Streaming is bounded by the per-chunk idle deadline, NOT by the connect /
+    // first-response deadlines: once `fetch` resolves, those are cleared. A stream
+    // that keeps producing — with each gap comfortably under the idle window —
+    // must run to completion no matter how long its TOTAL duration is, because the
+    // idle deadline RESETS on every chunk. It bounds a stall, never a long answer.
+    // (Contrast the park test below, where the body goes silent after one delta.)
+    const encoder = new TextEncoder()
+    const streamIdleMs = 200
+    const gapMs = streamIdleMs / 2
+    const liveStream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(encoder.encode(deltaLine('one ')))
+        for (const word of ['two ', 'three ', 'four']) {
+          await new Promise((resolve) => setTimeout(resolve, gapMs))
+          controller.enqueue(encoder.encode(deltaLine(word)))
+        }
+        controller.enqueue(encoder.encode('data: [DONE]\n'))
+        controller.close()
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, _init?: RequestInit) => new Response(liveStream))
+    )
+    const provider = createDeepSeekLlmProvider({ apiKey: 'sk-test', streamIdleMs })
+    const chunks = await collect(provider.streamCompletion(baseRequest))
+    expect(chunks).toEqual([
+      { content: 'one ', done: false },
+      { content: 'two ', done: false },
+      { content: 'three ', done: false },
+      { content: 'four', done: false },
+      { content: '', done: true },
+    ])
+  })
+})
+
+// --- streaming idle timeout: a stream that parks after its first delta must
+//     fail loud, not hang the turn forever (the bug this change fixes) -----------
+
+describe('createDeepSeekLlmProvider — streaming idle timeout', () => {
+  /**
+   * Build a body that emits exactly one content delta and then goes permanently
+   * silent: it never enqueues again and never closes. This is the faithful
+   * reproduction of the observed park — DeepSeek returns 200 + a first delta,
+   * then the SSE stream stalls. The first `reader.read()` resolves the delta; the
+   * second parks forever. Without the inter-chunk idle deadline, consuming this
+   * stream hangs indefinitely (the bug); with it, the read loses the race to the
+   * deadline and the provider throws.
+   */
+  function parkAfterFirstDelta(): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder()
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(deltaLine('first ')))
+        // Deliberately no further enqueue and no close() — the park.
+      },
+    })
+  }
+
+  it('aborts a stream that goes silent after the first delta and throws (fail loud, bounded)', async () => {
+    stubFetch(parkAfterFirstDelta())
+    const provider = createDeepSeekLlmProvider({ apiKey: 'sk-test', streamIdleMs: 40 })
+    const start = performance.now()
+    // The first delta surfaces, then consumption rejects within the idle window —
+    // it must NOT hang to the test timeout.
+    await expect(collect(provider.streamCompletion(baseRequest))).rejects.toThrow(
+      /deepseek: SSE stream idle for >40ms after first response/
+    )
+    expect(performance.now() - start).toBeLessThan(2000)
+  })
+})
+
+// --- sseStreamToChunks idle deadline (direct, controlled differential) ---------
+
+describe('sseStreamToChunks — idle deadline', () => {
+  it('rejects when the stream stalls past idleMs after a delta', async () => {
+    const encoder = new TextEncoder()
+    const stalling = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(deltaLine('hi ')))
+        // never enqueue again, never close
+      },
+    })
+    const consume = async (): Promise<LlmCompletionChunk[]> => {
+      const out: LlmCompletionChunk[] = []
+      for await (const chunk of sseStreamToChunks(stalling, undefined, 40)) out.push(chunk)
+      return out
     }
+    const start = performance.now()
+    await expect(consume()).rejects.toThrow(/SSE stream idle for >40ms/)
+    expect(performance.now() - start).toBeLessThan(2000)
+  })
+
+  it('WITHOUT an idle bound, a stalled stream does NOT settle (the park this guards, reproduced)', async () => {
+    // The other half of the controlled differential: the SAME first-delta-then-
+    // silence stream, consumed WITHOUT an idle bound, must NOT settle — that hang
+    // is the bug. We prove it behaviorally without letting the test itself park:
+    // drive the iterator by hand, race the stalled read against a short sentinel
+    // (the sentinel must win = it did not settle), then close the stream so the
+    // pending read resolves and the generator's cleanup runs and the test exits.
+    const encoder = new TextEncoder()
+    let streamController!: ReadableStreamDefaultController<Uint8Array>
+    const stalling = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller
+        controller.enqueue(encoder.encode(deltaLine('hi ')))
+        // never enqueue again, never close — until the test releases it below
+      },
+    })
+    const iterator = sseStreamToChunks(stalling)[Symbol.asyncIterator]() // no idleMs
+    expect((await iterator.next()).value).toEqual({ content: 'hi ', done: false })
+
+    // The next read parks: no further bytes, no close, and no idle guard.
+    const parkedNext = iterator.next()
+    const sentinel = Symbol('sentinel')
+    const winner = await Promise.race([
+      parkedNext.then(() => 'settled' as const),
+      new Promise<typeof sentinel>((resolve) => setTimeout(() => resolve(sentinel), 100)),
+    ])
+    expect(winner).toBe(sentinel) // did not settle within the window => parked (the bug)
+
+    // Release the park so the test exits cleanly: closing the stream resolves the
+    // pending read, the generator emits its terminal chunk, and cleanup runs.
+    streamController.close()
+    expect(await parkedNext).toEqual({ value: { content: '', done: true }, done: false })
+    await iterator.return?.(undefined)
+  })
+
+  it('does not arm an idle deadline when idleMs is omitted (pure parsing path unchanged)', async () => {
+    const stream = sseStream(deltaLine('a'), 'data: [DONE]\n')
+    const chunks = await collect(sseStreamToChunks(stream))
+    expect(chunks).toEqual([
+      { content: 'a', done: false },
+      { content: '', done: true },
+    ])
   })
 })

--- a/packages/platform-ai/src/providers/deepseek.ts
+++ b/packages/platform-ai/src/providers/deepseek.ts
@@ -26,7 +26,7 @@ import type {
   LlmProvider,
   LlmUsage,
 } from './types'
-import { startDeadline, TIMEOUTS } from './timeout'
+import { startDeadline, TIMEOUTS, type Deadline } from './timeout'
 
 /** Default DeepSeek OpenAI-compatible base URL (includes the `/v1` prefix). */
 const DEFAULT_BASE_URL = 'https://api.deepseek.com/v1'
@@ -63,6 +63,13 @@ export interface DeepSeekProviderOptions {
    * `LlmCompletionRequest` takes precedence when present.
    */
   model?: string
+  /**
+   * Override the inter-chunk idle deadline (ms) applied to the streaming
+   * response body. Defaults to `TIMEOUTS.streamIdleMs`. Exposed mainly so tests
+   * can inject a small value to drive the idle-abort path without real-time
+   * waits; production callers leave it unset and take the tuned default.
+   */
+  streamIdleMs?: number
 }
 
 /**
@@ -161,19 +168,49 @@ export function parseSseLine(line: string): SseEvent {
  * without one, when the body closes — so consumers always observe a clean end.
  *
  * `onUsage` is invoked if the vendor reports token usage on the final chunk.
+ *
+ * `idleMs`, when given, bounds the silent GAP between consecutive reads: a fresh
+ * idle deadline is armed before each `reader.read()` and cleared the instant it
+ * settles, so a stream that keeps producing runs unbounded while one that goes
+ * silent mid-flight (the DeepSeek SSE park this guards) is failed loud — the read
+ * loses the race to the deadline, this generator throws, and the caller's
+ * existing error path runs. Resetting per read is what makes a long-but-live
+ * stream safe: only a stall trips it, never total duration. Omit it (the default)
+ * to read with no idle bound — e.g. in the pure SSE-parsing unit tests.
  */
 export async function* sseStreamToChunks(
   stream: ReadableStream<Uint8Array>,
-  onUsage?: (usage: LlmUsage) => void
+  onUsage?: (usage: LlmUsage) => void,
+  idleMs?: number
 ): AsyncIterable<LlmCompletionChunk> {
   const reader = stream.getReader()
   const decoder = new TextDecoder()
   let buffer = ''
   let doneEmitted = false
 
+  // Read the next stream segment, bounding only the inter-chunk silence when
+  // `idleMs` is set. The idle deadline is armed per read and cancelled the
+  // instant the read settles, so it measures producer silence — not time the
+  // consumer spends between pulls. A stalled producer rejects here; a live one
+  // (even slow) never does.
+  const readNext = async (): Promise<Awaited<ReturnType<typeof reader.read>>> => {
+    if (idleMs === undefined) return reader.read()
+    let deadline: Deadline | undefined
+    const idle = new Promise<never>((_resolve, reject) => {
+      deadline = startDeadline(idleMs, () =>
+        reject(new Error(`deepseek: SSE stream idle for >${idleMs}ms after first response`))
+      )
+    })
+    try {
+      return await Promise.race([reader.read(), idle])
+    } finally {
+      deadline?.cancel()
+    }
+  }
+
   try {
     for (;;) {
-      const { done, value } = await reader.read()
+      const { done, value } = await readNext()
 
       if (value !== undefined) buffer += decoder.decode(value, { stream: true })
 
@@ -206,6 +243,14 @@ export async function* sseStreamToChunks(
       }
     }
   } finally {
+    // An idle-deadline bailout (or the early `[DONE]` return) can leave a read
+    // request outstanding; cancel the stream first so `releaseLock` does not
+    // throw on a pending read, and so the underlying body / socket is torn down.
+    try {
+      await reader.cancel()
+    } catch {
+      // Stream already errored or closed — nothing left to cancel.
+    }
     reader.releaseLock()
   }
 
@@ -255,6 +300,7 @@ function processSse(
 export function createDeepSeekLlmProvider(opts: DeepSeekProviderOptions): DeepSeekLlmProvider {
   const baseUrl = trimTrailingSlashes(opts.baseUrl ?? DEFAULT_BASE_URL)
   const endpoint = `${baseUrl}/chat/completions`
+  const streamIdleMs = opts.streamIdleMs ?? TIMEOUTS.streamIdleMs
 
   const provider: DeepSeekLlmProvider = {
     async *streamCompletion(request: LlmCompletionRequest): AsyncIterable<LlmCompletionChunk> {
@@ -286,9 +332,12 @@ export function createDeepSeekLlmProvider(opts: DeepSeekProviderOptions): DeepSe
       // the socket then never responds), with no error and no first byte. An
       // `AbortController` + connect deadline bounds exactly that window: if the
       // headers do not arrive in time the controller aborts, `fetch` rejects, and
-      // the turn fails loud instead of parking forever. The deadline is cleared
-      // the instant `fetch` resolves — the SSE body stream that follows is the
-      // model's (legitimately long) streaming output and is NOT timer-bound.
+      // the turn fails loud instead of parking forever. The connect deadline is
+      // cleared the instant `fetch` resolves; the SSE body stream that follows is
+      // then bounded NOT by this connect deadline but by the per-chunk
+      // `streamIdleMs` idle deadline inside `sseStreamToChunks` — a long but live
+      // stream runs freely, while one that delivers its first delta and then goes
+      // permanently silent (the park this guards) is failed loud there.
       const connectController = new AbortController()
       const connectDeadline = startDeadline(TIMEOUTS.connectMs, () =>
         connectController.abort(
@@ -307,8 +356,10 @@ export function createDeepSeekLlmProvider(opts: DeepSeekProviderOptions): DeepSe
           signal: connectController.signal,
         })
       } finally {
-        // Headers arrived (or the fetch failed / aborted) — stop the timer either
-        // way so the streaming phase runs with no deadline and no dangling handle.
+        // Headers arrived (or the fetch failed / aborted) — stop the CONNECT timer
+        // either way, leaving no dangling handle. The streaming phase that follows
+        // is not unguarded: it is bounded by the per-chunk `streamIdleMs` idle
+        // deadline inside `sseStreamToChunks`, not by this connect deadline.
         connectDeadline.cancel()
       }
 
@@ -328,9 +379,13 @@ export function createDeepSeekLlmProvider(opts: DeepSeekProviderOptions): DeepSe
       // Reset before consuming so a half-consumed prior stream cannot leak a
       // stale usage value into this completion.
       provider.lastUsage = undefined
-      yield* sseStreamToChunks(response.body, (usage) => {
-        provider.lastUsage = usage
-      })
+      yield* sseStreamToChunks(
+        response.body,
+        (usage) => {
+          provider.lastUsage = usage
+        },
+        streamIdleMs
+      )
     },
   }
 

--- a/packages/platform-ai/src/providers/timeout.ts
+++ b/packages/platform-ai/src/providers/timeout.ts
@@ -15,12 +15,21 @@
  * (provider throws -> `Promise.race` rejects -> DO closes the WS 1008) instead
  * of hanging.
  *
- * Scope discipline (the load-bearing invariant): these bound the CONNECT and
- * FIRST-RESPONSE phases ONLY, never a whole turn. A legitimate long streaming
- * response — first byte/event arrived in time, then the model streams for a
- * while — must never be killed by a timer. So every call site cancels its timer
- * the instant the first response lands, and the streaming that follows runs with
- * no timeout at all.
+ * Scope discipline (the load-bearing invariant): `connectMs` / `firstResponseMs`
+ * bound the CONNECT and FIRST-RESPONSE phases ONLY, never a whole turn. A
+ * legitimate long streaming response — first byte/event arrived in time, then the
+ * model streams for a while — must never be killed by a timer. So every call site
+ * cancels its connect / first-response timer the instant the first response lands.
+ *
+ * The streaming phase that follows is NOT wholly unbounded, however: a stream that
+ * delivers its first chunk and then goes silent forever is the exact park this
+ * module exists to prevent, one level deeper. `streamIdleMs` closes that gap with
+ * an INTER-CHUNK idle deadline — armed over each streaming read and RESET on every
+ * chunk that arrives, so it bounds only a silent GAP between chunks, never the
+ * stream's total duration. A stream that keeps producing (even slowly) runs as
+ * long as it likes; only a stalled-mid-stream producer is failed loud. This is the
+ * critical distinction from a whole-turn cap: per-chunk reset means a legitimately
+ * long answer is never the thing that trips it — only a dead silence is.
  *
  * The millisecond values in `TIMEOUTS` are conservative defaults chosen for
  * voice-turn reasonableness; they are L3-tunable — the L2 acceptance target says
@@ -30,7 +39,8 @@
  */
 
 /**
- * Connect / first-response deadlines, in milliseconds. Conservative voice-turn
+ * Provider-call deadlines, in milliseconds: the connect + first-response windows
+ * and the per-chunk streaming inter-chunk idle window. Conservative voice-turn
  * defaults; L3-tunable against measured provider latency (see file header).
  */
 export const TIMEOUTS = {
@@ -47,9 +57,26 @@ export const TIMEOUTS = {
    * the first ASR transcript. ~20s tolerates a slow first model token / server
    * handshake (voice models can take several seconds to first output) while
    * still bounding a server that accepts the connection then goes silent. Only
-   * the FIRST response is bounded; subsequent streaming is unbounded.
+   * the FIRST response is bounded by THIS deadline; subsequent streaming is
+   * bounded instead by the per-chunk `streamIdleMs` idle deadline below.
    */
   firstResponseMs: 20_000,
+  /**
+   * Inter-chunk idle window for a streaming response that has already produced
+   * its first chunk: the maximum silent GAP allowed between two consecutive SSE
+   * chunks before the stream is failed loud. Armed over each streaming read and
+   * RESET on every chunk, so it bounds a stall, never the total stream duration —
+   * a model that keeps streaming (even with multi-second think-pauses) is never
+   * killed, while a producer that emits one delta then goes permanently silent
+   * (the DeepSeek SSE park this guards) is aborted within the window instead of
+   * hanging the whole session until the platform hard timeout.
+   *
+   * ~20s is deliberately generous: real mid-stream pauses (the model composing a
+   * long sentence, a brief upstream hiccup) sit well under it, so a healthy turn
+   * never trips it. L3-tunable against measured provider behaviour, like the
+   * connect / first-response values above.
+   */
+  streamIdleMs: 20_000,
 } as const
 
 /**
@@ -108,7 +135,10 @@ export function startDeadline(ms: number, onTimeout: () => void): Deadline {
  * `cause`), so `Promise.race` always settles and the hang this module prevents
  * cannot reappear. The deadline is always cancelled once `promise` settles, so a
  * slow-but-valid first response leaves no live timer and the streaming that
- * follows is unbounded.
+ * follows is unbounded BY THIS deadline (a call site that needs to bound the
+ * streaming phase too — e.g. the DeepSeek SSE adapter — layers a separate
+ * per-chunk `streamIdleMs` idle deadline on top; this helper covers only the
+ * first event).
  *
  * This bounds ONLY the first event it is given — never a whole stream. Call it
  * on the gate/first-chunk await, not around the consuming loop.

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { runTurn, splitSentences, type SessionState, type TurnProviders } from './turn-pipeline'
+import { createDeepSeekLlmProvider } from './providers/deepseek'
 import type { AiResponseChunk, AudioChunk, ManualData } from './contract'
 import type {
   LlmCompletionChunk,
@@ -451,5 +452,69 @@ describe('runTurn', () => {
 
     await expect(collect(turn)).rejects.toThrow('llm boom')
     expect(ttsClosed).toBe(true)
+  })
+
+  // Regression (fix-llm-sse-stream-park): the LLM SSE stream returns its first
+  // delta then goes permanently silent. End to end through the REAL DeepSeek
+  // adapter, the turn must fail loud within a bounded time — never park forever —
+  // and the TTS side must be cleaned up. This is the integration counterpart to
+  // the adapter-level idle-timeout tests in deepseek.test.ts.
+  describe('LLM SSE stream parks after its first delta', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+      vi.restoreAllMocks()
+    })
+
+    it('fails the turn loud (bounded) instead of parking, and cleans up TTS', async () => {
+      const encoder = new TextEncoder()
+      // DeepSeek-shaped body: one content delta, then never enqueue again and
+      // never close — the observed park. The adapter's inter-chunk idle deadline
+      // (injected small here) is the only thing that turns this into a bounded
+      // failure rather than an infinite hang.
+      const hangingBody = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ choices: [{ delta: { content: 'first ' } }] })}\n`
+            )
+          )
+          // no further enqueue, no close — the park.
+        },
+      })
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (_url: string, _init?: RequestInit) => new Response(hangingBody))
+      )
+
+      let ttsClosed = false
+      const tts: TtsProvider = {
+        async *synthesize(text: AsyncIterable<string>): AsyncIterable<TtsAudioChunk> {
+          try {
+            for await (const sentence of text) {
+              void sentence
+              yield { audio: new Uint8Array(1), done: false }
+            }
+          } finally {
+            ttsClosed = true
+          }
+        },
+      }
+      const llm = createDeepSeekLlmProvider({ apiKey: 'sk-test', streamIdleMs: 40 })
+
+      const start = performance.now()
+      await expect(
+        collect(
+          runTurn(
+            providers(mockStt([{ text: 'q.', isFinal: true }]), llm, tts),
+            freshState(),
+            fromArray<AudioChunk>([new Uint8Array([1])])
+          )
+        )
+      ).rejects.toThrow(/deepseek: SSE stream idle for >40ms after first response/)
+      // Bounded fail-loud, not a hang to the test timeout.
+      expect(performance.now() - start).toBeLessThan(2000)
+      // The turn's cleanup ran: the TTS iterator was returned, nothing leaked.
+      expect(ttsClosed).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Fixes a permanent turn park in the platform-ai voice pipeline: when the DeepSeek LLM SSE stream returned HTTP 200 + a first delta and then went silent, the turn hung (`turnCount:0 / llmOutputTokens:0 / zero errors`) until the Cloudflare platform hard timeout. The adapter cleared its only deadline the instant `fetch` resolved and declared the body stream "not timer-bound", leaving the inter-chunk gap unguarded.
- Adds a per-chunk **inter-chunk idle deadline** (`TIMEOUTS.streamIdleMs`, 20s, L3-tunable) to `sseStreamToChunks`: armed before each read, reset on every chunk. A long-but-live stream is never killed; a stream that goes silent mid-flight is aborted and fails loud through the **existing** path (adapter throws → `runTurn` `Promise.race` rejects → DO closes the WS 1008).
- Root cause was localized to the producer/network side, not the consumer: the turn pipeline keeps an LLM `next()` eagerly outstanding and `ws.send` is non-blocking, so a parked turn is the body stream waiting at `reader.read()` for bytes that never arrive. Controlled-differential tests encode both halves (no guard → does not settle = the park; guard → bounded fail-loud).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (`@amiclaw/platform-ai` 279 tests; full repo `pnpm test:run` green)
- [x] New tests added if behavior changed — controlled-differential: a hanging stream reproduces the park (does not settle without the guard) and fails loud within bounds with it; a `runTurn` integration test drives the real DeepSeek adapter over a hanging mocked fetch and asserts bounded fail-loud + TTS cleanup; a long-but-live stream (gaps under the idle window) is verified not killed.
- [x] Tested manually and documented below — `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test:run` all green locally.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed — `CHANGELOG.md` (Unreleased); the architecture component spec timeout model is updated in the docs vault.
- [x] Breaking changes documented if any — none; behavior change is internal reliability only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
