### PR TITLE
feat(bombsquad): hands-free full-duplex mode② voice (AI-first + client VAD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② voice is now hands-free** - Change. The in-game AI defuse
+partner now runs as a continuous, hands-free conversation instead of hold-to-talk:
+the AI speaks first (it greets you and asks what you see when the session opens),
+you just talk — the client detects when you finish speaking and sends your turn
+automatically — and you can talk over the AI to interrupt it. A clear status
+shows whether the AI is 聆听中 (listening) / 思考中 (thinking) / 说话中 (speaking).
+Still behind the `?partner=platform` opt-in; mode① and the puzzle game are
+unchanged.
+
 **BombSquad mode② voice: later turns no longer drop the connection** - Fix. In
 the in-game voice partner, the first turn worked but a later turn (or the next
 module's session) could close with a connection error. The microphone capture

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -295,23 +295,26 @@ flows:
   # UI states only — never real audio or provider output.
 
   - id: mode2-voice-session-turn
-    name: mode② in-game voice turn
+    name: mode② in-game hands-free voice greeting
     description: >-
       An opted-in daily run (`?mode=daily&partner=platform`) mounts the in-game
-      platform voice panel: it connects to the platform-ai bridge and reaches the
-      ready/connected state, the player runs one push-to-talk turn, the AI's
-      streamed text reply renders, the "AI is speaking" indicator shows while the
-      stubbed TTS audio plays, and exiting the run tears the voice session down.
-      The `/ai-ws/*` WebSocket and the microphone are stubbed deterministically
-      (no live provider, no real audio); the real-provider turn is verified by a
-      human play-green and the standalone live-turn harness.
+      platform voice panel, hands-free full-duplex: it connects to the platform-ai
+      bridge and the AI greets first with no player input, the AI's streamed text
+      reply renders, the "说话中" (speaking) indicator shows while the stubbed TTS
+      audio plays, the panel settles back to "聆听中" (listening) when the greeting
+      ends, and exiting the run tears the voice session down. The `/ai-ws/*`
+      WebSocket and the microphone are stubbed deterministically (no live provider,
+      no real audio; the fake mic is fed a silent capture file so the client VAD
+      never fires a player turn); the real-provider turn and the VAD-triggered
+      player turn are verified by a human play-green and the standalone live-turn
+      harness.
     steps:
       [
         daily-platform-partner,
         voice-connected,
-        push-to-talk-turn,
-        ai-text-reply,
+        ai-greets-first,
         ai-speaking,
+        settle-listening,
         session-teardown,
       ]
     status: active

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -105,16 +105,18 @@ const LEADERBOARD_DEFAULT = readJson<{ get: LeaderboardGetResponse; post: Submit
 // The mode② voice panel connects to the platform-ai bridge over the same-origin
 // `/ai-ws/*` WebSocket. The harness mocks that socket (page.routeWebSocket) so
 // the panel is driven deterministically with no live Worker / provider. The
-// stubbed turn streams one text chunk then one audio chunk; the audio is a few
-// seconds of PCM16 16 kHz mono silence — long enough that the "AI is speaking"
-// indicator (which the hook drives off Web Audio playback) is observable.
+// AI-first opening greeting streams one text chunk then one audio chunk; the
+// audio is a few seconds of PCM16 16 kHz mono silence — long enough that the
+// "说话中" (speaking) indicator (which the hook drives off Web Audio playback) is
+// observable, then short enough that its `onended` lets the panel settle back to
+// "聆听中" (listening) well within the assertion window.
 const VOICE_REPLY_TEXT = '把红色的线接到第三个接线柱，先别动其它线。'
 /** PCM16 mono @16 kHz; the hook plays it back to set the "speaking" indicator. */
-const VOICE_AUDIO_SECONDS = 4
+const VOICE_AUDIO_SECONDS = 3
 const VOICE_AUDIO_BASE64 = Buffer.alloc(16_000 * VOICE_AUDIO_SECONDS * 2).toString('base64')
 
 interface VoiceMockState {
-  /** The AI's stubbed text reply rendered by the panel for the push-to-talk turn. */
+  /** The AI's stubbed text reply rendered by the panel for the opening greeting. */
   reply: string
   /** Base64 PCM16 16 kHz mono TTS payload streamed as the turn's audio. */
   audioBase64: string
@@ -457,14 +459,20 @@ export const test = base.extend<{ world: World }>({
       })
 
       // mode② voice bridge — mock the same-origin `/ai-ws/*` WebSocket the
-      // VoicePanel hook opens. Inert for every non-voice scenario (none opens
-      // that socket). Mock mode (no connectToServer) means Playwright opens the
-      // page socket automatically, so the hook's `onopen` create handshake runs.
-      // The stub mirrors the real session-do.ts envelope: `created` on create,
-      // then a text chunk + an audio chunk on each turn. Binary mic PCM frames
-      // (sent while the player holds to talk) arrive here as Buffers and are
-      // ignored — no STT runs. No `end`/`summary` is sent because the panel has
-      // no end control; the session ends by panel teardown on run exit.
+      // hands-free VoicePanel hook opens. Inert for every non-voice scenario
+      // (none opens that socket). Mock mode (no connectToServer) means Playwright
+      // opens the page socket automatically, so the hook's `onopen` create
+      // handshake runs. The stub mirrors the real session-do.ts envelope and its
+      // AI-first turn model: on `create` it replies `created` and then immediately
+      // streams the AI's opening greeting (one text chunk then one audio chunk,
+      // `done` on the last) with NO client `turn` required — the deployed server
+      // fires that opening turn itself via server-side VAD. Binary mic PCM frames
+      // (the continuous hands-free capture) arrive here as Buffers and are ignored
+      // — no STT runs. A client `turn` (the legacy no-op the hook still sends on a
+      // VAD utterance-end) is captured for assertions and otherwise ignored; the
+      // silent fake mic means it never actually fires. No `end`/`summary` is sent
+      // because the panel has no end control; the session ends by panel teardown
+      // on run exit.
       await page.routeWebSocket(/\/ai-ws\//, (ws) => {
         ws.onMessage((message) => {
           if (typeof message !== 'string') return // binary mic audio — ignore
@@ -476,8 +484,9 @@ export const test = base.extend<{ world: World }>({
           }
           world.voice.clientFrames.push(frame as Record<string, unknown>)
           if (frame.type === 'create') {
+            // AI-first: `created`, then the opening greeting (text then audio,
+            // `done` on the audio) with no client turn.
             ws.send(JSON.stringify({ type: 'created', sessionId: 'e2e-voice-session' }))
-          } else if (frame.type === 'turn') {
             ws.send(
               JSON.stringify({ type: 'chunk', kind: 'text', text: world.voice.reply, done: false })
             )

--- a/e2e/steps/voice.steps.ts
+++ b/e2e/steps/voice.steps.ts
@@ -1,9 +1,12 @@
 /**
- * mode② in-game voice-panel steps. Drives the VoicePanel through one
- * deterministic push-to-talk turn against the stubbed `/ai-ws/*` socket (see
- * e2e/steps/fixtures.ts `routeWebSocket`) and the Chromium fake mic device (see
- * playwright.config.ts launch flags). Asserts the panel's UI states only — never
- * real audio or provider output.
+ * mode② in-game voice-panel steps. Drives the hands-free VoicePanel through its
+ * deterministic opening greeting against the stubbed `/ai-ws/*` socket (see
+ * e2e/steps/fixtures.ts `routeWebSocket`) and the Chromium fake mic fed a silent
+ * capture file (see playwright.config.ts launch flags). There is no push-to-talk:
+ * the AI greets first on session-create, and the silent mic never crosses the
+ * client VAD threshold, so no player turn or barge-in fires. Asserts the panel's
+ * UI states only — never real audio or provider output, never the VAD-triggered
+ * player turn.
  */
 import { expect, type Locator, type Page } from '@playwright/test'
 import { When, Then } from './fixtures'
@@ -17,43 +20,36 @@ When('I enter a mode② daily run with the platform voice partner', async ({ wor
   await world.startPlatformVoiceDailyRun()
 })
 
-Then('the voice panel shows the AI partner is connected', async ({ page }) => {
+Then('the voice panel connects and the AI partner greets first', async ({ page, world }) => {
   const panel = voicePanel(page)
   await expect(panel).toBeVisible()
-  // `created` -> ready: the status reads 已连接 and the reply log invites a turn.
-  await expect(panel.getByText('已连接')).toBeVisible()
-  await expect(panel.getByText('按住下面的按钮，对 AI 说话')).toBeVisible()
-  // The push-to-talk control is enabled only once the session is ready.
-  await expect(panel.getByRole('button')).toBeEnabled()
+  // Hands-free + AI-first: the session connects (created -> ready) and the AI's
+  // opening greeting streams with NO player input — its stubbed text reply
+  // rendering in the panel's reply log is the proof of both.
+  await expect(panel.getByText(world.voice.reply)).toBeVisible()
 })
 
-When('I push and hold the talk button, then release', async ({ page }) => {
+Then('the panel shows the AI is speaking while the greeting audio plays', async ({ page }) => {
   const panel = voicePanel(page)
-  const talkBtn = panel.getByRole('button')
-  // Keyboard hold-to-talk (Space) — a trusted key event, no pointer-capture
-  // dance. Keydown starts the turn (fake-mic getUserMedia resolves), so the
-  // status flips to 通话中; hold until that is observed, then release to send
-  // the turn to the stubbed bridge.
-  await talkBtn.focus()
-  await page.keyboard.down('Space')
-  await expect(panel.getByText('通话中')).toBeVisible()
-  await page.keyboard.up('Space')
+  // While the greeting's TTS audio plays, the live 3-state indicator reads 说话中
+  // and the dedicated "speaking" cue (role=status, accessible name AI 正在说话)
+  // shows. `isAiSpeaking` is set synchronously when the audio chunk arrives, so
+  // this is observable even though the PCM is silent.
+  await expect(panel.getByText('说话中')).toBeVisible()
+  await expect(panel.getByRole('status', { name: 'AI 正在说话' })).toBeVisible()
 })
 
-Then("the panel renders the AI's stubbed voice reply", async ({ page, world }) => {
-  await expect(voicePanel(page).getByText(world.voice.reply)).toBeVisible()
+Then('the panel settles to the listening state when the greeting ends', async ({ page }) => {
+  // Once the greeting audio finishes (its AudioBufferSource `onended`, on the real
+  // audio-thread clock — independent of the frozen page clock), `isAiSpeaking`
+  // clears and the indicator settles to 聆听中. Give it a generous wait covering
+  // the few-second playback.
+  await expect(voicePanel(page).getByText('聆听中')).toBeVisible({ timeout: 12_000 })
 })
-
-Then(
-  'the panel shows the "AI is speaking" indicator while the reply audio plays',
-  async ({ page }) => {
-    await expect(voicePanel(page).getByText('AI 正在回应')).toBeVisible()
-  }
-)
 
 When('I exit the run', async ({ page }) => {
-  // `退出` confirms via window.confirm before navigating to the platform home;
-  // accept it so the run resets and the voice panel tears down.
+  // `退出当前关卡` confirms via window.confirm before navigating to the platform
+  // home; accept it so the run resets and the voice panel tears down.
   page.once('dialog', (dialog) => {
     void dialog.accept()
   })

--- a/e2e/voice-session-panel.gherkin
+++ b/e2e/voice-session-panel.gherkin
@@ -1,24 +1,27 @@
-# In-game voice partner panel (mode②) — the platform voice session wired into a
-# daily run. An opted-in daily run (`?mode=daily&partner=platform`) mounts the
-# VoicePanel, which connects to the platform-ai `/ai-ws/*` bridge, runs one
-# push-to-talk turn, renders the AI's streamed text reply, shows the "AI is
-# speaking" cue while the TTS audio plays, and tears the session down when the
-# run is exited.
+# In-game voice partner panel (mode②) — the platform voice partner wired into a
+# daily run, hands-free full-duplex. An opted-in daily run
+# (`?mode=daily&partner=platform`) mounts the VoicePanel, which connects to the
+# platform-ai `/ai-ws/*` bridge. There is no push-to-talk: the AI greets first
+# the instant the session is created, the panel renders its streamed text reply
+# and shows the "说话中" (speaking) indicator while the TTS audio plays, then
+# settles to "聆听中" (listening); exiting the run tears the session down.
 #
 # Deterministic + hermetic: the `/ai-ws/*` WebSocket is stubbed at the harness
-# boundary (e2e/steps/fixtures.ts `routeWebSocket`) so the panel is driven
-# through created -> chunk(text) -> chunk(audio) frames with no live Worker, no
-# DeepSeek/Volcengine, and no real network. The mic is the Chromium fake media
-# device (playwright.config.ts launch flags), so `getUserMedia` resolves without
-# a real microphone or a permission prompt. The real-provider voice turn is
-# verified separately by a human play-green plus the standalone live-turn
-# harness — this scenario asserts the panel's UI states only, never real audio
-# or provider output.
+# boundary (e2e/steps/fixtures.ts `routeWebSocket`) so the panel is driven through
+# created -> chunk(text) -> chunk(audio) frames with no live Worker, no
+# DeepSeek/Volcengine, and no real network — the stub emits the opening greeting
+# on session-create with no client turn. The mic is the Chromium fake media
+# device fed a SILENT capture file (playwright.config.ts launch flags), so the
+# continuous hands-free mic never crosses the client VAD threshold: no spurious
+# player turn, no barge-in. The real-provider voice turn (and the VAD-triggered
+# player turn) is verified separately by a human play-green plus the standalone
+# live-turn harness — this scenario asserts the panel's UI states only, never
+# real audio or provider output.
 
 Feature: In-game voice partner panel (mode②)
   As a daily-challenge player who opted into the platform voice partner
-  I want an in-game voice panel that connects, takes a push-to-talk turn, and
-  shows the AI replying
+  I want a hands-free in-game voice panel that connects, lets the AI greet
+  first, and shows the AI replying
   So that I can talk to my AI partner without leaving the run
 
   Background:
@@ -26,13 +29,11 @@ Feature: In-game voice partner panel (mode②)
 
   # Source: mode2-voice-session-turn
   @playwright
-  Scenario: A mode② daily run drives one voice turn through the panel
+  Scenario: A mode② daily run runs the hands-free voice partner's opening greeting
     When I enter a mode② daily run with the platform voice partner
-    Then the voice panel shows the AI partner is connected
-
-    When I push and hold the talk button, then release
-    Then the panel renders the AI's stubbed voice reply
-    And the panel shows the "AI is speaking" indicator while the reply audio plays
+    Then the voice panel connects and the AI partner greets first
+    And the panel shows the AI is speaking while the greeting audio plays
+    And the panel settles to the listening state when the greeting ends
 
     When I exit the run
     Then the voice session ends and the panel is gone

--- a/packages/game-bombsquad/src/voice/VoicePanel.module.css
+++ b/packages/game-bombsquad/src/voice/VoicePanel.module.css
@@ -47,22 +47,33 @@
   animation: voice-dot-pulse 1.4s ease-in-out infinite;
 }
 
-.statusDot[data-status='ready'] {
-  background: var(--green);
-  box-shadow: 0 0 8px rgba(75, 210, 102, 0.6);
-}
-
-.statusDot[data-status='in-turn'] {
-  background: var(--y);
-  box-shadow: 0 0 8px var(--y-glow-50);
-}
-
 .statusDot[data-status='error'] {
   background: var(--rose);
 }
 
 .statusDot[data-status='closed'] {
   background: var(--text-muted);
+}
+
+/* ----------  live 3-state conversation phase  ----------
+   When live, `data-phase` overrides the generic `data-status='ready'` dot with a
+   phase-specific colour + animation:聆听中 (green, breathing), 思考中 (yellow,
+   pulsing), 说话中 (yellow, steady glow). */
+.statusDot[data-phase='listening'] {
+  background: var(--green);
+  box-shadow: 0 0 8px rgba(75, 210, 102, 0.6);
+  animation: voice-dot-pulse 1.8s ease-in-out infinite;
+}
+
+.statusDot[data-phase='thinking'] {
+  background: var(--y);
+  box-shadow: 0 0 8px var(--y-glow-50);
+  animation: voice-dot-pulse 0.9s ease-in-out infinite;
+}
+
+.statusDot[data-phase='speaking'] {
+  background: var(--y);
+  box-shadow: 0 0 10px var(--y-glow-70);
 }
 
 .statusText {
@@ -140,59 +151,12 @@
   word-break: break-word;
 }
 
-/* ----------  push-to-talk  ---------- */
-.talkBtn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-height: var(--touch-target);
-  padding: 12px 24px;
-  background: var(--y);
-  color: #050511;
-  border: 2px solid transparent;
-  border-radius: var(--radius-pill);
-  font: 600 15px var(--font-body);
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  touch-action: none;
-  -webkit-user-select: none;
-  user-select: none;
-  transition:
-    box-shadow 0.15s ease,
-    transform 0.15s ease,
-    background 0.15s ease,
-    opacity 0.15s ease;
-}
-
-.talkBtn:hover,
-.talkBtn:focus-visible {
-  box-shadow: 0 0 24px var(--y-glow-50);
-  outline: none;
-}
-
-.talkBtn:focus-visible {
-  outline: 2px solid var(--y);
-  outline-offset: 3px;
-}
-
-.talkBtn:disabled {
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text-muted);
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-/* Live-mic state: a yellow glow pulse so the player can see the hold is
-   captured. Yellow (= active), not rose, per the Atlas palette. */
-.talkBtnActive {
-  border-color: var(--y);
-  animation: voice-talk-pulse 1.1s ease-in-out infinite;
-}
-
-.talkBtnIcon {
-  display: inline-flex;
-  align-items: center;
+/* ----------  hands-free hint  ---------- */
+.hint {
+  margin: 0;
+  font: 400 12px/1.45 var(--font-body);
+  color: var(--text-4);
+  text-align: center;
 }
 
 @keyframes voice-dot-pulse {
@@ -215,20 +179,9 @@
   }
 }
 
-@keyframes voice-talk-pulse {
-  0%,
-  100% {
-    box-shadow: 0 0 0 0 var(--y-glow-50);
-  }
-  50% {
-    box-shadow: 0 0 22px 2px var(--y-glow-50);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .statusDot,
-  .speakingDots i,
-  .talkBtnActive {
+  .speakingDots i {
     animation: none;
   }
 }

--- a/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
@@ -1,28 +1,26 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
 import type { UseVoiceSessionResult } from './useVoiceSession'
 import VoicePanel from './VoicePanel'
 
-// Mock the hook so the panel can be driven through every status / cue without a
+// Mock the hook so the panel can be driven through every status / phase without a
 // real WebSocket, mic, or AudioContext (those are the browser-only play-green).
 vi.mock('./useVoiceSession', () => ({ useVoiceSession: vi.fn() }))
 import { useVoiceSession } from './useVoiceSession'
 const mockHook = vi.mocked(useVoiceSession)
 
-const startTalking = vi.fn()
-const stopTalking = vi.fn()
 const endSession = vi.fn()
 
 function hookState(partial: Partial<UseVoiceSessionResult> = {}): UseVoiceSessionResult {
   return {
     status: 'ready',
+    conversationPhase: 'listening',
+    playerSpeaking: false,
     aiText: '',
     isAiSpeaking: false,
     error: null,
     summary: null,
-    startTalking,
-    stopTalking,
     endSession,
     ...partial,
   }
@@ -38,69 +36,82 @@ function renderPanel(partial: Partial<UseVoiceSessionResult> = {}) {
 
 beforeEach(() => {
   mockHook.mockReset()
-  startTalking.mockReset()
-  stopTalking.mockReset()
   endSession.mockReset()
 })
 
-describe('VoicePanel — status rendering', () => {
-  it('shows the connecting status with the talk control disabled', () => {
+describe('VoicePanel — connection status (non-live)', () => {
+  it('shows the connecting status', () => {
     renderPanel({ status: 'connecting' })
     expect(screen.getByText('连接中')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '按住说话' })).toBeDisabled()
   })
 
-  it('enables push-to-talk once ready', () => {
-    renderPanel({ status: 'ready' })
-    expect(screen.getByText('已连接')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '按住说话' })).toBeEnabled()
-  })
-
-  it('surfaces the connection-error status', () => {
+  it('shows the connection-error status', () => {
     renderPanel({ status: 'error', error: 'voice connection closed (1006)' })
     expect(screen.getByText('连接出错')).toBeInTheDocument()
   })
+
+  it('shows the ended status when closed', () => {
+    renderPanel({ status: 'closed' })
+    expect(screen.getByText('已结束')).toBeInTheDocument()
+  })
 })
 
-describe('VoicePanel — hook-state cues', () => {
+describe('VoicePanel — live 3-state conversation phase', () => {
+  it('shows 聆听中 while listening', () => {
+    renderPanel({ status: 'ready', conversationPhase: 'listening' })
+    expect(screen.getByText('聆听中')).toBeInTheDocument()
+  })
+
+  it('shows 思考中 while thinking', () => {
+    renderPanel({ status: 'ready', conversationPhase: 'thinking' })
+    expect(screen.getByText('思考中')).toBeInTheDocument()
+  })
+
+  it('shows 说话中 while speaking', () => {
+    renderPanel({ status: 'ready', conversationPhase: 'speaking', isAiSpeaking: true })
+    expect(screen.getByText('说话中')).toBeInTheDocument()
+  })
+
+  it('does not show a phase label before the session is live', () => {
+    renderPanel({ status: 'connecting', conversationPhase: 'listening' })
+    expect(screen.queryByText('聆听中')).not.toBeInTheDocument()
+  })
+})
+
+describe('VoicePanel — cues and content', () => {
   it('renders the accumulated AI text', () => {
     renderPanel({ aiText: 'Hold the button.' })
     expect(screen.getByText('Hold the button.')).toBeInTheDocument()
   })
 
-  it('shows the "AI is speaking" cue while speaking', () => {
-    renderPanel({ isAiSpeaking: true })
-    expect(screen.getByText('AI 正在回应')).toBeInTheDocument()
+  it('shows the speaking-bars cue while the AI is speaking and live', () => {
+    const { container } = renderPanel({
+      status: 'ready',
+      conversationPhase: 'speaking',
+      isAiSpeaking: true,
+    })
+    expect(container.querySelector('[aria-label="AI 正在说话"]')).toBeInTheDocument()
   })
 
-  it('hides the "AI is speaking" cue when not speaking', () => {
-    renderPanel({ isAiSpeaking: false })
-    expect(screen.queryByText('AI 正在回应')).not.toBeInTheDocument()
+  it('hides the speaking cue when the AI is not speaking', () => {
+    const { container } = renderPanel({ isAiSpeaking: false })
+    expect(container.querySelector('[aria-label="AI 正在说话"]')).not.toBeInTheDocument()
   })
 
   it('shows a bounded error line as an alert', () => {
     renderPanel({ error: 'microphone permission denied' })
-    const alert = screen.getByRole('alert')
-    expect(alert).toHaveTextContent('microphone permission denied')
+    expect(screen.getByRole('alert')).toHaveTextContent('microphone permission denied')
   })
 })
 
-describe('VoicePanel — push-to-talk wiring', () => {
-  it('starts talking on press and stops on release', () => {
+describe('VoicePanel — hands-free (no push-to-talk)', () => {
+  it('renders no push-to-talk button', () => {
     renderPanel({ status: 'ready' })
-    const btn = screen.getByRole('button', { name: /说话|结束/ })
-
-    fireEvent.pointerDown(btn)
-    expect(startTalking).toHaveBeenCalledTimes(1)
-
-    fireEvent.pointerUp(btn)
-    expect(stopTalking).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('does not call stopTalking on a release that never began a hold', () => {
+  it('shows the hands-free hint', () => {
     renderPanel({ status: 'ready' })
-    const btn = screen.getByRole('button', { name: '按住说话' })
-    fireEvent.pointerUp(btn)
-    expect(stopTalking).not.toHaveBeenCalled()
+    expect(screen.getByText(/免提对话已开启/)).toBeInTheDocument()
   })
 })

--- a/packages/game-bombsquad/src/voice/VoicePanel.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.tsx
@@ -1,8 +1,7 @@
-import { memo, useCallback, useState } from 'react'
-import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from 'react'
+import { memo } from 'react'
 import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
 import { useVoiceSession } from './useVoiceSession'
-import type { VoiceStatus } from './voice-session-protocol'
+import type { ConversationPhase, VoiceStatus } from './voice-session-protocol'
 import styles from './VoicePanel.module.css'
 
 interface VoicePanelProps {
@@ -15,105 +14,69 @@ interface VoicePanelProps {
 }
 
 /**
- * In-game voice panel for the BombSquad daily run (mode②). Renders the
- * `useVoiceSession` surface: a connection/turn status indicator, the AI's
- * streamed text reply, an "AI is speaking" cue, a bounded error line, and a
- * push-to-talk control (hold to talk). Presentation only — it reads hook state
- * and drives the hook's `startTalking` / `stopTalking`; it never touches game
- * logic. Dark-only, CSS-only animation (Atlas design system).
+ * In-game voice panel for the BombSquad daily run (mode②), hands-free. Renders
+ * the `useVoiceSession` surface: a prominent 3-state conversation indicator
+ * (聆听中 / 思考中 / 说话中) once the session is live, the connection status before
+ * that, the AI's streamed text reply, and a bounded error line. There is NO
+ * push-to-talk — the mic streams continuously and the AI greets first; the player
+ * just talks. Presentation only: it reads hook state and never touches game logic
+ * or the mic/socket. Dark-only, CSS-only animation (Atlas design system).
  */
 
-/** User-facing connection/turn status copy. Chinese — daily players are the reader. */
-const STATUS_LABEL: Record<VoiceStatus, string> = {
+/** Connection-status copy for the non-live states. Chinese — daily players read it. */
+const STATUS_LABEL: Record<Exclude<VoiceStatus, 'ready'>, string> = {
   idle: '准备中',
   connecting: '连接中',
-  ready: '已连接',
-  'in-turn': '通话中',
   error: '连接出错',
   closed: '已结束',
 }
 
+/** The 3-state conversation phase copy (shown while the session is live). */
+const PHASE_LABEL: Record<ConversationPhase, string> = {
+  listening: '聆听中',
+  thinking: '思考中',
+  speaking: '说话中',
+}
+
+function placeholderFor(status: VoiceStatus, phase: ConversationPhase): string {
+  if (status === 'ready') {
+    if (phase === 'thinking') return 'AI 正在思考…'
+    if (phase === 'speaking') return 'AI 正在回应…'
+    return '开口说话，AI 会即时回应'
+  }
+  if (status === 'closed') return '语音通话已结束'
+  if (status === 'error') return '语音连接已断开'
+  return '正在接通 AI 语音…'
+}
+
 function VoicePanelImpl({ manualData, gameState, gameId }: VoicePanelProps) {
-  const { status, aiText, isAiSpeaking, error, startTalking, stopTalking } = useVoiceSession({
+  const { status, conversationPhase, aiText, isAiSpeaking, error } = useVoiceSession({
     manualData,
     gameState,
     gameId,
   })
 
-  // Whether the player is currently holding the push-to-talk control. Tracked in
-  // state (not derived from `status`) because `in-turn` covers BOTH the player
-  // speaking and the AI responding — only an explicit hold should read as "live
-  // mic". Drives the button label + the listening pulse.
-  const [holding, setHolding] = useState(false)
-
-  // Push-to-talk: hold to talk. Pointer capture binds the release to this
-  // element even if the finger drifts off it, so a pointerup always pairs with
-  // its pointerdown. The hook guards every transition (no-op unless ready /
-  // already talking), so these handlers can fire unconditionally.
-  const beginTalk = useCallback(
-    (e: ReactPointerEvent<HTMLButtonElement>) => {
-      e.preventDefault()
-      try {
-        e.currentTarget.setPointerCapture(e.pointerId)
-      } catch {
-        /* pointer capture unsupported (e.g. jsdom) — the release path still fires */
-      }
-      setHolding(true)
-      startTalking()
-    },
-    [startTalking]
-  )
-
-  const endTalk = useCallback(() => {
-    setHolding((wasHolding) => {
-      if (wasHolding) stopTalking()
-      return false
-    })
-  }, [stopTalking])
-
-  // Keyboard hold-to-talk (Space / Enter) for non-pointer users. `repeat` guards
-  // the key auto-repeat so a held key starts capture exactly once.
-  const onKeyDown = useCallback(
-    (e: ReactKeyboardEvent<HTMLButtonElement>) => {
-      if (e.key !== ' ' && e.key !== 'Enter') return
-      if (e.repeat) return
-      e.preventDefault()
-      setHolding(true)
-      startTalking()
-    },
-    [startTalking]
-  )
-
-  const onKeyUp = useCallback(
-    (e: ReactKeyboardEvent<HTMLButtonElement>) => {
-      if (e.key !== ' ' && e.key !== 'Enter') return
-      endTalk()
-    },
-    [endTalk]
-  )
-
-  // Enabled when the session can take a turn (ready) or one is already in the
-  // player's hand (holding). While the AI responds after release — in-turn but
-  // not holding — the control is disabled, which also blocks starting a second
-  // overlapping turn.
-  const talkEnabled = status === 'ready' || holding
-  const talkLabel = holding ? '松开结束' : '按住说话'
-
-  const replyPlaceholder =
-    status === 'ready' || status === 'in-turn' ? '按住下面的按钮，对 AI 说话' : '正在接通 AI 语音…'
+  const isLive = status === 'ready'
+  // While live, the prominent indicator is the conversation phase; before that
+  // it is the connection status.
+  const indicatorLabel = isLive ? PHASE_LABEL[conversationPhase] : STATUS_LABEL[status]
 
   return (
     <section className={styles.panel} aria-label="AI 语音伙伴">
       <div className={styles.header}>
         <span className={styles.status}>
-          <span className={styles.statusDot} data-status={status} aria-hidden="true" />
+          <span
+            className={styles.statusDot}
+            data-status={status}
+            data-phase={isLive ? conversationPhase : undefined}
+            aria-hidden="true"
+          />
           <span className={styles.statusText} role="status">
-            {STATUS_LABEL[status]}
+            {indicatorLabel}
           </span>
         </span>
-        {isAiSpeaking && (
-          <span className={styles.speaking} role="status">
-            AI 正在回应
+        {isLive && isAiSpeaking && (
+          <span className={styles.speaking} role="status" aria-label="AI 正在说话">
             <span className={styles.speakingDots} aria-hidden="true">
               <i />
               <i />
@@ -127,7 +90,7 @@ function VoicePanelImpl({ manualData, gameState, gameId }: VoicePanelProps) {
         {aiText ? (
           <p className={styles.replyText}>{aiText}</p>
         ) : (
-          <p className={styles.replyPlaceholder}>{replyPlaceholder}</p>
+          <p className={styles.replyPlaceholder}>{placeholderFor(status, conversationPhase)}</p>
         )}
       </div>
 
@@ -137,33 +100,7 @@ function VoicePanelImpl({ manualData, gameState, gameId }: VoicePanelProps) {
         </p>
       )}
 
-      <button
-        type="button"
-        className={`${styles.talkBtn} ${holding ? styles.talkBtnActive : ''}`}
-        onPointerDown={beginTalk}
-        onPointerUp={endTalk}
-        onPointerCancel={endTalk}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        disabled={!talkEnabled}
-        aria-pressed={holding}
-        aria-label={talkLabel}
-      >
-        <span className={styles.talkBtnIcon} aria-hidden="true">
-          <svg
-            viewBox="0 0 24 24"
-            width="20"
-            height="20"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.6"
-          >
-            <rect x="9" y="3" width="6" height="12" rx="3" />
-            <path d="M5 11 a7 7 0 0 0 14 0 M12 18 V21 M9 21 H15" strokeLinecap="round" />
-          </svg>
-        </span>
-        {talkLabel}
-      </button>
+      <p className={styles.hint}>免提对话已开启，直接对 AI 说话即可，无需按键。</p>
     </section>
   )
 }

--- a/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
@@ -53,7 +53,6 @@ class MockWebSocket {
     this.onclose?.({ code, reason })
   }
 
-  /** The control messages this socket received, parsed. */
   controlMessages(): Array<Record<string, unknown>> {
     return this.sent
       .filter((m): m is string => typeof m === 'string')
@@ -65,12 +64,39 @@ class MockWebSocket {
   }
 }
 
+class MockBufferSource {
+  buffer: unknown = null
+  onended: Listener = null
+  started = false
+  stopped = false
+  connect(): void {}
+  disconnect(): void {}
+  start(): void {
+    this.started = true
+  }
+  stop(): void {
+    this.stopped = true
+  }
+}
+
+class MockScriptProcessor {
+  onaudioprocess: ((e: { inputBuffer: { getChannelData: () => Float32Array } }) => void) | null =
+    null
+  connect(): void {}
+  disconnect(): void {}
+}
+
 class MockAudioContext {
+  static instances: MockAudioContext[] = []
   currentTime = 0
   destination = {}
   sampleRate: number
+  processor: MockScriptProcessor | null = null
+  sources: MockBufferSource[] = []
+
   constructor(opts?: { sampleRate?: number }) {
     this.sampleRate = opts?.sampleRate ?? 48000
+    MockAudioContext.instances.push(this)
   }
   resume(): Promise<void> {
     return Promise.resolve()
@@ -81,19 +107,18 @@ class MockAudioContext {
   createBuffer(_ch: number, len: number, rate: number) {
     return { duration: len / rate, getChannelData: () => new Float32Array(len) }
   }
-  createBufferSource() {
-    return {
-      buffer: null as unknown,
-      connect() {},
-      start() {},
-      onended: null as Listener,
-    }
+  createBufferSource(): MockBufferSource {
+    const s = new MockBufferSource()
+    this.sources.push(s)
+    return s
   }
   createMediaStreamSource() {
     return { connect() {}, disconnect() {} }
   }
-  createScriptProcessor() {
-    return { connect() {}, disconnect() {}, onaudioprocess: null as Listener }
+  createScriptProcessor(): MockScriptProcessor {
+    const p = new MockScriptProcessor()
+    this.processor = p
+    return p
   }
 }
 
@@ -117,9 +142,34 @@ function summary(): SessionSummary {
   }
 }
 
+// The capture context is the only one that creates a ScriptProcessor.
+function captureProcessor(): MockScriptProcessor {
+  const ctx = MockAudioContext.instances.find((c) => c.processor)
+  if (!ctx?.processor) throw new Error('no capture processor yet')
+  return ctx.processor
+}
+
+// The playback context has buffer sources and no processor.
+function playbackSources(): MockBufferSource[] {
+  const ctx = MockAudioContext.instances.find((c) => !c.processor && c.sources.length > 0)
+  return ctx?.sources ?? []
+}
+
+const SAMPLES = 4096 // matches CAPTURE_BUFFER_SIZE; at 16 kHz that is 256ms/frame.
+
+/** Fire one capture frame of the given constant amplitude through the VAD path. */
+function fireFrame(amplitude: number): void {
+  const data = new Float32Array(SAMPLES).fill(amplitude)
+  captureProcessor().onaudioprocess?.({ inputBuffer: { getChannelData: () => data } })
+}
+
+const audioB64 = btoa(String.fromCharCode(0, 0, 1, 0)) // 2 PCM16 samples
+
 beforeEach(() => {
   MockWebSocket.instances = []
+  MockAudioContext.instances = []
   getUserMedia.mockClear()
+  getUserMedia.mockImplementation(async () => ({ getTracks: () => [{ stop() {} }] }))
   vi.stubGlobal('WebSocket', MockWebSocket)
   vi.stubGlobal('AudioContext', MockAudioContext)
   Object.defineProperty(globalThis.navigator, 'mediaDevices', {
@@ -138,7 +188,21 @@ function lastSocket(): MockWebSocket {
   return ws
 }
 
-describe('useVoiceSession', () => {
+/** Bring a hook to a live session with the mic streaming. */
+async function ready() {
+  const rendered = renderHook(() =>
+    useVoiceSession({ manualData: manualData(), gameState: gameState() })
+  )
+  const ws = lastSocket()
+  act(() => ws.fireOpen())
+  await act(async () => {
+    ws.fireMessage({ type: 'created', sessionId: 'sess-1' })
+  })
+  await waitFor(() => captureProcessor())
+  return { ...rendered, ws }
+}
+
+describe('useVoiceSession — connection', () => {
   it('stays idle until a manual is provided', () => {
     const { result } = renderHook(() =>
       useVoiceSession({ manualData: null, gameState: gameState() })
@@ -163,87 +227,8 @@ describe('useVoiceSession', () => {
       manualData: { version: 'v1' },
       gameState: { relevantSections: ['button'] },
     })
-    // Security invariant: no userId / prompt on the wire.
     expect(create).not.toHaveProperty('userId')
     expect(create).not.toHaveProperty('systemPrompt')
-  })
-
-  it('reaches ready on the created frame', () => {
-    const { result } = renderHook(() =>
-      useVoiceSession({ manualData: manualData(), gameState: gameState() })
-    )
-    const ws = lastSocket()
-    act(() => ws.fireOpen())
-    act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
-    expect(result.current.status).toBe('ready')
-  })
-
-  it('runs a full push-to-talk turn: capture -> turn -> stream -> ready', async () => {
-    const { result } = renderHook(() =>
-      useVoiceSession({ manualData: manualData(), gameState: gameState() })
-    )
-    const ws = lastSocket()
-    act(() => ws.fireOpen())
-    act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
-
-    await act(async () => {
-      result.current.startTalking()
-    })
-    await waitFor(() => expect(result.current.status).toBe('in-turn'))
-    expect(getUserMedia).toHaveBeenCalledOnce()
-
-    act(() => result.current.stopTalking())
-    const turn = ws.controlMessages().find((m) => m.type === 'turn')
-    expect(turn).toBeDefined()
-
-    act(() => {
-      ws.fireMessage({ type: 'chunk', kind: 'text', text: 'Hold ', done: false })
-      ws.fireMessage({ type: 'chunk', kind: 'text', text: 'the button.', done: false })
-    })
-    expect(result.current.aiText).toBe('Hold the button.')
-
-    // An audio chunk decodes + schedules playback without throwing, then done.
-    const audioB64 = btoa(String.fromCharCode(0, 0, 1, 0))
-    act(() => ws.fireMessage({ type: 'chunk', kind: 'audio', audio: audioB64, done: false }))
-    act(() => ws.fireMessage({ type: 'chunk', kind: 'text', text: '', done: true }))
-    expect(result.current.status).toBe('ready')
-  })
-
-  it('surfaces a bounded mic error and stays usable when permission is denied', async () => {
-    getUserMedia.mockRejectedValueOnce(new Error('denied'))
-    const { result } = renderHook(() =>
-      useVoiceSession({ manualData: manualData(), gameState: gameState() })
-    )
-    const ws = lastSocket()
-    act(() => ws.fireOpen())
-    act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
-
-    await act(async () => {
-      result.current.startTalking()
-    })
-    await waitFor(() => expect(result.current.error).toBe('microphone permission denied'))
-    // Mic failure is not a transport failure — the session is still ready.
-    expect(result.current.status).toBe('ready')
-    // No turn was requested without audio.
-    expect(ws.controlMessages().some((m) => m.type === 'turn')).toBe(false)
-  })
-
-  it('endSession sends end and lands closed with the summary', () => {
-    const { result } = renderHook(() =>
-      useVoiceSession({ manualData: manualData(), gameState: gameState() })
-    )
-    const ws = lastSocket()
-    act(() => ws.fireOpen())
-    act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
-
-    act(() => result.current.endSession())
-    expect(ws.controlMessages().some((m) => m.type === 'end')).toBe(true)
-
-    const s = summary()
-    act(() => ws.fireMessage({ type: 'summary', summary: s }))
-    act(() => ws.fireClose(1000))
-    expect(result.current.status).toBe('closed')
-    expect(result.current.summary).toMatchObject({ turnCount: 1 })
   })
 
   it('an unexpected socket close becomes a bounded transport error', () => {
@@ -265,10 +250,10 @@ describe('useVoiceSession', () => {
     const ws = lastSocket()
     act(() => ws.fireOpen())
     act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
-    act(() => ws.fireClose(1008, 'turn before create'))
+    act(() => ws.fireClose(1008, 'asr driver failed'))
     expect(result.current.status).toBe('error')
     expect(result.current.error).toContain('1008')
-    expect(result.current.error).toContain('turn before create')
+    expect(result.current.error).toContain('asr driver failed')
   })
 
   it('closes the socket on unmount (lifecycle hygiene)', () => {
@@ -280,5 +265,135 @@ describe('useVoiceSession', () => {
     expect(ws.readyState).toBe(MockWebSocket.OPEN)
     unmount()
     expect(ws.readyState).toBe(MockWebSocket.CLOSED)
+  })
+})
+
+describe('useVoiceSession — hands-free lifecycle', () => {
+  it('reaches ready and auto-opens the mic on created (no push-to-talk)', async () => {
+    const { result, ws } = await ready()
+    expect(result.current.status).toBe('ready')
+    expect(getUserMedia).toHaveBeenCalledOnce()
+    // No startTalking / stopTalking on the surface anymore.
+    expect(result.current).not.toHaveProperty('startTalking')
+    expect(result.current).not.toHaveProperty('stopTalking')
+    // Mic is streaming: a capture frame produces a binary WS frame.
+    act(() => fireFrame(0.0))
+    expect(ws.binaryFrameCount()).toBeGreaterThan(0)
+  })
+
+  it('renders the AI-first opening turn with no player input (thinking -> speaking)', async () => {
+    const { result, ws } = await ready()
+    // Opening greeting pending, AI not yet audible -> thinking.
+    expect(result.current.conversationPhase).toBe('thinking')
+
+    act(() => {
+      ws.fireMessage({ type: 'chunk', kind: 'text', text: 'Hi ', done: false })
+      ws.fireMessage({ type: 'chunk', kind: 'text', text: 'there.', done: false })
+      ws.fireMessage({ type: 'chunk', kind: 'audio', audio: audioB64, done: true })
+    })
+    expect(result.current.aiText).toBe('Hi there.')
+    expect(result.current.isAiSpeaking).toBe(true)
+    expect(result.current.conversationPhase).toBe('speaking')
+  })
+
+  it('clears the speaking state when the last buffer ends', async () => {
+    const { result, ws } = await ready()
+    act(() => ws.fireMessage({ type: 'chunk', kind: 'audio', audio: audioB64, done: true }))
+    expect(result.current.isAiSpeaking).toBe(true)
+    act(() => playbackSources().at(-1)?.onended?.())
+    expect(result.current.isAiSpeaking).toBe(false)
+  })
+
+  it('surfaces a bounded mic error and stays ready when permission is denied', async () => {
+    getUserMedia.mockRejectedValueOnce(new Error('denied'))
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    await act(async () => {
+      ws.fireMessage({ type: 'created', sessionId: 'sess-1' })
+    })
+    await waitFor(() => expect(result.current.error).toBe('microphone permission denied'))
+    expect(result.current.status).toBe('ready')
+  })
+
+  it('endSession sends end and lands closed with the summary', async () => {
+    const { result, ws } = await ready()
+    act(() => result.current.endSession())
+    expect(ws.controlMessages().some((m) => m.type === 'end')).toBe(true)
+
+    const s = summary()
+    act(() => ws.fireMessage({ type: 'summary', summary: s }))
+    act(() => ws.fireClose(1000))
+    expect(result.current.status).toBe('closed')
+    expect(result.current.summary).toMatchObject({ turnCount: 1 })
+  })
+})
+
+describe('useVoiceSession — client VAD', () => {
+  it('tracks the player speaking then going silent, and sends a turn on utterance-end', async () => {
+    const { result, ws } = await ready()
+
+    // One 256ms speech frame qualifies as a speech start.
+    act(() => fireFrame(0.5))
+    expect(result.current.playerSpeaking).toBe(true)
+    expect(result.current.conversationPhase).toBe('listening')
+
+    // Four 256ms silence frames (>= 800ms hangover) end the utterance.
+    act(() => {
+      fireFrame(0.0)
+      fireFrame(0.0)
+      fireFrame(0.0)
+      fireFrame(0.0)
+    })
+    expect(result.current.playerSpeaking).toBe(false)
+    expect(result.current.conversationPhase).toBe('thinking')
+    // Wire-spec / back-compat: a `turn` is sent on utterance-end (server no-ops it).
+    expect(ws.controlMessages().some((m) => m.type === 'turn')).toBe(true)
+  })
+
+  it('does not fire a turn on background noise below the threshold', async () => {
+    const { result, ws } = await ready()
+    act(() => {
+      for (let i = 0; i < 10; i += 1) fireFrame(0.005)
+    })
+    expect(result.current.playerSpeaking).toBe(false)
+    expect(ws.controlMessages().some((m) => m.type === 'turn')).toBe(false)
+  })
+})
+
+describe('useVoiceSession — barge-in', () => {
+  it('stops AI playback and drops the interrupted turn when the player talks over it', async () => {
+    const { result, ws } = await ready()
+
+    // AI is mid-response: text + audio streaming, not yet done.
+    act(() => {
+      ws.fireMessage({ type: 'chunk', kind: 'text', text: 'a long answer that goes', done: false })
+      ws.fireMessage({ type: 'chunk', kind: 'audio', audio: audioB64, done: false })
+    })
+    expect(result.current.isAiSpeaking).toBe(true)
+    const playing = playbackSources().at(-1)
+
+    // Player barges in.
+    act(() => fireFrame(0.5))
+    expect(playing?.stopped).toBe(true)
+    expect(result.current.isAiSpeaking).toBe(false)
+    expect(result.current.playerSpeaking).toBe(true)
+    expect(result.current.aiText).toBe('') // interrupted turn's text dropped
+
+    // The interrupted turn's tail keeps streaming from the server — drop it.
+    act(() => ws.fireMessage({ type: 'chunk', kind: 'text', text: ' on and on', done: true }))
+    expect(result.current.aiText).toBe('')
+
+    // After the player goes silent and the next turn streams, it renders fresh.
+    act(() => {
+      fireFrame(0.0)
+      fireFrame(0.0)
+      fireFrame(0.0)
+      fireFrame(0.0)
+    })
+    act(() => ws.fireMessage({ type: 'chunk', kind: 'text', text: 'new answer', done: false }))
+    expect(result.current.aiText).toBe('new answer')
   })
 })

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -1,12 +1,20 @@
 /**
- * `useVoiceSession` — the BombSquad client for one platform-ai voice session.
+ * `useVoiceSession` — the BombSquad client for one platform-ai voice session,
+ * hands-free full-duplex.
  *
- * Runs the whole turn lifecycle against the deployed `@amiclaw/platform-ai` Worker
- * over the same-origin `/ai-ws/*` WebSocket: connect -> create session -> hold-to-
- * talk PCM16 mic capture -> drive a turn -> render the AI's streamed text + play
- * its TTS audio -> end session. This round is the hook (logic + state) only; the
- * voice-panel UI + GamePage wiring land in the next round, but the API is shaped
- * for a panel to consume directly.
+ * Runs the whole conversation against the deployed `@amiclaw/platform-ai` Worker
+ * over the same-origin `/ai-ws/*` WebSocket: connect -> create session -> open
+ * the mic ONCE and stream PCM16 16 kHz frames continuously -> the AI greets first
+ * and answers each utterance -> render the AI's streamed text + play its TTS audio
+ * -> end session. There is NO push-to-talk; the player just talks.
+ *
+ * Turn model (important): the CLIENT runs the VAD. On `create` the server fires
+ * the AI-first opening greeting (no client input). Thereafter the hook streams the
+ * mic continuously and the client-side VAD detects end-of-utterance (the player
+ * went silent after speaking) and sends `{type:'turn'}`, which the server runs as
+ * a normal STT->LLM->TTS turn over the audio buffered since the last turn. The VAD
+ * additionally drives the 3-state conversation phase (listening / thinking /
+ * speaking) and barge-in (stop local playback when the player talks over the AI).
  *
  * Security invariant (load-bearing, mirrors the demo): this hook connects ONLY to
  * the same-origin Worker WS and sends ONLY `{gameId, manualData, gameState}` plus
@@ -16,27 +24,34 @@
  * Audio formats (both 16 kHz mono PCM16):
  *  - mic capture: `AudioContext({ sampleRate: 16000 })` + `ScriptProcessorNode`,
  *    Float32 -> Int16 LE per frame (`floatTo16BitPCM`), sent as binary WS frames.
- *    ScriptProcessor is deprecated but is what the demo uses and is sufficient
- *    here (capture parity; see the directive's note).
+ *    The mic stays open for the whole session. `getUserMedia` requests echo
+ *    cancellation + noise suppression so the open mic does not pick up the AI's
+ *    own voice (which would self-trigger barge-in).
  *  - TTS playback: base64 audio frame -> Int16 LE -> Float32 (`pcm16ToFloat32`),
- *    wrapped in an `AudioBuffer` at 16000 Hz and scheduled gaplessly. 16000 is the
- *    Volcengine TTS output rate (`volcengine.ts` `DEFAULT_SAMPLE_RATE`, which the
- *    factory never overrides). The playback `AudioContext` runs at its native rate
- *    and resamples the 16 kHz buffers, which is robust across platforms that
- *    refuse a forced 16 kHz output context.
+ *    wrapped in an `AudioBuffer` at 16000 Hz and scheduled gaplessly. The playback
+ *    `AudioContext` runs at its native rate and resamples the 16 kHz buffers.
  */
 
-import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
 import { base64ToBytes, floatTo16BitPCM, pcm16ToFloat32, resamplePcmFloat32 } from './audio-pcm'
 import {
   buildSessionUrl,
+  deriveConversationPhase,
   initialVoiceState,
   randomSessionName,
   voiceReducer,
+  type ConversationPhase,
   type ServerFrame,
   type VoiceStatus,
 } from './voice-session-protocol'
+import {
+  computeRms,
+  DEFAULT_VAD_CONFIG,
+  initialVadState,
+  vadStep,
+  type VadState,
+} from './voice-vad'
 
 /** Volcengine TTS output sample rate (`volcengine.ts` `DEFAULT_SAMPLE_RATE`). */
 const TTS_OUTPUT_SAMPLE_RATE = 16000
@@ -50,9 +65,6 @@ const CAPTURE_BUFFER_SIZE = 4096
  * (possible) rejection. Browsers cap the number of concurrent `AudioContext`s,
  * so a leaked context across turns / panel remounts eventually starves the next
  * `new AudioContext(...)` — which is the failure this hardening guards against.
- * Release is initiated synchronously by `close()`; React's cleanup contract
- * forbids a top-level `await`, so the returned promise is only used to discard a
- * rejection (a context already closing).
  */
 function closeAudioContext(ctx: AudioContext | null): void {
   if (!ctx) return
@@ -86,8 +98,12 @@ export interface UseVoiceSessionOptions {
 }
 
 export interface UseVoiceSessionResult {
-  /** Connection / turn status for the panel. */
+  /** Connection lifecycle status for the panel (socket state). */
   status: VoiceStatus
+  /** In-conversation 3-state phase for a live session (listening / thinking / speaking). */
+  conversationPhase: ConversationPhase
+  /** True while the client VAD reports the player is speaking. */
+  playerSpeaking: boolean
   /** Accumulated AI text for the current turn. */
   aiText: string
   /** True while TTS audio is scheduled/playing. */
@@ -96,34 +112,32 @@ export interface UseVoiceSessionResult {
   error: string | null
   /** Session summary, set once the session ends cleanly. */
   summary: import('@amiclaw/platform-ai/contract').SessionSummary | null
-  /** Begin push-to-talk capture (pointer-down). No-op unless `status === 'ready'`. */
-  startTalking: () => void
-  /** End push-to-talk, flush audio, and request the AI turn (pointer-up/leave). */
-  stopTalking: () => void
   /** End the session: send `end`, await the summary, and tear down. */
   endSession: () => void
 }
 
 /**
  * Module-change / `gameState` updates: the wire protocol exposes no mid-session
- * `gameState` update message (only `create` / `turn` / `end`, and a re-`create` is
+ * `gameState` update message (only `create` / `end`, and a re-`create` is
  * rejected `already_created`), so `relevantSections` are pinned at the value
  * captured when the session is created. The hook keeps the LATEST `gameState`/
  * `manualData` in refs and applies them at create time; to inject a new module's
- * sections the consumer creates a fresh session (remount / toggle the hosting
- * panel), which the next round decides. Within one live session, turns reuse the
- * created sections — documented as the chosen "carry, apply at create" behaviour.
+ * sections the consumer creates a fresh session (remount via the `VoicePanel`
+ * key). Within one live session, turns reuse the created sections.
  */
 export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessionResult {
   const { manualData, gameState, gameId = 'bombsquad' } = options
 
   const [state, dispatch] = useReducer(voiceReducer, initialVoiceState)
   const [isAiSpeaking, setIsAiSpeaking] = useState(false)
+  // Conversation-phase signals. State (drive re-render); mirrored to refs so the
+  // audio-thread callbacks + the once-bound socket handlers read current values.
+  const [playerSpeaking, setPlayerSpeaking] = useState(false)
+  const [awaitingResponse, setAwaitingResponse] = useState(false)
+  const awaitingResponseRef = useRef(false)
 
   // Latest inputs, captured at connect/create time without re-running the connect
-  // effect on every prop identity change. Synced in an effect (not during render)
-  // so the refs are current by the time any event handler / connect effect reads
-  // them, without the lint-flagged ref-write-during-render anti-pattern.
+  // effect on every prop identity change.
   const manualDataRef = useRef<ManualData | null>(manualData)
   const gameStateRef = useRef<GameState>(gameState)
   const gameIdRef = useRef<string>(gameId)
@@ -142,20 +156,32 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
   const captureCtxRef = useRef<AudioContext | null>(null)
   const captureSourceRef = useRef<MediaStreamAudioSourceNode | null>(null)
   const captureProcRef = useRef<ScriptProcessorNode | null>(null)
-  /** True between a successful mic acquire and `stopTalking` — gates the `turn`. */
+  /** True once the mic is acquired and streaming; guards a double mic-open. */
   const capturingRef = useRef(false)
-  /** True the instant `startTalking` runs; cleared by `stopTalking`, so a release
-   *  during the async `getUserMedia` aborts the capture that is still spinning up. */
-  const talkRequestedRef = useRef(false)
+  /** Running VAD state, folded one capture frame at a time. */
+  const vadStateRef = useRef<VadState>(initialVadState)
+  /** Analyzed-frame wall-clock duration (`bufferSize / actualRate`), ms. */
+  const frameMsRef = useRef<number>((CAPTURE_BUFFER_SIZE / CAPTURE_SAMPLE_RATE) * 1000)
 
   const playbackCtxRef = useRef<AudioContext | null>(null)
   /** Next scheduled playback start time, for gapless PCM frame queueing. */
   const playbackCursorRef = useRef(0)
   /** Count of scheduled-but-not-ended buffers, driving `isAiSpeaking`. */
   const playingCountRef = useRef(0)
+  /** Live scheduled sources, so barge-in can stop them without closing the context. */
+  const activeSourcesRef = useRef<Set<AudioBufferSourceNode>>(new Set())
+  /** True while the AI's current turn is still streaming (last chunk not `done`). */
+  const turnStreamingRef = useRef(false)
+  /** True while dropping the tail of a barged-in turn (until its `done` chunk). */
+  const suppressTurnRef = useRef(false)
 
   const safeDispatch = useCallback((action: Parameters<typeof dispatch>[0]) => {
     if (mountedRef.current) dispatch(action)
+  }, [])
+
+  const setAwaiting = useCallback((v: boolean) => {
+    awaitingResponseRef.current = v
+    if (mountedRef.current) setAwaitingResponse(v)
   }, [])
 
   // --- TTS playback (Web Audio side effects) ---
@@ -189,8 +215,10 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         source.start(startAt)
         playbackCursorRef.current = startAt + buffer.duration
         playingCountRef.current += 1
+        activeSourcesRef.current.add(source)
         setIsAiSpeaking(true)
         source.onended = () => {
+          activeSourcesRef.current.delete(source)
           playingCountRef.current = Math.max(0, playingCountRef.current - 1)
           if (playingCountRef.current === 0 && mountedRef.current) setIsAiSpeaking(false)
         }
@@ -201,19 +229,41 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     [ensurePlaybackCtx]
   )
 
-  const stopPlayback = useCallback(() => {
+  /**
+   * Stop all scheduled playback immediately but KEEP the playback context alive
+   * for the next turn. Used by barge-in — the next AI turn reuses the context.
+   */
+  const interruptPlayback = useCallback(() => {
+    for (const source of activeSourcesRef.current) {
+      try {
+        // eslint-disable-next-line react-hooks/immutability -- a Web Audio node held in a ref, not React state; detach its callback before stopping so teardown doesn't re-enter the onended bookkeeping.
+        source.onended = null
+        source.stop?.()
+        source.disconnect?.()
+      } catch {
+        /* ignore — source may already have ended */
+      }
+    }
+    activeSourcesRef.current.clear()
     playingCountRef.current = 0
-    playbackCursorRef.current = 0
-    setIsAiSpeaking(false)
-    const ctx = playbackCtxRef.current
-    playbackCtxRef.current = null
-    closeAudioContext(ctx)
+    playbackCursorRef.current = playbackCtxRef.current?.currentTime ?? 0
+    if (mountedRef.current) setIsAiSpeaking(false)
   }, [])
 
-  // --- Mic capture ---
+  /** Stop playback AND release the context — full teardown (unmount / end). */
+  const teardownPlayback = useCallback(() => {
+    interruptPlayback()
+    const ctx = playbackCtxRef.current
+    playbackCtxRef.current = null
+    playbackCursorRef.current = 0
+    closeAudioContext(ctx)
+  }, [interruptPlayback])
+
+  // --- Mic capture (continuous, full session) ---
 
   const stopCapture = useCallback(() => {
     capturingRef.current = false
+    vadStateRef.current = initialVadState
     const proc = captureProcRef.current
     if (proc) {
       proc.onaudioprocess = null
@@ -242,6 +292,97 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
       mediaStreamRef.current = null
     }
   }, [])
+
+  /** A VAD `utterance-end`: the player went silent after speaking. */
+  const onUtteranceEnd = useCallback(() => {
+    setPlayerSpeaking(false)
+    setAwaiting(true)
+    // Wire-spec / back-compat signal. The deployed server detects the endpoint
+    // itself and treats this as a no-op; it does not start the turn.
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      try {
+        ws.send(JSON.stringify({ type: 'turn' }))
+      } catch {
+        /* non-fatal — a dropped turn just means this utterance isn't answered */
+      }
+    }
+  }, [setAwaiting])
+
+  /** A VAD `speech-start`: the player began an utterance (incl. barge-in). */
+  const onSpeechStart = useCallback(() => {
+    setPlayerSpeaking(true)
+    // Barge-in: the player is talking while the AI's audio is playing. Stop the
+    // playback at once and drop the rest of the interrupted turn's streamed
+    // chunks (text + audio) — the server keeps streaming them (it cancels nothing
+    // in v1), so the client must locally discard them until that turn's `done`.
+    if (playingCountRef.current > 0) {
+      interruptPlayback()
+      if (turnStreamingRef.current) suppressTurnRef.current = true
+      safeDispatch({ type: 'barge-in' })
+    }
+  }, [interruptPlayback, safeDispatch])
+
+  const startCapture = useCallback(() => {
+    if (capturingRef.current) return
+    capturingRef.current = true
+    void (async () => {
+      let stream: MediaStream
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+        })
+      } catch {
+        capturingRef.current = false
+        safeDispatch({ type: 'mic-error', message: 'microphone permission denied' })
+        return
+      }
+      // The panel may have unmounted / the socket closed during the async acquire.
+      if (!mountedRef.current || !wsRef.current) {
+        stream.getTracks().forEach((t) => t.stop())
+        capturingRef.current = false
+        return
+      }
+      mediaStreamRef.current = stream
+      try {
+        const ctx = new AudioContext({ sampleRate: CAPTURE_SAMPLE_RATE })
+        captureCtxRef.current = ctx
+        // Browsers may ignore the requested 16 kHz and run the context at the
+        // hardware rate (e.g. 48000). The wire format is fixed at PCM16 16 kHz —
+        // resample each frame to the true target rate before encoding.
+        const actualRate = ctx.sampleRate
+        frameMsRef.current = (CAPTURE_BUFFER_SIZE / actualRate) * 1000
+        vadStateRef.current = initialVadState
+        const source = ctx.createMediaStreamSource(stream)
+        captureSourceRef.current = source
+        const proc = ctx.createScriptProcessor(CAPTURE_BUFFER_SIZE, 1, 1)
+        captureProcRef.current = proc
+        proc.onaudioprocess = (e) => {
+          const frame = e.inputBuffer.getChannelData(0)
+          // 1) VAD on the raw frame (energy is rate-independent), driving the
+          //    conversation phase + barge-in.
+          const rms = computeRms(frame)
+          const stepped = vadStep(vadStateRef.current, rms, frameMsRef.current, DEFAULT_VAD_CONFIG)
+          vadStateRef.current = stepped.state
+          if (stepped.event === 'speech-start') onSpeechStart()
+          else if (stepped.event === 'utterance-end') onUtteranceEnd()
+          // 2) Stream the frame continuously as PCM16 16 kHz.
+          const socket = wsRef.current
+          if (!socket || socket.readyState !== WebSocket.OPEN) return
+          const pcm =
+            actualRate === CAPTURE_SAMPLE_RATE
+              ? frame
+              : resamplePcmFloat32(frame, actualRate, CAPTURE_SAMPLE_RATE)
+          socket.send(floatTo16BitPCM(pcm))
+        }
+        source.connect(proc)
+        proc.connect(ctx.destination)
+      } catch {
+        stopCapture()
+        safeDispatch({ type: 'mic-error', message: 'microphone capture failed' })
+      }
+    })()
+  }, [onSpeechStart, onUtteranceEnd, safeDispatch, stopCapture])
 
   // --- WebSocket lifecycle ---
 
@@ -301,8 +442,32 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
       } catch {
         return
       }
-      if (frame.type === 'chunk' && frame.kind === 'audio' && frame.audio) {
-        playAudioFrame(base64ToBytes(frame.audio))
+      if (frame.type === 'created') {
+        // The AI greets first: open the mic now and mark the opening greeting
+        // pending (-> "thinking" until its audio plays).
+        setAwaiting(true)
+        startCapture()
+        safeDispatch({ type: 'frame', frame })
+        return
+      }
+      if (frame.type === 'chunk') {
+        // Drop the tail of a turn the player barged in on, until its `done`.
+        if (suppressTurnRef.current) {
+          if (frame.done) {
+            suppressTurnRef.current = false
+            turnStreamingRef.current = false
+          }
+          return
+        }
+        // A real chunk arriving means the AI is responding now — the player's
+        // wait is over.
+        turnStreamingRef.current = !frame.done
+        if (awaitingResponseRef.current) setAwaiting(false)
+        if (frame.kind === 'audio' && frame.audio) {
+          playAudioFrame(base64ToBytes(frame.audio))
+        }
+        safeDispatch({ type: 'frame', frame })
+        return
       }
       safeDispatch({ type: 'frame', frame })
     }
@@ -316,9 +481,8 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
       if (endedRef.current || event.code === 1000) {
         safeDispatch({ type: 'closed' })
       } else {
-        // The server attaches a bounded `safeCloseReason` to every 1008 (e.g.
-        // "turn before create", a provider error code) — surface it so a residual
-        // failure is self-explaining instead of a bare numeric code.
+        // The server attaches a bounded `safeCloseReason` to every 1008 — surface
+        // it so a residual failure is self-explaining, not a bare numeric code.
         const reason = event.reason ? `: ${event.reason}` : ''
         safeDispatch({
           type: 'transport-error',
@@ -326,84 +490,11 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         })
       }
     }
-  }, [playAudioFrame, safeDispatch])
+  }, [playAudioFrame, safeDispatch, setAwaiting, startCapture])
 
   // --- Public actions ---
 
-  const startTalking = useCallback(() => {
-    const ws = wsRef.current
-    if (!ws || ws.readyState !== WebSocket.OPEN) return
-    // Only one turn at a time, and only once the session is ready.
-    if (state.status !== 'ready' || talkRequestedRef.current) return
-    talkRequestedRef.current = true
-
-    void (async () => {
-      let stream: MediaStream
-      try {
-        stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-      } catch {
-        talkRequestedRef.current = false
-        safeDispatch({ type: 'mic-error', message: 'microphone permission denied' })
-        return
-      }
-      // A release (stopTalking) during the async acquire aborts spin-up.
-      if (!talkRequestedRef.current || !wsRef.current) {
-        stream.getTracks().forEach((t) => t.stop())
-        return
-      }
-      mediaStreamRef.current = stream
-      try {
-        const ctx = new AudioContext({ sampleRate: CAPTURE_SAMPLE_RATE })
-        captureCtxRef.current = ctx
-        // Browsers may ignore the requested 16 kHz and run the context at the
-        // hardware rate (e.g. 48000). The wire format is fixed at PCM16 16 kHz —
-        // resample each frame to the true target rate before encoding, so we
-        // never send mislabelled (wrong-rate) audio that the STT rejects (1008).
-        const actualRate = ctx.sampleRate
-        const source = ctx.createMediaStreamSource(stream)
-        captureSourceRef.current = source
-        const proc = ctx.createScriptProcessor(CAPTURE_BUFFER_SIZE, 1, 1)
-        captureProcRef.current = proc
-        proc.onaudioprocess = (e) => {
-          const socket = wsRef.current
-          if (!socket || socket.readyState !== WebSocket.OPEN) return
-          const frame = e.inputBuffer.getChannelData(0)
-          const pcm =
-            actualRate === CAPTURE_SAMPLE_RATE
-              ? frame
-              : resamplePcmFloat32(frame, actualRate, CAPTURE_SAMPLE_RATE)
-          socket.send(floatTo16BitPCM(pcm))
-        }
-        source.connect(proc)
-        proc.connect(ctx.destination)
-        capturingRef.current = true
-        safeDispatch({ type: 'talk-start' })
-      } catch {
-        stopCapture()
-        talkRequestedRef.current = false
-        safeDispatch({ type: 'mic-error', message: 'microphone capture failed' })
-      }
-    })()
-  }, [state.status, safeDispatch, stopCapture])
-
-  const stopTalking = useCallback(() => {
-    talkRequestedRef.current = false
-    const wasCapturing = capturingRef.current
-    stopCapture()
-    const ws = wsRef.current
-    // Only request a turn if we actually captured audio — an empty turn would
-    // drive STT over a silent bridge.
-    if (wasCapturing && ws && ws.readyState === WebSocket.OPEN) {
-      try {
-        ws.send(JSON.stringify({ type: 'turn' }))
-      } catch {
-        safeDispatch({ type: 'transport-error', message: 'failed to send turn' })
-      }
-    }
-  }, [stopCapture, safeDispatch])
-
   const endSession = useCallback(() => {
-    talkRequestedRef.current = false
     stopCapture()
     const ws = wsRef.current
     if (ws && ws.readyState === WebSocket.OPEN) {
@@ -432,19 +523,24 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     return () => {
       mountedRef.current = false
       stopCapture()
-      stopPlayback()
+      teardownPlayback()
       closeSocket(true)
     }
-  }, [hasManual, connect, stopCapture, stopPlayback, closeSocket])
+  }, [hasManual, connect, stopCapture, teardownPlayback, closeSocket])
+
+  const conversationPhase = useMemo(
+    () => deriveConversationPhase({ isAiSpeaking, playerSpeaking, awaitingResponse }),
+    [isAiSpeaking, playerSpeaking, awaitingResponse]
+  )
 
   return {
     status: state.status,
+    conversationPhase,
+    playerSpeaking,
     aiText: state.aiText,
     isAiSpeaking,
     error: state.error,
     summary: state.summary,
-    startTalking,
-    stopTalking,
     endSession,
   }
 }

--- a/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
+++ b/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
@@ -3,6 +3,7 @@ import type { SessionSummary } from '@amiclaw/platform-ai/contract'
 import {
   boundError,
   buildSessionUrl,
+  deriveConversationPhase,
   initialVoiceState,
   voiceReducer,
   type ServerFrame,
@@ -66,61 +67,70 @@ describe('voiceReducer', () => {
     expect(next.sessionId).toBe('sess-7')
   })
 
-  it('talk-start moves ready -> in-turn and clears prior text/error', () => {
+  it('keeps status ready for the whole live session (no in-turn flips)', () => {
     const next = run(
       { type: 'connecting' },
       { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
-      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'old reply', done: true } },
-      { type: 'talk-start' }
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'Hold ', done: false } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'on.', done: true } }
     )
-    expect(next.status).toBe('in-turn')
-    expect(next.aiText).toBe('')
+    expect(next.status).toBe('ready')
   })
 
-  it('talk-start is a no-op when not ready (no double-turn from in-turn)', () => {
-    const inTurn = run(
-      { type: 'connecting' },
-      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
-      { type: 'talk-start' }
-    )
-    expect(inTurn.status).toBe('in-turn')
-    expect(voiceReducer(inTurn, { type: 'talk-start' })).toBe(inTurn)
-  })
-
-  it('accumulates streamed text chunks across a turn', () => {
+  it('accumulates streamed text chunks within one turn', () => {
     const next = run(
       { type: 'connecting' },
       { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
-      { type: 'talk-start' },
       { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'Hold ', done: false } },
       { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'the ', done: false } },
       { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'button.', done: false } }
     )
     expect(next.aiText).toBe('Hold the button.')
-    expect(next.status).toBe('in-turn')
+  })
+
+  it('resets aiText when the next turn begins (first chunk after a done)', () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'first reply', done: true } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'second ', done: false } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'reply', done: false } }
+    )
+    // The done of turn 1 closes it; turn 2's first chunk starts fresh.
+    expect(next.aiText).toBe('second reply')
   })
 
   it('audio chunks do not change aiText but their done flag closes the turn', () => {
     const next = run(
       { type: 'connecting' },
       { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
-      { type: 'talk-start' },
       { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'ok', done: false } },
       { type: 'frame', frame: { type: 'chunk', kind: 'audio', audio: 'AAAA', done: true } }
     )
     expect(next.aiText).toBe('ok')
-    expect(next.status).toBe('ready')
+    expect(next.turnDone).toBe(true)
   })
 
-  it('a done text chunk returns the turn to ready', () => {
-    const next = run(
+  it('barge-in clears the interrupted turn text and closes the turn boundary', () => {
+    const interrupted = run(
       { type: 'connecting' },
       { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
-      { type: 'talk-start' },
-      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'done now', done: true } }
+      {
+        type: 'frame',
+        frame: { type: 'chunk', kind: 'text', text: 'long answer so f', done: false },
+      },
+      { type: 'barge-in' }
     )
-    expect(next.status).toBe('ready')
-    expect(next.aiText).toBe('done now')
+    expect(interrupted.aiText).toBe('')
+    expect(interrupted.turnDone).toBe(true)
+    expect(interrupted.status).toBe('ready')
+
+    // The AI's NEXT turn (answer to the interruption) renders fresh.
+    const answered = voiceReducer(interrupted, {
+      type: 'frame',
+      frame: { type: 'chunk', kind: 'text', text: 'new answer', done: false },
+    })
+    expect(answered.aiText).toBe('new answer')
   })
 
   it('summary moves to closed and exposes the summary', () => {
@@ -184,5 +194,52 @@ describe('voiceReducer', () => {
       frame: { type: 'mystery' } as unknown as ServerFrame,
     })
     expect(next).toEqual(ready)
+  })
+})
+
+describe('deriveConversationPhase', () => {
+  it('is speaking whenever the AI audio is playing (highest priority)', () => {
+    expect(
+      deriveConversationPhase({
+        isAiSpeaking: true,
+        playerSpeaking: false,
+        awaitingResponse: false,
+      })
+    ).toBe('speaking')
+    // AI audio wins even if the player just started talking over it (barge-in is
+    // resolved by the hook stopping playback, which clears isAiSpeaking).
+    expect(
+      deriveConversationPhase({ isAiSpeaking: true, playerSpeaking: true, awaitingResponse: true })
+    ).toBe('speaking')
+  })
+
+  it('is listening while the player is speaking (and the AI is not)', () => {
+    expect(
+      deriveConversationPhase({
+        isAiSpeaking: false,
+        playerSpeaking: true,
+        awaitingResponse: false,
+      })
+    ).toBe('listening')
+  })
+
+  it('is thinking once the player stopped and the AI has not started', () => {
+    expect(
+      deriveConversationPhase({
+        isAiSpeaking: false,
+        playerSpeaking: false,
+        awaitingResponse: true,
+      })
+    ).toBe('thinking')
+  })
+
+  it('is listening when idle (mic open, no one talking, nothing pending)', () => {
+    expect(
+      deriveConversationPhase({
+        isAiSpeaking: false,
+        playerSpeaking: false,
+        awaitingResponse: false,
+      })
+    ).toBe('listening')
   })
 })

--- a/packages/game-bombsquad/src/voice/voice-session-protocol.ts
+++ b/packages/game-bombsquad/src/voice/voice-session-protocol.ts
@@ -19,15 +19,51 @@
 import type { SessionSummary } from '@amiclaw/platform-ai/contract'
 
 /**
- * Connection / turn status surfaced to the panel.
+ * Connection lifecycle surfaced to the panel. This is the SOCKET state, distinct
+ * from the in-conversation `ConversationPhase` (listening / thinking / speaking)
+ * which the hands-free model layers on top of a live `ready` session.
  *  - `idle`        before the manual is ready / before connect.
  *  - `connecting`  socket opening and session being created.
- *  - `ready`       session created; the player may push-to-talk.
- *  - `in-turn`     a turn is in progress (player speaking or AI responding).
+ *  - `ready`       session created and live; the AI-first greeting + the
+ *                  continuous hands-free conversation run while status stays
+ *                  `ready` (the turn-by-turn detail lives in `ConversationPhase`).
  *  - `error`       the socket failed or closed unexpectedly (bounded `error` set).
  *  - `closed`      the session ended cleanly (a `summary` arrived / `end` acked).
  */
-export type VoiceStatus = 'idle' | 'connecting' | 'ready' | 'in-turn' | 'error' | 'closed'
+export type VoiceStatus = 'idle' | 'connecting' | 'ready' | 'error' | 'closed'
+
+/**
+ * In-conversation sub-state for a live (`ready`) hands-free session — the user-
+ * requested 3-state indicator. Derived (purely, see `deriveConversationPhase`)
+ * from live hook signals, NOT stored in the reducer:
+ *  - `listening`  mic open, hearing / waiting for the player.
+ *  - `thinking`   the player finished an utterance; awaiting the AI's response.
+ *  - `speaking`   the AI's TTS audio is playing.
+ */
+export type ConversationPhase = 'listening' | 'thinking' | 'speaking'
+
+/** Live signals the conversation phase is derived from. */
+export interface PhaseSignals {
+  /** TTS audio is currently scheduled / playing. */
+  isAiSpeaking: boolean
+  /** Client VAD reports the player is currently speaking. */
+  playerSpeaking: boolean
+  /** An utterance ended (or the opening greeting is pending) with no AI audio yet. */
+  awaitingResponse: boolean
+}
+
+/**
+ * Map the live signals to the 3-state conversation phase. Pure and total. Order
+ * is a strict priority: the AI speaking wins (`speaking`); else an active player
+ * utterance reads as `listening`; else a pending response reads as `thinking`;
+ * otherwise the session is idly `listening` for the player.
+ */
+export function deriveConversationPhase(s: PhaseSignals): ConversationPhase {
+  if (s.isAiSpeaking) return 'speaking'
+  if (s.playerSpeaking) return 'listening'
+  if (s.awaitingResponse) return 'thinking'
+  return 'listening'
+}
 
 /**
  * One server->client JSON frame. Structurally mirrors the envelope
@@ -46,8 +82,8 @@ export type ServerFrame =
 /** Reducer actions: server frames plus the local lifecycle transitions. */
 export type VoiceAction =
   | { type: 'connecting' }
-  | { type: 'talk-start' }
   | { type: 'frame'; frame: ServerFrame }
+  | { type: 'barge-in' }
   | { type: 'mic-error'; message: string }
   | { type: 'transport-error'; message: string }
   | { type: 'closed' }
@@ -58,6 +94,14 @@ export interface VoiceSessionState {
   sessionId: string | null
   /** Accumulated AI text for the current turn (cleared when a new turn starts). */
   aiText: string
+  /**
+   * True once the current turn's last (`done`) chunk has been seen — so the next
+   * turn's first chunk resets `aiText` instead of appending. With server-driven
+   * hands-free turns there is no client turn-start signal, so the turn boundary
+   * is detected from the `done` flag. Starts `true` so the first turn (the AI
+   * opening greeting) renders fresh.
+   */
+  turnDone: boolean
   /** Last bounded error message, or null. */
   error: string | null
   /** Session summary, set once `end` is acknowledged. */
@@ -68,6 +112,7 @@ export const initialVoiceState: VoiceSessionState = {
   status: 'idle',
   sessionId: null,
   aiText: '',
+  turnDone: true,
   error: null,
   summary: null,
 }
@@ -89,19 +134,19 @@ export function voiceReducer(state: VoiceSessionState, action: VoiceAction): Voi
       // Fresh connect resets the per-session surface.
       return { ...initialVoiceState, status: 'connecting' }
 
-    case 'talk-start':
-      // A new turn begins only from `ready`; clear the prior turn's text + error
-      // so the panel shows this turn's reply fresh.
-      if (state.status !== 'ready') return state
-      return { ...state, status: 'in-turn', aiText: '', error: null }
-
     case 'frame':
       return reduceFrame(state, action.frame)
 
+    case 'barge-in':
+      // The player interrupted the AI mid-response. Drop the interrupted turn's
+      // rendered text and mark the turn boundary closed so the AI's NEXT turn
+      // (the answer to the interruption) starts fresh. The hook separately stops
+      // playback and suppresses the interrupted turn's remaining chunks.
+      return { ...state, aiText: '', turnDone: true }
+
     case 'mic-error':
       // Mic capture failure is NOT a socket failure: surface the bounded message
-      // but keep the session usable (status unchanged — capture never reached
-      // `in-turn`, which is set only after the mic is acquired).
+      // but keep the session usable (status unchanged).
       return { ...state, error: boundError(action.message) }
 
     case 'transport-error':
@@ -123,16 +168,15 @@ function reduceFrame(state: VoiceSessionState, frame: ServerFrame): VoiceSession
       return { ...state, status: 'ready', sessionId: frame.sessionId }
 
     case 'chunk': {
-      // Text chunks accumulate into `aiText`; audio chunks are a playback side
-      // effect the hook handles, so only their `done` flag matters here. ANY
-      // chunk flagged `done` is the turn's last fragment -> back to `ready`.
-      const aiText = frame.kind === 'text' ? state.aiText + (frame.text ?? '') : state.aiText
-      const status: VoiceStatus = frame.done
-        ? 'ready'
-        : state.status === 'ready'
-          ? 'in-turn'
-          : state.status
-      return { ...state, aiText, status }
+      // Server-driven hands-free turns give no turn-start signal, so a turn
+      // boundary is detected from the prior chunk's `done`: the first chunk after
+      // a `done` (or the very first chunk) starts a fresh `aiText`; later chunks
+      // of the same turn append. Audio chunks are a playback side effect the hook
+      // owns — only their `done` flag matters here. Status stays `ready` for the
+      // whole live session; the conversation phase carries the turn-level detail.
+      const base = state.turnDone ? '' : state.aiText
+      const aiText = frame.kind === 'text' ? base + (frame.text ?? '') : base
+      return { ...state, aiText, turnDone: frame.done }
     }
 
     case 'summary':

--- a/packages/game-bombsquad/src/voice/voice-vad.test.ts
+++ b/packages/game-bombsquad/src/voice/voice-vad.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeRms,
+  initialVadState,
+  vadStep,
+  type VadConfig,
+  type VadEvent,
+  type VadState,
+} from './voice-vad'
+
+// Round-number config so the maths is obvious: 100ms frames, speech qualifies
+// after 200ms (2 contiguous speech frames), an utterance ends after 800ms (8
+// contiguous silence frames).
+const CONFIG: VadConfig = { speechThreshold: 0.02, silenceHangoverMs: 800, minSpeechMs: 200 }
+const FRAME_MS = 100
+const SPEECH = 0.5 // clearly above threshold
+const SILENCE = 0.0 // clearly below threshold
+
+/** Fold a sequence of frame RMS values, collecting every emitted boundary event. */
+function drive(rmsSeq: number[], from: VadState = initialVadState) {
+  let state = from
+  const events: VadEvent[] = []
+  for (const rms of rmsSeq) {
+    const stepped = vadStep(state, rms, FRAME_MS, CONFIG)
+    state = stepped.state
+    if (stepped.event) events.push(stepped.event)
+  }
+  return { state, events }
+}
+
+describe('computeRms', () => {
+  it('is 0 for an empty frame', () => {
+    expect(computeRms(new Float32Array(0))).toBe(0)
+  })
+
+  it('is 0 for pure silence', () => {
+    expect(computeRms(new Float32Array(64))).toBe(0)
+  })
+
+  it('is the amplitude for a constant signal', () => {
+    expect(computeRms(new Float32Array([0.5, 0.5, 0.5]))).toBeCloseTo(0.5, 6)
+    expect(computeRms(new Float32Array([-1, -1, -1, -1]))).toBeCloseTo(1, 6)
+  })
+})
+
+describe('vadStep — utterance detection', () => {
+  it('fires speech-start exactly once after minSpeechMs of contiguous speech', () => {
+    // 2 frames = 200ms reaches minSpeechMs; further speech frames do NOT re-fire.
+    const { events, state } = drive([SPEECH, SPEECH, SPEECH, SPEECH])
+    expect(events).toEqual(['speech-start'])
+    expect(state.speaking).toBe(true)
+  })
+
+  it('does not fire on the first speech frame (below minSpeechMs)', () => {
+    const { events, state } = drive([SPEECH])
+    expect(events).toEqual([])
+    expect(state.speaking).toBe(false)
+  })
+
+  it('fires utterance-end after silenceHangoverMs of trailing silence', () => {
+    // Start speaking, then go silent. 7 silence frames (700ms) is still inside an
+    // utterance; the 8th (800ms) ends it.
+    const seq = [SPEECH, SPEECH, ...Array(7).fill(SILENCE)]
+    const mid = drive(seq)
+    expect(mid.events).toEqual(['speech-start'])
+    expect(mid.state.speaking).toBe(true)
+
+    const end = drive([SILENCE], mid.state)
+    expect(end.events).toEqual(['utterance-end'])
+    expect(end.state.speaking).toBe(false)
+    expect(end.state).toEqual(initialVadState)
+  })
+
+  it('fires the full speech-then-silence boundary pair in one drive', () => {
+    const seq = [SPEECH, SPEECH, SPEECH, ...Array(8).fill(SILENCE)]
+    expect(drive(seq).events).toEqual(['speech-start', 'utterance-end'])
+  })
+})
+
+describe('vadStep — noise debounce', () => {
+  it('discards a single noise blip (sub-minSpeechMs speech then silence)', () => {
+    // One speech frame (100ms < 200ms) then silence: never a qualified utterance.
+    const { events, state } = drive([SPEECH, SILENCE, SILENCE, SILENCE])
+    expect(events).toEqual([])
+    expect(state).toEqual(initialVadState)
+  })
+
+  it('requires CONTIGUOUS speech — a gap resets the forming utterance', () => {
+    // speech, silence, speech: each speech run is only 100ms, never reaching the
+    // 200ms minimum, so no utterance starts.
+    const { events } = drive([SPEECH, SILENCE, SPEECH, SILENCE, SPEECH, SILENCE])
+    expect(events).toEqual([])
+  })
+
+  it('ignores steady background noise below the threshold', () => {
+    const { events, state } = drive(Array(20).fill(0.01))
+    expect(events).toEqual([])
+    expect(state).toEqual(initialVadState)
+  })
+})
+
+describe('vadStep — mid-utterance pauses', () => {
+  it('does not split a turn on a short pause shorter than the hangover', () => {
+    // Speak, pause 500ms (< 800ms hangover), keep speaking: still ONE utterance.
+    const seq = [
+      SPEECH,
+      SPEECH, // speech-start
+      ...Array(5).fill(SILENCE), // 500ms pause, not enough to end
+      SPEECH,
+      SPEECH,
+    ]
+    const { events, state } = drive(seq)
+    expect(events).toEqual(['speech-start'])
+    expect(state.speaking).toBe(true)
+  })
+
+  it('resets the silence counter when speech resumes mid-utterance', () => {
+    // After resuming speech, a fresh full hangover is needed to end the turn.
+    const seq = [SPEECH, SPEECH, ...Array(5).fill(SILENCE), SPEECH, ...Array(7).fill(SILENCE)]
+    const { events, state } = drive(seq)
+    expect(events).toEqual(['speech-start'])
+    expect(state.speaking).toBe(true) // 700ms of trailing silence < 800ms
+  })
+})

--- a/packages/game-bombsquad/src/voice/voice-vad.ts
+++ b/packages/game-bombsquad/src/voice/voice-vad.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure client-side voice-activity detection (VAD) for the hands-free BombSquad
+ * voice session. Side-effect-free (no Web Audio, no React) so the turn-boundary
+ * state machine is unit-testable by feeding it a sequence of frame energies.
+ *
+ * Role (load-bearing): the deployed `@amiclaw/platform-ai` server runs its OWN
+ * ASR-endpoint VAD and fires every turn server-side (the client `turn` message is
+ * a tolerated no-op — see `session-do.ts`). So this VAD does NOT trigger the
+ * turn; it drives two CLIENT concerns the server gives no signal for:
+ *  1. the 3-state conversation indicator — `speech-start` flips the UI to
+ *     "listening", `utterance-end` flips it to "thinking" while the AI replies;
+ *  2. barge-in — `speech-start` while the AI is speaking stops local playback.
+ *
+ * The detector is a small pure reducer: `vadStep(state, rms, frameMs, config)`
+ * folds one analyzed frame's RMS into the running state and emits at most one
+ * boundary event. The hook owns the Web Audio side (computing RMS per capture
+ * frame and reacting to the events); this module only does the math + the state
+ * transition, so it can be exhaustively tested with plain number sequences.
+ */
+
+/** Tunable VAD parameters. All durations in milliseconds; RMS is in [0, 1]. */
+export interface VadConfig {
+  /** A frame whose RMS is at or above this is "speech"; below is "silence". */
+  speechThreshold: number
+  /**
+   * Trailing silence (after a qualified utterance) that marks end-of-utterance.
+   * Long enough that a natural mid-sentence pause does not split a turn.
+   */
+  silenceHangoverMs: number
+  /**
+   * Minimum CONTIGUOUS speech before a run counts as a real utterance. Debounces
+   * a single noise blip into nothing — a brief spike followed by silence never
+   * reaches this and is discarded.
+   */
+  minSpeechMs: number
+}
+
+/**
+ * Default thresholds. Conservative starting point for a noise-suppressed,
+ * echo-cancelled mic; the exact values want real-device tuning (flagged) — the
+ * silence floor and speech level vary with hardware, AGC, and room noise.
+ */
+export const DEFAULT_VAD_CONFIG: VadConfig = {
+  speechThreshold: 0.02,
+  silenceHangoverMs: 800,
+  minSpeechMs: 200,
+}
+
+/** Running detector state. Reset to `initialVadState` per session / per capture. */
+export interface VadState {
+  /** True while a qualified utterance is in progress (past `minSpeechMs`). */
+  speaking: boolean
+  /** Cumulative contiguous speech in the current (forming) utterance. */
+  speechMs: number
+  /** Trailing silence accumulated since the last speech frame. */
+  silenceMs: number
+}
+
+export const initialVadState: VadState = { speaking: false, speechMs: 0, silenceMs: 0 }
+
+/** At most one boundary event per analyzed frame. */
+export type VadEvent = 'speech-start' | 'utterance-end' | null
+
+export interface VadStepResult {
+  state: VadState
+  event: VadEvent
+}
+
+/**
+ * Root-mean-square amplitude of a mono Float32 frame (range [0, 1] for samples in
+ * [-1, 1]) — the energy proxy the VAD thresholds against. Rate-independent, so it
+ * is computed on the raw capture frame regardless of the context sample rate.
+ * An empty frame is silent (0).
+ */
+export function computeRms(frame: Float32Array): number {
+  if (frame.length === 0) return 0
+  let sum = 0
+  for (let i = 0; i < frame.length; i += 1) {
+    const s = frame[i]
+    sum += s * s
+  }
+  return Math.sqrt(sum / frame.length)
+}
+
+/**
+ * Fold one frame's RMS into the detector state, emitting a boundary event when a
+ * qualified utterance starts (`speech-start`, once `minSpeechMs` of contiguous
+ * speech is reached) or ends (`utterance-end`, after `silenceHangoverMs` of
+ * trailing silence). Pure and total: every (state, rms) maps to a defined next
+ * state. `frameMs` is the analyzed frame's wall-clock duration
+ * (`bufferSize / sampleRate`), passed per step so the detector is sample-rate
+ * agnostic.
+ */
+export function vadStep(
+  state: VadState,
+  rms: number,
+  frameMs: number,
+  config: VadConfig
+): VadStepResult {
+  const isSpeech = rms >= config.speechThreshold
+  let { speaking, speechMs, silenceMs } = state
+  let event: VadEvent = null
+
+  if (isSpeech) {
+    silenceMs = 0
+    speechMs += frameMs
+    if (!speaking && speechMs >= config.minSpeechMs) {
+      speaking = true
+      event = 'speech-start'
+    }
+  } else if (speaking) {
+    // Inside a live utterance: short pauses are tolerated; only sustained
+    // silence (>= hangover) ends it.
+    silenceMs += frameMs
+    if (silenceMs >= config.silenceHangoverMs) {
+      speaking = false
+      speechMs = 0
+      silenceMs = 0
+      event = 'utterance-end'
+    }
+  } else {
+    // Not yet a qualified utterance and this frame is silence: discard any
+    // partial speech so a brief blip cannot accumulate into a spurious utterance
+    // across long gaps (the noise debounce — speech must be contiguous to count).
+    speechMs = 0
+    silenceMs = 0
+  }
+
+  return { state: { speaking, speechMs, silenceMs }, event }
+}

--- a/packages/platform-ai/demo/fullduplex-probe.mjs
+++ b/packages/platform-ai/demo/fullduplex-probe.mjs
@@ -1,0 +1,131 @@
+/* eslint-disable no-console -- stdout CLI probe for the full-duplex backend. */
+// Full-duplex backend probe: verifies AI-FIRST greeting + hands-free AUTO-TURN
+// (no client `turn` message) against the deployed Worker. Phase 1 sends NO audio
+// and expects an AI opening turn. Phase 2 streams the speech fixture + trailing
+// silence (so the ASR endpoint-detects the utterance end) WITHOUT a `turn`
+// message and expects an auto-fired turn. Phase 3 repeats to test multi-utterance.
+import { readFileSync } from 'node:fs'
+
+const SAMPLE_RATE = 16000
+const FRAME_BYTES = 8192
+const url = process.argv.includes('--url')
+  ? process.argv[process.argv.indexOf('--url') + 1]
+  : 'wss://claw.amio.fans'
+const gameId = process.argv.includes('--gameId')
+  ? process.argv[process.argv.indexOf('--gameId') + 1]
+  : 'bombsquad'
+const fixturePath = process.argv.includes('--fixture')
+  ? process.argv[process.argv.indexOf('--fixture') + 1]
+  : 'demo/fixture-red-wire.pcm'
+
+const speech = new Uint8Array(readFileSync(fixturePath))
+
+const name = `fdx-${Math.random().toString(36).slice(2, 10)}`
+const ws = new WebSocket(`${url}/ai-ws/${name}`)
+
+const phase = { idx: 0, label: 'connect', text: '', frames: 0 }
+const log = (m) => console.log(`[${phase.label}] ${m}`)
+let idleTimer = null
+
+function streamBytes(bytes) {
+  for (let off = 0; off < bytes.byteLength; off += FRAME_BYTES) {
+    ws.send(bytes.slice(off, Math.min(off + FRAME_BYTES, bytes.byteLength)).buffer)
+  }
+}
+function startPhase(idx, label) {
+  if (phase.text || phase.frames)
+    log(`done — text="${phase.text.slice(0, 80)}" frames=${phase.frames}`)
+  phase.idx = idx
+  phase.label = label
+  phase.text = ''
+  phase.frames = 0
+}
+// Advance to the next phase after a quiet gap (a turn's chunks stopped arriving).
+function bumpIdle(ms, next) {
+  if (idleTimer) clearTimeout(idleTimer)
+  idleTimer = setTimeout(next, ms)
+}
+
+ws.addEventListener('open', () => {
+  startPhase(1, 'ai-first')
+  ws.send(
+    JSON.stringify({
+      type: 'create',
+      gameId,
+      manualData: {
+        version: 'fdx',
+        sections: { button: { rule: 'Describe the button color and label.' } },
+      },
+      gameState: { relevantSections: ['button'] },
+    })
+  )
+})
+
+ws.addEventListener('message', (event) => {
+  if (typeof event.data !== 'string') return
+  let msg
+  try {
+    msg = JSON.parse(event.data)
+  } catch {
+    return
+  }
+  if (msg.type === 'created') {
+    log(`session created: ${msg.sessionId} — waiting for AI-FIRST greeting (no audio sent)…`)
+    // If no greeting arrives within 12s, move on to the auto-turn test anyway.
+    bumpIdle(12000, () => runAutoTurn(2, 'auto-turn-1'))
+    return
+  }
+  if (msg.type === 'chunk') {
+    if (msg.kind === 'text' && msg.text) phase.text += msg.text
+    else if (msg.kind === 'audio' && msg.audio) phase.frames += 1
+    // A response started → the endpoint fired a turn; stop the mic-mimic silence.
+    if (phase.idx >= 2) stopContinuousSilence()
+    // Each chunk resets the idle gap; when chunks stop for 6s, advance.
+    if (phase.idx === 1) bumpIdle(6000, () => runAutoTurn(2, 'auto-turn-1'))
+    else if (phase.idx === 2) bumpIdle(6000, () => runAutoTurn(3, 'auto-turn-2'))
+    else if (phase.idx === 3) bumpIdle(6000, finish)
+    return
+  }
+  if (msg.type === 'error') log(`server error: ${msg.code} — ${msg.message}`)
+})
+
+let silenceTimer = null
+function stopContinuousSilence() {
+  if (silenceTimer) {
+    clearInterval(silenceTimer)
+    silenceTimer = null
+  }
+}
+function runAutoTurn(idx, label) {
+  startPhase(idx, label)
+  log('streaming speech, then CONTINUOUS silence (mimic real mic, NO turn message)…')
+  streamBytes(speech)
+  // Keep the audio stream alive like a real mic: send a 256ms silence frame
+  // every 200ms so the ASR never hits its 8s inter-packet timeout, and its VAD
+  // can endpoint-detect the (speech-then-silence) utterance and auto-fire a turn.
+  const frame = new Uint8Array(SAMPLE_RATE * 2 * 0.256)
+  silenceTimer = setInterval(() => {
+    if (ws.readyState === WebSocket.OPEN) ws.send(frame.buffer.slice(0))
+  }, 200)
+  // Once a turn's chunks arrive, the message handler advances; here we just cap
+  // the wait. Stop the silence once we've seen a response (handled in onmessage).
+  bumpIdle(25000, () => {
+    stopContinuousSilence()
+    if (!phase.text && !phase.frames)
+      log('NO auto-turn within 25s of continuous audio — endpoint never fired')
+    if (idx === 2) runAutoTurn(3, 'auto-turn-2')
+    else finish()
+  })
+}
+function finish() {
+  if (phase.text || phase.frames)
+    log(`done — text="${phase.text.slice(0, 80)}" frames=${phase.frames}`)
+  ws.send(JSON.stringify({ type: 'end' }))
+  setTimeout(() => process.exit(0), 2000)
+}
+
+ws.addEventListener('close', (e) => {
+  console.log(`\n[close] code=${e.code} reason="${e.reason || ''}"`)
+  process.exit(0)
+})
+ws.addEventListener('error', () => console.log('[error] websocket error'))

--- a/packages/platform-ai/demo/live-turn.mjs
+++ b/packages/platform-ai/demo/live-turn.mjs
@@ -158,6 +158,11 @@ async function main() {
         gameId: args.gameId,
         manualData: MANUAL_DATA,
         gameState: GAME_STATE,
+        // This harness verifies ONE client-`turn`-driven player turn in
+        // isolation; suppress the AI-first opening greeting so the first
+        // `done:true` chunk belongs to the player turn (not the greeting), which
+        // is what the `end`-on-done step keys off.
+        opening: false,
       })
     )
   })

--- a/packages/platform-ai/src/session-do-test-kit.ts
+++ b/packages/platform-ai/src/session-do-test-kit.ts
@@ -208,12 +208,19 @@ export async function settle(): Promise<void> {
  * Send the `create` control message over the socket; return the minted session
  * id. Awaits the `created` ack (the DO's create branch first awaits the
  * best-effort, here absent, companion-context resolution).
+ *
+ * The AI-first opening greeting defaults to OFF here so the guard / cleanup /
+ * metering suites stay isolated from the greeting's chunk stream; pass
+ * `{ opening: true }` to exercise the AI-first path.
  */
 export async function createSessionOverWs(
   socket: TestSocket,
-  gameId = 'demo-mock'
+  gameId = 'demo-mock',
+  opts: { opening?: boolean } = {}
 ): Promise<string> {
-  socket.send(JSON.stringify({ type: 'create', gameId, manualData: MANUAL }))
+  socket.send(
+    JSON.stringify({ type: 'create', gameId, manualData: MANUAL, opening: opts.opening ?? false })
+  )
   await waitForMessage(socket, 'created')
   const created = socket.messagesOfType('created').at(-1) as { type: string; sessionId?: string }
   if (created.sessionId === undefined) throw new Error('created ack carried no sessionId')

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -7,11 +7,15 @@
  *   - It implements the four-method contract semantics
  *     (`createSession` / `onPlayerAudio` / `onAiResponse` / `endSession`),
  *     enforcing `sessionId <-> userId` ownership on every operation.
- *   - It drives `runTurn` over the WebSocket: inbound binary frames are player
- *     audio; outbound `AiResponseChunk`s are serialized back to the player.
+ *   - It drives `runTurn` over the WebSocket: the player pushes binary audio
+ *     frames, then a client `turn` control message fires the turn; outbound
+ *     `AiResponseChunk`s are serialized back to the player. The client owns turn
+ *     detection (its VAD sends `turn` when the player stops speaking).
+ *   - On `create` it also fires an AI-first opening greeting (`runOpeningTurn`,
+ *     LLM->TTS, no player audio) so the AI speaks first, when enabled (default).
  *
- * The orchestration logic itself lives in `runTurn` (pure, provider-mocked
- * unit tests); this class is the DO/WS adapter around it.
+ * The orchestration logic itself lives in `runTurn` / `runOpeningTurn` (pure,
+ * provider-mocked unit tests); this class is the DO/WS adapter around them.
  *
  * The class extends the Cloudflare Agents SDK `Agent` base (over `partyserver`),
  * with hibernation deliberately OFF (`static options = { hibernate: false }`).
@@ -74,8 +78,8 @@ import type { AiResponseChunk, AudioChunk, ManualData, SessionSummary } from './
 import type { GameState } from './manual-injection'
 import type { ProviderEnv } from './providers/factory'
 import { assembleSession } from './session-assembly'
-import { traceTurn } from './trace'
-import { runTurn, type SessionState, type TurnProviders } from './turn-pipeline'
+import { traceTurn, traceTurnError } from './trace'
+import { runOpeningTurn, runTurn, type SessionState, type TurnProviders } from './turn-pipeline'
 import { flushSessionUsage, type UsageKvWriter } from './usage-flush'
 import {
   assertSessionOwnership,
@@ -111,6 +115,13 @@ interface CreateSessionMessage {
    * metadata only — it never affects session behaviour.
    */
   gameRunId?: string
+  /**
+   * Whether the AI opens the conversation with an unprompted greeting turn
+   * (LLM->TTS, no player audio) right after the session is established. Defaults
+   * to `true` — AI-first is the product behaviour. A consumer (or a test) sets
+   * `false` to suppress the greeting.
+   */
+  opening?: boolean
 }
 
 /**
@@ -767,6 +778,90 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
   }
 
   /**
+   * Stream one turn's `AiResponseChunk`s to the socket under the serial-turn
+   * guard, shared by the client-`turn` path (STT->LLM->TTS via `runTurn`) and
+   * the AI-first opening greeting (LLM->TTS via `runOpeningTurn`).
+   *
+   * Holds the iterator explicitly (so a mid-turn `end` / owner close can cancel
+   * it via `return()`) and captures this turn's generation (`myEpoch`) at the
+   * same synchronous point the shared `turnInFlight`/`activeTurn` fields are set,
+   * so the `finally` clears the guard on every exit (normal end, provider error,
+   * cancellation) — but ONLY while this turn is still the live generation: a
+   * stale `finally` whose session was already ended/dropped must not null out a
+   * newer session's `turnInFlight`/`activeTurn` (see `turnEpoch`).
+   */
+  private async streamTurn(ws: Connection, turn: AsyncIterator<AiResponseChunk>): Promise<void> {
+    const myEpoch = this.turnEpoch
+    this.activeTurn = turn
+    this.turnInFlight = true
+    try {
+      for (;;) {
+        const next = await turn.next()
+        if (next.done) break
+        const chunk = next.value
+        if (chunk.kind === 'audio' && chunk.audio) {
+          ws.send(
+            JSON.stringify({
+              type: 'chunk',
+              kind: 'audio',
+              audio: base64FromBytes(chunk.audio),
+              done: chunk.done,
+            })
+          )
+        } else {
+          ws.send(
+            JSON.stringify({
+              type: 'chunk',
+              kind: 'text',
+              text: chunk.text ?? '',
+              done: chunk.done,
+            })
+          )
+        }
+      }
+    } finally {
+      if (this.turnEpoch === myEpoch) {
+        this.turnInFlight = false
+        this.activeTurn = undefined
+      }
+    }
+  }
+
+  /**
+   * Fire the AI-first opening greeting: an LLM->TTS-only turn from the
+   * server-side `OPENING_DIRECTIVE`, streamed to the socket with NO player audio.
+   * Background-launched on `create` (when enabled), so it owns its own errors:
+   * fail-loud (a provider error closes the OWNER socket with a 1008 policy close,
+   * exactly as the synchronous control path does) and self-fencing (the epoch
+   * guard inside `streamTurn` makes a stale `finally` a no-op, and the catch
+   * skips the close once a teardown has advanced the generation). The synthetic
+   * directive is never persisted and the greeting does not count as a player turn
+   * (see `runOpeningTurn`).
+   */
+  private async runOpeningGreeting(ws: Connection): Promise<void> {
+    const myEpoch = this.turnEpoch
+    try {
+      if (!this.sessionState || !this.providers || this.sessionId === undefined) return
+      traceTurn('turn', 'opening-start', { sessionId: this.sessionId })
+      const turn = runOpeningTurn(this.providers, this.sessionState)[Symbol.asyncIterator]()
+      await this.streamTurn(ws, turn)
+    } catch (err: unknown) {
+      // Skip the fail-loud close once a teardown has advanced the generation
+      // (the session this greeting belonged to is gone; a newer session may own
+      // the socket now).
+      if (this.turnEpoch === myEpoch) {
+        const reason = err instanceof Error ? err.message : 'opening greeting failed'
+        traceTurnError('turn', 'opening-error', { messageChars: reason.length })
+        try {
+          ws.close(1008, safeCloseReason(reason))
+        } catch {
+          // socket already gone — nothing to fail loud on.
+        }
+      }
+    }
+  }
+
+  /**
    * Reject cross-session / cross-user access. Delegates to the pure
    * `assertSessionOwnership` predicate (the L2 ownership invariant —
    * `onPlayerAudio` / `onAiResponse` / `endSession` verify ownership).
@@ -852,6 +947,13 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
         // (`already_created`) never repoints the owner.
         this.ownerSocket = ws
         ws.send(JSON.stringify({ type: 'created', sessionId }))
+        // AI speaks first: fire the opening greeting (LLM->TTS, no player audio)
+        // in the background, when enabled (default on — AI-first is the product
+        // behaviour). `runOpeningGreeting` owns its own errors (fail-loud 1008 on
+        // a provider error) and is epoch-fenced, so it is fire-and-forget; a
+        // mid-greeting `end`/owner close cancels it through the same
+        // `activeTurn`/`turnEpoch` machinery as a client turn.
+        if (msg.opening ?? true) void this.runOpeningGreeting(ws)
         return
       }
       case 'turn': {
@@ -877,65 +979,17 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
         traceTurn('turn', 'start', {
           sessionId,
         })
-        // Stream the AI response chunks back. Text rides as JSON; audio is
-        // base64-encoded so the whole turn stays on the JSON text channel and
-        // the binary frame direction remains player-audio-only. Ownership is
-        // checked against THIS socket's user, so a second client on the same DO
-        // cannot drive the first user's session.
-        //
-        // Hold the iterator explicitly so a mid-turn `end` / owner close can
-        // cancel it via `return()`. Mark in-flight BEFORE the first `await`
-        // (synchronous up to here) so an interleaved second `turn` sees the
-        // guard set. Capture THIS turn's generation (`myEpoch`) at the same
-        // synchronous point the shared fields are set, so the `finally` can tell
-        // "still my session" from "a newer session reused this DO after my
-        // session was torn down". The `finally` clears the guard + iterator on
-        // every exit (normal end, provider error, or cancellation) so the next
-        // turn can run — but ONLY while this turn is still the live generation
-        // (see `turnEpoch`): a stale `finally` whose session was already ended/
-        // dropped must not null out a newer session's `turnInFlight`/`activeTurn`.
+        // Stream the AI response chunks back under the serial-turn guard. Text
+        // rides as JSON; audio is base64-encoded so the whole turn stays on the
+        // JSON text channel and the binary frame direction remains
+        // player-audio-only. Ownership is checked against THIS socket's user (in
+        // `onAiResponse`), so a second client on the same DO cannot drive the
+        // first user's session. `streamTurn` owns the `turnInFlight`/`activeTurn`/
+        // `turnEpoch` machinery (see its docstring), so a mid-turn `end`/owner
+        // close cancels cleanly and a stale `finally` cannot clobber a newer
+        // session's guard.
         const turn = this.onAiResponse(sessionId, socketUserId)[Symbol.asyncIterator]()
-        const myEpoch = this.turnEpoch
-        this.activeTurn = turn
-        this.turnInFlight = true
-        try {
-          for (;;) {
-            const next = await turn.next()
-            if (next.done) break
-            const chunk = next.value
-            if (chunk.kind === 'audio' && chunk.audio) {
-              ws.send(
-                JSON.stringify({
-                  type: 'chunk',
-                  kind: 'audio',
-                  audio: base64FromBytes(chunk.audio),
-                  done: chunk.done,
-                })
-              )
-            } else {
-              ws.send(
-                JSON.stringify({
-                  type: 'chunk',
-                  kind: 'text',
-                  text: chunk.text ?? '',
-                  done: chunk.done,
-                })
-              )
-            }
-          }
-        } finally {
-          // Epoch guard: only release the guard + iterator if THIS turn is still
-          // the live generation. If `clearSession` (end / owner-close) already
-          // bumped the epoch and a newer session is running on this resident DO,
-          // `this.turnEpoch !== myEpoch` and we leave the new session's
-          // `turnInFlight`/`activeTurn` untouched — the stale `finally` is a
-          // no-op. In the normal single-session path the epoch is unchanged, so
-          // this clears exactly as before.
-          if (this.turnEpoch === myEpoch) {
-            this.turnInFlight = false
-            this.activeTurn = undefined
-          }
-        }
+        await this.streamTurn(ws, turn)
         return
       }
       case 'end': {

--- a/packages/platform-ai/src/session-opening-greeting.test.ts
+++ b/packages/platform-ai/src/session-opening-greeting.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Production-class tests for the AI-first opening greeting on the REAL
+ * `VoiceSessionDO` under the workerd runtime (`@cloudflare/vitest-pool-workers`).
+ *
+ * Right after `create`, the DO runs an opening greeting turn (LLM->TTS, NO
+ * player audio) from the server-side opening directive — the AI speaks first.
+ * Turn detection itself lives on the client (its VAD sends a `turn` message);
+ * the per-turn STT->LLM->TTS path is covered by the turn-guard / pipeline suites.
+ *
+ * Harness details: see `session-do-test-kit.ts`.
+ */
+
+import {
+  createSessionOverWs,
+  makeSessionDo,
+  messagesOfType,
+  openSocket,
+  sawDoneChunk,
+  settle,
+  waitFor,
+  waitForMessage,
+} from './session-do-test-kit'
+
+const END = JSON.stringify({ type: 'end' })
+
+describe('real VoiceSessionDO — AI-first opening greeting', () => {
+  it('streams an unprompted greeting turn right after create, with no player audio', async () => {
+    // Real demo-mock providers: the mock LLM greets, the mock TTS synthesizes —
+    // no player audio, no `turn` message.
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket, 'demo-mock', { opening: true })
+
+    // The greeting streams text + audio and completes with a terminal done chunk,
+    // purely from the server-side opening directive.
+    await waitFor(() => sawDoneChunk(socket), 'opening greeting completed')
+    const textChunks = messagesOfType(socket, 'chunk').filter(
+      (c) => c.kind === 'text' && c.text !== ''
+    )
+    expect(textChunks.length).toBeGreaterThan(0)
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    // The opening greeting is not a player turn — turnCount stays 0.
+    const summary = messagesOfType(socket, 'summary')[0].summary as { turnCount: number }
+    expect(summary.turnCount).toBe(0)
+  })
+
+  it('suppresses the greeting when opening is false (no chunks stream after create)', async () => {
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket, 'demo-mock', { opening: false })
+    await settle()
+
+    expect(messagesOfType(socket, 'chunk')).toEqual([])
+    expect(sawDoneChunk(socket)).toBe(false)
+  })
+})

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { runTurn, splitSentences, type SessionState, type TurnProviders } from './turn-pipeline'
+import {
+  OPENING_DIRECTIVE,
+  runOpeningTurn,
+  runTurn,
+  splitSentences,
+  type SessionState,
+  type TurnProviders,
+} from './turn-pipeline'
 import { createDeepSeekLlmProvider } from './providers/deepseek'
 import type { AiResponseChunk, AudioChunk, ManualData } from './contract'
 import type {
@@ -516,5 +523,77 @@ describe('runTurn', () => {
       // The turn's cleanup ran: the TTS iterator was returned, nothing leaked.
       expect(ttsClosed).toBe(true)
     })
+  })
+})
+
+// --- runOpeningTurn: the AI-first greeting (LLM->TTS, no player audio) --------
+
+describe('runOpeningTurn', () => {
+  it('runs LLM+TTS with NO player audio, greeting from the server directive', async () => {
+    const ttsReceived: string[] = []
+    let captured: LlmCompletionRequest | undefined
+    const state = freshState()
+    const chunks = await collect(
+      runOpeningTurn(
+        {
+          llm: mockLlm(['你好！', '请描述你看到的。'], { capture: (r) => (captured = r) }),
+          tts: mockTts(ttsReceived),
+        },
+        state
+      )
+    )
+
+    // No STT step: the synthetic, server-side opening directive stands in for the
+    // (absent) player utterance — it is NEVER client-provided.
+    expect(captured?.messages[0].role).toBe('system')
+    expect(captured?.messages.at(-1)).toEqual({ role: 'user', content: OPENING_DIRECTIVE })
+
+    // The greeting streams as text + audio chunks plus exactly one terminal done.
+    const textChunks = chunks.filter((c) => c.kind === 'text' && !c.done)
+    expect(textChunks.map((c) => c.text)).toEqual(['你好！', '请描述你看到的。'])
+    expect(chunks.filter((c) => c.kind === 'audio').length).toBeGreaterThan(0)
+    expect(chunks.filter((c) => c.done)).toHaveLength(1)
+    expect(ttsReceived).toEqual(['你好！', '请描述你看到的。'])
+
+    // History remembers ONLY the greeting (never the synthetic directive), and the
+    // opening turn does not count as a player turn.
+    expect(state.history).toEqual([{ role: 'assistant', content: '你好！请描述你看到的。' }])
+    expect(state.turnCount).toBe(0)
+  })
+
+  it('AI-speaks-first ordering: the greeting precedes the first player turn in context', async () => {
+    const state = freshState()
+    await collect(runOpeningTurn({ llm: mockLlm(['你好。']), tts: mockTts([]) }, state))
+
+    let captured: LlmCompletionRequest | undefined
+    await collect(
+      runTurn(
+        providers(
+          mockStt([{ text: '红色按钮。', isFinal: true }]),
+          mockLlm(['好的。'], { capture: (r) => (captured = r) }),
+          mockTts([])
+        ),
+        state,
+        fromArray<AudioChunk>([new Uint8Array([1])])
+      )
+    )
+
+    // The first player turn sees the AI's own greeting as prior context, then the
+    // player's transcribed utterance — exactly: system, assistant greeting, user.
+    expect(captured?.messages).toEqual([
+      { role: 'system', content: captured?.messages[0].content },
+      { role: 'assistant', content: '你好。' },
+      { role: 'user', content: '红色按钮。' },
+    ])
+    expect(state.turnCount).toBe(1)
+  })
+
+  it('does not meter STT for the opening turn (no audio consumed)', async () => {
+    const state = freshState()
+    await collect(runOpeningTurn({ llm: mockLlm(['hi.']), tts: mockTts([]) }, state))
+    // The opening turn consumes no player audio, so STT seconds stay zero and the
+    // session's STT annotation is untouched (still its initial provider-reported).
+    expect(state.usage.sttInputSeconds).toBe(0)
+    expect(state.sttSource).toBe('provider-reported')
   })
 })

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -227,53 +227,73 @@ class SentenceQueue {
 }
 
 /**
- * Run one player turn end to end.
- *
- * Yields the turn's `AiResponseChunk`s in order: incremental `text` chunks as
- * the LLM streams, `audio` chunks as TTS synthesizes the segmented sentences,
- * and exactly one terminal chunk with `done: true`. Mutates `state` (history,
- * turnCount, usage) as a side effect so the next turn sees this turn's context.
- *
- * I/O-free beyond driving the injected providers (it never touches the network,
- * a clock, or a socket directly) — fully unit-testable with mocked STT/LLM/TTS.
+ * Server-side opening directive for the AI-first greeting turn. This rides as
+ * the synthetic `user` message of the opening turn so the LLM has a turn to
+ * respond to; it is NEVER client-provided and NEVER persisted into history (the
+ * greeting it elicits is). The persona's own language rule (e.g. bombsquad's
+ * "always Chinese") governs the greeting language — the directive only sets the
+ * INTENT (greet + invite the player to describe what they see), not the words.
  */
-export async function* runTurn(
-  providers: TurnProviders,
-  state: SessionState,
-  audio: AsyncIterable<AudioChunk>
-): AsyncIterable<AiResponseChunk> {
-  // 1. STT: transcribe the player's audio; take the final cumulative transcript.
-  //    `audioBytes` is the inbound-frame byte total — the fallback STT metering
-  //    source at turn settle when the adapter reports no structured usage.
-  const turnStart = Date.now()
-  traceTurn('turn', 'pipeline-start', {
-    turnCount: state.turnCount,
-  })
-  const { transcript: playerText, audioBytes: sttAudioBytes } = await collectFinalTranscript(
-    providers.stt,
-    audio
-  )
-  // ASR hop boundary: the final cumulative transcript is in hand (length only —
-  // never the text). An empty transcript here explains a downstream LLM no-op.
-  traceTurn('asr', 'final-transcript', {
-    transcriptChars: playerText.length,
-    elapsedMs: Date.now() - turnStart,
-  })
+export const OPENING_DIRECTIVE =
+  '[session start] Open the conversation now. Greet the player warmly in their own ' +
+  'language and invite them to describe the current module — what they see on the ' +
+  'device in front of them. Keep it to one or two short sentences.'
 
-  // 2. Inject: deterministic system message (role + rules + manual subset),
-  //    then the rolling history, then this turn's player utterance.
-  const systemMessages = assembleLlmContext({
+/** The loop-internal tally a settled LLM+TTS turn reports back to its caller. */
+interface LlmTtsResult {
+  assistantText: string
+  ttsAudioBytes: number
+  llmDeltaCount: number
+  sentenceCount: number
+  ttsFrameCount: number
+}
+
+/** Assemble the deterministic server-side system message(s) for a turn. */
+function assembleSystem(state: SessionState): ChatMessage[] {
+  return assembleLlmContext({
     systemPromptConfig: state.config.systemPromptConfig,
     manualData: state.manualData,
     gameState: state.gameState,
     ...(state.companionContext !== undefined ? { companionContext: state.companionContext } : {}),
   })
-  const userMessage: ChatMessage = { role: 'user', content: playerText }
-  const messages: ChatMessage[] = [...systemMessages, ...state.history, userMessage]
+}
 
-  // 3. LLM + 4. TTS run concurrently: the LLM loop segments text into sentences
-  //    and feeds a queue the TTS provider drains. We interleave text chunks
-  //    (as the LLM streams) with audio chunks (as TTS produces them).
+/** Apply the LLM token usage + TTS output-seconds of a settled turn to state. */
+function applyLlmTtsUsage(
+  providers: Pick<TurnProviders, 'llm'>,
+  state: SessionState,
+  result: LlmTtsResult
+): { outputTokens?: number } {
+  const usage = (providers.llm as MaybeUsageProvider).lastUsage
+  if (usage) {
+    state.usage.llmInputTokens += usage.inputTokens
+    state.usage.llmOutputTokens += usage.outputTokens
+  }
+  // TTS seconds: exact conversion of the actual synthesized product — the byte
+  // tally of every audio frame this turn yielded, under the adapters' fixed
+  // PCM16 mono 16 kHz output contract.
+  state.usage.ttsOutputSeconds += audioSecondsFromBytes(result.ttsAudioBytes)
+  return { outputTokens: usage?.outputTokens }
+}
+
+/**
+ * The shared LLM->TTS half of a turn: given the fully-assembled `messages`, run
+ * the LLM stream and TTS concurrently and yield the interleaved `text`/`audio`
+ * chunks (NO terminal `done` — the caller emits that after its own settle). It
+ * is I/O-free beyond driving the injected LLM/TTS providers, and reports the
+ * per-turn tally as the generator's return value so the caller can settle usage
+ * and history. Reused by both `runTurn` (player-audio turn) and
+ * `runOpeningTurn` (the AI-first greeting).
+ */
+async function* streamLlmTts(
+  providers: Pick<TurnProviders, 'llm' | 'tts'>,
+  model: string,
+  messages: ChatMessage[],
+  turnStart: number
+): AsyncGenerator<AiResponseChunk, LlmTtsResult> {
+  // LLM + TTS run concurrently: the LLM loop segments text into sentences and
+  // feeds a queue the TTS provider drains. We interleave text chunks (as the
+  // LLM streams) with audio chunks (as TTS produces them).
   const sentenceQueue = new SentenceQueue()
   const ttsIterator = providers.tts.synthesize(sentenceQueue)[Symbol.asyncIterator]()
 
@@ -300,7 +320,7 @@ export async function* runTurn(
 
   const llmStream = providers.llm
     .streamCompletion({
-      model: state.config.llm.model,
+      model,
       messages,
     })
     [Symbol.asyncIterator]()
@@ -425,17 +445,58 @@ export async function* runTurn(
     await llmStream.return?.(undefined)
   }
 
+  return { assistantText, ttsAudioBytes, llmDeltaCount, sentenceCount, ttsFrameCount }
+}
+
+/**
+ * Run one player turn end to end (player audio -> STT -> LLM -> TTS).
+ *
+ * Yields the turn's `AiResponseChunk`s in order: incremental `text` chunks as
+ * the LLM streams, `audio` chunks as TTS synthesizes the segmented sentences,
+ * and exactly one terminal chunk with `done: true`. Mutates `state` (history,
+ * turnCount, usage) as a side effect so the next turn sees this turn's context.
+ *
+ * I/O-free beyond driving the injected providers (it never touches the network,
+ * a clock, or a socket directly) — fully unit-testable with mocked STT/LLM/TTS.
+ */
+export async function* runTurn(
+  providers: TurnProviders,
+  state: SessionState,
+  audio: AsyncIterable<AudioChunk>
+): AsyncIterable<AiResponseChunk> {
+  // 1. STT: transcribe the player's audio; take the final cumulative transcript.
+  //    `audioBytes` is the inbound-frame byte total — the fallback STT metering
+  //    source at turn settle when the adapter reports no structured usage.
+  const turnStart = Date.now()
+  traceTurn('turn', 'pipeline-start', {
+    turnCount: state.turnCount,
+  })
+  const { transcript: playerText, audioBytes: sttAudioBytes } = await collectFinalTranscript(
+    providers.stt,
+    audio
+  )
+  // ASR hop boundary: the final cumulative transcript is in hand (length only —
+  // never the text). An empty transcript here explains a downstream LLM no-op.
+  traceTurn('asr', 'final-transcript', {
+    transcriptChars: playerText.length,
+    elapsedMs: Date.now() - turnStart,
+  })
+
+  // 2. Inject: deterministic system message (role + rules + manual subset),
+  //    then the rolling history, then this turn's player utterance.
+  const userMessage: ChatMessage = { role: 'user', content: playerText }
+  const messages: ChatMessage[] = [...assembleSystem(state), ...state.history, userMessage]
+
+  // 3. LLM + 4. TTS run concurrently via the shared half.
+  const result = yield* streamLlmTts(providers, state.config.llm.model, messages, turnStart)
+
   // 5. Settle turn state: record history, count, and usage; emit the terminal
   //    chunk so the consumer can close out the turn.
   state.history.push(userMessage)
-  state.history.push({ role: 'assistant', content: assistantText })
+  state.history.push({ role: 'assistant', content: result.assistantText })
   state.turnCount += 1
 
-  const usage = (providers.llm as MaybeUsageProvider).lastUsage
-  if (usage) {
-    state.usage.llmInputTokens += usage.inputTokens
-    state.usage.llmOutputTokens += usage.outputTokens
-  }
+  const { outputTokens } = applyLlmTtsUsage(providers, state, result)
   // STT seconds: prefer the adapter's structured usage report (the Volcengine
   // adapter exposes the server's `audio_info.duration` when reported, or its
   // own exact bytes->duration conversion when not). When the adapter exposes
@@ -450,11 +511,6 @@ export async function* runTurn(
     state.usage.sttInputSeconds += audioSecondsFromBytes(sttAudioBytes)
     state.sttSource = 'derived-from-bytes'
   }
-  // TTS seconds: exact conversion of the actual synthesized product — the byte
-  // tally of every audio frame this turn yielded, under the adapters' fixed
-  // PCM16 mono 16 kHz output contract (the Volcengine TTS session requests
-  // exactly that format; the mock's placeholder bytes meter the same way).
-  state.usage.ttsOutputSeconds += audioSecondsFromBytes(ttsAudioBytes)
 
   // Turn settle: the per-turn accounting boundary. The counts here are the
   // single most diagnostic line for the silent-park — e.g. llmDeltaCount:0 +
@@ -462,11 +518,55 @@ export async function* runTurn(
   // ttsFrameCount:0 isolates TTS at the LLM->TTS boundary.
   traceTurn('turn', 'settle', {
     turnCount: state.turnCount,
-    llmDeltaCount,
-    llmOutputTokens: usage?.outputTokens,
-    sentenceCount,
-    ttsFrameCount,
-    ttsAudioBytes,
+    llmDeltaCount: result.llmDeltaCount,
+    llmOutputTokens: outputTokens,
+    sentenceCount: result.sentenceCount,
+    ttsFrameCount: result.ttsFrameCount,
+    ttsAudioBytes: result.ttsAudioBytes,
+    elapsedMs: Date.now() - turnStart,
+  })
+
+  yield { kind: 'text', text: '', done: true }
+}
+
+/**
+ * Run the AI-first opening greeting — an LLM+TTS-only turn the DO fires on
+ * session establishment, with NO player-audio STT step. The server-side
+ * {@link OPENING_DIRECTIVE} stands in for the (absent) player utterance so the
+ * LLM opens the conversation in the persona's voice.
+ *
+ * Yields the same ordered `AiResponseChunk` stream as `runTurn` (text + audio +
+ * one terminal `done`), reusing the shared LLM->TTS half. The synthetic
+ * directive is NEVER persisted to history (only the greeting it produces is),
+ * and the greeting does NOT count toward `turnCount` — it is not a player turn.
+ * STT seconds are not metered here (no player audio is consumed). Mutates
+ * `state` (history, LLM/TTS usage). I/O-free beyond the injected LLM/TTS
+ * providers.
+ */
+export async function* runOpeningTurn(
+  providers: Pick<TurnProviders, 'llm' | 'tts'>,
+  state: SessionState
+): AsyncIterable<AiResponseChunk> {
+  const turnStart = Date.now()
+  const userMessage: ChatMessage = { role: 'user', content: OPENING_DIRECTIVE }
+  const messages: ChatMessage[] = [...assembleSystem(state), ...state.history, userMessage]
+
+  const result = yield* streamLlmTts(providers, state.config.llm.model, messages, turnStart)
+
+  // Settle. The opening directive is synthetic and must never leak into history
+  // (the greeting it elicits is the only thing remembered). turnCount tracks
+  // player->AI turns, so the opening greeting does not increment it.
+  state.history.push({ role: 'assistant', content: result.assistantText })
+
+  const { outputTokens } = applyLlmTtsUsage(providers, state, result)
+
+  traceTurn('turn', 'opening-settle', {
+    turnCount: state.turnCount,
+    llmDeltaCount: result.llmDeltaCount,
+    llmOutputTokens: outputTokens,
+    sentenceCount: result.sentenceCount,
+    ttsFrameCount: result.ttsFrameCount,
+    ttsAudioBytes: result.ttsAudioBytes,
     elapsedMs: Date.now() - turnStart,
   })
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,6 +36,44 @@ function mirrorGherkinToFeatures(srcDir: string, destDir: string): void {
 mirrorGherkinToFeatures('e2e', '.features-mirror')
 
 /**
+ * The hands-free mode② voice panel opens the mic continuously and runs a client
+ * VAD over the capture stream. Chromium's DEFAULT fake audio device emits a
+ * ~0.13-RMS tone — well above the panel's 0.02 VAD speech threshold — which would
+ * fire a spurious "player is speaking" turn + barge-in that wipes the AI greeting
+ * the e2e asserts. Feeding the fake device a SILENT capture file keeps the
+ * continuous mic deterministically quiet (RMS 0), so no player turn / barge-in
+ * ever fires and only the AI-first greeting drives the asserted UI states. The
+ * file is generated here (gitignored `.cache/`) and handed to Chromium via
+ * `--use-file-for-fake-audio-capture`.
+ */
+const SILENT_MIC_WAV = join(process.cwd(), '.cache', 'e2e', 'fake-mic-silence.wav')
+
+function writeSilentMicWav(file: string): void {
+  const sampleRate = 16_000
+  const dataBytes = sampleRate * 2 // 1s of mono 16-bit silence; Chromium loops it.
+  const buf = Buffer.alloc(44 + dataBytes)
+  buf.write('RIFF', 0)
+  buf.writeUInt32LE(36 + dataBytes, 4)
+  buf.write('WAVE', 8)
+  buf.write('fmt ', 12)
+  buf.writeUInt32LE(16, 16)
+  buf.writeUInt16LE(1, 20) // PCM
+  buf.writeUInt16LE(1, 22) // mono
+  buf.writeUInt32LE(sampleRate, 24)
+  buf.writeUInt32LE(sampleRate * 2, 28) // byte rate
+  buf.writeUInt16LE(2, 32) // block align
+  buf.writeUInt16LE(16, 34) // bits per sample
+  buf.write('data', 36)
+  buf.writeUInt32LE(dataBytes, 40)
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, buf)
+}
+
+// Only the main process writes the file (workers just reference the path); the
+// guard mirrors mirrorGherkinToFeatures so concurrent worker loads don't race.
+if (process.env.TEST_WORKER_INDEX === undefined) writeSilentMicWav(SILENT_MIC_WAV)
+
+/**
  * `tags: '@playwright'` is load-bearing: only `@playwright`-tagged scenarios
  * are turned into runnable specs, so `@simulation` scenarios (the out-of-scope
  * dual-agent layer) never need step definitions. Generated specs land in
@@ -73,19 +111,27 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        // The mode② voice-panel scenario needs a deterministic mic + audio:
+        // The mode② hands-free voice-panel scenario needs a deterministic mic +
+        // audio:
         //  - fake media: getUserMedia returns a synthetic mic stream and the
-        //    permission prompt is auto-accepted, so push-to-talk capture works
+        //    permission prompt is auto-accepted, so the continuous capture works
         //    headless with no real device.
+        //  - SILENT capture file: the panel runs a client VAD over the open mic;
+        //    Chromium's default fake audio tone (~0.13 RMS) would cross the 0.02
+        //    VAD threshold and fire a spurious player turn + barge-in that wipes
+        //    the asserted AI greeting, so the fake device is fed a silent WAV
+        //    (RMS 0) — the mic stays deterministically quiet and only the AI-first
+        //    greeting drives the asserted UI states.
         //  - autoplay relaxation: the panel's TTS AudioContext can start without
-        //    a user-gesture gate, so the "AI is speaking" playback indicator
-        //    fires deterministically.
+        //    a user-gesture gate, so the "说话中" playback indicator fires and its
+        //    `onended` lets the panel settle back to "聆听中" deterministically.
         // Harmless to every other scenario (none uses getUserMedia or Web Audio
         // assertions).
         launchOptions: {
           args: [
             '--use-fake-ui-for-media-stream',
             '--use-fake-device-for-media-stream',
+            `--use-file-for-fake-audio-capture=${SILENT_MIC_WAV}`,
             '--autoplay-policy=no-user-gesture-required',
           ],
         },


### PR DESCRIPTION
## Summary

Reworks the mode② in-game voice partner from push-to-talk to a **hands-free, continuous conversation**, per product direction.

- **AI speaks first**: on session open the server runs one LLM→TTS greeting in the bombsquad persona (Chinese defuse-expert), no client input. *(verified live)*
- **Hands-free**: the mic opens once and streams PCM16 16kHz continuously; a pure RMS+hangover **client-side VAD** (`voice-vad.ts`) detects end-of-utterance and sends `turn` — no button. The proven per-turn STT→LLM→TTS backend is unchanged (`runTurn` byte-equivalent).
- **3-state status**: 聆听中 / 思考中 / 说话中 (`deriveConversationPhase` from playback + VAD + awaiting).
- **Barge-in**: talk over the AI → local playback stops immediately + the interrupted turn's tail is dropped (echoCancellation + noiseSuppression on so the AI's own voice doesn't self-trigger).

An earlier server-side continuous-ASR auto-turn was dropped: a live probe showed Volcengine ASR doesn't endpoint-detect on silence in continuous mode, so turn-detection is client-side (simpler, reuses the proven backend).

## Test plan

- [x] tsc / build / lint clean; platform-ai 309 + game-bombsquad 375 tests
- [x] AI-first opening turn verified live (probe)
- [ ] **play-green**: hands-free + barge-in on a real device

Still `?partner=platform`-gated; mode① + puzzle engine untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)