### PR TITLE
feat(bombsquad): mode② voice player subtitle + longer pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② voice: see what the AI heard, and more time to think** -
+Change. The voice panel now shows a subtitle of your own recognized speech
+(`你：…`) above the AI's reply, so you can tell whether you were understood. And
+the partner waits longer for you to finish — the pause before it takes its turn
+went from 0.8s to 1.5s, so you can think and gather your words mid-sentence
+without it cutting in.
+
 **BombSquad mode② voice: quieter, steadier hands-free conversation** - Fix.
 Three problems from a live device test are fixed. The stopwatch tick and other
 game sounds are now muted for the whole voice session, so they no longer talk

--- a/packages/game-bombsquad/src/voice/VoicePanel.module.css
+++ b/packages/game-bombsquad/src/voice/VoicePanel.module.css
@@ -114,6 +114,22 @@
   animation-delay: 0.3s;
 }
 
+/* ----------  player subtitle (own recognized speech)  ----------
+   Visually distinct from the AI reply box below: a lightweight unboxed line in
+   the muted body colour, with the `你：` label in the AMIO-yellow accent so the
+   player reads it as their own voice, not the AI's. */
+.playerTranscript {
+  margin: 0;
+  font: 400 13px/1.5 var(--font-body);
+  color: var(--soft);
+  word-break: break-word;
+}
+
+.playerTranscriptLabel {
+  font-weight: 600;
+  color: var(--y);
+}
+
 /* ----------  AI reply  ---------- */
 .reply {
   min-height: 44px;

--- a/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
@@ -18,6 +18,7 @@ function hookState(partial: Partial<UseVoiceSessionResult> = {}): UseVoiceSessio
     conversationPhase: 'listening',
     playerSpeaking: false,
     aiText: '',
+    playerTranscript: '',
     isAiSpeaking: false,
     error: null,
     summary: null,
@@ -82,6 +83,17 @@ describe('VoicePanel — cues and content', () => {
   it('renders the accumulated AI text', () => {
     renderPanel({ aiText: 'Hold the button.' })
     expect(screen.getByText('Hold the button.')).toBeInTheDocument()
+  })
+
+  it('renders the player subtitle (their own recognized speech) labeled 你：', () => {
+    renderPanel({ playerTranscript: '红色还是蓝色的线' })
+    const subtitle = screen.getByLabelText('你说的话')
+    expect(subtitle).toHaveTextContent('你：红色还是蓝色的线')
+  })
+
+  it('renders nothing for an empty player transcript', () => {
+    renderPanel({ playerTranscript: '' })
+    expect(screen.queryByLabelText('你说的话')).not.toBeInTheDocument()
   })
 
   it('shows the speaking-bars cue while the AI is speaking and live', () => {

--- a/packages/game-bombsquad/src/voice/VoicePanel.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.tsx
@@ -17,7 +17,8 @@ interface VoicePanelProps {
  * In-game voice panel for the BombSquad daily run (mode②), hands-free. Renders
  * the `useVoiceSession` surface: a prominent 3-state conversation indicator
  * (聆听中 / 思考中 / 说话中) once the session is live, the connection status before
- * that, the AI's streamed text reply, and a bounded error line. There is NO
+ * that, the player's own recognized-speech subtitle (你：…), the AI's streamed
+ * text reply, and a bounded error line. There is NO
  * push-to-talk — the mic streams continuously and the AI greets first; the player
  * just talks. Presentation only: it reads hook state and never touches game logic
  * or the mic/socket. Dark-only, CSS-only animation (Atlas design system).
@@ -50,11 +51,12 @@ function placeholderFor(status: VoiceStatus, phase: ConversationPhase): string {
 }
 
 function VoicePanelImpl({ manualData, gameState, gameId }: VoicePanelProps) {
-  const { status, conversationPhase, aiText, isAiSpeaking, error } = useVoiceSession({
-    manualData,
-    gameState,
-    gameId,
-  })
+  const { status, conversationPhase, aiText, playerTranscript, isAiSpeaking, error } =
+    useVoiceSession({
+      manualData,
+      gameState,
+      gameId,
+    })
 
   const isLive = status === 'ready'
   // While live, the prominent indicator is the conversation phase; before that
@@ -85,6 +87,13 @@ function VoicePanelImpl({ manualData, gameState, gameId }: VoicePanelProps) {
           </span>
         )}
       </div>
+
+      {playerTranscript && (
+        <p className={styles.playerTranscript} aria-label="你说的话">
+          <span className={styles.playerTranscriptLabel}>你：</span>
+          {playerTranscript}
+        </p>
+      )}
 
       <div className={styles.reply} role="log" aria-live="polite">
         {aiText ? (

--- a/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
@@ -296,6 +296,20 @@ describe('useVoiceSession — hands-free lifecycle', () => {
     expect(result.current.conversationPhase).toBe('speaking')
   })
 
+  it('exposes the player transcript from a transcript frame (before the AI reply)', async () => {
+    const { result, ws } = await ready()
+    expect(result.current.playerTranscript).toBe('')
+
+    // The server sends the player's recognized utterance before the reply chunks.
+    act(() => ws.fireMessage({ type: 'transcript', text: '剪红色的线吗' }))
+    expect(result.current.playerTranscript).toBe('剪红色的线吗')
+
+    // The AI reply streams independently and does not clobber the transcript.
+    act(() => ws.fireMessage({ type: 'chunk', kind: 'text', text: '先别剪', done: true }))
+    expect(result.current.aiText).toBe('先别剪')
+    expect(result.current.playerTranscript).toBe('剪红色的线吗')
+  })
+
   it('clears the speaking state when the last buffer ends', async () => {
     const { result, ws } = await ready()
     act(() => ws.fireMessage({ type: 'chunk', kind: 'audio', audio: audioB64, done: true }))
@@ -355,8 +369,10 @@ describe('useVoiceSession — client VAD', () => {
     expect(result.current.playerSpeaking).toBe(true)
     expect(result.current.conversationPhase).toBe('listening')
 
-    // Four 256ms silence frames (>= 800ms hangover) end it -> a turn is sent.
+    // Six 256ms silence frames (1536ms >= 1500ms hangover) end it -> a turn is sent.
     act(() => {
+      fireFrame(0.0)
+      fireFrame(0.0)
       fireFrame(0.0)
       fireFrame(0.0)
       fireFrame(0.0)

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -116,6 +116,8 @@ export interface UseVoiceSessionResult {
   playerSpeaking: boolean
   /** Accumulated AI text for the current turn. */
   aiText: string
+  /** The player's most recent recognized utterance (from the `transcript` frame). */
+  playerTranscript: string
   /** True while TTS audio is scheduled/playing. */
   isAiSpeaking: boolean
   /** Last bounded error message, or null. */
@@ -595,6 +597,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     conversationPhase,
     playerSpeaking,
     aiText: state.aiText,
+    playerTranscript: state.playerTranscript,
     isAiSpeaking,
     error: state.error,
     summary: state.summary,

--- a/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
+++ b/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
@@ -100,6 +100,31 @@ describe('voiceReducer', () => {
     expect(next.aiText).toBe('second reply')
   })
 
+  it('stores the player transcript without disturbing aiText, turn boundary, or status', () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'prior reply', done: true } },
+      { type: 'frame', frame: { type: 'transcript', text: '红色还是蓝色的线' } }
+    )
+    expect(next.playerTranscript).toBe('红色还是蓝色的线')
+    // The AI's previous reply text, turn boundary, and status are untouched.
+    expect(next.aiText).toBe('prior reply')
+    expect(next.turnDone).toBe(true)
+    expect(next.status).toBe('ready')
+  })
+
+  it('keeps the latest transcript across turns (most recent utterance wins)', () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'frame', frame: { type: 'transcript', text: 'first utterance' } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'reply one', done: true } },
+      { type: 'frame', frame: { type: 'transcript', text: 'second utterance' } }
+    )
+    expect(next.playerTranscript).toBe('second utterance')
+  })
+
   it('audio chunks do not change aiText but their done flag closes the turn', () => {
     const next = run(
       { type: 'connecting' },

--- a/packages/game-bombsquad/src/voice/voice-session-protocol.ts
+++ b/packages/game-bombsquad/src/voice/voice-session-protocol.ts
@@ -67,13 +67,16 @@ export function deriveConversationPhase(s: PhaseSignals): ConversationPhase {
 
 /**
  * One server->client JSON frame. Structurally mirrors the envelope
- * `session-do.ts` emits: `created` on session create, `chunk` per streamed
- * text/audio fragment (audio base64-encoded for the JSON channel), `summary` on
- * `end`, and a non-fatal in-band `error` (e.g. `turn_in_flight`,
- * `already_created`) that does NOT close the socket.
+ * `session-do.ts` emits: `created` on session create, `transcript` once per turn
+ * (only when non-empty) carrying the player's recognized utterance and sent
+ * before that turn's AI reply chunks, `chunk` per streamed text/audio fragment
+ * (audio base64-encoded for the JSON channel), `summary` on `end`, and a
+ * non-fatal in-band `error` (e.g. `turn_in_flight`, `already_created`) that does
+ * NOT close the socket.
  */
 export type ServerFrame =
   | { type: 'created'; sessionId: string }
+  | { type: 'transcript'; text: string }
   | { type: 'chunk'; kind: 'text'; text?: string; done: boolean }
   | { type: 'chunk'; kind: 'audio'; audio?: string; done: boolean }
   | { type: 'summary'; summary: SessionSummary }
@@ -95,6 +98,12 @@ export interface VoiceSessionState {
   /** Accumulated AI text for the current turn (cleared when a new turn starts). */
   aiText: string
   /**
+   * The player's most recent recognized utterance, from the latest `transcript`
+   * frame. Shown as the player's own subtitle. Empty until the first transcript
+   * arrives; a no-speech turn sends none, so the prior value persists.
+   */
+  playerTranscript: string
+  /**
    * True once the current turn's last (`done`) chunk has been seen — so the next
    * turn's first chunk resets `aiText` instead of appending. With server-driven
    * hands-free turns there is no client turn-start signal, so the turn boundary
@@ -112,6 +121,7 @@ export const initialVoiceState: VoiceSessionState = {
   status: 'idle',
   sessionId: null,
   aiText: '',
+  playerTranscript: '',
   turnDone: true,
   error: null,
   summary: null,
@@ -166,6 +176,12 @@ function reduceFrame(state: VoiceSessionState, frame: ServerFrame): VoiceSession
   switch (frame.type) {
     case 'created':
       return { ...state, status: 'ready', sessionId: frame.sessionId }
+
+    case 'transcript':
+      // The player's recognized utterance for the turn now starting, sent before
+      // the AI's reply chunks. Store the latest; it does not touch `aiText`, the
+      // turn boundary, or status — the AI reply still streams independently.
+      return { ...state, playerTranscript: frame.text }
 
     case 'chunk': {
       // Server-driven hands-free turns give no turn-start signal, so a turn

--- a/packages/game-bombsquad/src/voice/voice-vad.ts
+++ b/packages/game-bombsquad/src/voice/voice-vad.ts
@@ -56,7 +56,11 @@ export interface VadConfig {
  */
 export const DEFAULT_VAD_CONFIG: VadConfig = {
   speechThreshold: 0.07,
-  silenceHangoverMs: 800,
+  // 1500ms of trailing silence before an utterance is considered finished. A
+  // generous pause so the player can think and gather their words mid-sentence
+  // without the turn firing prematurely (a defuse player describes a device, then
+  // pauses to read the next part). Tunable per device feedback.
+  silenceHangoverMs: 1500,
   minSpeechMs: 400,
 }
 

--- a/packages/platform-ai/src/contract.ts
+++ b/packages/platform-ai/src/contract.ts
@@ -73,15 +73,24 @@ export interface GameState {
 
 /**
  * One chunk of the AI's streamed response. A turn produces an ordered stream of
- * these: incremental assistant text plus the synthesized audio frames pushed
- * back over the same WebSocket. `kind` discriminates the two; `done` marks the
- * final chunk of a turn so the consumer can close out the turn without a
- * separate end signal.
+ * these: an optional leading `transcript` chunk carrying the player's recognized
+ * utterance, then the incremental assistant text plus the synthesized audio
+ * frames pushed back over the same WebSocket. `kind` discriminates them; `done`
+ * marks the final chunk of a turn so the consumer can close out the turn without
+ * a separate end signal.
+ *
+ * The `transcript` variant is the PLAYER's own recognized speech (the final STT
+ * transcript), surfaced once per turn BEFORE the AI reply streams so the client
+ * can show a subtitle of what the AI heard. It never carries AI text and never
+ * sets `done` (the terminal chunk is always the AI reply's last `text` chunk).
  */
 export interface AiResponseChunk {
   /** Which modality this chunk carries. */
-  kind: 'text' | 'audio'
-  /** Incremental assistant text (present when `kind === 'text'`). */
+  kind: 'text' | 'audio' | 'transcript'
+  /**
+   * Incremental assistant text (present when `kind === 'text'`), or the player's
+   * recognized utterance (present when `kind === 'transcript'`).
+   */
   text?: string
   /** Synthesized TTS audio frame (present when `kind === 'audio'`). */
   audio?: Uint8Array

--- a/packages/platform-ai/src/session-do-test-kit.ts
+++ b/packages/platform-ai/src/session-do-test-kit.ts
@@ -403,6 +403,49 @@ export function makeInspectingProviders(): {
 }
 
 /**
+ * Provider bundle for a benign NO-SPEECH turn: the STT drains the audio bridge
+ * and closes with NO final transcript (a false-positive VAD trigger — a cough /
+ * ambient noise / stopwatch tick, surfacing as a clean no-final ASR close). The
+ * turn must skip: `runTurn` returns before driving the LLM and before yielding
+ * any chunk (including the player-transcript chunk), so the DO sends no
+ * `transcript` frame and no AI reply chunks.
+ *
+ * Exposes `sttCalls()` to confirm the turn still reached STT, and `llmCalls()`
+ * so a test can assert the skip never reached the LLM (a regression that drove
+ * the LLM would surface here AND as stray `chunk` frames on the wire).
+ */
+export function makeNoSpeechProviders(): {
+  providers: TurnProviders
+  sttCalls(): number
+  llmCalls(): number
+} {
+  let sttCalls = 0
+  let llmCalls = 0
+  const stt: SttProvider = {
+    // Drains the bridge, then closes with no transcript chunk: the benign
+    // no-final ASR close `collectFinalTranscript` surfaces as an empty utterance.
+    // eslint-disable-next-line require-yield
+    async *transcribe(audio): AsyncIterable<SttTranscriptChunk> {
+      sttCalls += 1
+      for await (const _frame of audio) {
+        // frames consumed, not inspected — matches the mock adapter
+      }
+    },
+  }
+  const llm: LlmProvider = {
+    async *streamCompletion() {
+      llmCalls += 1
+      yield { content: '', done: true }
+    },
+  }
+  return {
+    providers: { stt, llm, tts: createMockTtsProvider() },
+    sttCalls: () => sttCalls,
+    llmCalls: () => llmCalls,
+  }
+}
+
+/**
  * Build the gated provider bundle. Each `turn` control message ultimately calls
  * `streamCompletion` once; each call gets its own `DeltaFeed` + handle, so
  * multi-turn and multi-session (reconnect) scenarios stay independently

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -799,7 +799,19 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
         const next = await turn.next()
         if (next.done) break
         const chunk = next.value
-        if (chunk.kind === 'audio' && chunk.audio) {
+        if (chunk.kind === 'transcript') {
+          // The player's recognized utterance — its OWN wire frame, NOT a
+          // `chunk`: `{type:'transcript', text}`. Sent once per turn, before the
+          // AI reply chunks, so the client can show a subtitle of what was heard
+          // (`runTurn` only yields this for a non-empty transcript). It carries no
+          // `done` — the AI reply's terminal `chunk` still closes the turn.
+          ws.send(
+            JSON.stringify({
+              type: 'transcript',
+              text: chunk.text ?? '',
+            })
+          )
+        } else if (chunk.kind === 'audio' && chunk.audio) {
           ws.send(
             JSON.stringify({
               type: 'chunk',

--- a/packages/platform-ai/src/session-transcript.test.ts
+++ b/packages/platform-ai/src/session-transcript.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Production-class regression test for the player-transcript wire frame, driving
+ * the REAL `VoiceSessionDO` turn relay under the workerd runtime
+ * (`@cloudflare/vitest-pool-workers`).
+ *
+ * The DO must surface the player's recognized speech back to the client so the
+ * UI can show a subtitle of what the AI heard. After a turn's STT produces the
+ * final transcript and BEFORE the AI reply chunks stream, the DO sends one
+ * `{type:'transcript', text}` JSON frame (NOT a `chunk`). A benign no-speech
+ * turn (STT closes with no final transcript) sends none — consistent with the
+ * no-speech skip. The opening greeting carries no player transcript and sends
+ * none either (covered by `runOpeningTurn` never yielding a transcript chunk).
+ */
+
+const providerControl = vi.hoisted(() => ({
+  override: undefined as import('./turn-pipeline').TurnProviders | undefined,
+}))
+
+vi.mock('./providers/factory', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./providers/factory')>()
+  return {
+    ...actual,
+    createProviders: (...args: Parameters<typeof actual.createProviders>) =>
+      providerControl.override ?? actual.createProviders(...args),
+  }
+})
+
+import {
+  createSessionOverWs,
+  makeInspectingProviders,
+  makeNoSpeechProviders,
+  makeSessionDo,
+  messagesOfType,
+  openSocket,
+  sawDoneChunk,
+  settle,
+  waitFor,
+  waitForMessage,
+} from './session-do-test-kit'
+
+beforeEach(() => {
+  providerControl.override = undefined
+})
+
+const TURN = JSON.stringify({ type: 'turn' })
+const END = JSON.stringify({ type: 'end' })
+
+describe('real VoiceSessionDO — player transcript wire frame', () => {
+  it('sends {type:transcript, text} once, before the AI reply chunks', async () => {
+    const kit = makeInspectingProviders()
+    providerControl.override = kit.providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    socket.send(TURN)
+    await waitFor(() => kit.sttCalls() === 1, 'turn ran STT once')
+    await waitFor(() => sawDoneChunk(socket), 'turn emitted its terminal done chunk')
+
+    // Exactly one transcript frame, carrying the player's recognized utterance
+    // (the inspecting STT's fixed final transcript) — its OWN frame, NOT a
+    // `chunk`, and with no `done` key.
+    const transcripts = messagesOfType(socket, 'transcript')
+    expect(transcripts).toEqual([{ type: 'transcript', text: 'inspecting harness utterance' }])
+
+    // Ordering: the transcript frame arrives BEFORE the first AI reply chunk.
+    const transcriptIndex = socket.messages.findIndex((m) => m.type === 'transcript')
+    const firstChunkIndex = socket.messages.findIndex((m) => m.type === 'chunk')
+    expect(transcriptIndex).toBeGreaterThanOrEqual(0)
+    expect(firstChunkIndex).toBeGreaterThanOrEqual(0)
+    expect(transcriptIndex).toBeLessThan(firstChunkIndex)
+
+    // The AI reply chunks are unchanged: text/audio chunks still stream and end
+    // with exactly one terminal done chunk.
+    expect(sawDoneChunk(socket)).toBe(true)
+    const chunks = messagesOfType(socket, 'chunk')
+    expect(chunks.length).toBeGreaterThan(0)
+    expect(chunks.filter((c) => c.done === true)).toHaveLength(1)
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    expect(messagesOfType(socket, 'summary')).toHaveLength(1)
+  })
+
+  it('sends NO transcript frame on a benign no-speech turn', async () => {
+    const kit = makeNoSpeechProviders()
+    providerControl.override = kit.providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    socket.send(TURN)
+    await waitFor(() => kit.sttCalls() === 1, 'turn ran STT once')
+    // The no-speech skip emits nothing; let any (absent) frames drain so the
+    // "nothing was sent" assertion is meaningful.
+    await settle()
+
+    // No transcript frame, no AI reply chunks — the turn skipped benignly, and
+    // the LLM was never reached.
+    expect(messagesOfType(socket, 'transcript')).toEqual([])
+    expect(messagesOfType(socket, 'chunk')).toEqual([])
+    expect(kit.llmCalls()).toBe(0)
+    expect(socket.closeEvents).toEqual([])
+
+    // The session stays usable: end still summarizes cleanly with zero turns.
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    const summary = messagesOfType(socket, 'summary')[0].summary as { turnCount: number }
+    expect(summary.turnCount).toBe(0)
+  })
+})

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -186,6 +186,55 @@ describe('runTurn', () => {
     expect(chunks.at(-1)?.done).toBe(true)
   })
 
+  it('emits the player transcript as a leading chunk, before the AI reply chunks', async () => {
+    const turn = runTurn(
+      providers(
+        mockStt([{ text: 'I see a red wire.', isFinal: true }]),
+        mockLlm(['Cut the ', 'blue wire.']),
+        mockTts([])
+      ),
+      freshState(),
+      fromArray<AudioChunk>([new Uint8Array([1])])
+    )
+    const chunks = await collect(turn)
+
+    // Exactly one transcript chunk, carrying the PLAYER's recognized utterance
+    // (not AI text), not the terminal `done`.
+    const transcriptChunks = chunks.filter((c) => c.kind === 'transcript')
+    expect(transcriptChunks).toEqual([
+      { kind: 'transcript', text: 'I see a red wire.', done: false },
+    ])
+
+    // It precedes every AI text/audio chunk: the first emitted chunk IS the
+    // transcript, and no AI chunk appears before it.
+    expect(chunks[0]).toEqual({ kind: 'transcript', text: 'I see a red wire.', done: false })
+    const firstAiIndex = chunks.findIndex((c) => c.kind === 'text' || c.kind === 'audio')
+    expect(chunks.findIndex((c) => c.kind === 'transcript')).toBeLessThan(firstAiIndex)
+
+    // The AI reply chunks are unchanged: same text deltas, audio present, one
+    // terminal done — the transcript chunk (kind 'transcript', done false) is not
+    // counted among them.
+    const textChunks = chunks.filter((c) => c.kind === 'text' && !c.done)
+    expect(textChunks.map((c) => c.text)).toEqual(['Cut the ', 'blue wire.'])
+    expect(chunks.filter((c) => c.kind === 'audio').length).toBeGreaterThan(0)
+    expect(chunks.filter((c) => c.done)).toHaveLength(1)
+    expect(chunks.at(-1)?.done).toBe(true)
+  })
+
+  it('emits NO transcript chunk on a skipped no-speech turn', async () => {
+    const chunks = await collect(
+      runTurn(
+        providers(mockStt([]), mockLlm(['ignored.']), mockTts([])),
+        freshState(),
+        fromArray<AudioChunk>([new Uint8Array([1])])
+      )
+    )
+    // The benign no-speech skip returns before yielding anything — no transcript
+    // chunk, no AI chunks at all.
+    expect(chunks.filter((c) => c.kind === 'transcript')).toEqual([])
+    expect(chunks).toEqual([])
+  })
+
   it('takes the last isFinal transcript (cumulative ASR semantics)', async () => {
     let capturedRequest: LlmCompletionRequest | undefined
     const turn = runTurn(

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -502,6 +502,15 @@ export async function* runTurn(
     return
   }
 
+  // 1b. Surface the player's recognized utterance to the client BEFORE the AI
+  //     reply streams, so the UI can show a subtitle of what the AI heard.
+  //     Emitted exactly once per turn and only for a NON-empty transcript (the
+  //     no-speech skip above already returned, so a skipped turn yields nothing).
+  //     This is the player's OWN speech returned to that same client — never
+  //     prompt or secret material; it carries `done: false` (the AI reply's last
+  //     text chunk is still the turn's terminal `done`).
+  yield { kind: 'transcript', text: playerText, done: false }
+
   // 2. Inject: deterministic system message (role + rules + manual subset),
   //    then the rolling history, then this turn's player utterance.
   const userMessage: ChatMessage = { role: 'user', content: playerText }


### PR DESCRIPTION
## Summary

Two device-test asks:
- **Player subtitle** — the server sends the player's recognized speech as a `{type:'transcript', text}` frame (new `runTurn` `kind:'transcript'` yield → DO relays it before the AI reply; non-empty turns only). The panel shows it as a `你：…` line above the AI's reply, so the player can tell whether they were understood.
- **Longer pause** — VAD `silenceHangoverMs` 0.8s→1.5s, so the player can pause to think/gather words without the turn firing early.

## Test plan
- [x] tsc/build/lint clean; game-bombsquad 387 + platform-ai 318
- [ ] device re-test (subtitle accuracy + pause feel)

`?partner=platform`-gated; mode① untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)