### PR TITLE
feat(platform-ai): register bombsquad game config + Chinese defuse-partner prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad registered as a platform-AI game** - Internal change. Adds a
+`bombsquad` configuration to the platform AI's server-side game registry: a
+Chinese system prompt giving the AI the persona of a calm, precise defuse-expert
+partner (it guides the player by voice and defers all per-module defuse logic to
+the manual injected per module), on the same verified provider stack as the demo.
+This is the AI-side configuration only; it is not yet wired into the BombSquad
+game, so there is no player-facing change.
+
 **Platform-AI voice turns now complete end to end with the real speech
 providers** - Internal reliability fix. Until now the first real (non-mock) voice
 turn never actually finished: the speech-synthesis step sent a malformed request

--- a/packages/platform-ai/src/provider-config.test.ts
+++ b/packages/platform-ai/src/provider-config.test.ts
@@ -55,6 +55,48 @@ describe('resolveConfig — hit', () => {
   })
 })
 
+describe('resolveConfig — bombsquad', () => {
+  it('resolves the bombsquad game config with a Chinese defuse-expert persona and full rule discipline', () => {
+    const resolved = resolveConfig('bombsquad')
+    expect(resolved.gameId).toBe('bombsquad')
+
+    const { role, ruleTemplate } = resolved.systemPromptConfig
+
+    // Persona marker: a Chinese calm-defuse-expert voice, not an empty/stub role.
+    expect(role.length).toBeGreaterThan(0)
+    expect(role).toContain('拆弹')
+
+    // The rule set carries the full discipline contract, not a placeholder:
+    // manual-only + cross-module flow + ask-for-values + one-action +
+    // no-recite + no-imagine + daily-strike + Chinese-voice.
+    expect(ruleTemplate.length).toBeGreaterThanOrEqual(8)
+    for (const rule of ruleTemplate) {
+      expect(rule.length).toBeGreaterThan(0)
+    }
+
+    // Key discipline markers, asserted semantically so a future reword does not
+    // break the test: defer to the manual, speak Chinese, and the daily
+    // 3-strike detonation rule.
+    const joined = ruleTemplate.join('\n')
+    expect(joined).toContain('手册')
+    expect(joined).toContain('中文')
+    expect(joined).toContain('引爆')
+  })
+
+  it('mirrors the demo provider stack: DeepSeek v4 LLM + Volcengine voice', () => {
+    // BombSquad runs the same verified production stack as `demo`: DeepSeek v4
+    // flash LLM, Volcengine `bigmodel` ASR, and the empty-string TTS
+    // resource-id-default sentinel. Only the system prompt differs.
+    const { llm, stt, tts } = resolveConfig('bombsquad')
+    expect(llm.provider).toBe('deepseek')
+    expect(llm.model).toBe('deepseek-v4-flash')
+    expect(stt.provider).toBe('volcengine')
+    expect(stt.model).toBe('bigmodel')
+    expect(tts.provider).toBe('volcengine')
+    expect(tts.model).toBe('')
+  })
+})
+
 describe('resolveConfig — miss', () => {
   it('throws an explicit error on an unregistered gameId (no silent fallback)', () => {
     expect(() => resolveConfig('not-a-real-game')).toThrowError(

--- a/packages/platform-ai/src/provider-config.ts
+++ b/packages/platform-ai/src/provider-config.ts
@@ -88,6 +88,14 @@ export interface ResolvedConfig extends ProviderConfig {
  * layers select the deterministic `mock` provider, so the full
  * STT -> LLM -> TTS pipeline runs locally without real DeepSeek / Volcengine
  * keys. It reuses the same sample manual-explainer system prompt as `demo`.
+ *
+ * The `bombsquad` entry backs BombSquad mode② daily voice sessions. Its provider
+ * stack mirrors `demo` exactly (the verified DeepSeek + Volcengine production
+ * stack); only its `systemPromptConfig` differs — a Chinese calm-defuse-expert
+ * persona. The system prompt sets role + cross-module discipline + voice ONLY;
+ * each module's concrete defuse logic lives in the injected per-module manual
+ * `rule` (see `packages/manual/data/*.yaml`), so the prompt defers to it rather
+ * than restating it.
  */
 const PROVIDER_REGISTRY: Record<GameId, ProviderConfig> = {
   demo: {
@@ -158,6 +166,42 @@ const PROVIDER_REGISTRY: Record<GameId, ProviderConfig> = {
     tts: {
       provider: 'mock',
       model: 'mock-tts',
+    },
+  },
+  bombsquad: {
+    systemPromptConfig: {
+      // Chinese, agent-voice: a calm, precise defuse-expert partner. Sets role +
+      // cross-module discipline + voice ONLY. The per-module defuse logic lives
+      // in the injected manual `rule` (packages/manual/data/*.yaml); this prompt
+      // defers to it and never restates it. Server-side config — never shipped to
+      // the client.
+      role: '你是一位冷静、精准的拆弹协作伙伴：你手里有参考手册，玩家只能看到设备本身；你通过语音引导玩家一步步把炸弹拆掉。',
+      ruleTemplate: [
+        '只依据上下文里提供的手册内容作答，绝不编造规则；模块的具体判定以注入的当前模块手册规则为准，逐字遵守（每回合你只会看到玩家当前所在模块的规则）。',
+        'daily 模式依次包含 4 个模块，你一次只引导玩家当前所在的那个模块，拆解完才进入下一个；模块之间你只做流程衔接，绝不预判或复述其他模块的拆解逻辑（每个模块的规则只在轮到它时才注入给你）。',
+        '先让玩家描述他看到的（模块名、颜色、文字、符号、指示灯、电池数量等），再确定性地把局面映射到手册规则；手册需要而玩家还没报的场景信息（如电池数、某指示灯是否点亮），先问清确切值再作答，绝不靠猜。',
+        '一次只下达一个玩家此刻就能执行的具体动作，确认做完再进入下一步。',
+        '绝不向玩家复述手册原文、规则表或内部字段，也绝不暴露你在读注入的手册子集；只把查表结果转成一句可执行的口语指令。',
+        '绝不替玩家臆想你看不到的画面（指针朝向、钟点、统一目标排列等手册未定义的东西）；只采信玩家亲口报出、且手册需要的信息。',
+        'daily 模式下累计三次错误才引爆，前两次只是可见的 strike；时间只计分、不引爆——出错时保持沉着，让玩家把当前局面重新报清再继续（答错时同一道题仍在，原地重试）。',
+        '始终用中文，口语、简洁、精确；冷静不慌、不说废话。',
+      ],
+    },
+    // Provider stack mirrors `demo` exactly — the verified DeepSeek + Volcengine
+    // production stack. See the `demo` entry above for the per-layer rationale
+    // (the `bigmodel` ASR wire model and the empty-string TTS resource-id-default
+    // sentinel).
+    llm: {
+      provider: 'deepseek',
+      model: 'deepseek-v4-flash',
+    },
+    stt: {
+      provider: 'volcengine',
+      model: 'bigmodel',
+    },
+    tts: {
+      provider: 'volcengine',
+      model: '',
     },
   },
 }


### PR DESCRIPTION
## Summary

Registers `bombsquad` in the platform-AI server-side game registry (`PROVIDER_REGISTRY`) so `createSession('bombsquad', …)` can assemble the BombSquad mode② daily AI partner's system prompt from the gameId.

- **Chinese system prompt**, persona = calm precise defuse expert (user-confirmed). Sets **role + cross-module discipline + voice only**; defers all per-module defuse logic to the manual `rule` injected per current module (never restates or recites it). Honors the contract: prompt resolved server-side from gameId, deterministic manual injection.
- **Provider stack mirrors the verified `demo` entry** (deepseek-v4-flash / volcengine bigmodel ASR / volcengine seed-tts-2.0) — the live-verified production stack.
- Unit tests assert `resolveConfig('bombsquad')` resolves with exact provider values + a non-trivial Chinese persona prompt.

**Inert until the game-side wiring lands** (the next cascade step) — no player-facing change yet.

## Test plan

- [x] `tsc --noEmit` clean; full monorepo unit suite green (platform-ai 304 tests)
- [x] Independent cross-model verifier (codex): provider stack / server-side gameId resolution / manual-injection boundary conform; flow-fact + test-strengthening fixes applied
- [x] Chinese prompt reviewed for native voice (calm precise expert, no translationese)

🤖 Generated with [Claude Code](https://claude.com/claude-code)