### PR TITLE
fix(game-bombsquad): mode② voice later-turn 1008 — resample mic to true 16kHz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② voice: later turns no longer drop the connection** - Fix. In
+the in-game voice partner, the first turn worked but a later turn (or the next
+module's session) could close with a connection error. The microphone capture
+asked the browser for 16 kHz audio but did not verify the browser actually
+honoured it; when it silently ran at the hardware rate, the audio sent to the
+speech recognizer was the wrong speed and the server rejected the turn. Capture
+now reads the real sample rate and resamples to 16 kHz, fully tears down its
+audio resources between turns (so nothing leaks across turns or module changes),
+and surfaces the server's close reason in the error text.
+
 **BombSquad mode② in-game voice partner (opt-in wiring)** - BombSquad's daily
 run can now host the platform's AI defuse partner over an in-page voice panel:
 hold to talk, and the AI guides you by voice using the manual it can see while

--- a/packages/game-bombsquad/src/voice/audio-pcm.test.ts
+++ b/packages/game-bombsquad/src/voice/audio-pcm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { base64ToBytes, floatTo16BitPCM, pcm16ToFloat32 } from './audio-pcm'
+import { base64ToBytes, floatTo16BitPCM, pcm16ToFloat32, resamplePcmFloat32 } from './audio-pcm'
 
 describe('floatTo16BitPCM', () => {
   it('produces 2 little-endian bytes per sample', () => {
@@ -49,6 +49,60 @@ describe('pcm16ToFloat32', () => {
     for (let i = 0; i < samples.length; i += 1) {
       expect(decoded[i]).toBeCloseTo(samples[i], 3)
     }
+  })
+})
+
+describe('resamplePcmFloat32', () => {
+  it('returns the input unchanged when the rates already match', () => {
+    const input = new Float32Array([0.1, 0.2, 0.3])
+    expect(resamplePcmFloat32(input, 16000, 16000)).toBe(input)
+  })
+
+  it('returns an empty array unchanged regardless of rates', () => {
+    const input = new Float32Array(0)
+    expect(resamplePcmFloat32(input, 48000, 16000)).toBe(input)
+  })
+
+  it('downsamples 48k -> 16k to a third of the length', () => {
+    const input = new Float32Array(300).fill(0.5)
+    const out = resamplePcmFloat32(input, 48000, 16000)
+    expect(out.length).toBe(100)
+  })
+
+  it('upsamples 8k -> 16k to double the length', () => {
+    const input = new Float32Array(100).fill(-0.25)
+    const out = resamplePcmFloat32(input, 8000, 16000)
+    expect(out.length).toBe(200)
+  })
+
+  it('preserves a constant signal across resampling', () => {
+    const input = new Float32Array(96).fill(0.42)
+    const out = resamplePcmFloat32(input, 48000, 16000)
+    for (let i = 0; i < out.length; i += 1) {
+      expect(out[i]).toBeCloseTo(0.42, 6)
+    }
+  })
+
+  it('linearly interpolates between neighbouring samples', () => {
+    // 2 input samples upsampled 2x -> 4 output samples at input positions
+    // 0, 0.5, 1, 1.5 -> values 0, 0.5, 1, 1 (last clamps to the final sample).
+    const out = resamplePcmFloat32(new Float32Array([0, 1]), 1, 2)
+    expect(out.length).toBe(4)
+    expect(out[0]).toBeCloseTo(0, 6)
+    expect(out[1]).toBeCloseTo(0.5, 6)
+    expect(out[2]).toBeCloseTo(1, 6)
+    expect(out[3]).toBeCloseTo(1, 6)
+  })
+
+  it('keeps the first sample exact (output[0] == input[0])', () => {
+    const input = new Float32Array([0.9, 0.1, -0.3, 0.7, -0.6, 0.2])
+    const out = resamplePcmFloat32(input, 48000, 16000)
+    expect(out[0]).toBeCloseTo(input[0], 6)
+  })
+
+  it('rejects a non-positive sample rate', () => {
+    expect(() => resamplePcmFloat32(new Float32Array([0.1]), 0, 16000)).toThrow()
+    expect(() => resamplePcmFloat32(new Float32Array([0.1]), 16000, -1)).toThrow()
   })
 })
 

--- a/packages/game-bombsquad/src/voice/audio-pcm.ts
+++ b/packages/game-bombsquad/src/voice/audio-pcm.ts
@@ -38,6 +38,46 @@ export function floatTo16BitPCM(samples: Float32Array): ArrayBuffer {
 }
 
 /**
+ * Linear-resample mono Float32 PCM samples from `fromRate` to `toRate`.
+ *
+ * The mic capture wire format is fixed at PCM16 16 kHz mono, but a browser is
+ * free to ignore `new AudioContext({ sampleRate: 16000 })` and hand back a
+ * context at the hardware rate (commonly 48000). Sending those samples to the
+ * server mislabelled as 16 kHz feeds the STT garbage and the server fails the
+ * session loud with a 1008. Resampling to the true 16 kHz before
+ * `floatTo16BitPCM` keeps the wire contract correct on any device.
+ *
+ * Linear interpolation is sufficient for speech (the directive's accepted
+ * trade-off): output sample `i` lands at input position `i * fromRate / toRate`
+ * and is the linear blend of its two neighbouring input samples. When the rates
+ * already match (or the input is empty) the input is returned unchanged, so the
+ * common 16 kHz path stays allocation-free. Downsampling applies no anti-alias
+ * pre-filter — acceptable for the narrow-band speech the STT consumes.
+ */
+export function resamplePcmFloat32(
+  input: Float32Array,
+  fromRate: number,
+  toRate: number
+): Float32Array {
+  if (fromRate <= 0 || toRate <= 0) {
+    throw new Error('resamplePcmFloat32: sample rates must be positive')
+  }
+  if (fromRate === toRate || input.length === 0) return input
+  const outLength = Math.max(1, Math.round((input.length * toRate) / fromRate))
+  const out = new Float32Array(outLength)
+  const step = fromRate / toRate
+  const lastIndex = input.length - 1
+  for (let i = 0; i < outLength; i += 1) {
+    const pos = i * step
+    const i0 = Math.floor(pos)
+    const i1 = i0 < lastIndex ? i0 + 1 : lastIndex
+    const frac = pos - i0
+    out[i] = input[i0] * (1 - frac) + input[i1] * frac
+  }
+  return out
+}
+
+/**
  * Decode a base64 string (a JSON-transported audio frame) to its raw bytes.
  * Uses the browser `atob` over a latin1 string, byte-by-byte — the inverse of the
  * server's `base64FromBytes` (`session-do.ts`). Frames are small per-sentence TTS

--- a/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
@@ -18,7 +18,7 @@ class MockWebSocket {
   onopen: Listener = null
   onmessage: ((event: { data: unknown }) => void) | null = null
   onerror: Listener = null
-  onclose: ((event: { code: number }) => void) | null = null
+  onclose: ((event: { code: number; reason?: string }) => void) | null = null
 
   constructor(url: string) {
     this.url = url
@@ -31,7 +31,7 @@ class MockWebSocket {
 
   close(): void {
     this.readyState = MockWebSocket.CLOSED
-    this.onclose?.({ code: 1000 })
+    this.onclose?.({ code: 1000, reason: '' })
   }
 
   // --- test drivers ---
@@ -48,9 +48,9 @@ class MockWebSocket {
     this.onerror?.()
   }
 
-  fireClose(code: number): void {
+  fireClose(code: number, reason = ''): void {
     this.readyState = MockWebSocket.CLOSED
-    this.onclose?.({ code })
+    this.onclose?.({ code, reason })
   }
 
   /** The control messages this socket received, parsed. */
@@ -256,6 +256,19 @@ describe('useVoiceSession', () => {
     act(() => ws.fireClose(1006))
     expect(result.current.status).toBe('error')
     expect(result.current.error).toContain('1006')
+  })
+
+  it('surfaces the server close reason alongside the code on a 1008', () => {
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
+    act(() => ws.fireClose(1008, 'turn before create'))
+    expect(result.current.status).toBe('error')
+    expect(result.current.error).toContain('1008')
+    expect(result.current.error).toContain('turn before create')
   })
 
   it('closes the socket on unmount (lifecycle hygiene)', () => {

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -28,7 +28,7 @@
 
 import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
 import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
-import { base64ToBytes, floatTo16BitPCM, pcm16ToFloat32 } from './audio-pcm'
+import { base64ToBytes, floatTo16BitPCM, pcm16ToFloat32, resamplePcmFloat32 } from './audio-pcm'
 import {
   buildSessionUrl,
   initialVoiceState,
@@ -44,6 +44,29 @@ const TTS_OUTPUT_SAMPLE_RATE = 16000
 const CAPTURE_SAMPLE_RATE = 16000
 /** ScriptProcessor buffer size (frames). Matches the demo. */
 const CAPTURE_BUFFER_SIZE = 4096
+
+/**
+ * Close an `AudioContext` and release its hardware resources, swallowing the
+ * (possible) rejection. Browsers cap the number of concurrent `AudioContext`s,
+ * so a leaked context across turns / panel remounts eventually starves the next
+ * `new AudioContext(...)` — which is the failure this hardening guards against.
+ * Release is initiated synchronously by `close()`; React's cleanup contract
+ * forbids a top-level `await`, so the returned promise is only used to discard a
+ * rejection (a context already closing).
+ */
+function closeAudioContext(ctx: AudioContext | null): void {
+  if (!ctx) return
+  try {
+    const closing = ctx.close()
+    if (closing && typeof closing.then === 'function') {
+      closing.catch(() => {
+        /* ignore — context may already be closed */
+      })
+    }
+  } catch {
+    /* ignore — context may already be closed */
+  }
+}
 
 export interface UseVoiceSessionOptions {
   /**
@@ -180,16 +203,11 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
 
   const stopPlayback = useCallback(() => {
     playingCountRef.current = 0
+    playbackCursorRef.current = 0
     setIsAiSpeaking(false)
     const ctx = playbackCtxRef.current
     playbackCtxRef.current = null
-    if (ctx) {
-      try {
-        void ctx.close()
-      } catch {
-        // ignore — context may already be closed
-      }
-    }
+    closeAudioContext(ctx)
   }, [])
 
   // --- Mic capture ---
@@ -217,13 +235,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     }
     const ctx = captureCtxRef.current
     captureCtxRef.current = null
-    if (ctx) {
-      try {
-        void ctx.close()
-      } catch {
-        /* ignore */
-      }
-    }
+    closeAudioContext(ctx)
     const stream = mediaStreamRef.current
     if (stream) {
       stream.getTracks().forEach((t) => t.stop())
@@ -304,9 +316,13 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
       if (endedRef.current || event.code === 1000) {
         safeDispatch({ type: 'closed' })
       } else {
+        // The server attaches a bounded `safeCloseReason` to every 1008 (e.g.
+        // "turn before create", a provider error code) — surface it so a residual
+        // failure is self-explaining instead of a bare numeric code.
+        const reason = event.reason ? `: ${event.reason}` : ''
         safeDispatch({
           type: 'transport-error',
-          message: `voice connection closed (${event.code})`,
+          message: `voice connection closed (${event.code}${reason})`,
         })
       }
     }
@@ -339,6 +355,11 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
       try {
         const ctx = new AudioContext({ sampleRate: CAPTURE_SAMPLE_RATE })
         captureCtxRef.current = ctx
+        // Browsers may ignore the requested 16 kHz and run the context at the
+        // hardware rate (e.g. 48000). The wire format is fixed at PCM16 16 kHz —
+        // resample each frame to the true target rate before encoding, so we
+        // never send mislabelled (wrong-rate) audio that the STT rejects (1008).
+        const actualRate = ctx.sampleRate
         const source = ctx.createMediaStreamSource(stream)
         captureSourceRef.current = source
         const proc = ctx.createScriptProcessor(CAPTURE_BUFFER_SIZE, 1, 1)
@@ -346,7 +367,12 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         proc.onaudioprocess = (e) => {
           const socket = wsRef.current
           if (!socket || socket.readyState !== WebSocket.OPEN) return
-          socket.send(floatTo16BitPCM(e.inputBuffer.getChannelData(0)))
+          const frame = e.inputBuffer.getChannelData(0)
+          const pcm =
+            actualRate === CAPTURE_SAMPLE_RATE
+              ? frame
+              : resamplePcmFloat32(frame, actualRate, CAPTURE_SAMPLE_RATE)
+          socket.send(floatTo16BitPCM(pcm))
         }
         source.connect(proc)
         proc.connect(ctx.destination)


### PR DESCRIPTION
## Summary

Found via the in-game play-green: the first voice turn worked, but a later turn / the next module's session closed with a server `1008`.

**Root cause** (client-only): `startTalking` created `new AudioContext({ sampleRate: 16000 })`, but browsers don't guarantee the requested rate — when a prior context wasn't fully torn down, the second session's context ran at the hardware rate (e.g. 48k). The PCM16 was labeled 16k but sampled at 48k → the ASR received wrong-rate audio → the turn failed loud (1008). The backend was verified independently robust (headless harness: immediate + idle multi-turn both pass against the deployed Worker).

**Fixes** (`packages/game-bombsquad/src/voice/`):
- **Resample**: `resamplePcmFloat32` + `startTalking` reads the real `ctx.sampleRate` and resamples to true 16kHz before `floatTo16BitPCM` — the wire is always genuine PCM16 16kHz.
- **Teardown**: `closeAudioContext` fully closes capture + playback AudioContexts (`close()` + `disconnect()` + `track.stop()` + ref-null) on every turn end and on unmount — no leaked contexts across turns or the per-module remount.
- **Diagnostics**: `ws.onclose` now surfaces the server's `safeCloseReason` so any residual failure is self-explaining.

## Test plan

- [x] tsc / build / eslint / prettier clean; 351 game-bombsquad tests (+9: resampler + close-reason)
- [x] Backend multi-turn proven robust independently (harness)
- [ ] **Re-play-green**: a real in-game multi-turn (across a module advance) on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)