### PR TITLE
fix(platform-ai): bound Volcengine ASR/TTS inter-chunk gap so a stalled speech stream fails loud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Platform-AI voice turns can no longer hang when a speech stream stalls
+mid-stream** - Internal reliability hardening. This extends the same fix made for
+the language-model stream to the two speech streams: turning the player's voice
+into text (speech recognition) and turning the AI's reply into audio (speech
+synthesis). Each runs over a live connection that, once it has produced its first
+result, used to have no bound on silence — if the speech server sent some output
+and then went quiet without finishing or closing, the turn parked until the
+platform's hard timeout. Both streams now bound the silent gap between results: a
+stream that has already started but then stalls fails cleanly and frees the
+session instead of hanging. The guard resets on every result, so a legitimately
+long transcription or a long stretch of synthesized speech — pauses and all — is
+never cut off; only a truly stuck stream is. No player-facing behavior changes
+beyond turns no longer hanging.
+
 **Platform-AI voice turns can no longer hang when the LLM stream stalls
 mid-reply** - Internal reliability hardening. The AI's language model streams its
 answer back token by token; if it sent the first token and then went silent —

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -1681,12 +1681,16 @@ describe('createVolcengineSpeechProvider.tts.synthesize — handshake first-resp
     expect(sentEvents(socket)).not.toContain(TtsEvent.TaskRequest)
   })
 
-  it('does NOT bound the close-side: a long synthesis stream past the deadline is not killed', async () => {
+  it('does NOT bound the close-side: a long-but-live synthesis stream is not killed (gaps under the idle bound)', async () => {
     // Once both opening gates are acknowledged, the session may legitimately stay
     // open far longer than firstResponseMs while the server streams audio. The
-    // close-side `sessionFinished` gate is intentionally NOT deadlined, so a long
-    // stream (audio arriving well past the first-response budget) completes
-    // normally — bounding it would be a whole-turn timeout, which this fix avoids.
+    // close-side `sessionFinished` gate is intentionally NOT deadlined, and the
+    // inter-chunk idle guard measures only the GAP between audio chunks (reset on
+    // each), never total duration. So a stream whose total span exceeds
+    // firstResponseMs completes normally SO LONG AS each gap stays under
+    // streamIdleMs — here two ~15s gaps sum past firstResponseMs yet neither trips
+    // the idle guard. Bounding total duration would be a whole-turn timeout, which
+    // this fix avoids.
     vi.useFakeTimers()
     const socket = new MockSocket()
     const { connect } = mockConnector(socket)
@@ -1702,15 +1706,112 @@ describe('createVolcengineSpeechProvider.tts.synthesize — handshake first-resp
     socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
     await vi.advanceTimersByTimeAsync(0)
 
-    // Stream audio across a span LONGER than every deadline, then finish.
+    // Stream audio across a total span LONGER than firstResponseMs, but with each
+    // inter-chunk gap UNDER streamIdleMs so the idle guard keeps resetting.
     socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('A1'), sessionId))
-    await vi.advanceTimersByTimeAsync(TIMEOUTS.firstResponseMs + 10_000)
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.streamIdleMs - 5_000)
     socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('A2'), sessionId))
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.streamIdleMs - 5_000)
+    socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('A3'), sessionId))
     socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
 
     const chunks = await collected
     const audio = chunks.filter((c) => !c.done).map((c) => decoder.decode(c.audio))
-    expect(audio).toEqual(['A1', 'A2'])
+    expect(audio).toEqual(['A1', 'A2', 'A3'])
+    expect(chunks[chunks.length - 1].done).toBe(true)
+  })
+
+  it('fails loud when the audio stream goes idle mid-synthesis after a first chunk', async () => {
+    // The inter-chunk idle guard for the audio-streaming phase: after the opening
+    // handshake and a first audio chunk, a server that falls silent — no further
+    // audio, no SessionFinished, never closing — would park `yield* queue` forever
+    // (the close-side gate is intentionally unbounded). After streamIdleMs of
+    // silence the guard aborts the handshake, fails the queue + closes the socket so
+    // the consumer throws (fail loud) instead of the turn hanging to the platform cap.
+    vi.useFakeTimers()
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ apiKey: 'k', connect })
+
+    const consumed = collect(tts.synthesize(asyncFromSync(['念完整一段话'])))
+    const assertion = expect(consumed).rejects.toThrow(/audio stream idle for >.*during synthesis/)
+    await vi.advanceTimersByTimeAsync(0)
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await vi.advanceTimersByTimeAsync(0)
+    const sessionId =
+      socket.sent.map((b) => parseFrame(b)).find((f) => f.event === TtsEvent.StartSession)
+        ?.sessionId ?? 's'
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    await vi.advanceTimersByTimeAsync(0)
+
+    // First audio chunk lands — arms the inter-chunk idle guard.
+    socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('A1'), sessionId))
+    // Then the server goes silent past streamIdleMs — the idle guard fires.
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.streamIdleMs)
+    await assertion
+    // The idle guard's fail path also closes the outbound socket.
+    expect(socket.closed).toBe(true)
+  })
+
+  it('fails loud when the handshake completes but the server produces NO audio and NO SessionFinished', async () => {
+    // The handshake gates (ConnectionStarted / SessionStarted) are first-response-
+    // bounded, and the close-side `sessionFinished` gate is intentionally unbounded.
+    // That leaves a hang window the per-audio-chunk guard alone does not cover: the
+    // session is accepted and FinishSession is sent, but the server then produces
+    // neither an audio frame nor SessionFinished. `await handshake.sessionFinished`
+    // would park forever. The idle guard, armed when FinishSession is sent (all text
+    // already drained, so a slow LLM cannot false-trip it), bounds this gap and fails
+    // loud after streamIdleMs.
+    vi.useFakeTimers()
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ apiKey: 'k', connect })
+
+    const consumed = collect(tts.synthesize(asyncFromSync(['念完整一段话'])))
+    const assertion = expect(consumed).rejects.toThrow(/audio stream idle for >.*during synthesis/)
+    await vi.advanceTimersByTimeAsync(0)
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await vi.advanceTimersByTimeAsync(0)
+    const sessionId =
+      socket.sent.map((b) => parseFrame(b)).find((f) => f.event === TtsEvent.StartSession)
+        ?.sessionId ?? 's'
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    // Pump now sends the TaskRequest(s) + FinishSession and arms the idle guard.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(sentEvents(socket)).toContain(TtsEvent.FinishSession)
+    // No audio and no SessionFinished ever arrive — the idle guard fires.
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.streamIdleMs)
+    await assertion
+    expect(socket.closed).toBe(true)
+  })
+
+  it('does NOT fire the post-FinishSession idle guard when audio then SessionFinished arrive in time', async () => {
+    // Complement to the no-audio hang test: the guard armed at FinishSession must not
+    // kill a session that promptly streams its audio and finishes. A first audio
+    // chunk and SessionFinished arriving within streamIdleMs complete normally.
+    vi.useFakeTimers()
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { tts } = createVolcengineSpeechProvider({ apiKey: 'k', connect })
+
+    const collected = collect(tts.synthesize(asyncFromSync(['念完整一段话'])))
+    await vi.advanceTimersByTimeAsync(0)
+    socket.emitMessage(ttsServerFrame(TtsEvent.ConnectionStarted, encoder.encode('{}')))
+    await vi.advanceTimersByTimeAsync(0)
+    const sessionId =
+      socket.sent.map((b) => parseFrame(b)).find((f) => f.event === TtsEvent.StartSession)
+        ?.sessionId ?? 's'
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionStarted, encoder.encode('{}'), sessionId))
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Audio arrives a little after FinishSession (under the idle bound), then finish.
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.streamIdleMs - 5_000)
+    socket.emitMessage(ttsServerFrame(TtsEvent.TtsResponse, encoder.encode('A1'), sessionId))
+    socket.emitMessage(ttsServerFrame(TtsEvent.SessionFinished, encoder.encode('{}'), sessionId))
+
+    const chunks = await collected
+    const audio = chunks.filter((c) => !c.done).map((c) => decoder.decode(c.audio))
+    expect(audio).toEqual(['A1'])
     expect(chunks[chunks.length - 1].done).toBe(true)
   })
 })
@@ -1740,11 +1841,13 @@ describe('createVolcengineSpeechProvider.stt.transcribe — first-response timeo
     expect(socket.closed).toBe(true)
   })
 
-  it('does NOT kill a slow-first-then-long transcript stream', async () => {
-    // The deadline bounds only the FIRST transcript: a first chunk that arrives in
-    // time cancels it, and subsequent chunks may span far past firstResponseMs. A
-    // first (non-final) chunk lands promptly; the final one arrives much later and
-    // the stream still completes (no whole-stream timeout).
+  it('does NOT kill a long-but-live transcript stream (gaps under the idle bound)', async () => {
+    // Neither deadline bounds total stream length: the first-response deadline is
+    // cancelled by the first chunk, and the inter-chunk idle deadline only measures
+    // the GAP between consecutive transcripts (reset on each). A stream whose total
+    // span far exceeds firstResponseMs is fine SO LONG AS each gap stays under
+    // streamIdleMs — every transcript resets the idle guard. Here two ~15s gaps sum
+    // to ~30s (> firstResponseMs) yet each is < streamIdleMs, so nothing fires.
     vi.useFakeTimers()
     const socket = new MockSocket()
     const { connect } = mockConnector(socket)
@@ -1752,21 +1855,70 @@ describe('createVolcengineSpeechProvider.stt.transcribe — first-response timeo
 
     const drained = collect(stt.transcribe(asyncFromSync([encoder.encode('f1')])))
     await vi.advanceTimersByTimeAsync(0)
-    // First (non-final) transcript arrives within the budget — cancels the deadline.
+    // First (non-final) transcript arrives within the budget — cancels the
+    // first-response deadline and arms the inter-chunk idle guard.
     socket.emitMessage(
       sttServerFrame({ result: { text: '你', utterances: [{ definite: false }] } })
     )
-    // A long pause AFTER the first chunk — longer than firstResponseMs. With the
-    // deadline cancelled this is fine; a whole-stream timeout would wrongly fire.
-    await vi.advanceTimersByTimeAsync(TIMEOUTS.firstResponseMs + 10_000)
+    // A pause under streamIdleMs, then another chunk that resets the idle guard.
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.streamIdleMs - 5_000)
     socket.emitMessage(
-      sttServerFrame({ result: { text: '你好', utterances: [{ definite: true }] } })
+      sttServerFrame({ result: { text: '你好', utterances: [{ definite: false }] } })
+    )
+    // Another sub-idle pause — total span now exceeds firstResponseMs — then final.
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.streamIdleMs - 5_000)
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '你好吗', utterances: [{ definite: true }] } })
     )
 
     const chunks = await drained
     expect(chunks).toEqual([
       { text: '你', isFinal: false },
-      { text: '你好', isFinal: true },
+      { text: '你好', isFinal: false },
+      { text: '你好吗', isFinal: true },
     ])
+  })
+
+  it('fails loud when the stream goes idle mid-flight after a first transcript', async () => {
+    // The inter-chunk idle guard: once a first transcript lands (first-response
+    // deadline cancelled), a server that then falls silent — no further transcript,
+    // no final, never closing the socket — would park `yield* queue` forever. After
+    // streamIdleMs of silence the guard fails the queue + closes the socket so the
+    // consumer throws (fail loud) instead of the turn hanging to the platform cap.
+    vi.useFakeTimers()
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ apiKey: 'k', connect })
+
+    const consumed = collect(stt.transcribe(asyncFromSync([encoder.encode('f1')])))
+    const assertion = expect(consumed).rejects.toThrow(/stream idle for >.*after first transcript/)
+    await vi.advanceTimersByTimeAsync(0)
+    // First (non-final) transcript lands — cancels first-response, arms idle guard.
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '你', utterances: [{ definite: false }] } })
+    )
+    // Server goes silent for longer than streamIdleMs — the idle guard fires.
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.streamIdleMs)
+    await assertion
+    // The idle guard's fail path also closes the outbound socket.
+    expect(socket.closed).toBe(true)
+  })
+
+  it('does NOT fire the idle guard before the first transcript (that window is the first-response deadline)', async () => {
+    // Belt-and-braces: the idle guard arms only once a first transcript has landed.
+    // Before that, the (separate) first-response deadline owns the bound. A connect
+    // with no transcript must reject as a first-response timeout, never a stream-idle
+    // one — confirming the two phases stay distinct.
+    vi.useFakeTimers()
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ apiKey: 'k', connect })
+
+    const consumed = collect(stt.transcribe(asyncFromSync([encoder.encode('f1')])))
+    const assertion = expect(consumed).rejects.toThrow(/no transcript within/)
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(TIMEOUTS.firstResponseMs)
+    await assertion
+    expect(socket.closed).toBe(true)
   })
 })

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -32,9 +32,12 @@
  *    server-gated*: the client must wait for the server to accept each step
  *    before advancing — StartConnection -> (await ConnectionStarted, event 50)
  *    -> StartSession -> (await SessionStarted, event 150) -> TaskRequest* ->
- *    FinishSession -> FinishConnection; the server then streams `TTSResponse`
- *    (event 352) audio frames + `SessionFinished` (event 152). The handshake
- *    gates live in `TtsHandshake` so the timing is unit-testable with a mock WS.
+ *    FinishSession -> (server streams `TTSResponse` (event 352) audio frames, then
+ *    `SessionFinished` (event 152); await SessionFinished) -> FinishConnection.
+ *    FinishConnection is gated on SessionFinished — not fired right after
+ *    FinishSession — so the tail audio frames are drained before the connection
+ *    closes. The handshake gates live in `TtsHandshake` so the timing is
+ *    unit-testable with a mock WS.
  *
  * Protocol references (consulted 2026-06):
  *  - ASR binary protocol + sequence flags + auth headers:
@@ -66,7 +69,7 @@
 
 import type { AudioChunk } from '../contract'
 import type { SttProvider, SttTranscriptChunk, SttUsage, TtsAudioChunk, TtsProvider } from './types'
-import { awaitWithTimeout, startDeadline, TIMEOUTS } from './timeout'
+import { awaitWithTimeout, startDeadline, TIMEOUTS, type Deadline } from './timeout'
 
 // --- Public options ---
 
@@ -992,6 +995,30 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         socket.close()
       })
 
+      // Inter-chunk idle guard for the streaming phase. `firstResponseDeadline`
+      // above bounds only the gap to the FIRST transcript; once streaming, a server
+      // that falls silent mid-stream (sends no further transcript, no final, never
+      // closes the socket) would park `yield* queue` forever — the same hang the
+      // LLM SSE layer guards with `TIMEOUTS.streamIdleMs`. This bounds the silent
+      // GAP between consecutive transcripts: (re)armed on each non-final chunk,
+      // cancelled the instant the stream ends (final / close / error / generator
+      // exit). A live stream keeps resetting it so only a stall trips it — failing
+      // the queue loud and closing the socket, the existing premature-close fail
+      // path. Volcengine is a push model (AsyncQueue + message listener), so this is
+      // a re-armable deadline reset per pushed frame, NOT the SSE per-read race.
+      let streamIdleDeadline: Deadline | undefined
+      const resetStreamIdle = (): void => {
+        streamIdleDeadline?.cancel()
+        streamIdleDeadline = startDeadline(TIMEOUTS.streamIdleMs, () => {
+          queue.fail(
+            new Error(
+              `Volcengine ASR: stream idle for >${TIMEOUTS.streamIdleMs}ms after first transcript`
+            )
+          )
+          socket.close()
+        })
+      }
+
       socket.addEventListener('message', (event) => {
         try {
           const frame = parseFrame(event.data)
@@ -1012,13 +1039,23 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
           // the normal end-of-stream path (idempotent; mirrors the TTS layer).
           if (chunk.isFinal) {
             finalReached = true
+            // Normal end-of-stream: clear the inter-chunk idle guard so it can never
+            // fire late against an already-closed queue.
+            streamIdleDeadline?.cancel()
             queue.close()
             socket.close()
+          } else {
+            // Streaming continues — (re)arm the inter-chunk idle guard for the gap
+            // to the next transcript.
+            resetStreamIdle()
           }
         } catch (err) {
           // Observability: an error frame (parseSttResponse throws with the
           // server's code/message) or a malformed frame lands here — surface it
           // instead of letting it vanish into the generic queue failure.
+          // Clear the idle guard first so a stalled deadline never outlives a
+          // failed stream.
+          streamIdleDeadline?.cancel()
           console.error(
             `[volc-asr] frame error: ${err instanceof Error ? err.message : String(err)}`
           )
@@ -1041,13 +1078,19 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
             event?.reason ?? ''
           )} finalReached=${finalReached}`
         )
+        // The stream has ended either way — stop the idle guard so it cannot fire
+        // late against an already-settled queue.
+        streamIdleDeadline?.cancel()
         if (finalReached) {
           queue.close()
         } else {
           queue.fail(new Error('Volcengine ASR socket closed before a final transcript'))
         }
       })
-      socket.addEventListener('error', (err) => queue.fail(err))
+      socket.addEventListener('error', (err) => {
+        streamIdleDeadline?.cancel()
+        queue.fail(err)
+      })
 
       // Pump audio in the background so we can yield transcripts as they arrive.
       //
@@ -1122,10 +1165,12 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
             ? { durationMs: reportedDurationMs, source: 'provider-reported' }
             : { durationMs: (sentAudioBytes * 1000) / bytesPerSecond, source: 'derived-from-bytes' }
         cancelled = true
-        // Stop the first-response deadline on every exit path (it may still be
-        // armed if the stream ended via cancellation / error before any
-        // transcript) so it never fires late against an already-settled queue.
+        // Stop both deadlines on every exit path (either may still be armed if the
+        // stream ended via cancellation / error) so neither fires late against an
+        // already-settled queue: the first-response deadline (no transcript yet) and
+        // the inter-chunk idle deadline (streaming was in progress).
         firstResponseDeadline.cancel()
+        streamIdleDeadline?.cancel()
         await audioIterator.return?.(undefined)
         queue.close()
         socket.close()
@@ -1151,11 +1196,44 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       // TTS audio fails loudly instead of settling silently without audio.
       let sessionFinished = false
 
+      // Idle guard for the audio-streaming phase. The opening handshake gates
+      // (ConnectionStarted / SessionStarted) are first-response-bounded by
+      // `awaitWithTimeout` in the pump, and the close-side `sessionFinished` gate is
+      // intentionally unbounded (a long synthesis legitimately keeps it open). That
+      // leaves the audio stream that follows the handshake unbounded in two ways:
+      //  (1) after the first `TtsResponse` chunk — the server emits audio then falls
+      //      silent (no further audio, no SessionFinished, never closes); and
+      //  (2) BEFORE any audio — the handshake completes and FinishSession is sent,
+      //      then the server produces neither audio nor SessionFinished.
+      // Either parks `yield* queue` forever — the LLM SSE park, one layer over. This
+      // guard bounds the silent GAP during synthesis: armed when the pump sends
+      // FinishSession (case 2; by then all text is drained, so a slow upstream LLM
+      // can't false-trip it) AND (re)armed on each `TtsResponse` chunk (case 1),
+      // cancelled the instant the session ends (SessionFinished / SessionFailed /
+      // close / error / generator exit). On a stall it drives the same fail-loud path
+      // a mid-stream drop takes (abort the handshake gates, fail the queue, close the
+      // socket). Push model, so it is a re-armable deadline reset per pushed frame /
+      // milestone, NOT the SSE per-read race. Bounds only the gap, never total
+      // synthesis length — a long but live stream keeps resetting it.
+      let streamIdleDeadline: Deadline | undefined
+      const resetStreamIdle = (): void => {
+        streamIdleDeadline?.cancel()
+        streamIdleDeadline = startDeadline(TIMEOUTS.streamIdleMs, () => {
+          const err = new Error(
+            `Volcengine TTS: audio stream idle for >${TIMEOUTS.streamIdleMs}ms during synthesis`
+          )
+          handshake.abort(err)
+          queue.fail(err)
+          socket.close()
+        })
+      }
+
       socket.addEventListener('message', (event) => {
         try {
           const frame = parseFrame(event.data)
           if (frame.messageType === MessageType.ErrorResponse) {
             const err = new Error(`Volcengine TTS error: ${decodeUtf8(frame.payload)}`)
+            streamIdleDeadline?.cancel()
             handshake.abort(err)
             queue.fail(err)
             return
@@ -1168,19 +1246,25 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
           }
           if (frame.event === TtsEvent.TtsResponse && frame.payload.length > 0) {
             queue.push({ audio: copyBytes(frame.payload), done: false })
+            // Streaming audio — (re)arm the inter-chunk idle guard for the gap to
+            // the next audio chunk.
+            resetStreamIdle()
           } else if (frame.event === TtsEvent.SessionFinished) {
             // Normal completion: push the final done frame, mark the session
             // finished so a subsequent socket close is the clean end-of-stream,
-            // and end iteration.
+            // and end iteration. Clear the idle guard so it cannot fire late.
             sessionFinished = true
+            streamIdleDeadline?.cancel()
             queue.push({ audio: new Uint8Array(0), done: true })
             queue.close()
           } else if (frame.event === TtsEvent.SessionFailed) {
             const err = new Error(`Volcengine TTS session failed: ${decodeUtf8(frame.payload)}`)
+            streamIdleDeadline?.cancel()
             handshake.abort(err)
             queue.fail(err)
           }
         } catch (err) {
+          streamIdleDeadline?.cancel()
           handshake.abort(err)
           queue.fail(err)
         }
@@ -1190,6 +1274,9 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       // `abort` is harmless once the gates have all settled (no-op on a settled
       // gate), so it runs unconditionally on every close.
       socket.addEventListener('close', () => {
+        // The session has ended either way — stop the idle guard so it cannot fire
+        // late against an already-settled queue.
+        streamIdleDeadline?.cancel()
         handshake.abort(new Error('Volcengine TTS socket closed before session completed'))
         // Distinguish a normal-completion close from a premature one. After
         // SessionFinished (152) the close is the expected end-of-stream -> close
@@ -1204,6 +1291,7 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         }
       })
       socket.addEventListener('error', (err) => {
+        streamIdleDeadline?.cancel()
         handshake.abort(err)
         queue.fail(err)
       })
@@ -1278,6 +1366,14 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         }
         if (cancelled) return
         socket.send(asArrayBuffer(buildTtsFinishSessionFrame(sessionId)))
+        // Arm the idle guard for the synthesis-output phase now that all text is
+        // drained: from here the server must produce audio frames then
+        // SessionFinished. If it instead goes fully silent (no audio, no
+        // SessionFinished), `await handshake.sessionFinished` below — the
+        // intentionally-unbounded close gate — would park the turn forever. Arming
+        // here (post-text, so a slow LLM can't false-trip it) bounds that gap; the
+        // first audio frame / SessionFinished cancels or resets it via the listener.
+        resetStreamIdle()
         await handshake.sessionFinished
         if (cancelled) return
         socket.send(asArrayBuffer(buildTtsFinishConnectionFrame()))
@@ -1302,6 +1398,10 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         //  - `socket.close()` deterministically releases the outbound connection
         //    (idempotent; the normal path relies on the server closing it).
         cancelled = true
+        // Stop the inter-chunk idle guard on every exit path (it may still be armed
+        // if the stream ended via cancellation / error mid-synthesis) so it never
+        // fires late against an already-settled queue.
+        streamIdleDeadline?.cancel()
         handshake.abort(new Error('Volcengine TTS synthesize cancelled'))
         queue.close()
         socket.close()


### PR DESCRIPTION
## Summary

- Extends the LLM SSE inter-chunk idle guard (#172) to the two Volcengine WebSocket speech streams (火山 ASR + 豆包 TTS). Once a stream has produced its first response, a silent gap longer than `TIMEOUTS.streamIdleMs` now fails the turn loud (via the existing `queue.fail` / `handshake.abort` + `socket.close` path → DO closes the WS) instead of parking to the Cloudflare hard timeout.
- Volcengine is a push model (`AsyncQueue` + a socket `message` listener), so each guard is a **re-armable rolling deadline reset per pushed frame** — not the SSE per-read race. It bounds only the inter-chunk gap, never total stream length, so a long-but-live stream keeps resetting it.
- **TTS subtlety:** the first-response window is the handshake (ConnectionStarted / SessionStarted). The audio stream that follows was unbounded both *after the first audio chunk* and — the gap a per-chunk guard alone misses — *when the handshake completes but the server then produces neither audio nor SessionFinished*. The guard is armed when `FinishSession` is sent (all text drained, so a slow upstream LLM cannot false-trip it) and re-armed on each audio chunk; the LLM-feeding window before that is already covered by the upstream LLM stream's own idle guard.
- ASR is symmetric: `firstResponseDeadline` bounds up to the first transcript, the rolling idle guard bounds the gaps after it; armed/reset/cancelled at every termination point.
- Reuses `TIMEOUTS.streamIdleMs` — no new primitive, no whole-turn timeout, no change to frame parsing.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (full monorepo suite green; platform-ai 289 tests)
- [x] New tests added if behavior changed
- [ ] Tested manually and documented below

Controlled-differential vitest coverage (mock-socket + fake timers):
- ASR/TTS stall → fail-loud (incl. the TTS no-audio-after-handshake case); the stall rejects with the idle error and closes the socket.
- Long-but-live streams (each gap < `streamIdleMs`, total span > `firstResponseMs`) complete normally — proves gap-bound, not total-duration-bound.
- ASR first-response phase stays distinct from the idle phase; TTS post-FinishSession arm does not false-fire when audio + SessionFinished arrive in time.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (architecture spec invariant + L3 timeout-threshold row updated to cover all three hops; CHANGELOG entry added)
- [x] Breaking changes documented if any (none — internal reliability hardening, no player-facing behavior change)

Independently verified cross-model (Codex, 3-axis: Conformance / Coherence / Soundness — passed).