### PR TITLE
fix(bombsquad): quieter, steadier hands-free mode② voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② voice: quieter, steadier hands-free conversation** - Fix.
+Three problems from a live device test are fixed. The stopwatch tick and other
+game sounds are now muted for the whole voice session, so they no longer talk
+over the AI or leak back into the always-on microphone — the timer keeps running,
+only its sound is silenced, and the bring-your-own-AI mode① still plays every
+sound. Voice detection is far less twitchy, so a tick, a click, or the AI's own
+voice no longer registers as you starting to speak. And the partner no longer
+sends a turn while the AI is still speaking or mid-greeting, so the spurious "a
+turn is already in progress" error — and the dropped connection that followed it
+on refresh — is gone; a refresh now restarts the conversation cleanly.
+
 **BombSquad mode② voice is now hands-free** - Change. The in-game AI defuse
 partner now runs as a continuous, hands-free conversation instead of hold-to-talk:
 the AI speaks first (it greets you and asks what you see when the session opens),

--- a/packages/game-bombsquad/src/audio/audio-context.ts
+++ b/packages/game-bombsquad/src/audio/audio-context.ts
@@ -131,3 +131,23 @@ export function setMasterMuted(muted: boolean): void {
     masterGain.gain.value = muted ? 0 : 1
   }
 }
+
+let sfxSuppressed = false
+
+/**
+ * Suppress ALL game SFX regardless of the user's mute preference. Orthogonal to
+ * `setMasterMuted`: that is the player's persistent mute toggle, this is a
+ * transient gate the app raises while the mode② voice partner is active, so the
+ * stopwatch tick (and every other cue) neither disturbs the conversation nor
+ * bleeds into the always-on mic. `playSfx` reads it at the top and short-circuits
+ * — no audio graph is touched, so the user's mute state is left untouched and
+ * restored verbatim when the gate drops. GamePage is the sole caller.
+ */
+export function setSfxSuppressed(suppressed: boolean): void {
+  sfxSuppressed = suppressed
+}
+
+/** Whether SFX are currently suppressed by the voice-active gate. */
+export function isSfxSuppressed(): boolean {
+  return sfxSuppressed
+}

--- a/packages/game-bombsquad/src/audio/useSfx.ts
+++ b/packages/game-bombsquad/src/audio/useSfx.ts
@@ -21,7 +21,7 @@
  * design doc.
  */
 
-import { getAudioContext, getBuffer, getMasterGain } from './audio-context'
+import { getAudioContext, getBuffer, getMasterGain, isSfxSuppressed } from './audio-context'
 import { SFX_PRESETS, type ChimePreset, type SfxType } from './presets'
 
 /**
@@ -57,6 +57,11 @@ function playChime(preset: ChimePreset, ctx: AudioContext): void {
 }
 
 export function playSfx(type: SfxType): void {
+  // Single chokepoint for the voice-active gate: while the mode② voice partner
+  // is up, every cue is silenced so it neither talks over the AI nor leaks into
+  // the open mic. The user's own mute preference is enforced separately, by the
+  // master gain — this leaves it untouched.
+  if (isSfxSuppressed()) return
   const preset = SFX_PRESETS[type]
   if (!preset) return
   const ctx = getAudioContext()

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -33,7 +33,7 @@ import KeypadModule from '@/modules/keypad/KeypadModule'
 import practiceYamlRaw from '../../../manual/data/practice.yaml?raw'
 import { generateSceneInfo } from '@/engine/scene-info'
 import { getAttemptNumberForMode, getRunSeed } from '@/utils/session'
-import { getAudioContext } from '@/audio/audio-context'
+import { getAudioContext, setSfxSuppressed } from '@/audio/audio-context'
 import VoicePanel from '@/voice/VoicePanel'
 import { deriveVoicePanelInputs, isPlatformVoicePartner } from '@/voice/voice-panel-inputs'
 import styles from './GamePage.module.css'
@@ -212,6 +212,18 @@ export default function GamePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [usePlatformVoice, state.manual, state.currentModuleIndex]
   )
+
+  // Mute every game SFX while the mode② voice partner is mounted. The stopwatch
+  // tick fires twice a second and the mic is always open, so an unmuted cue both
+  // disturbs the conversation and bleeds back in as false speech. Only the SOUND
+  // is gated — the stopwatch keeps counting (the elapsed time IS the score). A
+  // mode① run never mounts the panel (`voiceInputs === null`), so it keeps all
+  // SFX. Cleanup restores audio on exit / module change.
+  const voiceActive = voiceInputs !== null
+  useEffect(() => {
+    setSfxSuppressed(voiceActive)
+    return () => setSfxSuppressed(false)
+  }, [voiceActive])
 
   // A wrong answer pulses a red border around the whole module panel so the
   // mistake is obvious at a glance in both modes. Incrementing this key

--- a/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
@@ -331,16 +331,31 @@ describe('useVoiceSession — hands-free lifecycle', () => {
   })
 })
 
-describe('useVoiceSession — client VAD', () => {
-  it('tracks the player speaking then going silent, and sends a turn on utterance-end', async () => {
-    const { result, ws } = await ready()
+/**
+ * Finish the AI-first opening greeting so the AI is idle (awaiting cleared,
+ * playback ended): one done audio chunk, then its source's `onended`. After this
+ * the hook will accept a player turn on the next utterance-end.
+ */
+function finishGreeting(ws: MockWebSocket): void {
+  act(() => ws.fireMessage({ type: 'chunk', kind: 'audio', audio: audioB64, done: true }))
+  act(() => playbackSources().at(-1)?.onended?.())
+}
 
-    // One 256ms speech frame qualifies as a speech start.
-    act(() => fireFrame(0.5))
+describe('useVoiceSession — client VAD', () => {
+  it('sends a turn on utterance-end once the AI is idle', async () => {
+    const { result, ws } = await ready()
+    finishGreeting(ws)
+    expect(result.current.isAiSpeaking).toBe(false)
+
+    // Two 256ms speech frames (>= 400ms minSpeechMs) start the utterance.
+    act(() => {
+      fireFrame(0.5)
+      fireFrame(0.5)
+    })
     expect(result.current.playerSpeaking).toBe(true)
     expect(result.current.conversationPhase).toBe('listening')
 
-    // Four 256ms silence frames (>= 800ms hangover) end the utterance.
+    // Four 256ms silence frames (>= 800ms hangover) end it -> a turn is sent.
     act(() => {
       fireFrame(0.0)
       fireFrame(0.0)
@@ -349,8 +364,25 @@ describe('useVoiceSession — client VAD', () => {
     })
     expect(result.current.playerSpeaking).toBe(false)
     expect(result.current.conversationPhase).toBe('thinking')
-    // Wire-spec / back-compat: a `turn` is sent on utterance-end (server no-ops it).
     expect(ws.controlMessages().some((m) => m.type === 'turn')).toBe(true)
+  })
+
+  it('does not send a turn while the AI-first opening greeting is in flight', async () => {
+    const { result, ws } = await ready()
+    // No greeting chunk yet: the hook is awaiting the opening reply. Noise the
+    // open mic picks up (the greeting's own voice / the stopwatch tick) must NOT
+    // be handed to the server as a turn — that races the in-flight greeting and
+    // earns a `turn_in_flight` rejection.
+    act(() => {
+      fireFrame(0.5)
+      fireFrame(0.5)
+      fireFrame(0.0)
+      fireFrame(0.0)
+      fireFrame(0.0)
+      fireFrame(0.0)
+    })
+    expect(ws.controlMessages().some((m) => m.type === 'turn')).toBe(false)
+    expect(result.current.status).toBe('ready')
   })
 
   it('does not fire a turn on background noise below the threshold', async () => {
@@ -360,6 +392,19 @@ describe('useVoiceSession — client VAD', () => {
     })
     expect(result.current.playerSpeaking).toBe(false)
     expect(ws.controlMessages().some((m) => m.type === 'turn')).toBe(false)
+  })
+
+  it('treats a turn_in_flight server error as a benign no-op (no visible error)', async () => {
+    const { result, ws } = await ready()
+    act(() =>
+      ws.fireMessage({
+        type: 'error',
+        code: 'turn_in_flight',
+        message: 'a turn is already in progress',
+      })
+    )
+    expect(result.current.error).toBeNull()
+    expect(result.current.status).toBe('ready')
   })
 })
 
@@ -375,8 +420,11 @@ describe('useVoiceSession — barge-in', () => {
     expect(result.current.isAiSpeaking).toBe(true)
     const playing = playbackSources().at(-1)
 
-    // Player barges in.
-    act(() => fireFrame(0.5))
+    // Player barges in (2 frames >= the 400ms minSpeechMs).
+    act(() => {
+      fireFrame(0.5)
+      fireFrame(0.5)
+    })
     expect(playing?.stopped).toBe(true)
     expect(result.current.isAiSpeaking).toBe(false)
     expect(result.current.playerSpeaking).toBe(true)

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -12,8 +12,12 @@
  * the AI-first opening greeting (no client input). Thereafter the hook streams the
  * mic continuously and the client-side VAD detects end-of-utterance (the player
  * went silent after speaking) and sends `{type:'turn'}`, which the server runs as
- * a normal STT->LLM->TTS turn over the audio buffered since the last turn. The VAD
- * additionally drives the 3-state conversation phase (listening / thinking /
+ * a normal STT->LLM->TTS turn over the audio buffered since the last turn. Turns
+ * are SERIAL server-side: a `turn` sent while one is in flight is rejected with a
+ * benign `turn_in_flight`, so the hook only sends when the AI is idle (not
+ * speaking, not awaiting, not mid-stream) — otherwise the open mic picking up the
+ * AI's own greeting / the stopwatch tick would fire spurious, rejected turns. The
+ * VAD additionally drives the 3-state conversation phase (listening / thinking /
  * speaking) and barge-in (stop local playback when the player talks over the AI).
  *
  * Security invariant (load-bearing, mirrors the demo): this hook connects ONLY to
@@ -59,6 +63,12 @@ const TTS_OUTPUT_SAMPLE_RATE = 16000
 const CAPTURE_SAMPLE_RATE = 16000
 /** ScriptProcessor buffer size (frames). Matches the demo. */
 const CAPTURE_BUFFER_SIZE = 4096
+/**
+ * How long to wait for a turn's first response chunk before assuming the server
+ * skipped it (a no-speech / spurious-VAD turn yields no chunks and no `done`).
+ * Generous enough to cover a real STT->LLM->TTS first-chunk latency.
+ */
+const NO_RESPONSE_TIMEOUT_MS = 12000
 
 /**
  * Close an `AudioContext` and release its hardware resources, swallowing the
@@ -135,6 +145,13 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
   const [playerSpeaking, setPlayerSpeaking] = useState(false)
   const [awaitingResponse, setAwaitingResponse] = useState(false)
   const awaitingResponseRef = useRef(false)
+  /**
+   * Watchdog for a turn that gets no response. The server skips a no-speech turn
+   * (a spurious VAD trigger / inaudible utterance) silently — zero chunks, no
+   * `done` — so without this the UI would hang in `thinking` forever. If no
+   * response chunk arrives within the budget, fall back to `listening`.
+   */
+  const awaitingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Latest inputs, captured at connect/create time without re-running the connect
   // effect on every prop identity change.
@@ -182,6 +199,19 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
   const setAwaiting = useCallback((v: boolean) => {
     awaitingResponseRef.current = v
     if (mountedRef.current) setAwaitingResponse(v)
+    if (awaitingTimeoutRef.current) {
+      clearTimeout(awaitingTimeoutRef.current)
+      awaitingTimeoutRef.current = null
+    }
+    if (v) {
+      // No response within the budget => the server skipped this turn (no speech);
+      // release the `thinking` wait so the conversation can continue.
+      awaitingTimeoutRef.current = setTimeout(() => {
+        awaitingTimeoutRef.current = null
+        awaitingResponseRef.current = false
+        if (mountedRef.current) setAwaitingResponse(false)
+      }, NO_RESPONSE_TIMEOUT_MS)
+    }
   }, [])
 
   // --- TTS playback (Web Audio side effects) ---
@@ -296,9 +326,22 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
   /** A VAD `utterance-end`: the player went silent after speaking. */
   const onUtteranceEnd = useCallback(() => {
     setPlayerSpeaking(false)
+    // Only hand the floor to the server when the AI is idle. The server runs each
+    // `turn` as a real, SERIAL turn and rejects an overlap with `turn_in_flight`,
+    // so a `turn` sent while the AI's audio is still playing, while we are already
+    // awaiting a reply, or while a (non-barged-in) turn is still streaming would
+    // race the in-flight turn — the AI-first opening greeting is the worst case,
+    // where the greeting's own voice / the stopwatch tick leaking into the open
+    // mic fired a spurious utterance. Suppress those. The one mid-stream case that
+    // DOES still send is a genuine barge-in: `onSpeechStart` already stopped
+    // playback and flagged the interrupted turn (`suppressTurnRef`), so the player
+    // has taken the floor and their next utterance is a real turn.
+    const aiHoldsFloor =
+      playingCountRef.current > 0 ||
+      awaitingResponseRef.current ||
+      (turnStreamingRef.current && !suppressTurnRef.current)
+    if (aiHoldsFloor) return
     setAwaiting(true)
-    // Wire-spec / back-compat signal. The deployed server detects the endpoint
-    // itself and treats this as a no-op; it does not start the turn.
     const ws = wsRef.current
     if (ws && ws.readyState === WebSocket.OPEN) {
       try {
@@ -469,6 +512,16 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         safeDispatch({ type: 'frame', frame })
         return
       }
+      if (frame.type === 'error') {
+        // A benign in-band rejection leaves the socket open and must NOT read as
+        // an error. The common one is `turn_in_flight` (our VAD raced the server's
+        // own in-flight turn): release any pending "thinking" wait so the UI falls
+        // back to listening. The reducer drops the benign codes, so no error line
+        // shows; an unexpected code still surfaces through the reducer.
+        if (frame.code === 'turn_in_flight' && awaitingResponseRef.current) setAwaiting(false)
+        safeDispatch({ type: 'frame', frame })
+        return
+      }
       safeDispatch({ type: 'frame', frame })
     }
 
@@ -522,6 +575,10 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     connect()
     return () => {
       mountedRef.current = false
+      if (awaitingTimeoutRef.current) {
+        clearTimeout(awaitingTimeoutRef.current)
+        awaitingTimeoutRef.current = null
+      }
       stopCapture()
       teardownPlayback()
       closeSocket(true)

--- a/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
+++ b/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
@@ -144,17 +144,32 @@ describe('voiceReducer', () => {
     expect(next.summary).toBe(s)
   })
 
-  it('an in-band error frame surfaces a bounded message without changing status', () => {
+  it('an unexpected in-band error frame surfaces a bounded message without changing status', () => {
     const ready = run(
       { type: 'connecting' },
       { type: 'frame', frame: { type: 'created', sessionId: 's1' } }
     )
     const next = voiceReducer(ready, {
       type: 'frame',
-      frame: { type: 'error', code: 'turn_in_flight', message: 'a turn is already in progress' },
+      frame: { type: 'error', code: 'provider_unavailable', message: 'speech provider down' },
     })
     expect(next.status).toBe('ready')
-    expect(next.error).toBe('a turn is already in progress')
+    expect(next.error).toBe('speech provider down')
+  })
+
+  it('drops benign in-band rejections (turn_in_flight / already_created) with no visible error', () => {
+    const ready = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } }
+    )
+    for (const code of ['turn_in_flight', 'already_created'] as const) {
+      const next = voiceReducer(ready, {
+        type: 'frame',
+        frame: { type: 'error', code, message: 'a turn is already in progress' },
+      })
+      expect(next.status).toBe('ready')
+      expect(next.error).toBeNull()
+    }
   })
 
   it('mic-error surfaces a bounded message but keeps the session usable', () => {

--- a/packages/game-bombsquad/src/voice/voice-session-protocol.ts
+++ b/packages/game-bombsquad/src/voice/voice-session-protocol.ts
@@ -183,9 +183,12 @@ function reduceFrame(state: VoiceSessionState, frame: ServerFrame): VoiceSession
       return { ...state, status: 'closed', summary: frame.summary }
 
     case 'error':
-      // In-band, non-fatal server error (e.g. `turn_in_flight`). Surface the
-      // bounded message; leave status to the streaming/lifecycle handlers (the
-      // rejected message did not close the socket).
+      // In-band, non-fatal server error; it does NOT close the socket. The benign
+      // rejections the hands-free client provokes on its own — `turn_in_flight`
+      // (the VAD raced the server's in-flight turn) and `already_created` (a
+      // duplicate create) — are no-ops the player should never see, so they leave
+      // state untouched. Any other in-band error still surfaces a bounded message.
+      if (frame.code === 'turn_in_flight' || frame.code === 'already_created') return state
       return { ...state, error: boundError(frame.message ?? frame.code ?? 'session error') }
 
     default:

--- a/packages/game-bombsquad/src/voice/voice-vad.test.ts
+++ b/packages/game-bombsquad/src/voice/voice-vad.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   computeRms,
+  DEFAULT_VAD_CONFIG,
   initialVadState,
   vadStep,
   type VadConfig,
@@ -96,6 +97,52 @@ describe('vadStep — noise debounce', () => {
     const { events, state } = drive(Array(20).fill(0.01))
     expect(events).toEqual([])
     expect(state).toEqual(initialVadState)
+  })
+})
+
+describe('DEFAULT_VAD_CONFIG — conservative defaults reject transients', () => {
+  // The real capture frame is 4096 samples at 16 kHz ≈ 256ms, so minSpeechMs
+  // (400) needs 2 contiguous speech frames to qualify; a single transient frame
+  // (a stopwatch tick / click) can never reach it. These cases pin the rejection
+  // of brief loud blips and of faint-but-audible ambient so a device re-tune is a
+  // visible, intentional change rather than a silent regression.
+  const FRAME = 256
+  const TICK_LEVEL = 0.05 // a faint tick / ambient: above the OLD 0.02 floor, below 0.07
+
+  function driveDefault(rmsSeq: number[]) {
+    let state = initialVadState
+    const events: VadEvent[] = []
+    for (const rms of rmsSeq) {
+      const stepped = vadStep(state, rms, FRAME, DEFAULT_VAD_CONFIG)
+      state = stepped.state
+      if (stepped.event) events.push(stepped.event)
+    }
+    return { state, events }
+  }
+
+  it('keeps a high speech threshold and a long min-speech window', () => {
+    expect(DEFAULT_VAD_CONFIG.speechThreshold).toBeGreaterThanOrEqual(0.06)
+    expect(DEFAULT_VAD_CONFIG.minSpeechMs).toBeGreaterThanOrEqual(350)
+  })
+
+  it('rejects a single loud tick frame (one 256ms transient, < minSpeechMs)', () => {
+    const { events, state } = driveDefault([SPEECH, SILENCE, SILENCE, SILENCE, SILENCE])
+    expect(events).toEqual([])
+    expect(state).toEqual(initialVadState)
+  })
+
+  it('treats a faint tick / ambient between the old and new floor as silence', () => {
+    // 0.05 crossed the old 0.02 threshold; under the 0.07 floor it is silence.
+    const { events, state } = driveDefault(Array(10).fill(TICK_LEVEL))
+    expect(events).toEqual([])
+    expect(state).toEqual(initialVadState)
+  })
+
+  it('accepts sustained speech (>= minSpeechMs of contiguous energy)', () => {
+    // 2 frames = 512ms >= 400ms minSpeechMs -> a real utterance starts.
+    const { events, state } = driveDefault([SPEECH, SPEECH, SPEECH])
+    expect(events).toEqual(['speech-start'])
+    expect(state.speaking).toBe(true)
   })
 })
 

--- a/packages/game-bombsquad/src/voice/voice-vad.ts
+++ b/packages/game-bombsquad/src/voice/voice-vad.ts
@@ -3,13 +3,17 @@
  * voice session. Side-effect-free (no Web Audio, no React) so the turn-boundary
  * state machine is unit-testable by feeding it a sequence of frame energies.
  *
- * Role (load-bearing): the deployed `@amiclaw/platform-ai` server runs its OWN
- * ASR-endpoint VAD and fires every turn server-side (the client `turn` message is
- * a tolerated no-op — see `session-do.ts`). So this VAD does NOT trigger the
- * turn; it drives two CLIENT concerns the server gives no signal for:
- *  1. the 3-state conversation indicator — `speech-start` flips the UI to
+ * Role (load-bearing): the deployed `@amiclaw/platform-ai` server runs each
+ * client `turn` as a real, SERIAL STT->LLM->TTS turn and rejects an overlapping
+ * one with `turn_in_flight` (see `session-do.ts`). So this VAD gates three CLIENT
+ * concerns off the same frame stream:
+ *  1. the end-of-utterance turn send — `utterance-end` is when the hook may hand
+ *     the buffered audio to the server (the hook additionally suppresses the send
+ *     while the AI holds the floor, so a leaked tick / the AI's own voice cannot
+ *     race the server's in-flight turn);
+ *  2. the 3-state conversation indicator — `speech-start` flips the UI to
  *     "listening", `utterance-end` flips it to "thinking" while the AI replies;
- *  2. barge-in — `speech-start` while the AI is speaking stops local playback.
+ *  3. barge-in — `speech-start` while the AI is speaking stops local playback.
  *
  * The detector is a small pure reducer: `vadStep(state, rms, frameMs, config)`
  * folds one analyzed frame's RMS into the running state and emits at most one
@@ -36,14 +40,24 @@ export interface VadConfig {
 }
 
 /**
- * Default thresholds. Conservative starting point for a noise-suppressed,
- * echo-cancelled mic; the exact values want real-device tuning (flagged) — the
- * silence floor and speech level vary with hardware, AGC, and room noise.
+ * Default thresholds — deliberately conservative so brief, loud transients
+ * (the stopwatch tick, UI clicks, a door slam) and ambient room noise do NOT
+ * start an utterance. Two knobs do the work:
+ *  - `speechThreshold: 0.07` — a stopwatch tick / ambient hum sits well under
+ *    this, while real near-mic speech RMS lands ~0.1–0.3. (The old 0.02 floor
+ *    let a tick + room tone read as speech, false-triggering turns.)
+ *  - `minSpeechMs: 400` — a real utterance must hold the floor for ≥400ms of
+ *    CONTIGUOUS above-threshold energy; a single tick frame (one capture frame
+ *    is 256ms at 16 kHz) can never reach it and is discarded by the debounce.
+ *
+ * These are a STARTING point, not a final tuning: the silence floor and speech
+ * level vary with hardware, AGC, and room noise, so they want a real-device
+ * pass (flagged). They live here, in one place, so re-tuning is a single edit.
  */
 export const DEFAULT_VAD_CONFIG: VadConfig = {
-  speechThreshold: 0.02,
+  speechThreshold: 0.07,
   silenceHangoverMs: 800,
-  minSpeechMs: 200,
+  minSpeechMs: 400,
 }
 
 /** Running detector state. Reset to `initialVadState` per session / per capture. */

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -671,14 +671,15 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
     await expect(consumed).rejects.toThrow(/Volcengine ASR error/)
   })
 
-  it('fails loudly if the socket closes before a final transcript (premature close)', async () => {
-    // The ASR dual of the TTS premature-close fix. A socket close that arrives
-    // before any final/definite transcript — handshake-period failure or a
-    // mid-stream network drop — must REJECT the consumer, not settle it as a clean
-    // empty/incomplete end-of-stream. Otherwise `collectFinalTranscript` would
-    // proceed with an empty (or partial, non-definite) transcript and the turn
-    // would continue silently on bad input. Here the server emits only a
-    // non-definite chunk, then the socket drops.
+  it('settles cleanly (benign no-speech) when the socket closes before a final transcript', async () => {
+    // The hands-free no-speech reinterpretation: a socket close before any
+    // final/definite transcript, with NO error frame, is benign — the player's
+    // buffered audio held nothing transcribable (a false-positive VAD trigger).
+    // The stream must SETTLE CLEANLY (no throw), yielding only the partial /
+    // non-definite chunks that did arrive, so `collectFinalTranscript` returns an
+    // empty/partial transcript and the turn is skipped upstream instead of the
+    // session being torn down. (Genuine faults — error frame, idle stall — still
+    // fail loud; they latch the queue error before this close path.)
     const socket = new MockSocket()
     const { connect } = mockConnector(socket)
     const { stt } = createVolcengineSpeechProvider({ apiKey: 'k', connect })
@@ -687,7 +688,7 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
 
     await new Promise((r) => setTimeout(r, 0))
     // A partial (non-definite) transcript arrives, then the socket closes BEFORE
-    // any definite/final result — a premature close.
+    // any definite/final result — the benign no-final close.
     socket.emitMessage(
       sttServerFrame({ result: { text: '你', utterances: [{ definite: false }] } })
     )
@@ -696,9 +697,29 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
     const guard = new Promise<never>((_, reject) =>
       setTimeout(() => reject(new Error('transcribe did not settle after an early close')), 50)
     )
-    await expect(Promise.race([consumed, guard])).rejects.toThrow(
-      /closed before a final transcript/
+    const chunks = await Promise.race([consumed, guard])
+    // No throw — the stream ended cleanly with just the non-definite chunk.
+    expect(chunks).toEqual([{ text: '你', isFinal: false }])
+  })
+
+  it('settles cleanly with no chunks when the socket closes having sent nothing (no speech)', async () => {
+    // The pure no-speech case: the server accepts the connection and closes
+    // without ever sending a transcript frame. The stream ends as an EMPTY clean
+    // stream (no throw), so the upstream transcript is empty and the turn skips.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ apiKey: 'k', connect })
+
+    const consumed = collect(stt.transcribe(await asyncFrom([encoder.encode('f1')])))
+
+    await new Promise((r) => setTimeout(r, 0))
+    socket.emitClose()
+
+    const guard = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('transcribe did not settle after an early close')), 50)
     )
+    const chunks = await Promise.race([consumed, guard])
+    expect(chunks).toEqual([])
   })
 
   it('treats a socket close AFTER a final transcript as a clean end-of-stream', async () => {
@@ -1480,9 +1501,11 @@ describe('createVolcengineSpeechProvider — cancellation cleanup (iterator.retu
     await expect(Promise.race([consumed, guard])).rejects.toThrow(/closed before session finished/)
   })
 
-  it('ASR premature-close fail-loud is not reverted by the cleanup finally', async () => {
-    // ASR guard dual: a socket close before a final transcript still rejects the
-    // consumer; the cleanup finally on the error unwind does not mask it.
+  it('ASR error-frame fail-loud is not reverted by the cleanup finally', async () => {
+    // ASR guard dual: a genuine fault (an ASR error frame) still rejects the
+    // consumer; the cleanup finally on the error unwind does not mask it. (A bare
+    // no-final close is now benign — covered separately — so the genuine-fault
+    // case here is the error frame, which latches the queue error.)
     const socket = new MockSocket()
     const { connect } = mockConnector(socket)
     const { stt } = createVolcengineSpeechProvider({ apiKey: 'k', connect })
@@ -1490,17 +1513,22 @@ describe('createVolcengineSpeechProvider — cancellation cleanup (iterator.retu
     const consumed = collect(stt.transcribe(await asyncFrom([encoder.encode('f1')])))
 
     await tick()
-    socket.emitMessage(
-      sttServerFrame({ result: { text: '你', utterances: [{ definite: false }] } })
-    )
+    const errFrame = buildSttRequestFrame({
+      messageType: MessageType.ErrorResponse,
+      flags: MessageFlag.PositiveSequence,
+      serialization: Serialization.Json,
+      sequence: 1,
+      payload: encoder.encode('auth failed'),
+    })
+    socket.emitMessage(errFrame)
+    // A close follows the error frame (the adapter closes the socket on unwind).
+    // The cleanup finally's queue.close() must NOT mask the latched error.
     socket.emitClose()
 
     const guard = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error('transcribe did not settle after an early close')), 50)
+      setTimeout(() => reject(new Error('transcribe did not settle after an error frame')), 50)
     )
-    await expect(Promise.race([consumed, guard])).rejects.toThrow(
-      /closed before a final transcript/
-    )
+    await expect(Promise.race([consumed, guard])).rejects.toThrow(/Volcengine ASR error/)
   })
 })
 

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -1009,11 +1009,14 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       const socket = await connect(STT_URL, headers)
       const queue = new AsyncQueue<SttTranscriptChunk>()
       // Tracks whether a final/definite transcript arrived — the ASR normal
-      // completion signal. A socket close is only a clean end-of-stream once this
-      // is set; a close BEFORE it (handshake-period failure, mid-stream network
-      // drop) is a premature close that must fail the queue, so a turn does not
-      // proceed with an empty/incomplete transcript. Mirrors the TTS layer's
-      // SessionFinished gate.
+      // completion signal. Used by the message listener (final → close the queue
+      // and the socket) and surfaced in the close trace. A socket close is a
+      // clean end-of-stream EITHER way now: with a final it is the normal
+      // teardown; without one (and without a prior error frame) it is a benign
+      // no-speech turn the consumer skips (see the close listener). Unlike the
+      // TTS layer's SessionFinished gate — a missing AI response is a fault — a
+      // missing player transcript is benign, so the ASR close path does NOT fail
+      // the queue on a no-final close.
       let finalReached = false
       // Per-connection metering state. `reportedDurationMs` follows the server's
       // cumulative `audio_info.duration` — each response overwrites it, so it
@@ -1116,18 +1119,16 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
           queue.fail(err)
         }
       })
-      // Distinguish a normal-completion close from a premature one. After a
-      // final/definite transcript the close is the expected end-of-stream ->
-      // close the queue normally. Before it (handshake race / mid-stream drop)
-      // the close is premature: fail the queue so the consumer
-      // (`collectFinalTranscript`) throws and the turn fails loud, rather than
-      // continuing with an empty/incomplete transcript.
+      // A socket close ends the stream. After a final/definite transcript it is
+      // the expected end-of-stream; before one (and with no prior error frame) it
+      // is a benign no-speech close (see below). Either way the queue settles
+      // cleanly — a genuine fault has already latched the queue error before the
+      // close arrives.
       socket.addEventListener('close', (event) => {
-        // Observability: the Volcengine ASR close CODE (numeric) + reason LENGTH
-        // that the generic "closed before a final transcript" error used to
-        // swallow. A clean 1000/empty close after silence vs a non-1000 protocol
-        // close points at very different root causes — the numeric code carries
-        // that signal without logging the raw reason text.
+        // Observability: the Volcengine ASR close CODE (numeric) + reason LENGTH.
+        // A clean 1000/empty close after silence vs a non-1000 protocol close
+        // points at very different root causes — the numeric code (with
+        // `finalReached`) carries that signal without logging the raw reason text.
         traceTurn('asr', 'socket-close', {
           code: event?.code,
           reasonChars: (event?.reason ?? '').length,
@@ -1136,11 +1137,24 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         // The stream has ended either way — stop the idle guard so it cannot fire
         // late against an already-settled queue.
         streamIdleDeadline?.cancel()
-        if (finalReached) {
-          queue.close()
-        } else {
-          queue.fail(new Error('Volcengine ASR socket closed before a final transcript'))
-        }
+        // Settle the queue CLEANLY whether or not a final transcript arrived. A
+        // close AFTER a final/definite transcript is the normal end-of-stream. A
+        // close WITHOUT one and without a prior error frame is a benign no-speech
+        // turn: the player's buffered audio held nothing transcribable (a
+        // false-positive VAD trigger — a stopwatch tick, a cough, ambient noise),
+        // so the server closed without ever sending a definite result. It must
+        // NOT fail the turn — the consumer (`collectFinalTranscript`) surfaces an
+        // empty (or partial, non-definite) transcript and the turn is skipped
+        // upstream, keeping the session alive and listening.
+        //
+        // Genuine faults are unaffected and still fail loud (1008): an error
+        // frame (`parseSttResponse` throw), the first-response deadline, and the
+        // inter-chunk idle guard each `queue.fail(...)` — latching `queue.error`
+        // — BEFORE this close fires. The iterator checks a latched error ahead of
+        // a clean close, so this `queue.close()` is a no-op on an already-failed
+        // queue and the latched error is what the consumer sees. (A connect
+        // failure throws before the queue exists, so it never reaches here.)
+        queue.close()
       })
       socket.addEventListener('error', (err) => {
         streamIdleDeadline?.cancel()

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -206,6 +206,129 @@ describe('runTurn', () => {
     expect(capturedRequest?.messages.at(-1)).toEqual({ role: 'user', content: 'I see a red wire' })
   })
 
+  // --- benign no-speech turn (hands-free false-positive VAD) -------------
+  // A `turn` whose STT closes with no final transcript (no speech, no error) is
+  // skipped: no AI response, no state change, no throw — the session stays alive.
+
+  it('skips a no-speech turn: zero chunks, never drives LLM/TTS, no state mutation, no throw', async () => {
+    const state = freshState()
+    let llmCalled = false
+    const ttsReceived: string[] = []
+    const llm: LlmProvider = {
+      async *streamCompletion(): AsyncIterable<LlmCompletionChunk> {
+        llmCalled = true
+        yield { content: '', done: true }
+      },
+    }
+
+    // Empty STT stream — the adapter's benign no-final close surfaces here as an
+    // empty transcript (see collectFinalTranscript / the volcengine close path).
+    const chunks = await collect(
+      runTurn(
+        providers(mockStt([]), llm, mockTts(ttsReceived)),
+        state,
+        fromArray<AudioChunk>([new Uint8Array([1])])
+      )
+    )
+
+    // No AI response chunks at all (not even a terminal done) and no downstream work.
+    expect(chunks).toEqual([])
+    expect(llmCalled).toBe(false)
+    expect(ttsReceived).toEqual([])
+    // State is byte-for-byte untouched: no history, no turn count, no usage.
+    expect(state.turnCount).toBe(0)
+    expect(state.history).toEqual([])
+    expect(state.usage).toEqual({
+      llmInputTokens: 0,
+      llmOutputTokens: 0,
+      sttInputSeconds: 0,
+      ttsOutputSeconds: 0,
+    })
+    expect(state.sttSource).toBe('provider-reported')
+  })
+
+  it('treats a whitespace-only final transcript as no-speech and skips it', async () => {
+    const state = freshState()
+    let llmCalled = false
+    const llm: LlmProvider = {
+      async *streamCompletion(): AsyncIterable<LlmCompletionChunk> {
+        llmCalled = true
+        yield { content: '', done: true }
+      },
+    }
+    const chunks = await collect(
+      runTurn(
+        providers(mockStt([{ text: '   ', isFinal: true }]), llm, mockTts([])),
+        state,
+        fromArray<AudioChunk>([new Uint8Array([1])])
+      )
+    )
+    expect(chunks).toEqual([])
+    expect(llmCalled).toBe(false)
+    expect(state.turnCount).toBe(0)
+  })
+
+  it('leaves the session usable: a normal turn runs right after a skipped no-speech turn', async () => {
+    const state = freshState()
+    await collect(
+      runTurn(
+        providers(mockStt([]), mockLlm(['ignored.']), mockTts([])),
+        state,
+        fromArray<AudioChunk>([new Uint8Array([1])])
+      )
+    )
+    // The skip left no residue.
+    expect(state.turnCount).toBe(0)
+    expect(state.history).toEqual([])
+
+    const ttsReceived: string[] = []
+    const chunks = await collect(
+      runTurn(
+        providers(
+          mockStt([{ text: 'I see a red wire.', isFinal: true }]),
+          mockLlm(['Cut it.']),
+          mockTts(ttsReceived)
+        ),
+        state,
+        fromArray<AudioChunk>([new Uint8Array([1])])
+      )
+    )
+    // The next real turn runs normally end to end.
+    expect(state.turnCount).toBe(1)
+    expect(state.history).toEqual([
+      { role: 'user', content: 'I see a red wire.' },
+      { role: 'assistant', content: 'Cut it.' },
+    ])
+    expect(ttsReceived).toEqual(['Cut it.'])
+    expect(chunks.filter((c) => c.done)).toHaveLength(1)
+  })
+
+  it('still fails loud when STT throws a real ASR error (NOT a benign no-speech close)', async () => {
+    // A genuine ASR error frame surfaces as a throw out of transcribe. That is a
+    // real fault, not a benign no-speech close: the turn must propagate it (the
+    // DO turns it into a 1008), never silently skip.
+    const state = freshState()
+    const throwingStt: SttProvider = {
+      async *transcribe(audio: AsyncIterable<AudioChunk>): AsyncIterable<SttTranscriptChunk> {
+        for await (const _ of audio) void _
+        yield { text: '部分', isFinal: false }
+        throw new Error('Volcengine ASR error: auth failed')
+      },
+    }
+    await expect(
+      collect(
+        runTurn(
+          providers(throwingStt, mockLlm(['nope.']), mockTts([])),
+          state,
+          fromArray<AudioChunk>([new Uint8Array([1])])
+        )
+      )
+    ).rejects.toThrow(/Volcengine ASR error/)
+    // A failed turn never settles, so it never mutates session state.
+    expect(state.turnCount).toBe(0)
+    expect(state.history).toEqual([])
+  })
+
   it('accumulates usage and history across a turn', async () => {
     const state = freshState()
     const turn = runTurn(

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -151,7 +151,10 @@ export function splitSentences(buffer: string): { sentences: string[]; remainder
  * Drain an STT transcript stream and return the player's utterance for the
  * turn: the text of the last `isFinal` chunk (cumulative ASR semantics). If no
  * `isFinal` chunk arrives, fall back to the last chunk's text (best effort), or
- * empty string for an empty stream.
+ * empty string for an empty stream. A clean no-final ASR close (a benign
+ * no-speech turn) surfaces here as that empty/partial transcript rather than a
+ * throw, so `runTurn` can skip the turn; only a genuine fault (error frame,
+ * connect failure, idle stall) throws out of the underlying `transcribe`.
  *
  * Also reports `audioBytes`: the total byte length of the inbound audio frames
  * the STT provider actually pulled, tapped via a counting passthrough. The
@@ -481,6 +484,23 @@ export async function* runTurn(
     transcriptChars: playerText.length,
     elapsedMs: Date.now() - turnStart,
   })
+
+  // Benign no-speech turn: the player's buffered audio held nothing
+  // transcribable (a false-positive VAD trigger — a stopwatch tick, a cough,
+  // ambient noise — surfacing as a clean ASR close with no final transcript).
+  // Skip the turn: emit NO response chunks, mutate NO state (history, turnCount,
+  // usage all untouched), and meter nothing — the player effectively spoke
+  // nothing this turn (undercount-only, consistent with the session metering
+  // stance). The session stays ready and the next `turn` runs normally. This is
+  // NOT an error: a real ASR error frame / connect failure / mid-stream stall
+  // still throws out of `collectFinalTranscript` above and fails the turn loud.
+  if (playerText.trim().length === 0) {
+    traceTurn('turn', 'skip-no-speech', {
+      turnCount: state.turnCount,
+      elapsedMs: Date.now() - turnStart,
+    })
+    return
+  }
 
   // 2. Inject: deterministic system message (role + rules + manual subset),
   //    then the rolling history, then this turn's player utterance.


### PR DESCRIPTION
## Summary

Fixes from a live device test (the ticking, the spurious "a turn is already in progress", and the 1008 on refresh — all one chain):

- **Mute game SFX during the voice session** — the stopwatch tick (twice/sec) + other SFX are silenced while the mode② panel is mounted (it disturbed the conversation and bled into the always-on mic). Timer/score still run; mode① keeps all sound.
- **Less twitchy VAD** — `speechThreshold` 0.02→0.07, `minSpeechMs` 200→400, so a tick / click / the AI's own voice no longer registers as speech. (Starting values; re-tunable against device tests.)
- **No turn while the AI holds the floor** — suppress VAD→`turn` while AI audio plays / a turn is in flight / awaiting a reply (greeting included); genuine barge-in still sends. `turn_in_flight` is a silent no-op, not a visible error.
- **Benign no-speech turn** (backend) — a turn whose ASR closes with no final transcript is skipped (no chunks, session stays alive) instead of 1008-ing the socket. Real errors / connect failures / mid-stream stalls still fail loud.
- **No-response watchdog** — a skipped turn yields no chunks/`done`, so a 12s timeout releases `thinking`→`listening` (no hang).

## Test plan

- [x] tsc / build / lint clean; game-bombsquad 382 + platform-ai 314 tests
- [ ] **re-play-green**: hands-free, no ticking, no spurious disconnects, on a real device

`?partner=platform`-gated; mode① + puzzle engine untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)