### PR TITLE
feat(game-bombsquad): wire mode② in-game platform voice partner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② in-game voice partner (opt-in wiring)** - BombSquad's daily
+run can now host the platform's AI defuse partner over an in-page voice panel:
+hold to talk, and the AI guides you by voice using the manual it can see while
+you only see the device. It is wired into the daily run behind an explicit
+opt-in (`?partner=platform`) — the polished mode-selection landing and the login
+gate are separate follow-ups, so there is no change to the default experience
+yet. The bring-your-own-AI flow (mode①), the puzzle game, timer, and strikes are
+untouched. The whole voice turn runs server-side; the browser holds no API key
+or system prompt, and the AI's per-module guidance comes from the manual the
+platform injects for the current module only.
+
 **BombSquad registered as a platform-AI game** - Internal change. Adds a
 `bombsquad` configuration to the platform AI's server-side game registry: a
 Chinese system prompt giving the AI the persona of a calm, precise defuse-expert

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -21,9 +21,9 @@
 #
 # --- Regression size budget --------------------------------------------------
 # Per the governance model (rule 3): the e2e regression suite is capped at
-# 2 x the journey-scenario count. With 23 active flows <-> 23 journey
-# scenarios, the regression size budget is 46 (2026-06-11, after the three
-# mode② companion-memory flows were added as @simulation journeys).
+# 2 x the journey-scenario count. With 24 active flows <-> 24 journey
+# scenarios, the regression size budget is 48 (2026-06-28, after the mode②
+# in-game voice-panel flow was added as a @playwright journey).
 # Crossing it triggers a forced prune audit. Current regression count: 2.
 #
 # --- Retired scenario --------------------------------------------------------
@@ -285,4 +285,33 @@ flows:
       off (PUT /api/companion/profile) stops claim injection immediately while
       visible memories and the companion identity remain.
     steps: [session-create, resolver, deterministic-injection, profile-switch]
+    status: active
+
+  # === mode② in-game voice flow ===============================================
+  # The account-anchored platform voice partner wired into a daily run. The
+  # real-provider turn (DeepSeek + Volcengine over the live `/ai-ws/*` bridge) is
+  # verified by a human play-green plus the standalone live-turn harness, so the
+  # e2e journey stubs the WebSocket boundary and the mic and asserts the panel's
+  # UI states only — never real audio or provider output.
+
+  - id: mode2-voice-session-turn
+    name: mode② in-game voice turn
+    description: >-
+      An opted-in daily run (`?mode=daily&partner=platform`) mounts the in-game
+      platform voice panel: it connects to the platform-ai bridge and reaches the
+      ready/connected state, the player runs one push-to-talk turn, the AI's
+      streamed text reply renders, the "AI is speaking" indicator shows while the
+      stubbed TTS audio plays, and exiting the run tears the voice session down.
+      The `/ai-ws/*` WebSocket and the microphone are stubbed deterministically
+      (no live provider, no real audio); the real-provider turn is verified by a
+      human play-green and the standalone live-turn harness.
+    steps:
+      [
+        daily-platform-partner,
+        voice-connected,
+        push-to-talk-turn,
+        ai-text-reply,
+        ai-speaking,
+        session-teardown,
+      ]
     status: active

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -100,6 +100,28 @@ const LEADERBOARD_DEFAULT = readJson<{ get: LeaderboardGetResponse; post: Submit
   'leaderboard-default.json'
 )
 
+// --- Voice-session stub ------------------------------------------------------
+//
+// The mode② voice panel connects to the platform-ai bridge over the same-origin
+// `/ai-ws/*` WebSocket. The harness mocks that socket (page.routeWebSocket) so
+// the panel is driven deterministically with no live Worker / provider. The
+// stubbed turn streams one text chunk then one audio chunk; the audio is a few
+// seconds of PCM16 16 kHz mono silence — long enough that the "AI is speaking"
+// indicator (which the hook drives off Web Audio playback) is observable.
+const VOICE_REPLY_TEXT = '把红色的线接到第三个接线柱，先别动其它线。'
+/** PCM16 mono @16 kHz; the hook plays it back to set the "speaking" indicator. */
+const VOICE_AUDIO_SECONDS = 4
+const VOICE_AUDIO_BASE64 = Buffer.alloc(16_000 * VOICE_AUDIO_SECONDS * 2).toString('base64')
+
+interface VoiceMockState {
+  /** The AI's stubbed text reply rendered by the panel for the push-to-talk turn. */
+  reply: string
+  /** Base64 PCM16 16 kHz mono TTS payload streamed as the turn's audio. */
+  audioBase64: string
+  /** Captured client->server JSON frames (create / turn / end) for assertions. */
+  clientFrames: Record<string, unknown>[]
+}
+
 /** Buffer that comfortably exceeds the install -> goto -> pauseAt latency. */
 const CLOCK_BUFFER_MS = 60_000
 /** Countdown budgets — verbatim from store/game-context.tsx TIME_BUDGET_MS. */
@@ -130,6 +152,12 @@ export class World {
   authIdentity: { user_id: string; email: string } | null = null
   /** Captured POST /api/auth/magic-link/request bodies for assertions. */
   readonly magicLinkRequests: Record<string, unknown>[] = []
+  /** Stub config + captured frames for the mode② voice WebSocket. */
+  readonly voice: VoiceMockState = {
+    reply: VOICE_REPLY_TEXT,
+    audioBase64: VOICE_AUDIO_BASE64,
+    clientFrames: [],
+  }
   private clockInstalled = false
 
   constructor(page: Page) {
@@ -280,6 +308,23 @@ export class World {
     await this.waitForRunStarted()
   }
 
+  /**
+   * Enter a mode② daily run with the platform voice partner. The voice panel
+   * mounts only on a daily run opted in via `?partner=platform` (there is no
+   * connect-flow affordance for it yet — it is a pure URL signal), so the run is
+   * reached by a direct deep-link goto. The seed-pinning clock installed by the
+   * preceding `I open /` step stays frozen across this navigation, so GamePage
+   * mounts under the pinned daily seed exactly as a connect-flow entry would,
+   * and the route-mocked manual loads the same fixture. PLAYING (the visible
+   * stopwatch) implies the manual loaded, so the VoicePanel is mounted and its
+   * `/ai-ws/*` socket — stubbed in the fixture wiring — is connecting.
+   */
+  async startPlatformVoiceDailyRun(): Promise<void> {
+    this.runMode = 'daily'
+    await this.page.goto('/bombsquad/run?mode=daily&partner=platform')
+    await this.waitForRunStarted()
+  }
+
   // --- Module solving --------------------------------------------------------
 
   /**
@@ -409,6 +454,43 @@ export const test = base.extend<{ world: World }>({
       // Daily/practice manual fetch -> fixture YAML.
       await page.route('**/manual/**', async (route) => {
         await route.fulfill({ status: 200, contentType: 'text/yaml', body: MANUAL_YAML })
+      })
+
+      // mode② voice bridge — mock the same-origin `/ai-ws/*` WebSocket the
+      // VoicePanel hook opens. Inert for every non-voice scenario (none opens
+      // that socket). Mock mode (no connectToServer) means Playwright opens the
+      // page socket automatically, so the hook's `onopen` create handshake runs.
+      // The stub mirrors the real session-do.ts envelope: `created` on create,
+      // then a text chunk + an audio chunk on each turn. Binary mic PCM frames
+      // (sent while the player holds to talk) arrive here as Buffers and are
+      // ignored — no STT runs. No `end`/`summary` is sent because the panel has
+      // no end control; the session ends by panel teardown on run exit.
+      await page.routeWebSocket(/\/ai-ws\//, (ws) => {
+        ws.onMessage((message) => {
+          if (typeof message !== 'string') return // binary mic audio — ignore
+          let frame: { type?: string }
+          try {
+            frame = JSON.parse(message) as { type?: string }
+          } catch {
+            return
+          }
+          world.voice.clientFrames.push(frame as Record<string, unknown>)
+          if (frame.type === 'create') {
+            ws.send(JSON.stringify({ type: 'created', sessionId: 'e2e-voice-session' }))
+          } else if (frame.type === 'turn') {
+            ws.send(
+              JSON.stringify({ type: 'chunk', kind: 'text', text: world.voice.reply, done: false })
+            )
+            ws.send(
+              JSON.stringify({
+                type: 'chunk',
+                kind: 'audio',
+                audio: world.voice.audioBase64,
+                done: true,
+              })
+            )
+          }
+        })
       })
 
       // Fire-and-forget telemetry -> 200 stub. POST bodies are captured first

--- a/e2e/steps/voice.steps.ts
+++ b/e2e/steps/voice.steps.ts
@@ -1,0 +1,66 @@
+/**
+ * mode② in-game voice-panel steps. Drives the VoicePanel through one
+ * deterministic push-to-talk turn against the stubbed `/ai-ws/*` socket (see
+ * e2e/steps/fixtures.ts `routeWebSocket`) and the Chromium fake mic device (see
+ * playwright.config.ts launch flags). Asserts the panel's UI states only — never
+ * real audio or provider output.
+ */
+import { expect, type Locator, type Page } from '@playwright/test'
+import { When, Then } from './fixtures'
+
+/** The voice panel — `<section aria-label="AI 语音伙伴">` renders as a region. */
+function voicePanel(page: Page): Locator {
+  return page.getByRole('region', { name: 'AI 语音伙伴' })
+}
+
+When('I enter a mode② daily run with the platform voice partner', async ({ world }) => {
+  await world.startPlatformVoiceDailyRun()
+})
+
+Then('the voice panel shows the AI partner is connected', async ({ page }) => {
+  const panel = voicePanel(page)
+  await expect(panel).toBeVisible()
+  // `created` -> ready: the status reads 已连接 and the reply log invites a turn.
+  await expect(panel.getByText('已连接')).toBeVisible()
+  await expect(panel.getByText('按住下面的按钮，对 AI 说话')).toBeVisible()
+  // The push-to-talk control is enabled only once the session is ready.
+  await expect(panel.getByRole('button')).toBeEnabled()
+})
+
+When('I push and hold the talk button, then release', async ({ page }) => {
+  const panel = voicePanel(page)
+  const talkBtn = panel.getByRole('button')
+  // Keyboard hold-to-talk (Space) — a trusted key event, no pointer-capture
+  // dance. Keydown starts the turn (fake-mic getUserMedia resolves), so the
+  // status flips to 通话中; hold until that is observed, then release to send
+  // the turn to the stubbed bridge.
+  await talkBtn.focus()
+  await page.keyboard.down('Space')
+  await expect(panel.getByText('通话中')).toBeVisible()
+  await page.keyboard.up('Space')
+})
+
+Then("the panel renders the AI's stubbed voice reply", async ({ page, world }) => {
+  await expect(voicePanel(page).getByText(world.voice.reply)).toBeVisible()
+})
+
+Then(
+  'the panel shows the "AI is speaking" indicator while the reply audio plays',
+  async ({ page }) => {
+    await expect(voicePanel(page).getByText('AI 正在回应')).toBeVisible()
+  }
+)
+
+When('I exit the run', async ({ page }) => {
+  // `退出` confirms via window.confirm before navigating to the platform home;
+  // accept it so the run resets and the voice panel tears down.
+  page.once('dialog', (dialog) => {
+    void dialog.accept()
+  })
+  await page.getByRole('button', { name: '退出当前关卡' }).click()
+})
+
+Then('the voice session ends and the panel is gone', async ({ page }) => {
+  await page.waitForURL((url) => new URL(url).pathname === '/', { timeout: 12_000 })
+  await expect(voicePanel(page)).toHaveCount(0)
+})

--- a/e2e/voice-session-panel.gherkin
+++ b/e2e/voice-session-panel.gherkin
@@ -1,0 +1,38 @@
+# In-game voice partner panel (mode②) — the platform voice session wired into a
+# daily run. An opted-in daily run (`?mode=daily&partner=platform`) mounts the
+# VoicePanel, which connects to the platform-ai `/ai-ws/*` bridge, runs one
+# push-to-talk turn, renders the AI's streamed text reply, shows the "AI is
+# speaking" cue while the TTS audio plays, and tears the session down when the
+# run is exited.
+#
+# Deterministic + hermetic: the `/ai-ws/*` WebSocket is stubbed at the harness
+# boundary (e2e/steps/fixtures.ts `routeWebSocket`) so the panel is driven
+# through created -> chunk(text) -> chunk(audio) frames with no live Worker, no
+# DeepSeek/Volcengine, and no real network. The mic is the Chromium fake media
+# device (playwright.config.ts launch flags), so `getUserMedia` resolves without
+# a real microphone or a permission prompt. The real-provider voice turn is
+# verified separately by a human play-green plus the standalone live-turn
+# harness — this scenario asserts the panel's UI states only, never real audio
+# or provider output.
+
+Feature: In-game voice partner panel (mode②)
+  As a daily-challenge player who opted into the platform voice partner
+  I want an in-game voice panel that connects, takes a push-to-talk turn, and
+  shows the AI replying
+  So that I can talk to my AI partner without leaving the run
+
+  Background:
+    Given I open /
+
+  # Source: mode2-voice-session-turn
+  @playwright
+  Scenario: A mode② daily run drives one voice turn through the panel
+    When I enter a mode② daily run with the platform voice partner
+    Then the voice panel shows the AI partner is connected
+
+    When I push and hold the talk button, then release
+    Then the panel renders the AI's stubbed voice reply
+    And the panel shows the "AI is speaking" indicator while the reply audio plays
+
+    When I exit the run
+    Then the voice session ends and the panel is gone

--- a/packages/game-bombsquad/package.json
+++ b/packages/game-bombsquad/package.json
@@ -17,6 +17,7 @@
     "react-router-dom": "^7.18.0"
   },
   "devDependencies": {
+    "@amiclaw/platform-ai": "workspace:*",
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.5.0",

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import yaml from 'js-yaml'
 import type { Manual, SceneInfo, ModuleConfig, ModuleAnswer } from '@shared/manual-schema'
@@ -34,6 +34,8 @@ import practiceYamlRaw from '../../../manual/data/practice.yaml?raw'
 import { generateSceneInfo } from '@/engine/scene-info'
 import { getAttemptNumberForMode, getRunSeed } from '@/utils/session'
 import { getAudioContext } from '@/audio/audio-context'
+import VoicePanel from '@/voice/VoicePanel'
+import { deriveVoicePanelInputs, isPlatformVoicePartner } from '@/voice/voice-panel-inputs'
 import styles from './GamePage.module.css'
 
 // Module display labels — the Atlas redesign renames three of the four
@@ -194,6 +196,22 @@ export default function GamePage() {
   const customUrl = searchParams.get('url')
 
   const { state, dispatch } = useGame()
+
+  // mode② gate: the in-game platform voice partner mounts ONLY on a daily run
+  // explicitly opted in via `?partner=platform`. Practice and an un-opted daily
+  // run stay mode① (BYO-AI) and never mount the panel. Additive — derives from
+  // game state only, never alters game logic.
+  const usePlatformVoice = isPlatformVoicePartner(mode, searchParams.get('partner'))
+
+  // Voice-session inputs for the current module, recomputed only when the loaded
+  // manual or the current module changes (NOT on every timer-frame re-render).
+  // `moduleKey` keys the panel's remount so advancing modules tears down the old
+  // session and reconnects with the new module's `relevantSections`.
+  const voiceInputs = useMemo(
+    () => (usePlatformVoice ? deriveVoicePanelInputs(state) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [usePlatformVoice, state.manual, state.currentModuleIndex]
+  )
 
   // A wrong answer pulses a red border around the whole module panel so the
   // mistake is obvious at a glance in both modes. Incrementing this key
@@ -635,6 +653,14 @@ export default function GamePage() {
           <div key={`ok-${successPulseKey}`} className={styles.successPulse} aria-hidden="true" />
         )}
       </div>
+
+      {voiceInputs && (
+        <VoicePanel
+          key={voiceInputs.moduleKey}
+          manualData={voiceInputs.manualData}
+          gameState={voiceInputs.gameState}
+        />
+      )}
 
       <div className={styles.bottomArea}>
         {state.sceneInfo && (

--- a/packages/game-bombsquad/src/voice/VoicePanel.module.css
+++ b/packages/game-bombsquad/src/voice/VoicePanel.module.css
@@ -1,0 +1,234 @@
+/* In-game voice panel (mode②) — Atlas star-chart visual language. Glass
+   surface, AMIO-yellow accent, dark-only, CSS-only animation. Mirrors the
+   GamePage glass-chrome recipe (refresh banner / scene-info row). */
+
+.panel {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 16px 16px;
+  background: var(--glass);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-xl);
+}
+
+/* ----------  status header  ---------- */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 18px;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.statusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex: none;
+}
+
+.statusDot[data-status='connecting'],
+.statusDot[data-status='idle'] {
+  background: var(--y);
+  animation: voice-dot-pulse 1.4s ease-in-out infinite;
+}
+
+.statusDot[data-status='ready'] {
+  background: var(--green);
+  box-shadow: 0 0 8px rgba(75, 210, 102, 0.6);
+}
+
+.statusDot[data-status='in-turn'] {
+  background: var(--y);
+  box-shadow: 0 0 8px var(--y-glow-50);
+}
+
+.statusDot[data-status='error'] {
+  background: var(--rose);
+}
+
+.statusDot[data-status='closed'] {
+  background: var(--text-muted);
+}
+
+.statusText {
+  font: 500 11px var(--amio-font-mono);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--soft);
+}
+
+/* ----------  AI-speaking cue  ---------- */
+.speaking {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: 500 11px var(--font-body);
+  color: var(--green);
+}
+
+.speakingDots {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+.speakingDots i {
+  width: 3px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--green);
+  animation: voice-bars 1s ease-in-out infinite;
+}
+
+.speakingDots i:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.speakingDots i:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+/* ----------  AI reply  ---------- */
+.reply {
+  min-height: 44px;
+  max-height: 132px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-md);
+}
+
+.replyText {
+  margin: 0;
+  font: 400 14px/1.55 var(--font-body);
+  color: rgba(255, 255, 255, 0.9);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.replyPlaceholder {
+  margin: 0;
+  font: 400 13px/1.5 var(--font-body);
+  color: var(--text-4);
+}
+
+/* ----------  error line  ---------- */
+.error {
+  margin: 0;
+  padding: 8px 12px;
+  font: 400 12px/1.45 var(--font-body);
+  color: var(--rose);
+  background: rgba(255, 107, 157, 0.08);
+  border: 1px solid rgba(255, 107, 157, 0.25);
+  border-radius: var(--radius-md);
+  word-break: break-word;
+}
+
+/* ----------  push-to-talk  ---------- */
+.talkBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: var(--touch-target);
+  padding: 12px 24px;
+  background: var(--y);
+  color: #050511;
+  border: 2px solid transparent;
+  border-radius: var(--radius-pill);
+  font: 600 15px var(--font-body);
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+  transition:
+    box-shadow 0.15s ease,
+    transform 0.15s ease,
+    background 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.talkBtn:hover,
+.talkBtn:focus-visible {
+  box-shadow: 0 0 24px var(--y-glow-50);
+  outline: none;
+}
+
+.talkBtn:focus-visible {
+  outline: 2px solid var(--y);
+  outline-offset: 3px;
+}
+
+.talkBtn:disabled {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+/* Live-mic state: a yellow glow pulse so the player can see the hold is
+   captured. Yellow (= active), not rose, per the Atlas palette. */
+.talkBtnActive {
+  border-color: var(--y);
+  animation: voice-talk-pulse 1.1s ease-in-out infinite;
+}
+
+.talkBtnIcon {
+  display: inline-flex;
+  align-items: center;
+}
+
+@keyframes voice-dot-pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes voice-bars {
+  0%,
+  100% {
+    transform: scaleY(0.5);
+  }
+  50% {
+    transform: scaleY(1);
+  }
+}
+
+@keyframes voice-talk-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 var(--y-glow-50);
+  }
+  50% {
+    box-shadow: 0 0 22px 2px var(--y-glow-50);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .statusDot,
+  .speakingDots i,
+  .talkBtnActive {
+    animation: none;
+  }
+}

--- a/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
+import type { UseVoiceSessionResult } from './useVoiceSession'
+import VoicePanel from './VoicePanel'
+
+// Mock the hook so the panel can be driven through every status / cue without a
+// real WebSocket, mic, or AudioContext (those are the browser-only play-green).
+vi.mock('./useVoiceSession', () => ({ useVoiceSession: vi.fn() }))
+import { useVoiceSession } from './useVoiceSession'
+const mockHook = vi.mocked(useVoiceSession)
+
+const startTalking = vi.fn()
+const stopTalking = vi.fn()
+const endSession = vi.fn()
+
+function hookState(partial: Partial<UseVoiceSessionResult> = {}): UseVoiceSessionResult {
+  return {
+    status: 'ready',
+    aiText: '',
+    isAiSpeaking: false,
+    error: null,
+    summary: null,
+    startTalking,
+    stopTalking,
+    endSession,
+    ...partial,
+  }
+}
+
+const manualData: ManualData = { version: 'v1', sections: { button: { rule: 'hold' } } }
+const gameState: GameState = { relevantSections: ['button'] }
+
+function renderPanel(partial: Partial<UseVoiceSessionResult> = {}) {
+  mockHook.mockReturnValue(hookState(partial))
+  return render(<VoicePanel manualData={manualData} gameState={gameState} />)
+}
+
+beforeEach(() => {
+  mockHook.mockReset()
+  startTalking.mockReset()
+  stopTalking.mockReset()
+  endSession.mockReset()
+})
+
+describe('VoicePanel — status rendering', () => {
+  it('shows the connecting status with the talk control disabled', () => {
+    renderPanel({ status: 'connecting' })
+    expect(screen.getByText('连接中')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '按住说话' })).toBeDisabled()
+  })
+
+  it('enables push-to-talk once ready', () => {
+    renderPanel({ status: 'ready' })
+    expect(screen.getByText('已连接')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '按住说话' })).toBeEnabled()
+  })
+
+  it('surfaces the connection-error status', () => {
+    renderPanel({ status: 'error', error: 'voice connection closed (1006)' })
+    expect(screen.getByText('连接出错')).toBeInTheDocument()
+  })
+})
+
+describe('VoicePanel — hook-state cues', () => {
+  it('renders the accumulated AI text', () => {
+    renderPanel({ aiText: 'Hold the button.' })
+    expect(screen.getByText('Hold the button.')).toBeInTheDocument()
+  })
+
+  it('shows the "AI is speaking" cue while speaking', () => {
+    renderPanel({ isAiSpeaking: true })
+    expect(screen.getByText('AI 正在回应')).toBeInTheDocument()
+  })
+
+  it('hides the "AI is speaking" cue when not speaking', () => {
+    renderPanel({ isAiSpeaking: false })
+    expect(screen.queryByText('AI 正在回应')).not.toBeInTheDocument()
+  })
+
+  it('shows a bounded error line as an alert', () => {
+    renderPanel({ error: 'microphone permission denied' })
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('microphone permission denied')
+  })
+})
+
+describe('VoicePanel — push-to-talk wiring', () => {
+  it('starts talking on press and stops on release', () => {
+    renderPanel({ status: 'ready' })
+    const btn = screen.getByRole('button', { name: /说话|结束/ })
+
+    fireEvent.pointerDown(btn)
+    expect(startTalking).toHaveBeenCalledTimes(1)
+
+    fireEvent.pointerUp(btn)
+    expect(stopTalking).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call stopTalking on a release that never began a hold', () => {
+    renderPanel({ status: 'ready' })
+    const btn = screen.getByRole('button', { name: '按住说话' })
+    fireEvent.pointerUp(btn)
+    expect(stopTalking).not.toHaveBeenCalled()
+  })
+})

--- a/packages/game-bombsquad/src/voice/VoicePanel.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.tsx
@@ -1,0 +1,177 @@
+import { memo, useCallback, useState } from 'react'
+import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from 'react'
+import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
+import { useVoiceSession } from './useVoiceSession'
+import type { VoiceStatus } from './voice-session-protocol'
+import styles from './VoicePanel.module.css'
+
+interface VoicePanelProps {
+  /** Per-run manual payload (`null` while the manual is still loading). */
+  manualData: ManualData | null
+  /** Game state driving the manual-subset selection for this module. */
+  gameState: GameState
+  /** Platform game id; defaults to `'bombsquad'` inside the hook. */
+  gameId?: string
+}
+
+/**
+ * In-game voice panel for the BombSquad daily run (mode②). Renders the
+ * `useVoiceSession` surface: a connection/turn status indicator, the AI's
+ * streamed text reply, an "AI is speaking" cue, a bounded error line, and a
+ * push-to-talk control (hold to talk). Presentation only — it reads hook state
+ * and drives the hook's `startTalking` / `stopTalking`; it never touches game
+ * logic. Dark-only, CSS-only animation (Atlas design system).
+ */
+
+/** User-facing connection/turn status copy. Chinese — daily players are the reader. */
+const STATUS_LABEL: Record<VoiceStatus, string> = {
+  idle: '准备中',
+  connecting: '连接中',
+  ready: '已连接',
+  'in-turn': '通话中',
+  error: '连接出错',
+  closed: '已结束',
+}
+
+function VoicePanelImpl({ manualData, gameState, gameId }: VoicePanelProps) {
+  const { status, aiText, isAiSpeaking, error, startTalking, stopTalking } = useVoiceSession({
+    manualData,
+    gameState,
+    gameId,
+  })
+
+  // Whether the player is currently holding the push-to-talk control. Tracked in
+  // state (not derived from `status`) because `in-turn` covers BOTH the player
+  // speaking and the AI responding — only an explicit hold should read as "live
+  // mic". Drives the button label + the listening pulse.
+  const [holding, setHolding] = useState(false)
+
+  // Push-to-talk: hold to talk. Pointer capture binds the release to this
+  // element even if the finger drifts off it, so a pointerup always pairs with
+  // its pointerdown. The hook guards every transition (no-op unless ready /
+  // already talking), so these handlers can fire unconditionally.
+  const beginTalk = useCallback(
+    (e: ReactPointerEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId)
+      } catch {
+        /* pointer capture unsupported (e.g. jsdom) — the release path still fires */
+      }
+      setHolding(true)
+      startTalking()
+    },
+    [startTalking]
+  )
+
+  const endTalk = useCallback(() => {
+    setHolding((wasHolding) => {
+      if (wasHolding) stopTalking()
+      return false
+    })
+  }, [stopTalking])
+
+  // Keyboard hold-to-talk (Space / Enter) for non-pointer users. `repeat` guards
+  // the key auto-repeat so a held key starts capture exactly once.
+  const onKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+      if (e.key !== ' ' && e.key !== 'Enter') return
+      if (e.repeat) return
+      e.preventDefault()
+      setHolding(true)
+      startTalking()
+    },
+    [startTalking]
+  )
+
+  const onKeyUp = useCallback(
+    (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+      if (e.key !== ' ' && e.key !== 'Enter') return
+      endTalk()
+    },
+    [endTalk]
+  )
+
+  // Enabled when the session can take a turn (ready) or one is already in the
+  // player's hand (holding). While the AI responds after release — in-turn but
+  // not holding — the control is disabled, which also blocks starting a second
+  // overlapping turn.
+  const talkEnabled = status === 'ready' || holding
+  const talkLabel = holding ? '松开结束' : '按住说话'
+
+  const replyPlaceholder =
+    status === 'ready' || status === 'in-turn' ? '按住下面的按钮，对 AI 说话' : '正在接通 AI 语音…'
+
+  return (
+    <section className={styles.panel} aria-label="AI 语音伙伴">
+      <div className={styles.header}>
+        <span className={styles.status}>
+          <span className={styles.statusDot} data-status={status} aria-hidden="true" />
+          <span className={styles.statusText} role="status">
+            {STATUS_LABEL[status]}
+          </span>
+        </span>
+        {isAiSpeaking && (
+          <span className={styles.speaking} role="status">
+            AI 正在回应
+            <span className={styles.speakingDots} aria-hidden="true">
+              <i />
+              <i />
+              <i />
+            </span>
+          </span>
+        )}
+      </div>
+
+      <div className={styles.reply} role="log" aria-live="polite">
+        {aiText ? (
+          <p className={styles.replyText}>{aiText}</p>
+        ) : (
+          <p className={styles.replyPlaceholder}>{replyPlaceholder}</p>
+        )}
+      </div>
+
+      {error && (
+        <p className={styles.error} role="alert">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="button"
+        className={`${styles.talkBtn} ${holding ? styles.talkBtnActive : ''}`}
+        onPointerDown={beginTalk}
+        onPointerUp={endTalk}
+        onPointerCancel={endTalk}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+        disabled={!talkEnabled}
+        aria-pressed={holding}
+        aria-label={talkLabel}
+      >
+        <span className={styles.talkBtnIcon} aria-hidden="true">
+          <svg
+            viewBox="0 0 24 24"
+            width="20"
+            height="20"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+          >
+            <rect x="9" y="3" width="6" height="12" rx="3" />
+            <path d="M5 11 a7 7 0 0 0 14 0 M12 18 V21 M9 21 H15" strokeLinecap="round" />
+          </svg>
+        </span>
+        {talkLabel}
+      </button>
+    </section>
+  )
+}
+
+/**
+ * Memoized so the ~60fps GamePage timer re-render does not re-render the panel:
+ * with the stable, memoized `manualData` / `gameState` props from GamePage it
+ * only re-renders on its own hook-state changes.
+ */
+const VoicePanel = memo(VoicePanelImpl)
+export default VoicePanel

--- a/packages/game-bombsquad/src/voice/audio-pcm.test.ts
+++ b/packages/game-bombsquad/src/voice/audio-pcm.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { base64ToBytes, floatTo16BitPCM, pcm16ToFloat32 } from './audio-pcm'
+
+describe('floatTo16BitPCM', () => {
+  it('produces 2 little-endian bytes per sample', () => {
+    const buf = floatTo16BitPCM(new Float32Array([0, 0, 0]))
+    expect(buf.byteLength).toBe(6)
+  })
+
+  it('maps the full-scale endpoints to the asymmetric Int16 range', () => {
+    const view = new DataView(floatTo16BitPCM(new Float32Array([0, 1, -1])))
+    expect(view.getInt16(0, true)).toBe(0)
+    expect(view.getInt16(2, true)).toBe(0x7fff) // +1.0 -> 32767
+    expect(view.getInt16(4, true)).toBe(-0x8000) // -1.0 -> -32768
+  })
+
+  it('clamps out-of-range samples to [-1, 1]', () => {
+    const view = new DataView(floatTo16BitPCM(new Float32Array([2, -2])))
+    expect(view.getInt16(0, true)).toBe(0x7fff)
+    expect(view.getInt16(2, true)).toBe(-0x8000)
+  })
+})
+
+describe('pcm16ToFloat32', () => {
+  it('decodes Int16 LE bytes back to Float32 samples', () => {
+    const pcm = floatTo16BitPCM(new Float32Array([0, 1, -1]))
+    const floats = pcm16ToFloat32(new Uint8Array(pcm))
+    expect(floats.length).toBe(3)
+    expect(floats[0]).toBeCloseTo(0, 5)
+    expect(floats[1]).toBeCloseTo(1, 4)
+    expect(floats[2]).toBeCloseTo(-1, 4)
+  })
+
+  it('ignores a trailing odd byte (incomplete Int16)', () => {
+    expect(pcm16ToFloat32(new Uint8Array([0x00, 0x40, 0xff])).length).toBe(1)
+  })
+
+  it('reads through a subarray view without grabbing the whole buffer', () => {
+    const backing = new Uint8Array([0xff, 0xff, 0x00, 0x40, 0x00, 0x00])
+    const view = backing.subarray(2, 4) // the +0.5-ish sample only
+    const floats = pcm16ToFloat32(view)
+    expect(floats.length).toBe(1)
+    expect(floats[0]).toBeCloseTo(0x4000 / 0x7fff, 4)
+  })
+
+  it('round-trips arbitrary samples within one quantization step', () => {
+    const samples = new Float32Array([0.5, -0.5, 0.25, -0.75, 0.123, -0.987])
+    const decoded = pcm16ToFloat32(new Uint8Array(floatTo16BitPCM(samples)))
+    for (let i = 0; i < samples.length; i += 1) {
+      expect(decoded[i]).toBeCloseTo(samples[i], 3)
+    }
+  })
+})
+
+describe('base64ToBytes', () => {
+  it('decodes base64 to the original bytes', () => {
+    const original = new Uint8Array([0, 1, 2, 250, 255])
+    const b64 = btoa(String.fromCharCode(...original))
+    expect(Array.from(base64ToBytes(b64))).toEqual(Array.from(original))
+  })
+
+  it('decodes an empty string to an empty array', () => {
+    expect(base64ToBytes('').length).toBe(0)
+  })
+
+  it('round-trips a PCM frame through base64 (server transport shape)', () => {
+    const pcm = new Uint8Array(floatTo16BitPCM(new Float32Array([0.5, -0.5])))
+    const b64 = btoa(String.fromCharCode(...pcm))
+    expect(Array.from(base64ToBytes(b64))).toEqual(Array.from(pcm))
+  })
+})

--- a/packages/game-bombsquad/src/voice/audio-pcm.ts
+++ b/packages/game-bombsquad/src/voice/audio-pcm.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure audio-format helpers for the BombSquad voice session.
+ *
+ * Side-effect-free: no DOM / Web Audio / WebSocket access at module top level, so
+ * these are safe to import from both the React hook (`useVoiceSession.ts`) and the
+ * vitest unit tests. The hook owns all Web Audio side effects; this module only
+ * converts byte/sample representations.
+ *
+ * Two directions are needed by the voice session:
+ *  - mic capture: Float32 samples (Web Audio) -> Int16 little-endian PCM, the exact
+ *    wire format the STT adapter expects (`volcengine.ts`: format 'pcm', bits 16,
+ *    rate 16000, channel 1).
+ *  - TTS playback: base64 JSON-transported audio frame -> Int16 LE PCM bytes ->
+ *    Float32 samples, which the hook wraps in an `AudioBuffer` for scheduled
+ *    playback.
+ */
+
+/**
+ * Convert mono Float32 PCM samples (range [-1, 1]) to 16-bit little-endian PCM.
+ *
+ * Each sample is clamped to [-1, 1], scaled to the signed 16-bit range (negative
+ * side uses 0x8000, positive side uses 0x7FFF), rounded, and written
+ * little-endian. The result is `samples.length * 2` bytes — the wire format the
+ * STT adapter expects (`format:'pcm', bits:16`). Mirrors the demo's
+ * `floatTo16BitPCM` (`demo/audio-pcm.js`) so the capture path is protocol-identical.
+ */
+export function floatTo16BitPCM(samples: Float32Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(samples.length * 2)
+  const view = new DataView(buffer)
+  for (let i = 0; i < samples.length; i += 1) {
+    let s = samples[i]
+    if (s > 1) s = 1
+    else if (s < -1) s = -1
+    const int = s < 0 ? Math.round(s * 0x8000) : Math.round(s * 0x7fff)
+    view.setInt16(i * 2, int, true)
+  }
+  return buffer
+}
+
+/**
+ * Decode a base64 string (a JSON-transported audio frame) to its raw bytes.
+ * Uses the browser `atob` over a latin1 string, byte-by-byte — the inverse of the
+ * server's `base64FromBytes` (`session-do.ts`). Frames are small per-sentence TTS
+ * chunks, so the per-char loop stays cheap.
+ */
+export function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+/**
+ * Convert Int16 little-endian PCM bytes to mono Float32 samples in [-1, 1) — the
+ * inverse of `floatTo16BitPCM`, used to load a TTS audio frame into an
+ * `AudioBuffer` for playback. Negative samples divide by 0x8000 and positive by
+ * 0x7FFF, mirroring the asymmetric scale the encoder used so the round-trip is
+ * tight (within one quantization step).
+ *
+ * A trailing odd byte (incomplete Int16) is ignored — `floor(byteLength / 2)`
+ * samples are produced. Reads through a `DataView` over the exact byte range so a
+ * subarray view never grabs the whole backing buffer.
+ */
+export function pcm16ToFloat32(bytes: Uint8Array): Float32Array {
+  const sampleCount = Math.floor(bytes.byteLength / 2)
+  const out = new Float32Array(sampleCount)
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  for (let i = 0; i < sampleCount; i += 1) {
+    const int = view.getInt16(i * 2, true)
+    out[i] = int < 0 ? int / 0x8000 : int / 0x7fff
+  }
+  return out
+}

--- a/packages/game-bombsquad/src/voice/manual-data.test.ts
+++ b/packages/game-bombsquad/src/voice/manual-data.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import type { Manual } from '@shared/manual-schema'
+import type { ModuleKind } from '@/store/game-context'
+import { bombsquadManualToManualData, moduleKindToRelevantSections } from './manual-data'
+
+/** Every ModuleKind variant, used to assert exhaustive, non-empty mapping. */
+const ALL_MODULE_KINDS: ModuleKind[] = ['wire', 'dial', 'button', 'keypad']
+
+/** A minimal but schema-valid manual carrying all four real modules + a decoy. */
+function makeManual(): Manual {
+  return {
+    meta: { version: '2026-06-28', type: 'daily' },
+    modules: {
+      wire_routing: {
+        rules: [
+          { condition: { wire_count: 4 }, action: 'cut_wire', target: { position: 'first' } },
+        ],
+      },
+      symbol_dial: {
+        columns: [['delta', 'star', 'diamond', 'trident', 'cross']],
+        rule: 'dial rule text',
+      },
+      button: {
+        rules: [{ condition: { color: 'red' }, action: { type: 'tap' } }],
+      },
+      keypad: {
+        sequences: [['psi', 'omega', 'lambda', 'sigma', 'theta', 'phi']],
+        rule: 'keypad rule text',
+      },
+    },
+    decoy_modules: {
+      morse_code: { rule: 'a decoy module that must not leak into ManualData' },
+    },
+  }
+}
+
+describe('moduleKindToRelevantSections', () => {
+  it('maps each ModuleKind to its real manual section id', () => {
+    expect(moduleKindToRelevantSections('wire')).toEqual(['wire_routing'])
+    expect(moduleKindToRelevantSections('dial')).toEqual(['symbol_dial'])
+    expect(moduleKindToRelevantSections('button')).toEqual(['button'])
+    expect(moduleKindToRelevantSections('keypad')).toEqual(['keypad'])
+  })
+
+  it('returns a non-empty array for every ModuleKind', () => {
+    for (const kind of ALL_MODULE_KINDS) {
+      expect(moduleKindToRelevantSections(kind).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('returns a fresh array each call (callers cannot mutate the shared mapping)', () => {
+    const first = moduleKindToRelevantSections('wire')
+    first.push('tampered')
+    expect(moduleKindToRelevantSections('wire')).toEqual(['wire_routing'])
+  })
+
+  it('only references section ids that exist in the produced ManualData', () => {
+    const manualData = bombsquadManualToManualData(makeManual(), 'v1')
+    for (const kind of ALL_MODULE_KINDS) {
+      for (const sectionId of moduleKindToRelevantSections(kind)) {
+        expect(manualData.sections).toHaveProperty(sectionId)
+      }
+    }
+  })
+})
+
+describe('bombsquadManualToManualData', () => {
+  it('carries the supplied version through unchanged', () => {
+    expect(bombsquadManualToManualData(makeManual(), '2026-06-28').version).toBe('2026-06-28')
+  })
+
+  it('keys sections by the real module-section ids', () => {
+    const { sections } = bombsquadManualToManualData(makeManual(), 'v1')
+    expect(Object.keys(sections).sort()).toEqual(
+      ['button', 'keypad', 'symbol_dial', 'wire_routing'].sort()
+    )
+  })
+
+  it('preserves each module section content verbatim', () => {
+    const manual = makeManual()
+    const { sections } = bombsquadManualToManualData(manual, 'v1')
+    expect(sections.wire_routing).toEqual(manual.modules.wire_routing)
+    expect(sections.symbol_dial).toEqual(manual.modules.symbol_dial)
+    expect(sections.button).toEqual(manual.modules.button)
+    expect(sections.keypad).toEqual(manual.modules.keypad)
+  })
+
+  it('excludes decoy_modules — only real modules are injected', () => {
+    const { sections } = bombsquadManualToManualData(makeManual(), 'v1')
+    expect(sections).not.toHaveProperty('morse_code')
+  })
+
+  it('does not mutate the source manual', () => {
+    const manual = makeManual()
+    const before = JSON.stringify(manual)
+    bombsquadManualToManualData(manual, 'v1')
+    expect(JSON.stringify(manual)).toBe(before)
+  })
+})

--- a/packages/game-bombsquad/src/voice/manual-data.ts
+++ b/packages/game-bombsquad/src/voice/manual-data.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure transformers bridging BombSquad's loaded manual + module model into the
+ * game-agnostic `@amiclaw/platform-ai` voice-session contract.
+ *
+ * Both functions are pure — no I/O, no React, no side effects — so the voice
+ * hook/UI rounds can build on a unit-tested seam. The platform-ai types are
+ * imported type-only from the `./contract` subpath, which carries the wire
+ * shapes only (no Durable Object / agents / provider runtime), keeping the
+ * frontend bundle free of Worker code.
+ */
+
+import type { Manual } from '@shared/manual-schema'
+import type { ManualData } from '@amiclaw/platform-ai/contract'
+import type { ModuleKind } from '@/store/game-context'
+
+/**
+ * Map a game `ModuleKind` to the manual section id(s) it grounds on. Section
+ * ids match the real manual data keys under `Manual.modules`
+ * (`wire_routing` / `symbol_dial` / `button` / `keypad`) and the platform-ai
+ * `GameState.relevantSections` contract. Typed as `Record<ModuleKind, ...>` so
+ * a new `ModuleKind` variant fails the build until its mapping is added.
+ */
+const MODULE_KIND_TO_SECTION_IDS: Record<ModuleKind, readonly string[]> = {
+  wire: ['wire_routing'],
+  dial: ['symbol_dial'],
+  button: ['button'],
+  keypad: ['keypad'],
+}
+
+/**
+ * Resolve the manual section id(s) the platform should inject for the given
+ * module. Feeds `gameState.relevantSections` so the platform deterministically
+ * injects the current module's manual subset. Returns a fresh array so callers
+ * cannot mutate the shared mapping.
+ */
+export function moduleKindToRelevantSections(kind: ModuleKind): string[] {
+  return [...MODULE_KIND_TO_SECTION_IDS[kind]]
+}
+
+/**
+ * Map a loaded BombSquad `Manual` into the platform-ai `ManualData` shape. The
+ * `sections` record is keyed by the manual's real module-section ids; each
+ * value is that module's manual content (rules / columns / sequences).
+ *
+ * Only the real `modules` are included — `decoy_modules` are intentionally
+ * dropped. The AI grounds on real module rules, and `relevantSections` only
+ * ever references real modules (see `moduleKindToRelevantSections`), so decoys
+ * would only be unreachable injection weight.
+ */
+export function bombsquadManualToManualData(manual: Manual, version: string): ManualData {
+  return {
+    version,
+    sections: Object.fromEntries(Object.entries(manual.modules)),
+  }
+}

--- a/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { GameState, ManualData, SessionSummary } from '@amiclaw/platform-ai/contract'
+import { useVoiceSession } from './useVoiceSession'
+
+// --- Mocks: WebSocket / AudioContext / getUserMedia ---
+
+type Listener = ((arg?: unknown) => void) | null
+
+class MockWebSocket {
+  static OPEN = 1
+  static CLOSED = 3
+  static instances: MockWebSocket[] = []
+
+  url: string
+  readyState = 0
+  sent: Array<string | ArrayBuffer> = []
+  onopen: Listener = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onerror: Listener = null
+  onclose: ((event: { code: number }) => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  send(data: string | ArrayBuffer): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.({ code: 1000 })
+  }
+
+  // --- test drivers ---
+  fireOpen(): void {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  fireMessage(obj: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(obj) })
+  }
+
+  fireError(): void {
+    this.onerror?.()
+  }
+
+  fireClose(code: number): void {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.({ code })
+  }
+
+  /** The control messages this socket received, parsed. */
+  controlMessages(): Array<Record<string, unknown>> {
+    return this.sent
+      .filter((m): m is string => typeof m === 'string')
+      .map((m) => JSON.parse(m) as Record<string, unknown>)
+  }
+
+  binaryFrameCount(): number {
+    return this.sent.filter((m) => typeof m !== 'string').length
+  }
+}
+
+class MockAudioContext {
+  currentTime = 0
+  destination = {}
+  sampleRate: number
+  constructor(opts?: { sampleRate?: number }) {
+    this.sampleRate = opts?.sampleRate ?? 48000
+  }
+  resume(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+  createBuffer(_ch: number, len: number, rate: number) {
+    return { duration: len / rate, getChannelData: () => new Float32Array(len) }
+  }
+  createBufferSource() {
+    return {
+      buffer: null as unknown,
+      connect() {},
+      start() {},
+      onended: null as Listener,
+    }
+  }
+  createMediaStreamSource() {
+    return { connect() {}, disconnect() {} }
+  }
+  createScriptProcessor() {
+    return { connect() {}, disconnect() {}, onaudioprocess: null as Listener }
+  }
+}
+
+const getUserMedia = vi.fn(async () => ({
+  getTracks: () => [{ stop() {} }],
+}))
+
+function manualData(): ManualData {
+  return { version: 'v1', sections: { button: { rule: 'hold it' } } }
+}
+function gameState(): GameState {
+  return { relevantSections: ['button'] }
+}
+function summary(): SessionSummary {
+  return {
+    sessionId: 's1',
+    gameId: 'bombsquad',
+    userId: 'u1',
+    turnCount: 1,
+    usage: { llmInputTokens: 0, llmOutputTokens: 0, sttInputSeconds: 0, ttsOutputSeconds: 0 },
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  getUserMedia.mockClear()
+  vi.stubGlobal('WebSocket', MockWebSocket)
+  vi.stubGlobal('AudioContext', MockAudioContext)
+  Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+    value: { getUserMedia },
+    configurable: true,
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function lastSocket(): MockWebSocket {
+  const ws = MockWebSocket.instances.at(-1)
+  if (!ws) throw new Error('no WebSocket constructed')
+  return ws
+}
+
+describe('useVoiceSession', () => {
+  it('stays idle until a manual is provided', () => {
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: null, gameState: gameState() })
+    )
+    expect(result.current.status).toBe('idle')
+    expect(MockWebSocket.instances.length).toBe(0)
+  })
+
+  it('connects same-origin and sends create with no userId/prompt', () => {
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    expect(result.current.status).toBe('connecting')
+    const ws = lastSocket()
+    expect(ws.url).toMatch(/^ws:\/\/[^/]+\/ai-ws\/bombsquad-/)
+
+    act(() => ws.fireOpen())
+    const create = ws.controlMessages()[0]
+    expect(create).toMatchObject({
+      type: 'create',
+      gameId: 'bombsquad',
+      manualData: { version: 'v1' },
+      gameState: { relevantSections: ['button'] },
+    })
+    // Security invariant: no userId / prompt on the wire.
+    expect(create).not.toHaveProperty('userId')
+    expect(create).not.toHaveProperty('systemPrompt')
+  })
+
+  it('reaches ready on the created frame', () => {
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
+    expect(result.current.status).toBe('ready')
+  })
+
+  it('runs a full push-to-talk turn: capture -> turn -> stream -> ready', async () => {
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
+
+    await act(async () => {
+      result.current.startTalking()
+    })
+    await waitFor(() => expect(result.current.status).toBe('in-turn'))
+    expect(getUserMedia).toHaveBeenCalledOnce()
+
+    act(() => result.current.stopTalking())
+    const turn = ws.controlMessages().find((m) => m.type === 'turn')
+    expect(turn).toBeDefined()
+
+    act(() => {
+      ws.fireMessage({ type: 'chunk', kind: 'text', text: 'Hold ', done: false })
+      ws.fireMessage({ type: 'chunk', kind: 'text', text: 'the button.', done: false })
+    })
+    expect(result.current.aiText).toBe('Hold the button.')
+
+    // An audio chunk decodes + schedules playback without throwing, then done.
+    const audioB64 = btoa(String.fromCharCode(0, 0, 1, 0))
+    act(() => ws.fireMessage({ type: 'chunk', kind: 'audio', audio: audioB64, done: false }))
+    act(() => ws.fireMessage({ type: 'chunk', kind: 'text', text: '', done: true }))
+    expect(result.current.status).toBe('ready')
+  })
+
+  it('surfaces a bounded mic error and stays usable when permission is denied', async () => {
+    getUserMedia.mockRejectedValueOnce(new Error('denied'))
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
+
+    await act(async () => {
+      result.current.startTalking()
+    })
+    await waitFor(() => expect(result.current.error).toBe('microphone permission denied'))
+    // Mic failure is not a transport failure — the session is still ready.
+    expect(result.current.status).toBe('ready')
+    // No turn was requested without audio.
+    expect(ws.controlMessages().some((m) => m.type === 'turn')).toBe(false)
+  })
+
+  it('endSession sends end and lands closed with the summary', () => {
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
+
+    act(() => result.current.endSession())
+    expect(ws.controlMessages().some((m) => m.type === 'end')).toBe(true)
+
+    const s = summary()
+    act(() => ws.fireMessage({ type: 'summary', summary: s }))
+    act(() => ws.fireClose(1000))
+    expect(result.current.status).toBe('closed')
+    expect(result.current.summary).toMatchObject({ turnCount: 1 })
+  })
+
+  it('an unexpected socket close becomes a bounded transport error', () => {
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
+    act(() => ws.fireClose(1006))
+    expect(result.current.status).toBe('error')
+    expect(result.current.error).toContain('1006')
+  })
+
+  it('closes the socket on unmount (lifecycle hygiene)', () => {
+    const { unmount } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    expect(ws.readyState).toBe(MockWebSocket.OPEN)
+    unmount()
+    expect(ws.readyState).toBe(MockWebSocket.CLOSED)
+  })
+})

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -1,0 +1,424 @@
+/**
+ * `useVoiceSession` — the BombSquad client for one platform-ai voice session.
+ *
+ * Runs the whole turn lifecycle against the deployed `@amiclaw/platform-ai` Worker
+ * over the same-origin `/ai-ws/*` WebSocket: connect -> create session -> hold-to-
+ * talk PCM16 mic capture -> drive a turn -> render the AI's streamed text + play
+ * its TTS audio -> end session. This round is the hook (logic + state) only; the
+ * voice-panel UI + GamePage wiring land in the next round, but the API is shaped
+ * for a panel to consume directly.
+ *
+ * Security invariant (load-bearing, mirrors the demo): this hook connects ONLY to
+ * the same-origin Worker WS and sends ONLY `{gameId, manualData, gameState}` plus
+ * binary audio. It carries NO provider key, NO system prompt, and NO userId — the
+ * session cookie authenticates same-origin and the server holds every secret.
+ *
+ * Audio formats (both 16 kHz mono PCM16):
+ *  - mic capture: `AudioContext({ sampleRate: 16000 })` + `ScriptProcessorNode`,
+ *    Float32 -> Int16 LE per frame (`floatTo16BitPCM`), sent as binary WS frames.
+ *    ScriptProcessor is deprecated but is what the demo uses and is sufficient
+ *    here (capture parity; see the directive's note).
+ *  - TTS playback: base64 audio frame -> Int16 LE -> Float32 (`pcm16ToFloat32`),
+ *    wrapped in an `AudioBuffer` at 16000 Hz and scheduled gaplessly. 16000 is the
+ *    Volcengine TTS output rate (`volcengine.ts` `DEFAULT_SAMPLE_RATE`, which the
+ *    factory never overrides). The playback `AudioContext` runs at its native rate
+ *    and resamples the 16 kHz buffers, which is robust across platforms that
+ *    refuse a forced 16 kHz output context.
+ */
+
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
+import { base64ToBytes, floatTo16BitPCM, pcm16ToFloat32 } from './audio-pcm'
+import {
+  buildSessionUrl,
+  initialVoiceState,
+  randomSessionName,
+  voiceReducer,
+  type ServerFrame,
+  type VoiceStatus,
+} from './voice-session-protocol'
+
+/** Volcengine TTS output sample rate (`volcengine.ts` `DEFAULT_SAMPLE_RATE`). */
+const TTS_OUTPUT_SAMPLE_RATE = 16000
+/** Mic capture rate — the STT adapter's exact wire rate (PCM16 16 kHz mono). */
+const CAPTURE_SAMPLE_RATE = 16000
+/** ScriptProcessor buffer size (frames). Matches the demo. */
+const CAPTURE_BUFFER_SIZE = 4096
+
+export interface UseVoiceSessionOptions {
+  /**
+   * The per-run manual payload (built via `bombsquadManualToManualData`). `null`
+   * while the manual is still loading — the hook stays `idle` and connects once a
+   * non-null value is provided.
+   */
+  manualData: ManualData | null
+  /**
+   * The game state driving manual-subset selection (`relevantSections` via
+   * `moduleKindToRelevantSections`). Applied at session-create time; see the
+   * module-change note on the return type.
+   */
+  gameState: GameState
+  /** Platform game id. Defaults to `'bombsquad'`. */
+  gameId?: string
+}
+
+export interface UseVoiceSessionResult {
+  /** Connection / turn status for the panel. */
+  status: VoiceStatus
+  /** Accumulated AI text for the current turn. */
+  aiText: string
+  /** True while TTS audio is scheduled/playing. */
+  isAiSpeaking: boolean
+  /** Last bounded error message, or null. */
+  error: string | null
+  /** Session summary, set once the session ends cleanly. */
+  summary: import('@amiclaw/platform-ai/contract').SessionSummary | null
+  /** Begin push-to-talk capture (pointer-down). No-op unless `status === 'ready'`. */
+  startTalking: () => void
+  /** End push-to-talk, flush audio, and request the AI turn (pointer-up/leave). */
+  stopTalking: () => void
+  /** End the session: send `end`, await the summary, and tear down. */
+  endSession: () => void
+}
+
+/**
+ * Module-change / `gameState` updates: the wire protocol exposes no mid-session
+ * `gameState` update message (only `create` / `turn` / `end`, and a re-`create` is
+ * rejected `already_created`), so `relevantSections` are pinned at the value
+ * captured when the session is created. The hook keeps the LATEST `gameState`/
+ * `manualData` in refs and applies them at create time; to inject a new module's
+ * sections the consumer creates a fresh session (remount / toggle the hosting
+ * panel), which the next round decides. Within one live session, turns reuse the
+ * created sections — documented as the chosen "carry, apply at create" behaviour.
+ */
+export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessionResult {
+  const { manualData, gameState, gameId = 'bombsquad' } = options
+
+  const [state, dispatch] = useReducer(voiceReducer, initialVoiceState)
+  const [isAiSpeaking, setIsAiSpeaking] = useState(false)
+
+  // Latest inputs, captured at connect/create time without re-running the connect
+  // effect on every prop identity change. Synced in an effect (not during render)
+  // so the refs are current by the time any event handler / connect effect reads
+  // them, without the lint-flagged ref-write-during-render anti-pattern.
+  const manualDataRef = useRef<ManualData | null>(manualData)
+  const gameStateRef = useRef<GameState>(gameState)
+  const gameIdRef = useRef<string>(gameId)
+  useEffect(() => {
+    manualDataRef.current = manualData
+    gameStateRef.current = gameState
+    gameIdRef.current = gameId
+  })
+
+  // Side-effect handles (never trigger re-render).
+  const wsRef = useRef<WebSocket | null>(null)
+  const endedRef = useRef(false)
+  const mountedRef = useRef(true)
+
+  const mediaStreamRef = useRef<MediaStream | null>(null)
+  const captureCtxRef = useRef<AudioContext | null>(null)
+  const captureSourceRef = useRef<MediaStreamAudioSourceNode | null>(null)
+  const captureProcRef = useRef<ScriptProcessorNode | null>(null)
+  /** True between a successful mic acquire and `stopTalking` — gates the `turn`. */
+  const capturingRef = useRef(false)
+  /** True the instant `startTalking` runs; cleared by `stopTalking`, so a release
+   *  during the async `getUserMedia` aborts the capture that is still spinning up. */
+  const talkRequestedRef = useRef(false)
+
+  const playbackCtxRef = useRef<AudioContext | null>(null)
+  /** Next scheduled playback start time, for gapless PCM frame queueing. */
+  const playbackCursorRef = useRef(0)
+  /** Count of scheduled-but-not-ended buffers, driving `isAiSpeaking`. */
+  const playingCountRef = useRef(0)
+
+  const safeDispatch = useCallback((action: Parameters<typeof dispatch>[0]) => {
+    if (mountedRef.current) dispatch(action)
+  }, [])
+
+  // --- TTS playback (Web Audio side effects) ---
+
+  const ensurePlaybackCtx = useCallback((): AudioContext | null => {
+    if (playbackCtxRef.current) return playbackCtxRef.current
+    try {
+      const ctx = new AudioContext()
+      void ctx.resume?.()
+      playbackCtxRef.current = ctx
+      playbackCursorRef.current = ctx.currentTime
+      return ctx
+    } catch {
+      return null
+    }
+  }, [])
+
+  const playAudioFrame = useCallback(
+    (bytes: Uint8Array) => {
+      const floats = pcm16ToFloat32(bytes)
+      if (floats.length === 0) return
+      const ctx = ensurePlaybackCtx()
+      if (!ctx) return
+      try {
+        const buffer = ctx.createBuffer(1, floats.length, TTS_OUTPUT_SAMPLE_RATE)
+        buffer.getChannelData(0).set(floats)
+        const source = ctx.createBufferSource()
+        source.buffer = buffer
+        source.connect(ctx.destination)
+        const startAt = Math.max(ctx.currentTime, playbackCursorRef.current)
+        source.start(startAt)
+        playbackCursorRef.current = startAt + buffer.duration
+        playingCountRef.current += 1
+        setIsAiSpeaking(true)
+        source.onended = () => {
+          playingCountRef.current = Math.max(0, playingCountRef.current - 1)
+          if (playingCountRef.current === 0 && mountedRef.current) setIsAiSpeaking(false)
+        }
+      } catch {
+        // A playback failure must never break the turn — text still renders.
+      }
+    },
+    [ensurePlaybackCtx]
+  )
+
+  const stopPlayback = useCallback(() => {
+    playingCountRef.current = 0
+    setIsAiSpeaking(false)
+    const ctx = playbackCtxRef.current
+    playbackCtxRef.current = null
+    if (ctx) {
+      try {
+        void ctx.close()
+      } catch {
+        // ignore — context may already be closed
+      }
+    }
+  }, [])
+
+  // --- Mic capture ---
+
+  const stopCapture = useCallback(() => {
+    capturingRef.current = false
+    const proc = captureProcRef.current
+    if (proc) {
+      proc.onaudioprocess = null
+      try {
+        proc.disconnect()
+      } catch {
+        /* ignore */
+      }
+      captureProcRef.current = null
+    }
+    const source = captureSourceRef.current
+    if (source) {
+      try {
+        source.disconnect()
+      } catch {
+        /* ignore */
+      }
+      captureSourceRef.current = null
+    }
+    const ctx = captureCtxRef.current
+    captureCtxRef.current = null
+    if (ctx) {
+      try {
+        void ctx.close()
+      } catch {
+        /* ignore */
+      }
+    }
+    const stream = mediaStreamRef.current
+    if (stream) {
+      stream.getTracks().forEach((t) => t.stop())
+      mediaStreamRef.current = null
+    }
+  }, [])
+
+  // --- WebSocket lifecycle ---
+
+  const closeSocket = useCallback((detachHandlers: boolean) => {
+    const ws = wsRef.current
+    wsRef.current = null
+    if (!ws) return
+    if (detachHandlers) {
+      ws.onopen = null
+      ws.onmessage = null
+      ws.onerror = null
+      ws.onclose = null
+    }
+    try {
+      ws.close()
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
+  const connect = useCallback(() => {
+    // Double-connect guard: only one socket per mounted lifecycle.
+    if (wsRef.current) return
+    const data = manualDataRef.current
+    if (!data) return
+    endedRef.current = false
+    safeDispatch({ type: 'connecting' })
+
+    let ws: WebSocket
+    try {
+      ws = new WebSocket(buildSessionUrl(window.location, randomSessionName()))
+    } catch {
+      safeDispatch({ type: 'transport-error', message: 'failed to open voice connection' })
+      return
+    }
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      const create = {
+        type: 'create' as const,
+        gameId: gameIdRef.current,
+        manualData: manualDataRef.current,
+        gameState: gameStateRef.current,
+      }
+      try {
+        ws.send(JSON.stringify(create))
+      } catch {
+        safeDispatch({ type: 'transport-error', message: 'failed to create voice session' })
+      }
+    }
+
+    ws.onmessage = (event) => {
+      if (typeof event.data !== 'string') return
+      let frame: ServerFrame
+      try {
+        frame = JSON.parse(event.data) as ServerFrame
+      } catch {
+        return
+      }
+      if (frame.type === 'chunk' && frame.kind === 'audio' && frame.audio) {
+        playAudioFrame(base64ToBytes(frame.audio))
+      }
+      safeDispatch({ type: 'frame', frame })
+    }
+
+    ws.onerror = () => {
+      safeDispatch({ type: 'transport-error', message: 'voice connection error' })
+    }
+
+    ws.onclose = (event) => {
+      wsRef.current = null
+      if (endedRef.current || event.code === 1000) {
+        safeDispatch({ type: 'closed' })
+      } else {
+        safeDispatch({
+          type: 'transport-error',
+          message: `voice connection closed (${event.code})`,
+        })
+      }
+    }
+  }, [playAudioFrame, safeDispatch])
+
+  // --- Public actions ---
+
+  const startTalking = useCallback(() => {
+    const ws = wsRef.current
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+    // Only one turn at a time, and only once the session is ready.
+    if (state.status !== 'ready' || talkRequestedRef.current) return
+    talkRequestedRef.current = true
+
+    void (async () => {
+      let stream: MediaStream
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      } catch {
+        talkRequestedRef.current = false
+        safeDispatch({ type: 'mic-error', message: 'microphone permission denied' })
+        return
+      }
+      // A release (stopTalking) during the async acquire aborts spin-up.
+      if (!talkRequestedRef.current || !wsRef.current) {
+        stream.getTracks().forEach((t) => t.stop())
+        return
+      }
+      mediaStreamRef.current = stream
+      try {
+        const ctx = new AudioContext({ sampleRate: CAPTURE_SAMPLE_RATE })
+        captureCtxRef.current = ctx
+        const source = ctx.createMediaStreamSource(stream)
+        captureSourceRef.current = source
+        const proc = ctx.createScriptProcessor(CAPTURE_BUFFER_SIZE, 1, 1)
+        captureProcRef.current = proc
+        proc.onaudioprocess = (e) => {
+          const socket = wsRef.current
+          if (!socket || socket.readyState !== WebSocket.OPEN) return
+          socket.send(floatTo16BitPCM(e.inputBuffer.getChannelData(0)))
+        }
+        source.connect(proc)
+        proc.connect(ctx.destination)
+        capturingRef.current = true
+        safeDispatch({ type: 'talk-start' })
+      } catch {
+        stopCapture()
+        talkRequestedRef.current = false
+        safeDispatch({ type: 'mic-error', message: 'microphone capture failed' })
+      }
+    })()
+  }, [state.status, safeDispatch, stopCapture])
+
+  const stopTalking = useCallback(() => {
+    talkRequestedRef.current = false
+    const wasCapturing = capturingRef.current
+    stopCapture()
+    const ws = wsRef.current
+    // Only request a turn if we actually captured audio — an empty turn would
+    // drive STT over a silent bridge.
+    if (wasCapturing && ws && ws.readyState === WebSocket.OPEN) {
+      try {
+        ws.send(JSON.stringify({ type: 'turn' }))
+      } catch {
+        safeDispatch({ type: 'transport-error', message: 'failed to send turn' })
+      }
+    }
+  }, [stopCapture, safeDispatch])
+
+  const endSession = useCallback(() => {
+    talkRequestedRef.current = false
+    stopCapture()
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      // Mark ended so the eventual close is treated as clean; let the socket stay
+      // open to receive the `summary`, then its `onclose` finalizes to `closed`.
+      endedRef.current = true
+      try {
+        ws.send(JSON.stringify({ type: 'end' }))
+      } catch {
+        closeSocket(true)
+        safeDispatch({ type: 'closed' })
+      }
+    } else {
+      closeSocket(true)
+      safeDispatch({ type: 'closed' })
+    }
+  }, [stopCapture, closeSocket, safeDispatch])
+
+  // --- Connect on mount (once the manual is ready); full teardown on unmount ---
+
+  const hasManual = manualData !== null
+  useEffect(() => {
+    if (!hasManual) return
+    mountedRef.current = true
+    connect()
+    return () => {
+      mountedRef.current = false
+      stopCapture()
+      stopPlayback()
+      closeSocket(true)
+    }
+  }, [hasManual, connect, stopCapture, stopPlayback, closeSocket])
+
+  return {
+    status: state.status,
+    aiText: state.aiText,
+    isAiSpeaking,
+    error: state.error,
+    summary: state.summary,
+    startTalking,
+    stopTalking,
+    endSession,
+  }
+}

--- a/packages/game-bombsquad/src/voice/voice-panel-inputs.test.ts
+++ b/packages/game-bombsquad/src/voice/voice-panel-inputs.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import type { Manual } from '@shared/manual-schema'
+import type { GameState } from '@/store/game-context'
+import {
+  deriveVoicePanelInputs,
+  isPlatformVoicePartner,
+  MODE2_PARTNER_VALUE,
+} from './voice-panel-inputs'
+
+/** A minimal but schema-valid manual carrying all four real modules. */
+function makeManual(): Manual {
+  return {
+    meta: { version: '2026-06-28', type: 'daily' },
+    modules: {
+      wire_routing: {
+        rules: [
+          { condition: { wire_count: 4 }, action: 'cut_wire', target: { position: 'first' } },
+        ],
+      },
+      symbol_dial: {
+        columns: [['delta', 'star', 'diamond', 'trident', 'cross']],
+        rule: 'dial rule text',
+      },
+      button: { rules: [{ condition: { color: 'red' }, action: { type: 'tap' } }] },
+      keypad: {
+        sequences: [['psi', 'omega', 'lambda', 'sigma', 'theta', 'phi']],
+        rule: 'keypad rule text',
+      },
+    },
+    decoy_modules: { morse_code: { rule: 'decoy' } },
+  } as unknown as Manual
+}
+
+/** A daily-run game state at the given module index, with a loaded manual. */
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    status: 'PLAYING',
+    mode: 'daily',
+    manual: makeManual(),
+    manualUrl: 'https://claw.amio.fans/manual/2026-06-28',
+    sceneInfo: null,
+    moduleSequence: ['wire', 'dial', 'button', 'keypad'],
+    moduleConfigs: [],
+    moduleAnswers: [],
+    currentModuleIndex: 0,
+    moduleStats: [],
+    totalStartTime: null,
+    totalEndTime: null,
+    currentModuleStartTime: null,
+    currentModuleErrorCount: 0,
+    strikeCount: 0,
+    timeBudgetMs: 0,
+    outcome: null,
+    errorMessage: null,
+    errorKind: null,
+    attemptNumber: 1,
+    rngSeed: 0,
+    ...overrides,
+  }
+}
+
+describe('isPlatformVoicePartner (mode② gating)', () => {
+  it('opts in only a daily run carrying ?partner=platform', () => {
+    expect(isPlatformVoicePartner('daily', MODE2_PARTNER_VALUE)).toBe(true)
+  })
+
+  it('keeps a daily run mode① without the explicit signal', () => {
+    expect(isPlatformVoicePartner('daily', null)).toBe(false)
+    expect(isPlatformVoicePartner('daily', 'byo')).toBe(false)
+    expect(isPlatformVoicePartner('daily', '')).toBe(false)
+  })
+
+  it('never opts in practice, even with the signal', () => {
+    expect(isPlatformVoicePartner('practice', MODE2_PARTNER_VALUE)).toBe(false)
+    expect(isPlatformVoicePartner('practice', null)).toBe(false)
+  })
+})
+
+describe('deriveVoicePanelInputs (current module -> hook inputs)', () => {
+  it('maps the current module kind to its relevantSections', () => {
+    const dial = deriveVoicePanelInputs(makeState({ currentModuleIndex: 1 }))
+    expect(dial?.gameState.relevantSections).toEqual(['symbol_dial'])
+    expect(dial?.moduleKind).toBe('dial')
+
+    const keypad = deriveVoicePanelInputs(makeState({ currentModuleIndex: 3 }))
+    expect(keypad?.gameState.relevantSections).toEqual(['keypad'])
+    expect(keypad?.moduleKind).toBe('keypad')
+  })
+
+  it('carries the manual version into manualData and excludes decoys', () => {
+    const inputs = deriveVoicePanelInputs(makeState())
+    expect(inputs?.manualData.version).toBe('2026-06-28')
+    expect(Object.keys(inputs?.manualData.sections ?? {}).sort()).toEqual(
+      ['button', 'keypad', 'symbol_dial', 'wire_routing'].sort()
+    )
+    expect(inputs?.manualData.sections).not.toHaveProperty('morse_code')
+  })
+
+  it('produces a distinct moduleKey per module so the panel remounts on advance', () => {
+    const first = deriveVoicePanelInputs(makeState({ currentModuleIndex: 0 }))
+    const second = deriveVoicePanelInputs(makeState({ currentModuleIndex: 1 }))
+    expect(first?.moduleKey).toBe('0-wire')
+    expect(second?.moduleKey).toBe('1-dial')
+    expect(first?.moduleKey).not.toBe(second?.moduleKey)
+  })
+
+  it('returns null until a manual is loaded', () => {
+    expect(deriveVoicePanelInputs(makeState({ manual: null }))).toBeNull()
+  })
+
+  it('returns null when there is no current module kind', () => {
+    expect(
+      deriveVoicePanelInputs(makeState({ moduleSequence: [], currentModuleIndex: 0 }))
+    ).toBeNull()
+  })
+})

--- a/packages/game-bombsquad/src/voice/voice-panel-inputs.ts
+++ b/packages/game-bombsquad/src/voice/voice-panel-inputs.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure wiring seam between the live BombSquad game state and the voice-session
+ * hook inputs. Side-effect-free (no React, no I/O) so the mode②-gating and the
+ * current-module -> `relevantSections` derivation are unit-testable without a
+ * browser. `GamePage` consumes these to mount `VoicePanel` only for an opted-in
+ * daily run, and to remount it (fresh session) on every module advance.
+ */
+
+import type { GameState as BombSquadGameState, GameMode, ModuleKind } from '@/store/game-context'
+import type { GameState as VoiceGameState, ManualData } from '@amiclaw/platform-ai/contract'
+import { bombsquadManualToManualData, moduleKindToRelevantSections } from './manual-data'
+
+/** Query-param value that opts a daily run into the platform voice partner (mode②). */
+export const MODE2_PARTNER_PARAM = 'partner'
+export const MODE2_PARTNER_VALUE = 'platform'
+
+/**
+ * mode②-gating. The in-game platform voice partner mounts only on a DAILY run
+ * explicitly opted in via `?partner=platform`. Practice runs and an un-opted
+ * daily run stay mode① (BYO-AI) and never mount the panel — keeping mode① the
+ * default and fully unchanged.
+ */
+export function isPlatformVoicePartner(mode: GameMode, partnerParam: string | null): boolean {
+  return mode === 'daily' && partnerParam === MODE2_PARTNER_VALUE
+}
+
+export interface VoicePanelInputs {
+  /** Per-run manual payload for the voice session. */
+  manualData: ManualData
+  /** Drives the platform's manual-subset selection for the current module. */
+  gameState: VoiceGameState
+  /**
+   * Stable per-module identity. Used as the `VoicePanel` React `key`, so when
+   * the player advances modules the panel tears down (WS/mic/AudioContext) and
+   * reconnects with the new module's `relevantSections` — the locked
+   * per-module-session model.
+   */
+  moduleKey: string
+  /** The current module kind (surfaced for labelling / callers). */
+  moduleKind: ModuleKind
+}
+
+/**
+ * Derive the voice-session inputs from the live game state for the current
+ * module. Returns null until the manual is loaded and a current module kind
+ * exists — the panel stays unmounted (and the hook idle) until then. Pure: it
+ * reads game state and the Round-1 transformers only, never game logic.
+ */
+export function deriveVoicePanelInputs(state: BombSquadGameState): VoicePanelInputs | null {
+  const moduleKind = state.moduleSequence[state.currentModuleIndex]
+  if (!moduleKind || state.manual === null) return null
+  return {
+    manualData: bombsquadManualToManualData(state.manual, state.manual.meta.version),
+    gameState: { relevantSections: moduleKindToRelevantSections(moduleKind) },
+    moduleKey: `${state.currentModuleIndex}-${moduleKind}`,
+    moduleKind,
+  }
+}

--- a/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
+++ b/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest'
+import type { SessionSummary } from '@amiclaw/platform-ai/contract'
+import {
+  boundError,
+  buildSessionUrl,
+  initialVoiceState,
+  voiceReducer,
+  type ServerFrame,
+  type VoiceSessionState,
+} from './voice-session-protocol'
+
+function summary(): SessionSummary {
+  return {
+    sessionId: 's1',
+    gameId: 'bombsquad',
+    userId: 'u1',
+    turnCount: 2,
+    usage: { llmInputTokens: 0, llmOutputTokens: 0, sttInputSeconds: 0, ttsOutputSeconds: 0 },
+  }
+}
+
+/** Drive the reducer from `initialVoiceState` through a sequence of actions. */
+function run(...actions: Parameters<typeof voiceReducer>[1][]): VoiceSessionState {
+  return actions.reduce(voiceReducer, initialVoiceState)
+}
+
+describe('buildSessionUrl', () => {
+  it('uses wss on https', () => {
+    expect(buildSessionUrl({ protocol: 'https:', host: 'claw.amio.fans' }, 'abc')).toBe(
+      'wss://claw.amio.fans/ai-ws/abc'
+    )
+  })
+
+  it('uses ws on http (and preserves host:port)', () => {
+    expect(buildSessionUrl({ protocol: 'http:', host: 'localhost:5173' }, 'xyz')).toBe(
+      'ws://localhost:5173/ai-ws/xyz'
+    )
+  })
+})
+
+describe('boundError', () => {
+  it('passes short messages through unchanged', () => {
+    expect(boundError('nope')).toBe('nope')
+  })
+
+  it('caps very long messages', () => {
+    const out = boundError('x'.repeat(500))
+    expect(out.length).toBe(200)
+    expect(out.endsWith('…')).toBe(true)
+  })
+})
+
+describe('voiceReducer', () => {
+  it('connecting resets to a fresh connecting state', () => {
+    const dirty = run({ type: 'frame', frame: { type: 'created', sessionId: 's1' } })
+    const next = voiceReducer({ ...dirty, aiText: 'stale', error: 'old' }, { type: 'connecting' })
+    expect(next).toEqual({ ...initialVoiceState, status: 'connecting' })
+  })
+
+  it('created moves connecting -> ready and stores the sessionId', () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 'sess-7' } }
+    )
+    expect(next.status).toBe('ready')
+    expect(next.sessionId).toBe('sess-7')
+  })
+
+  it('talk-start moves ready -> in-turn and clears prior text/error', () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'old reply', done: true } },
+      { type: 'talk-start' }
+    )
+    expect(next.status).toBe('in-turn')
+    expect(next.aiText).toBe('')
+  })
+
+  it('talk-start is a no-op when not ready (no double-turn from in-turn)', () => {
+    const inTurn = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'talk-start' }
+    )
+    expect(inTurn.status).toBe('in-turn')
+    expect(voiceReducer(inTurn, { type: 'talk-start' })).toBe(inTurn)
+  })
+
+  it('accumulates streamed text chunks across a turn', () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'talk-start' },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'Hold ', done: false } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'the ', done: false } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'button.', done: false } }
+    )
+    expect(next.aiText).toBe('Hold the button.')
+    expect(next.status).toBe('in-turn')
+  })
+
+  it('audio chunks do not change aiText but their done flag closes the turn', () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'talk-start' },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'ok', done: false } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'audio', audio: 'AAAA', done: true } }
+    )
+    expect(next.aiText).toBe('ok')
+    expect(next.status).toBe('ready')
+  })
+
+  it('a done text chunk returns the turn to ready', () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'talk-start' },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'done now', done: true } }
+    )
+    expect(next.status).toBe('ready')
+    expect(next.aiText).toBe('done now')
+  })
+
+  it('summary moves to closed and exposes the summary', () => {
+    const s = summary()
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'frame', frame: { type: 'summary', summary: s } }
+    )
+    expect(next.status).toBe('closed')
+    expect(next.summary).toBe(s)
+  })
+
+  it('an in-band error frame surfaces a bounded message without changing status', () => {
+    const ready = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } }
+    )
+    const next = voiceReducer(ready, {
+      type: 'frame',
+      frame: { type: 'error', code: 'turn_in_flight', message: 'a turn is already in progress' },
+    })
+    expect(next.status).toBe('ready')
+    expect(next.error).toBe('a turn is already in progress')
+  })
+
+  it('mic-error surfaces a bounded message but keeps the session usable', () => {
+    const ready = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } }
+    )
+    const next = voiceReducer(ready, { type: 'mic-error', message: 'microphone permission denied' })
+    expect(next.status).toBe('ready')
+    expect(next.error).toBe('microphone permission denied')
+  })
+
+  it('transport-error moves to error with a bounded message', () => {
+    const next = voiceReducer(run({ type: 'connecting' }), {
+      type: 'transport-error',
+      message: 'voice connection closed (1006)',
+    })
+    expect(next.status).toBe('error')
+    expect(next.error).toBe('voice connection closed (1006)')
+  })
+
+  it('closed lands a clean closed state', () => {
+    const ready = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } }
+    )
+    expect(voiceReducer(ready, { type: 'closed' }).status).toBe('closed')
+  })
+
+  it('ignores unknown frame types (forward-compatible)', () => {
+    const ready = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } }
+    )
+    const next = voiceReducer(ready, {
+      type: 'frame',
+      frame: { type: 'mystery' } as unknown as ServerFrame,
+    })
+    expect(next).toEqual(ready)
+  })
+})

--- a/packages/game-bombsquad/src/voice/voice-session-protocol.ts
+++ b/packages/game-bombsquad/src/voice/voice-session-protocol.ts
@@ -1,0 +1,172 @@
+/**
+ * Pure protocol layer for the BombSquad voice session: the server->client wire
+ * envelope types, the exposed-state reducer, and the WebSocket URL builder.
+ *
+ * Side-effect-free (no React, no WebSocket, no Web Audio) so the turn-lifecycle
+ * state machine is unit-testable by feeding it mock frames. `useVoiceSession.ts`
+ * owns the side effects (socket, mic, playback) and delegates all exposed-state
+ * computation to `voiceReducer` here.
+ *
+ * The server->client envelope shapes (`created` / `chunk` / `summary` / `error`)
+ * are NOT exported from `@amiclaw/platform-ai/contract` — that subpath carries the
+ * semantic contract types only (`ManualData` / `GameState` / `AiResponseChunk` /
+ * `SessionSummary`), and the JSON envelope lives in the Worker-side
+ * `session-do.ts`, which must never be pulled into the frontend bundle. So the
+ * envelope is re-declared here, structurally matching `session-do.ts`, importing
+ * only `SessionSummary` (type-only) from the contract for the `summary` frame.
+ */
+
+import type { SessionSummary } from '@amiclaw/platform-ai/contract'
+
+/**
+ * Connection / turn status surfaced to the panel.
+ *  - `idle`        before the manual is ready / before connect.
+ *  - `connecting`  socket opening and session being created.
+ *  - `ready`       session created; the player may push-to-talk.
+ *  - `in-turn`     a turn is in progress (player speaking or AI responding).
+ *  - `error`       the socket failed or closed unexpectedly (bounded `error` set).
+ *  - `closed`      the session ended cleanly (a `summary` arrived / `end` acked).
+ */
+export type VoiceStatus = 'idle' | 'connecting' | 'ready' | 'in-turn' | 'error' | 'closed'
+
+/**
+ * One server->client JSON frame. Structurally mirrors the envelope
+ * `session-do.ts` emits: `created` on session create, `chunk` per streamed
+ * text/audio fragment (audio base64-encoded for the JSON channel), `summary` on
+ * `end`, and a non-fatal in-band `error` (e.g. `turn_in_flight`,
+ * `already_created`) that does NOT close the socket.
+ */
+export type ServerFrame =
+  | { type: 'created'; sessionId: string }
+  | { type: 'chunk'; kind: 'text'; text?: string; done: boolean }
+  | { type: 'chunk'; kind: 'audio'; audio?: string; done: boolean }
+  | { type: 'summary'; summary: SessionSummary }
+  | { type: 'error'; code?: string; message?: string }
+
+/** Reducer actions: server frames plus the local lifecycle transitions. */
+export type VoiceAction =
+  | { type: 'connecting' }
+  | { type: 'talk-start' }
+  | { type: 'frame'; frame: ServerFrame }
+  | { type: 'mic-error'; message: string }
+  | { type: 'transport-error'; message: string }
+  | { type: 'closed' }
+
+/** The reducer-owned slice of the hook's exposed state. */
+export interface VoiceSessionState {
+  status: VoiceStatus
+  sessionId: string | null
+  /** Accumulated AI text for the current turn (cleared when a new turn starts). */
+  aiText: string
+  /** Last bounded error message, or null. */
+  error: string | null
+  /** Session summary, set once `end` is acknowledged. */
+  summary: SessionSummary | null
+}
+
+export const initialVoiceState: VoiceSessionState = {
+  status: 'idle',
+  sessionId: null,
+  aiText: '',
+  error: null,
+  summary: null,
+}
+
+/** Cap an error message to a bounded length so a provider error never floods state. */
+const MAX_ERROR_CHARS = 200
+export function boundError(message: string): string {
+  return message.length > MAX_ERROR_CHARS ? `${message.slice(0, MAX_ERROR_CHARS - 1)}…` : message
+}
+
+/**
+ * Compute the next exposed state from the current state and one action. Pure and
+ * total — every action maps to a defined transition, and unknown/irrelevant
+ * frames are no-ops. This is the single source of truth for the turn lifecycle.
+ */
+export function voiceReducer(state: VoiceSessionState, action: VoiceAction): VoiceSessionState {
+  switch (action.type) {
+    case 'connecting':
+      // Fresh connect resets the per-session surface.
+      return { ...initialVoiceState, status: 'connecting' }
+
+    case 'talk-start':
+      // A new turn begins only from `ready`; clear the prior turn's text + error
+      // so the panel shows this turn's reply fresh.
+      if (state.status !== 'ready') return state
+      return { ...state, status: 'in-turn', aiText: '', error: null }
+
+    case 'frame':
+      return reduceFrame(state, action.frame)
+
+    case 'mic-error':
+      // Mic capture failure is NOT a socket failure: surface the bounded message
+      // but keep the session usable (status unchanged — capture never reached
+      // `in-turn`, which is set only after the mic is acquired).
+      return { ...state, error: boundError(action.message) }
+
+    case 'transport-error':
+      return { ...state, status: 'error', error: boundError(action.message) }
+
+    case 'closed':
+      // A clean close after `summary` keeps `closed`; an explicit close with no
+      // prior terminal state still lands `closed`.
+      return state.status === 'closed' ? state : { ...state, status: 'closed' }
+
+    default:
+      return state
+  }
+}
+
+function reduceFrame(state: VoiceSessionState, frame: ServerFrame): VoiceSessionState {
+  switch (frame.type) {
+    case 'created':
+      return { ...state, status: 'ready', sessionId: frame.sessionId }
+
+    case 'chunk': {
+      // Text chunks accumulate into `aiText`; audio chunks are a playback side
+      // effect the hook handles, so only their `done` flag matters here. ANY
+      // chunk flagged `done` is the turn's last fragment -> back to `ready`.
+      const aiText = frame.kind === 'text' ? state.aiText + (frame.text ?? '') : state.aiText
+      const status: VoiceStatus = frame.done
+        ? 'ready'
+        : state.status === 'ready'
+          ? 'in-turn'
+          : state.status
+      return { ...state, aiText, status }
+    }
+
+    case 'summary':
+      return { ...state, status: 'closed', summary: frame.summary }
+
+    case 'error':
+      // In-band, non-fatal server error (e.g. `turn_in_flight`). Surface the
+      // bounded message; leave status to the streaming/lifecycle handlers (the
+      // rejected message did not close the socket).
+      return { ...state, error: boundError(frame.message ?? frame.code ?? 'session error') }
+
+    default:
+      return state
+  }
+}
+
+/** Minimal view of `window.location` the URL builder needs. */
+export interface LocationLike {
+  protocol: string
+  host: string
+}
+
+/**
+ * Build the same-origin voice WebSocket URL: `wss://` on https, `ws://` on http,
+ * host from `location.host`, path `/ai-ws/<sessionName>`. The session cookie
+ * rides along same-origin, so the hook sends no userId — auth is the Worker's
+ * handshake concern. Mirrors the demo's connect URL construction.
+ */
+export function buildSessionUrl(location: LocationLike, sessionName: string): string {
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws'
+  return `${proto}://${location.host}/ai-ws/${sessionName}`
+}
+
+/** Generate a random, collision-unlikely session name for the WS path. */
+export function randomSessionName(): string {
+  return `bombsquad-${Math.random().toString(36).slice(2, 10)}`
+}

--- a/packages/platform-ai/package.json
+++ b/packages/platform-ai/package.json
@@ -2,6 +2,12 @@
   "name": "@amiclaw/platform-ai",
   "private": true,
   "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./contract": "./src/contract.ts"
+  },
   "scripts": {
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",

--- a/packages/platform-ai/src/contract.ts
+++ b/packages/platform-ai/src/contract.ts
@@ -59,6 +59,19 @@ export interface ManualData {
 }
 
 /**
+ * Game state that drives manual-subset selection. `relevantSections` is the
+ * ordered list of manual section ids the platform deems relevant for the
+ * current turn (e.g. the current module/phase). The game owns how it derives
+ * this list; injection only consumes it. Kept here in the pure contract module
+ * (rather than alongside the injection runtime) so browser-side consumers can
+ * type their game state without pulling any server runtime.
+ */
+export interface GameState {
+  /** Ordered manual section ids to inject for this turn. */
+  relevantSections: string[]
+}
+
+/**
  * One chunk of the AI's streamed response. A turn produces an ordered stream of
  * these: incremental assistant text plus the synthesized audio frames pushed
  * back over the same WebSocket. `kind` discriminates the two; `done` marks the

--- a/packages/platform-ai/src/index.ts
+++ b/packages/platform-ai/src/index.ts
@@ -16,6 +16,7 @@ export type {
   UserId,
   AudioChunk,
   ManualData,
+  GameState,
   AiResponseChunk,
   SessionSummary,
   VoiceSessionContract,
@@ -48,7 +49,7 @@ export type {
 export { resolveConfig } from './provider-config'
 
 // Deterministic manual injection.
-export type { GameState, AssembleLlmContextInput } from './manual-injection'
+export type { AssembleLlmContextInput } from './manual-injection'
 export { assembleLlmContext } from './manual-injection'
 
 // Provider factory — wire a resolved config to concrete R2 adapters.

--- a/packages/platform-ai/src/manual-injection.ts
+++ b/packages/platform-ai/src/manual-injection.ts
@@ -20,20 +20,14 @@
  */
 
 import type { CompanionContext } from '../../companion-memory/src/types'
-import type { ManualData } from './contract'
+import type { GameState, ManualData } from './contract'
 import type { ChatMessage } from './providers/types'
 import type { SystemPromptConfig } from './provider-config'
 
-/**
- * Game state that drives manual-subset selection. `relevantSections` is the
- * ordered list of manual section ids the platform deems relevant for the
- * current turn (e.g. the current module/phase). The game owns how it derives
- * this list; injection only consumes it.
- */
-export interface GameState {
-  /** Ordered manual section ids to inject for this turn. */
-  relevantSections: string[]
-}
+// `GameState` is defined in the pure contract module; re-exported here so the
+// existing `from './manual-injection'` importers (turn-pipeline, session-do,
+// session-assembly) keep their import path unchanged.
+export type { GameState }
 
 /** Input to `assembleLlmContext`. */
 export interface AssembleLlmContextInput {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,7 +68,30 @@ export default defineConfig({
     baseURL: 'http://localhost:4173',
     trace: 'retain-on-failure',
   },
-  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // The mode② voice-panel scenario needs a deterministic mic + audio:
+        //  - fake media: getUserMedia returns a synthetic mic stream and the
+        //    permission prompt is auto-accepted, so push-to-talk capture works
+        //    headless with no real device.
+        //  - autoplay relaxation: the panel's TTS AudioContext can start without
+        //    a user-gesture gate, so the "AI is speaking" playback indicator
+        //    fires deterministically.
+        // Harmless to every other scenario (none uses getUserMedia or Web Audio
+        // assertions).
+        launchOptions: {
+          args: [
+            '--use-fake-ui-for-media-stream',
+            '--use-fake-device-for-media-stream',
+            '--autoplay-policy=no-user-gesture-required',
+          ],
+        },
+      },
+    },
+  ],
   webServer: {
     // Serve the assembled `pnpm build` artifact (packages/platform/dist — the
     // deploy root that hosts the platform shell at /, BombSquad under

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
+      '@amiclaw/platform-ai':
+        specifier: workspace:*
+        version: link:../platform-ai
       '@testing-library/jest-dom':
         specifier: ^6.4.0
         version: 6.9.1


### PR DESCRIPTION
## Summary

Wires BombSquad's **daily** run into the `@amiclaw/platform-ai` voice session — the platform AI's **first real game consumer**. Purely additive and mode②-gated: mode① (BYO-AI), the puzzle engine, timer, and strikes are byte-unchanged.

- **Type seam**: platform-ai exposes a pure `@amiclaw/platform-ai/contract` subpath (GameState moved into the pure contract.ts) — frontend imports wire types type-only, **zero Worker runtime in the bundle**.
- **Pure transformers**: `bombsquadManualToManualData` + `moduleKindToRelevantSections` (wire→wire_routing, dial→symbol_dial, button→button, keypad→keypad).
- **`useVoiceSession` hook** + pure protocol reducer + audio utils: same-origin `/ai-ws/*` WS, push-to-talk PCM16 16kHz mic capture, create/turn/end control, AI text render + gapless 16k TTS playback, endSession. Sends no userId/keys/prompt.
- **VoicePanel + GamePage**, gated on `?mode=daily&partner=platform`. **Per-module session** (panel remounts keyed on module) so each module gets a fresh session with its own injected manual subset — matches the deterministic-injection invariant.
- **e2e**: deterministic Playwright-BDD scenario stubbing the `/ai-ws/*` WS boundary + fake media; registered in flow-inventory. mode① e2e untouched.

**Inert at the default experience** until the mode-selection landing + login gate land (follow-ups).

## Test plan

- [x] tsc / build / eslint / prettier clean
- [x] 342 game-bombsquad unit tests (+39 across the voice work) + 304 platform-ai
- [x] e2e 27/27 (new mode② voice scenario + mode① untouched)
- [ ] **play-green**: a real in-game voice turn against the deployed Worker (manual, via this PR's Pages preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)