### PR TITLE
fix(bombsquad): full + streaming ASR transcript for mode② voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② voice: full speech recognition + live captions** - Fix. Two
+problems: the recognizer cut off after your first few words, and your subtitle
+only showed up late. Both came from ending recognition at the first stabilized
+phrase. Recognition now runs to the true end of your utterance (using the speech
+provider's last-packet signal instead of a mid-sentence marker), so the whole
+sentence is captured; and the `你：…` caption now streams live, building up as you
+speak, well before the AI replies.
+
 **BombSquad mode② voice: see what the AI heard, and more time to think** -
 Change. The voice panel now shows a subtitle of your own recognized speech
 (`你：…`) above the AI's reply, so you can tell whether you were understood. And

--- a/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
@@ -96,6 +96,29 @@ describe('VoicePanel — cues and content', () => {
     expect(screen.queryByLabelText('你说的话')).not.toBeInTheDocument()
   })
 
+  it('streams the player subtitle live and replaces it for a new utterance (no append)', () => {
+    // The panel is memoized; in the real app a hook-state change re-renders it.
+    // Pass a fresh (equal) prop object per rerender to force that re-render so the
+    // mocked hook's new value is read — simulating successive `transcript` frames.
+    const props = () => ({ manualData: { ...manualData }, gameState: { ...gameState } })
+
+    mockHook.mockReturnValue(hookState({ playerTranscript: '红' }))
+    const { rerender } = render(<VoicePanel {...props()} />)
+    expect(screen.getByLabelText('你说的话')).toHaveTextContent('你：红')
+
+    // An interim grows: the subtitle builds up to the latest cumulative text.
+    mockHook.mockReturnValue(hookState({ playerTranscript: '红色的线' }))
+    rerender(<VoicePanel {...props()} />)
+    expect(screen.getByLabelText('你说的话')).toHaveTextContent('你：红色的线')
+
+    // The next utterance's first interim replaces the prior subtitle, not appends.
+    mockHook.mockReturnValue(hookState({ playerTranscript: '第' }))
+    rerender(<VoicePanel {...props()} />)
+    const subtitle = screen.getByLabelText('你说的话')
+    expect(subtitle).toHaveTextContent('你：第')
+    expect(subtitle).not.toHaveTextContent('红色的线')
+  })
+
   it('shows the speaking-bars cue while the AI is speaking and live', () => {
     const { container } = renderPanel({
       status: 'ready',

--- a/packages/game-bombsquad/src/voice/VoicePanel.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.tsx
@@ -17,8 +17,9 @@ interface VoicePanelProps {
  * In-game voice panel for the BombSquad daily run (mode②), hands-free. Renders
  * the `useVoiceSession` surface: a prominent 3-state conversation indicator
  * (聆听中 / 思考中 / 说话中) once the session is live, the connection status before
- * that, the player's own recognized-speech subtitle (你：…), the AI's streamed
- * text reply, and a bounded error line. There is NO
+ * that, the player's own recognized-speech subtitle (你：…) streaming live as
+ * recognition builds, the AI's streamed text reply, and a bounded error line.
+ * There is NO
  * push-to-talk — the mic streams continuously and the AI greets first; the player
  * just talks. Presentation only: it reads hook state and never touches game logic
  * or the mic/socket. Dark-only, CSS-only animation (Atlas design system).

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -116,7 +116,7 @@ export interface UseVoiceSessionResult {
   playerSpeaking: boolean
   /** Accumulated AI text for the current turn. */
   aiText: string
-  /** The player's most recent recognized utterance (from the `transcript` frame). */
+  /** The player's live recognized speech, streamed as recognition builds (from the `transcript` frames). */
   playerTranscript: string
   /** True while TTS audio is scheduled/playing. */
   isAiSpeaking: boolean

--- a/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
+++ b/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
@@ -125,6 +125,48 @@ describe('voiceReducer', () => {
     expect(next.playerTranscript).toBe('second utterance')
   })
 
+  it('builds the live subtitle up across interim transcript frames (cumulative text)', () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'frame', frame: { type: 'transcript', text: '红', final: false } },
+      { type: 'frame', frame: { type: 'transcript', text: '红色', final: false } },
+      { type: 'frame', frame: { type: 'transcript', text: '红色的线', final: false } }
+    )
+    expect(next.playerTranscript).toBe('红色的线')
+  })
+
+  it('settles the full utterance on the final transcript frame', () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'frame', frame: { type: 'transcript', text: '红色', final: false } },
+      { type: 'frame', frame: { type: 'transcript', text: '红色的线', final: true } }
+    )
+    expect(next.playerTranscript).toBe('红色的线')
+  })
+
+  it("replaces the prior subtitle on the next utterance's first interim (no append across utterances)", () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'frame', frame: { type: 'transcript', text: '第一句话', final: true } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'reply', done: true } },
+      { type: 'frame', frame: { type: 'transcript', text: '第', final: false } }
+    )
+    // The next utterance's first interim ('第') replaces the prior final — never appends.
+    expect(next.playerTranscript).toBe('第')
+  })
+
+  it('treats a transcript with no `final` flag as a non-terminal interim (stores the latest text)', () => {
+    const next = run(
+      { type: 'connecting' },
+      { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
+      { type: 'frame', frame: { type: 'transcript', text: 'no final flag here' } }
+    )
+    expect(next.playerTranscript).toBe('no final flag here')
+  })
+
   it('audio chunks do not change aiText but their done flag closes the turn', () => {
     const next = run(
       { type: 'connecting' },

--- a/packages/game-bombsquad/src/voice/voice-session-protocol.ts
+++ b/packages/game-bombsquad/src/voice/voice-session-protocol.ts
@@ -67,16 +67,19 @@ export function deriveConversationPhase(s: PhaseSignals): ConversationPhase {
 
 /**
  * One server->client JSON frame. Structurally mirrors the envelope
- * `session-do.ts` emits: `created` on session create, `transcript` once per turn
- * (only when non-empty) carrying the player's recognized utterance and sent
- * before that turn's AI reply chunks, `chunk` per streamed text/audio fragment
- * (audio base64-encoded for the JSON channel), `summary` on `end`, and a
- * non-fatal in-band `error` (e.g. `turn_in_flight`, `already_created`) that does
- * NOT close the socket.
+ * `session-do.ts` emits: `created` on session create, `transcript` STREAMED as
+ * recognition builds (repeated interim frames whose `text` is the CUMULATIVE
+ * recognized utterance so far with `final: false`/absent, then one `final: true`
+ * frame carrying the full utterance; the running `text` resets per utterance and
+ * a no-speech turn sends none) and arriving before that turn's AI reply chunks,
+ * `chunk` per streamed text/audio fragment (audio base64-encoded for the JSON
+ * channel), `summary` on `end`, and a non-fatal in-band `error` (e.g.
+ * `turn_in_flight`, `already_created`) that does NOT close the socket. `final` is
+ * optional; a missing flag is treated as a non-terminal interim.
  */
 export type ServerFrame =
   | { type: 'created'; sessionId: string }
-  | { type: 'transcript'; text: string }
+  | { type: 'transcript'; text: string; final?: boolean }
   | { type: 'chunk'; kind: 'text'; text?: string; done: boolean }
   | { type: 'chunk'; kind: 'audio'; audio?: string; done: boolean }
   | { type: 'summary'; summary: SessionSummary }
@@ -98,9 +101,11 @@ export interface VoiceSessionState {
   /** Accumulated AI text for the current turn (cleared when a new turn starts). */
   aiText: string
   /**
-   * The player's most recent recognized utterance, from the latest `transcript`
-   * frame. Shown as the player's own subtitle. Empty until the first transcript
-   * arrives; a no-speech turn sends none, so the prior value persists.
+   * The player's live recognized speech, from the latest `transcript` frame. The
+   * server streams it as recognition builds (cumulative `text`, reset per
+   * utterance), so this updates on every interim frame to drive a live subtitle
+   * and is replaced by the next utterance's first interim. Empty until the first
+   * transcript arrives; a no-speech turn sends none, so the prior value persists.
    */
   playerTranscript: string
   /**
@@ -178,9 +183,14 @@ function reduceFrame(state: VoiceSessionState, frame: ServerFrame): VoiceSession
       return { ...state, status: 'ready', sessionId: frame.sessionId }
 
     case 'transcript':
-      // The player's recognized utterance for the turn now starting, sent before
-      // the AI's reply chunks. Store the latest; it does not touch `aiText`, the
-      // turn boundary, or status — the AI reply still streams independently.
+      // Live player subtitle. The server streams the recognized utterance as it
+      // builds: each frame's `text` is the CUMULATIVE text so far (interim frames
+      // grow it; the `final` frame settles the full utterance), and the running
+      // text resets per utterance. So always storing the latest `text` both builds
+      // the subtitle up within an utterance AND replaces it on the next utterance's
+      // first interim — no append, no boundary bookkeeping, and `final` needs no
+      // behavioral branch (a missing flag is non-terminal-safe). It does not touch
+      // `aiText`, the turn boundary, or status — the AI reply streams independently.
       return { ...state, playerTranscript: frame.text }
 
     case 'chunk': {

--- a/packages/platform-ai/demo/live-turn.mjs
+++ b/packages/platform-ai/demo/live-turn.mjs
@@ -206,6 +206,10 @@ async function main() {
         }
         break
       }
+      case 'transcript': {
+        console.log(`[transcript ${msg.final ? 'FINAL' : 'interim'}] "${msg.text}"`)
+        break
+      }
       case 'summary': {
         summary = msg.summary
         break

--- a/packages/platform-ai/src/contract.ts
+++ b/packages/platform-ai/src/contract.ts
@@ -73,27 +73,38 @@ export interface GameState {
 
 /**
  * One chunk of the AI's streamed response. A turn produces an ordered stream of
- * these: an optional leading `transcript` chunk carrying the player's recognized
- * utterance, then the incremental assistant text plus the synthesized audio
- * frames pushed back over the same WebSocket. `kind` discriminates them; `done`
- * marks the final chunk of a turn so the consumer can close out the turn without
- * a separate end signal.
+ * these: a leading STREAMING series of `transcript` chunks carrying the player's
+ * recognized utterance as it is recognized, then the incremental assistant text
+ * plus the synthesized audio frames pushed back over the same WebSocket. `kind`
+ * discriminates them; `done` marks the final chunk of a turn so the consumer can
+ * close out the turn without a separate end signal.
  *
- * The `transcript` variant is the PLAYER's own recognized speech (the final STT
- * transcript), surfaced once per turn BEFORE the AI reply streams so the client
- * can show a subtitle of what the AI heard. It never carries AI text and never
- * sets `done` (the terminal chunk is always the AI reply's last `text` chunk).
+ * The `transcript` variant is the PLAYER's own recognized speech (the STT
+ * result), surfaced BEFORE the AI reply streams so the client can build a live
+ * subtitle of what the AI heard. It arrives as a series: zero or more interim
+ * chunks (`final: false`) each carrying the running CUMULATIVE recognized text
+ * (not a delta) as the ASR stabilizes more of the utterance, then exactly one
+ * terminal chunk (`final: true`) carrying the COMPLETE utterance once STT
+ * finishes. A benign no-speech turn streams none. Transcript chunks never carry
+ * AI text and never set `done` (the turn's terminal `done` is always the AI
+ * reply's last `text` chunk).
  */
 export interface AiResponseChunk {
   /** Which modality this chunk carries. */
   kind: 'text' | 'audio' | 'transcript'
   /**
    * Incremental assistant text (present when `kind === 'text'`), or the player's
-   * recognized utterance (present when `kind === 'transcript'`).
+   * running/complete recognized utterance (present when `kind === 'transcript'`).
    */
   text?: string
   /** Synthesized TTS audio frame (present when `kind === 'audio'`). */
   audio?: Uint8Array
+  /**
+   * For a `transcript` chunk: `false` on an interim running-text update, `true`
+   * on the terminal complete-utterance chunk. Absent for `text` / `audio` chunks
+   * (those use `done` for turn termination, not `final`).
+   */
+  final?: boolean
   /** True on the last chunk of the current turn. */
   done: boolean
 }

--- a/packages/platform-ai/src/providers/types.ts
+++ b/packages/platform-ai/src/providers/types.ts
@@ -81,9 +81,13 @@ export interface LlmProvider {
 // --- STT layer (streaming speech-to-text) ---
 
 /**
- * One streamed transcription result. `text` is the cumulative-or-incremental
- * transcript for this chunk (the adapter owns which); `isFinal` marks a
- * stabilized segment the turn pipeline may forward to the LLM.
+ * One streamed transcription result. `text` is the CUMULATIVE transcript so far
+ * (full text recognized to this point, not a per-segment delta — the Volcengine
+ * big-model ASR returns it cumulatively). `isFinal` marks the TERMINAL result —
+ * the whole utterance is complete (the ASR processed all audio and returned its
+ * final cumulative result). It does NOT mark a mid-utterance stabilized segment:
+ * the turn pipeline streams every chunk as a live interim subtitle and takes the
+ * last `isFinal` chunk's text as the complete utterance forwarded to the LLM.
  */
 export interface SttTranscriptChunk {
   text: string

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -15,6 +15,7 @@ import {
   Compression,
   createVolcengineSpeechProvider,
   defaultConnect,
+  isLastPackageFlags,
   MessageFlag,
   MessageType,
   parseFrame,
@@ -122,6 +123,24 @@ function sttServerFrame(body: unknown, flags = MessageFlag.PositiveSequence): Ui
     flags,
     serialization: Serialization.Json,
     sequence: 1,
+    payload,
+  })
+}
+
+/**
+ * Build the TERMINAL ASR server response — the last-package frame the server
+ * sends after the client's end-of-audio packet. It carries the
+ * `NegativeWithSequence` flags (`& 0x02` last-package bit + negative sequence),
+ * exactly as the real server marks the final cumulative result. `parseSttResponse`
+ * keys `isFinal` off this bit (NOT `utterances[].definite`).
+ */
+function sttFinalServerFrame(body: unknown): Uint8Array {
+  const payload = encoder.encode(JSON.stringify(body))
+  return buildSttRequestFrame({
+    messageType: MessageType.FullServerResponse,
+    flags: MessageFlag.NegativeWithSequence,
+    serialization: Serialization.Json,
+    sequence: -1,
     payload,
   })
 }
@@ -264,27 +283,33 @@ describe('STT frame codec', () => {
 // --- ASR server-response mapping --------------------------------------------
 
 describe('parseSttResponse', () => {
-  it('maps a non-definite utterance to a non-final transcript chunk', () => {
-    const chunk = parseSttResponse(
-      parseFrame(sttServerFrame({ result: { text: '你好', utterances: [{ definite: false }] } }))
-    )
+  it('maps a non-terminal (positive-sequence) response to a non-final chunk', () => {
+    const chunk = parseSttResponse(parseFrame(sttServerFrame({ result: { text: '你好' } })))
     expect(chunk).toEqual({ text: '你好', isFinal: false })
   })
 
-  it('marks the chunk final when any utterance is definite', () => {
-    const chunk = parseSttResponse(
-      parseFrame(
-        sttServerFrame({
-          result: { text: '你好世界', utterances: [{ definite: false }, { definite: true }] },
-        })
-      )
+  it('marks the chunk final ONLY on the last-package response, not a mid-utterance definite', () => {
+    // Truncation-bug guard at the parse level: a `definite: true` utterance on a
+    // NON-last-package frame must stay isFinal:false — `definite` marks a
+    // mid-utterance stabilized segment, not the end of the whole utterance.
+    const midDefinite = parseSttResponse(
+      parseFrame(sttServerFrame({ result: { text: '我看到', utterances: [{ definite: true }] } }))
     )
-    expect(chunk).toEqual({ text: '你好世界', isFinal: true })
+    expect(midDefinite).toEqual({ text: '我看到', isFinal: false })
+
+    // The terminal last-package frame (flags & 0x02) is what marks the utterance
+    // complete — even with no `utterances` field at all.
+    const terminal = parseSttResponse(
+      parseFrame(sttFinalServerFrame({ result: { text: '我看到红色的电线' } }))
+    )
+    expect(terminal).toEqual({ text: '我看到红色的电线', isFinal: true })
   })
 
-  it('treats a missing utterances array as not-final', () => {
-    const chunk = parseSttResponse(parseFrame(sttServerFrame({ result: { text: 'hi' } })))
-    expect(chunk).toEqual({ text: 'hi', isFinal: false })
+  it('isLastPackageFlags reads the 0x02 bit for both terminal flag dialects', () => {
+    expect(isLastPackageFlags(MessageFlag.NoSequence)).toBe(false)
+    expect(isLastPackageFlags(MessageFlag.PositiveSequence)).toBe(false)
+    expect(isLastPackageFlags(MessageFlag.LastNoSequence)).toBe(true)
+    expect(isLastPackageFlags(MessageFlag.NegativeWithSequence)).toBe(true)
   })
 
   it('returns undefined for an empty / textless ack frame', () => {
@@ -300,16 +325,17 @@ describe('parseSttResponse', () => {
 
   it('parses audio_info.duration alongside the transcript fields', () => {
     // The example-JSON-only field (doc 6561/1354869): present -> the cumulative
-    // recognized duration in milliseconds.
+    // recognized duration in milliseconds. This is an interim (non-terminal)
+    // frame, so its transcript parse is non-final.
     const frame = parseFrame(
       sttServerFrame({
-        result: { text: '你好', utterances: [{ definite: true }] },
+        result: { text: '你好' },
         audio_info: { duration: 3696 },
       })
     )
     expect(parseSttAudioDurationMs(frame)).toBe(3696)
     // The transcript parse is unaffected by the extra field.
-    expect(parseSttResponse(frame)).toEqual({ text: '你好', isFinal: true })
+    expect(parseSttResponse(frame)).toEqual({ text: '你好', isFinal: false })
   })
 
   it('returns undefined duration when audio_info is absent or malformed (best-effort field)', () => {
@@ -480,14 +506,12 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
       return out
     })()
 
-    // Let the pump send its frames before we emit responses.
+    // Let the pump send its frames before we emit responses. The first response
+    // is an interim (positive sequence); the second is the terminal last-package
+    // response (the complete cumulative result).
     await new Promise((r) => setTimeout(r, 0))
-    socket.emitMessage(
-      sttServerFrame({ result: { text: '你', utterances: [{ definite: false }] } })
-    )
-    socket.emitMessage(
-      sttServerFrame({ result: { text: '你好', utterances: [{ definite: true }] } })
-    )
+    socket.emitMessage(sttServerFrame({ result: { text: '你' } }))
+    socket.emitMessage(sttFinalServerFrame({ result: { text: '你好' } }))
 
     const chunks = await collected
     expect(chunks).toEqual([
@@ -605,13 +629,13 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
     await consumed
   })
 
-  it('ends the iteration on a definite transcript without waiting for a WS close', async () => {
+  it('ends the iteration on the terminal last-package response without waiting for a WS close', async () => {
     // Regression: `collectFinalTranscript` drains `transcribe` to iterator end
     // (it does not break early like the test above). If the adapter only closed
     // on a separate WS `close` event, a server that keeps the socket open after
-    // the definite result would hang the whole turn. Here the server emits a
-    // definite frame and never closes the socket; the iterator must still end
-    // and surface the final chunk.
+    // the final result would hang the whole turn. Here the server emits the
+    // terminal last-package frame and never closes the socket; the iterator must
+    // still end and surface the final chunk.
     const socket = new MockSocket()
     const { connect } = mockConnector(socket)
     const { stt } = createVolcengineSpeechProvider({ apiKey: 'k', connect })
@@ -626,20 +650,16 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
     })()
     const guard = new Promise<never>((_, reject) =>
       setTimeout(
-        () => reject(new Error('transcribe did not terminate on a definite transcript')),
+        () => reject(new Error('transcribe did not terminate on the last-package response')),
         50
       )
     )
 
     await new Promise((r) => setTimeout(r, 0))
-    socket.emitMessage(
-      sttServerFrame({ result: { text: '在', utterances: [{ definite: false }] } })
-    )
-    socket.emitMessage(
-      sttServerFrame({ result: { text: '在的', utterances: [{ definite: true }] } })
-    )
+    socket.emitMessage(sttServerFrame({ result: { text: '在' } }))
+    socket.emitMessage(sttFinalServerFrame({ result: { text: '在的' } }))
     // Intentionally do NOT emit a WS `close` — termination must come from the
-    // definite transcript alone.
+    // last-package response alone.
 
     const chunks = await Promise.race([drained, guard])
     expect(chunks).toEqual([
@@ -648,6 +668,58 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
     ])
     // The adapter also closes the ASR socket as the normal end-of-stream path.
     expect(socket.closed).toBe(true)
+  })
+
+  it('does NOT truncate at a mid-utterance definite — captures the full text through the last-package response', async () => {
+    // The truncation bug, reproduced at the adapter level: Volcengine marks
+    // segments `definite` PROGRESSIVELY as they stabilize, so a long utterance
+    // emits an early `definite: true` segment BEFORE the whole utterance is done.
+    // The OLD adapter ended the stream on that first definite, dropping the rest.
+    // Now `isFinal` keys off the last-package flag, so the early definite is just
+    // another interim and the stream keeps reading until the terminal response —
+    // surfacing the COMPLETE cumulative text, not the truncated head.
+    //
+    // NOTE: this is a MOCK of the live 火山 cadence; the real ASR behavior (does
+    // the server keep streaming past an early definite, and does it set the
+    // last-package bit on the final response) must be confirmed by live verify.
+    const socket = new MockSocket()
+    const { connect } = mockConnector(socket)
+    const { stt } = createVolcengineSpeechProvider({ apiKey: 'k', connect })
+
+    const drained = (async () => {
+      const out = []
+      for await (const chunk of stt.transcribe(await asyncFrom([encoder.encode('f1')]))) {
+        out.push(chunk)
+      }
+      return out
+    })()
+    const guard = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('transcribe did not terminate')), 50)
+    )
+
+    await new Promise((r) => setTimeout(r, 0))
+    // An EARLY stabilized segment (definite) — under the old code this ended the
+    // stream and truncated the transcript to "我看到".
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '我看到', utterances: [{ definite: true }] } })
+    )
+    // The utterance continues (more cumulative text) and only THEN does the
+    // terminal last-package response arrive with the complete utterance.
+    socket.emitMessage(
+      sttServerFrame({ result: { text: '我看到红色', utterances: [{ definite: true }] } })
+    )
+    socket.emitMessage(sttFinalServerFrame({ result: { text: '我看到红色的电线' } }))
+
+    const chunks = await Promise.race([drained, guard])
+    // The stream did NOT stop at the first definite "我看到": every cumulative
+    // result flowed, and the LAST chunk is the complete, untruncated utterance.
+    expect(chunks).toEqual([
+      { text: '我看到', isFinal: false },
+      { text: '我看到红色', isFinal: false },
+      { text: '我看到红色的电线', isFinal: true },
+    ])
+    expect(chunks.at(-1)?.text).toBe('我看到红色的电线')
+    expect(chunks.at(-1)?.isFinal).toBe(true)
   })
 
   it('propagates a server error frame as a thrown error', async () => {
@@ -734,10 +806,8 @@ describe('createVolcengineSpeechProvider.stt.transcribe', () => {
     const collected = collect(stt.transcribe(await asyncFrom([encoder.encode('f1')])))
 
     await new Promise((r) => setTimeout(r, 0))
-    socket.emitMessage(
-      sttServerFrame({ result: { text: '你好', utterances: [{ definite: true }] } })
-    )
-    // A close arriving after the definite transcript is the normal teardown
+    socket.emitMessage(sttFinalServerFrame({ result: { text: '你好' } }))
+    // A close arriving after the terminal transcript is the normal teardown
     // (the adapter itself also closes the socket on a final transcript).
     socket.emitClose()
 
@@ -759,13 +829,13 @@ describe('createVolcengineSpeechProvider.stt — per-connection usage metering',
     await tick()
     socket.emitMessage(
       sttServerFrame({
-        result: { text: '你', utterances: [{ definite: false }] },
+        result: { text: '你' },
         audio_info: { duration: 1200 },
       })
     )
     socket.emitMessage(
-      sttServerFrame({
-        result: { text: '你好', utterances: [{ definite: true }] },
+      sttFinalServerFrame({
+        result: { text: '你好' },
         audio_info: { duration: 3696 },
       })
     )
@@ -786,7 +856,7 @@ describe('createVolcengineSpeechProvider.stt — per-connection usage metering',
       stt.transcribe(await asyncFrom([new Uint8Array(8000), new Uint8Array(8000)]))
     )
     await tick()
-    socket.emitMessage(sttServerFrame({ result: { text: '好', utterances: [{ definite: true }] } }))
+    socket.emitMessage(sttFinalServerFrame({ result: { text: '好' } }))
     await drained
 
     expect(stt.lastUsage).toEqual({ durationMs: 500, source: 'derived-from-bytes' })
@@ -804,8 +874,8 @@ describe('createVolcengineSpeechProvider.stt — per-connection usage metering',
     const drained1 = collect(stt.transcribe(await asyncFrom([new Uint8Array(64000)])))
     await tick()
     socket1.emitMessage(
-      sttServerFrame({
-        result: { text: 'one', utterances: [{ definite: true }] },
+      sttFinalServerFrame({
+        result: { text: 'one' },
         audio_info: { duration: 9999 },
       })
     )
@@ -814,9 +884,7 @@ describe('createVolcengineSpeechProvider.stt — per-connection usage metering',
 
     const drained2 = collect(stt.transcribe(await asyncFrom([new Uint8Array(32000)])))
     await tick()
-    sockets[1].emitMessage(
-      sttServerFrame({ result: { text: 'two', utterances: [{ definite: true }] } })
-    )
+    sockets[1].emitMessage(sttFinalServerFrame({ result: { text: 'two' } }))
     await drained2
 
     expect(stt.lastUsage).toEqual({ durationMs: 1000, source: 'derived-from-bytes' })
@@ -1933,11 +2001,10 @@ describe('createVolcengineSpeechProvider.stt.transcribe — first-response timeo
     socket.emitMessage(
       sttServerFrame({ result: { text: '你好', utterances: [{ definite: false }] } })
     )
-    // Another sub-idle pause — total span now exceeds firstResponseMs — then final.
+    // Another sub-idle pause — total span now exceeds firstResponseMs — then the
+    // terminal last-package response ends the stream.
     await vi.advanceTimersByTimeAsync(TIMEOUTS.streamIdleMs - 5_000)
-    socket.emitMessage(
-      sttServerFrame({ result: { text: '你好吗', utterances: [{ definite: true }] } })
-    )
+    socket.emitMessage(sttFinalServerFrame({ result: { text: '你好吗' } }))
 
     const chunks = await drained
     expect(chunks).toEqual([

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -13,7 +13,12 @@
  *    rejects the 2.0 resource with a 400 "not allowed" (verified by live probe
  *    2026-06-25). The first frame is a JSON full-client config request;
  *    subsequent frames are raw audio. Server responses carry a JSON transcript
- *    whose `utterances[].definite` marks a stabilized segment. This ASR protocol
+ *    whose `result.text` is the CUMULATIVE recognized text so far; the FINAL
+ *    response (after the client's negative-sequence end-of-audio packet) sets the
+ *    "last package" flag bit (`flags & 0x02`) to mark the whole utterance
+ *    complete. (`utterances[].definite` marks only a per-segment stabilization
+ *    that fires progressively mid-utterance — it is NOT the end-of-utterance.)
+ *    This ASR protocol
  *    is *client-push-first by design*: the documented flow is "send full-client
  *    request, then stream audio packets (~100-200ms each)"; there is NO
  *    connection/session-accepted handshake event the client must wait for before
@@ -23,9 +28,10 @@
  *    endpoint returns a new full server response ONLY when the result changes
  *    (no longer one response per input audio packet), so the receive loop must
  *    not assume "every input packet yields a response packet" — this adapter's
- *    loop is already response-count-agnostic (it ends on a definite transcript,
- *    a server error, a socket close, or the first-response deadline — never on a
- *    per-packet response count), so the optimized cadence needs no adaptation.
+ *    loop is already response-count-agnostic (it ends on the terminal
+ *    last-package transcript, a server error, a socket close, or the
+ *    first-response deadline — never on a per-packet response count), so the
+ *    optimized cadence needs no adaptation.
  *  - TTS: Doubao TTS 2.0 bidirectional streaming over the event-based binary
  *    protocol (`wss://openspeech.bytedance.com/api/v3/tts/bidirection`,
  *    resource `seed-tts-2.0`). This protocol is *stateful and
@@ -760,9 +766,40 @@ export function parseFrame(data: unknown): ParsedFrame {
 }
 
 /**
+ * The "last package" bit of the message-type-specific flags nibble. The
+ * Volcengine big-model ASR server sets it on the FINAL response — the one that
+ * answers the client's negative-sequence end-of-audio packet — to mark the whole
+ * utterance complete. It is shared by both wire dialects of a terminal frame:
+ * no-sequence (`LastNoSequence` 0b0010) and with-sequence (`NegativeWithSequence`
+ * 0b0011) both carry it. Ground truth (first-party + community clients all derive
+ * `is_last_package` from `flags & 0x02`): volcengine/ai-app-lab
+ * arkitect/core/component/asr/asr_client.py (`ASRFullServerResponse.last_package`),
+ * volcengine/veadk-python asr_client.py, and thundersoft-td/mcp-server-speech
+ * src/.../asr_ws.py.
+ */
+const LAST_PACKAGE_FLAG_BIT = 0x02
+
+/** True when the frame's flags carry the "last package" (end-of-utterance) bit. */
+export function isLastPackageFlags(flags: number): boolean {
+  return (flags & LAST_PACKAGE_FLAG_BIT) !== 0
+}
+
+/**
  * Map a parsed ASR server-response frame to a transcript chunk. Returns
- * `undefined` for frames with no transcript text (e.g. an empty ack). A
- * segment is final when any utterance reports `definite: true`.
+ * `undefined` for frames with no transcript text (e.g. an empty ack).
+ *
+ * `text` is the server's CUMULATIVE recognized text (full-so-far, not a
+ * per-segment delta). `isFinal` marks the TERMINAL response — the last-package
+ * frame (`flags & 0x02`) the server sends after it has processed the client's
+ * end-of-audio packet and produced the complete cumulative result.
+ *
+ * It is keyed off the last-package flag, NOT `utterances[].definite`: `definite`
+ * marks a per-segment stabilization that fires PROGRESSIVELY mid-utterance, so
+ * any utterance longer than its first stabilized segment has multiple `definite`
+ * results before the end. Ending on the first `definite` truncated the
+ * transcript to the opening segment — the bug this fix removes. The genuine
+ * end-of-utterance is the last-package response (or, as a fallback, the socket
+ * close the server performs right after it — handled by the transcribe loop).
  */
 export function parseSttResponse(frame: ParsedFrame): SttTranscriptChunk | undefined {
   if (frame.messageType === MessageType.ErrorResponse) {
@@ -772,17 +809,13 @@ export function parseSttResponse(frame: ParsedFrame): SttTranscriptChunk | undef
     return undefined
   }
   const body = JSON.parse(textDecoder.decode(frame.payload)) as {
-    result?: {
-      text?: string
-      utterances?: Array<{ definite?: boolean }>
-    }
+    result?: { text?: string }
   }
   const result = body.result
   if (!result || typeof result.text !== 'string') {
     return undefined
   }
-  const isFinal = (result.utterances ?? []).some((u) => u.definite === true)
-  return { text: result.text, isFinal }
+  return { text: result.text, isFinal: isLastPackageFlags(frame.flags) }
 }
 
 /**
@@ -1008,10 +1041,10 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       )
       const socket = await connect(STT_URL, headers)
       const queue = new AsyncQueue<SttTranscriptChunk>()
-      // Tracks whether a final/definite transcript arrived — the ASR normal
-      // completion signal. Used by the message listener (final → close the queue
-      // and the socket) and surfaced in the close trace. A socket close is a
-      // clean end-of-stream EITHER way now: with a final it is the normal
+      // Tracks whether the terminal (last-package) transcript arrived — the ASR
+      // normal completion signal. Used by the message listener (terminal → close
+      // the queue and the socket) and surfaced in the close trace. A socket close
+      // is a clean end-of-stream EITHER way now: with a terminal it is the normal
       // teardown; without one (and without a prior error frame) it is a benign
       // no-speech turn the consumer skips (see the close listener). Unlike the
       // TTS layer's SessionFinished gate — a missing AI response is a fault — a
@@ -1079,17 +1112,22 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
           // First transcript landed in time — stop the first-response deadline so
           // the rest of the stream runs unbounded.
           firstResponseDeadline.cancel()
+          // Every chunk (interim cumulative result + the terminal one) is pushed
+          // to the queue, so the consumer streams them as live subtitle updates.
           queue.push(chunk)
-          // A final/definite transcript is the normal completion signal: end the
-          // iteration here instead of waiting for a separate WS `close`. Without
-          // this, `collectFinalTranscript` (which drains `transcribe` to iterator
-          // end) would hang the whole turn whenever the server keeps the socket
-          // open after the definite result. Push the chunk first, then close, so
-          // the final transcript is never dropped. Also close the ASR socket as
-          // the normal end-of-stream path (idempotent; mirrors the TTS layer).
+          // The TERMINAL (last-package) transcript is the normal completion
+          // signal: end the iteration here instead of waiting for a separate WS
+          // `close`. Without this, the consumer (which drains `transcribe` to
+          // iterator end) would hang the whole turn whenever the server keeps the
+          // socket open after the final result. Push the chunk first, then close,
+          // so the complete transcript is never dropped. Crucially `chunk.isFinal`
+          // now means the last-package response (the whole utterance is done) —
+          // NOT a mid-utterance `definite` segment — so a long utterance is no
+          // longer truncated at its first stabilized segment. Also close the ASR
+          // socket as the normal end-of-stream path (idempotent; mirrors TTS).
           if (chunk.isFinal) {
             finalReached = true
-            // ASR final/definite transcript — the normal completion signal
+            // ASR terminal/last-package transcript — the normal completion signal
             // (length only, never the text).
             traceTurn('asr', 'final', {
               transcriptChars: chunk.text.length,
@@ -1119,11 +1157,13 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
           queue.fail(err)
         }
       })
-      // A socket close ends the stream. After a final/definite transcript it is
-      // the expected end-of-stream; before one (and with no prior error frame) it
-      // is a benign no-speech close (see below). Either way the queue settles
-      // cleanly — a genuine fault has already latched the queue error before the
-      // close arrives.
+      // A socket close ends the stream. After the terminal last-package transcript
+      // it is the expected end-of-stream; before one (and with no prior error
+      // frame) it is a benign no-speech close (see below) — and it also backstops
+      // the case where the server closes after the final cumulative result without
+      // setting the last-package flag (the consumer then falls back to the last
+      // cumulative text). Either way the queue settles cleanly — a genuine fault
+      // has already latched the queue error before the close arrives.
       socket.addEventListener('close', (event) => {
         // Observability: the Volcengine ASR close CODE (numeric) + reason LENGTH.
         // A clean 1000/empty close after silence vs a non-1000 protocol close
@@ -1137,15 +1177,15 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
         // The stream has ended either way — stop the idle guard so it cannot fire
         // late against an already-settled queue.
         streamIdleDeadline?.cancel()
-        // Settle the queue CLEANLY whether or not a final transcript arrived. A
-        // close AFTER a final/definite transcript is the normal end-of-stream. A
-        // close WITHOUT one and without a prior error frame is a benign no-speech
-        // turn: the player's buffered audio held nothing transcribable (a
-        // false-positive VAD trigger — a stopwatch tick, a cough, ambient noise),
-        // so the server closed without ever sending a definite result. It must
-        // NOT fail the turn — the consumer (`collectFinalTranscript`) surfaces an
-        // empty (or partial, non-definite) transcript and the turn is skipped
-        // upstream, keeping the session alive and listening.
+        // Settle the queue CLEANLY whether or not a terminal transcript arrived. A
+        // close AFTER the terminal last-package transcript is the normal
+        // end-of-stream. A close WITHOUT one and without a prior error frame is a
+        // benign no-speech turn: the player's buffered audio held nothing
+        // transcribable (a false-positive VAD trigger — a stopwatch tick, a cough,
+        // ambient noise), so the server closed without ever sending a terminal
+        // result. It must NOT fail the turn — the consumer (`collectFinalTranscript`)
+        // surfaces an empty (or partial, non-terminal) transcript and the turn is
+        // skipped upstream, keeping the session alive and listening.
         //
         // Genuine faults are unaffected and still fail loud (1008): an error
         // frame (`parseSttResponse` throw), the first-response deadline, and the
@@ -1209,8 +1249,8 @@ export function createVolcengineSpeechProvider(opts: VolcengineSpeechOptions): {
       try {
         yield* queue
       } finally {
-        // Runs on every exit path: normal completion (a definite transcript closed
-        // the queue), a provider error (the queue was failed), and — the
+        // Runs on every exit path: normal completion (the terminal transcript
+        // closed the queue), a provider error (the queue was failed), and — the
         // resource-leak fix — consumer cancellation via `transcribe`'s iterator
         // `return()` when the turn exits early. On the cancellation path the queue
         // is still open and the pump may be parked pulling the next audio frame, so

--- a/packages/platform-ai/src/session-do-test-kit.ts
+++ b/packages/platform-ai/src/session-do-test-kit.ts
@@ -403,6 +403,41 @@ export function makeInspectingProviders(): {
 }
 
 /**
+ * Provider bundle whose STT replays a fixed sequence of transcript chunks — the
+ * live-subtitle streaming case. Used to assert the DO relays the player-transcript
+ * SERIES: each non-final chunk surfaces as a `{type:'transcript', text, final:false}`
+ * wire frame (running cumulative text), then the terminal (isFinal) chunk as one
+ * `{type:'transcript', text, final:true}` frame, all before the AI reply chunks.
+ * The LLM completes immediately so the turn runs end-to-end with no manual release.
+ */
+export function makeStreamingTranscriptProviders(transcripts: SttTranscriptChunk[]): {
+  providers: TurnProviders
+  sttCalls(): number
+} {
+  let calls = 0
+  const stt: SttProvider = {
+    async *transcribe(audio): AsyncIterable<SttTranscriptChunk> {
+      calls += 1
+      for await (const _frame of audio) {
+        // frames consumed, not inspected — matches the mock adapter
+      }
+      yield* (async function* () {
+        for (const chunk of transcripts) yield chunk
+      })()
+    },
+  }
+  const llm: LlmProvider = {
+    async *streamCompletion() {
+      yield { content: 'ok.', done: true }
+    },
+  }
+  return {
+    providers: { stt, llm, tts: createMockTtsProvider() },
+    sttCalls: () => calls,
+  }
+}
+
+/**
  * Provider bundle for a benign NO-SPEECH turn: the STT drains the audio bridge
  * and closes with NO final transcript (a false-positive VAD trigger — a cough /
  * ambient noise / stopwatch tick, surfacing as a clean no-final ASR close). The

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -801,14 +801,18 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
         const chunk = next.value
         if (chunk.kind === 'transcript') {
           // The player's recognized utterance — its OWN wire frame, NOT a
-          // `chunk`: `{type:'transcript', text}`. Sent once per turn, before the
-          // AI reply chunks, so the client can show a subtitle of what was heard
-          // (`runTurn` only yields this for a non-empty transcript). It carries no
-          // `done` — the AI reply's terminal `chunk` still closes the turn.
+          // `chunk`: `{type:'transcript', text, final}`. Streamed as a series
+          // before the AI reply chunks so the client can build a live subtitle:
+          // zero or more interim frames (`final:false`, running cumulative text)
+          // then one terminal frame (`final:true`, the complete utterance).
+          // `runTurn` only yields these for a non-empty transcript (a no-speech
+          // turn sends none). They carry no `done` — the AI reply's terminal
+          // `chunk` still closes the turn.
           ws.send(
             JSON.stringify({
               type: 'transcript',
               text: chunk.text ?? '',
+              final: chunk.final ?? false,
             })
           )
         } else if (chunk.kind === 'audio' && chunk.audio) {

--- a/packages/platform-ai/src/session-transcript.test.ts
+++ b/packages/platform-ai/src/session-transcript.test.ts
@@ -6,12 +6,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * (`@cloudflare/vitest-pool-workers`).
  *
  * The DO must surface the player's recognized speech back to the client so the
- * UI can show a subtitle of what the AI heard. After a turn's STT produces the
- * final transcript and BEFORE the AI reply chunks stream, the DO sends one
- * `{type:'transcript', text}` JSON frame (NOT a `chunk`). A benign no-speech
- * turn (STT closes with no final transcript) sends none — consistent with the
- * no-speech skip. The opening greeting carries no player transcript and sends
- * none either (covered by `runOpeningTurn` never yielding a transcript chunk).
+ * UI can build a LIVE subtitle of what the AI heard. As the STT result grows, the
+ * DO streams a SERIES of `{type:'transcript', text, final}` JSON frames (NOT
+ * `chunk`s) BEFORE the AI reply chunks: zero or more interim frames (`final:false`,
+ * running cumulative text) then one terminal frame (`final:true`, the complete
+ * utterance). A benign no-speech turn (STT closes with no final transcript) sends
+ * none — consistent with the no-speech skip. The opening greeting carries no
+ * player transcript and sends none either (covered by `runOpeningTurn` never
+ * yielding a transcript chunk).
  */
 
 const providerControl = vi.hoisted(() => ({
@@ -32,6 +34,7 @@ import {
   makeInspectingProviders,
   makeNoSpeechProviders,
   makeSessionDo,
+  makeStreamingTranscriptProviders,
   messagesOfType,
   openSocket,
   sawDoneChunk,
@@ -59,11 +62,13 @@ describe('real VoiceSessionDO — player transcript wire frame', () => {
     await waitFor(() => kit.sttCalls() === 1, 'turn ran STT once')
     await waitFor(() => sawDoneChunk(socket), 'turn emitted its terminal done chunk')
 
-    // Exactly one transcript frame, carrying the player's recognized utterance
-    // (the inspecting STT's fixed final transcript) — its OWN frame, NOT a
-    // `chunk`, and with no `done` key.
+    // Exactly one transcript frame — the terminal (final:true) complete utterance
+    // (the inspecting STT yields a single isFinal chunk, so no interim frames) —
+    // its OWN frame, NOT a `chunk`, and with no `done` key.
     const transcripts = messagesOfType(socket, 'transcript')
-    expect(transcripts).toEqual([{ type: 'transcript', text: 'inspecting harness utterance' }])
+    expect(transcripts).toEqual([
+      { type: 'transcript', text: 'inspecting harness utterance', final: true },
+    ])
 
     // Ordering: the transcript frame arrives BEFORE the first AI reply chunk.
     const transcriptIndex = socket.messages.findIndex((m) => m.type === 'transcript')
@@ -78,6 +83,46 @@ describe('real VoiceSessionDO — player transcript wire frame', () => {
     const chunks = messagesOfType(socket, 'chunk')
     expect(chunks.length).toBeGreaterThan(0)
     expect(chunks.filter((c) => c.done === true)).toHaveLength(1)
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    expect(messagesOfType(socket, 'summary')).toHaveLength(1)
+  })
+
+  it('streams the transcript SERIES: interim {final:false} frames then one {final:true}', async () => {
+    const kit = makeStreamingTranscriptProviders([
+      { text: '我看到', isFinal: false },
+      { text: '我看到红色', isFinal: false },
+      { text: '我看到红色的电线', isFinal: true },
+    ])
+    providerControl.override = kit.providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    socket.send(TURN)
+    await waitFor(() => kit.sttCalls() === 1, 'turn ran STT once')
+    await waitFor(() => sawDoneChunk(socket), 'turn emitted its terminal done chunk')
+
+    // The running cumulative interims stream first (final:false), then exactly one
+    // terminal frame carries the COMPLETE utterance (final:true) — not truncated to
+    // the first stabilized segment.
+    const transcripts = messagesOfType(socket, 'transcript')
+    expect(transcripts).toEqual([
+      { type: 'transcript', text: '我看到', final: false },
+      { type: 'transcript', text: '我看到红色', final: false },
+      { type: 'transcript', text: '我看到红色的电线', final: true },
+    ])
+    expect(transcripts.filter((t) => t.final === true)).toHaveLength(1)
+
+    // The whole transcript series precedes the first AI reply chunk.
+    const lastTranscriptIndex =
+      socket.messages.length -
+      1 -
+      [...socket.messages].reverse().findIndex((m) => m.type === 'transcript')
+    const firstChunkIndex = socket.messages.findIndex((m) => m.type === 'chunk')
+    expect(firstChunkIndex).toBeGreaterThanOrEqual(0)
+    expect(lastTranscriptIndex).toBeLessThan(firstChunkIndex)
 
     socket.send(END)
     await waitForMessage(socket, 'summary')

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -189,6 +189,8 @@ describe('runTurn', () => {
   it('emits the player transcript as a leading chunk, before the AI reply chunks', async () => {
     const turn = runTurn(
       providers(
+        // A single terminal (isFinal) STT chunk: no interim updates, just the
+        // complete utterance — emitted once as the terminal `final: true` frame.
         mockStt([{ text: 'I see a red wire.', isFinal: true }]),
         mockLlm(['Cut the ', 'blue wire.']),
         mockTts([])
@@ -198,16 +200,22 @@ describe('runTurn', () => {
     )
     const chunks = await collect(turn)
 
-    // Exactly one transcript chunk, carrying the PLAYER's recognized utterance
-    // (not AI text), not the terminal `done`.
+    // Exactly one transcript chunk — the terminal complete utterance (final:true)
+    // carrying the PLAYER's recognized utterance (not AI text), not the turn's
+    // terminal `done`.
     const transcriptChunks = chunks.filter((c) => c.kind === 'transcript')
     expect(transcriptChunks).toEqual([
-      { kind: 'transcript', text: 'I see a red wire.', done: false },
+      { kind: 'transcript', text: 'I see a red wire.', final: true, done: false },
     ])
 
     // It precedes every AI text/audio chunk: the first emitted chunk IS the
     // transcript, and no AI chunk appears before it.
-    expect(chunks[0]).toEqual({ kind: 'transcript', text: 'I see a red wire.', done: false })
+    expect(chunks[0]).toEqual({
+      kind: 'transcript',
+      text: 'I see a red wire.',
+      final: true,
+      done: false,
+    })
     const firstAiIndex = chunks.findIndex((c) => c.kind === 'text' || c.kind === 'audio')
     expect(chunks.findIndex((c) => c.kind === 'transcript')).toBeLessThan(firstAiIndex)
 
@@ -219,6 +227,44 @@ describe('runTurn', () => {
     expect(chunks.filter((c) => c.kind === 'audio').length).toBeGreaterThan(0)
     expect(chunks.filter((c) => c.done)).toHaveLength(1)
     expect(chunks.at(-1)?.done).toBe(true)
+  })
+
+  it('streams interim transcript frames (final:false) then one terminal final:true', async () => {
+    // The live-subtitle contract: as the cumulative ASR result grows, each interim
+    // result streams as a `transcript` chunk with `final: false` (the running
+    // cumulative text, not a delta); the terminal (isFinal) result is emitted ONCE
+    // as `final: true` carrying the complete utterance — never as a duplicate
+    // interim. This is the full-transcript fix's client-facing half.
+    const turn = runTurn(
+      providers(
+        mockStt([
+          { text: 'I', isFinal: false },
+          { text: 'I see', isFinal: false },
+          { text: 'I see a red wire', isFinal: true },
+        ]),
+        mockLlm(['ok.']),
+        mockTts([])
+      ),
+      freshState(),
+      fromArray<AudioChunk>([new Uint8Array([1])])
+    )
+    const chunks = await collect(turn)
+
+    const transcriptChunks = chunks.filter((c) => c.kind === 'transcript')
+    expect(transcriptChunks).toEqual([
+      { kind: 'transcript', text: 'I', final: false, done: false },
+      { kind: 'transcript', text: 'I see', final: false, done: false },
+      { kind: 'transcript', text: 'I see a red wire', final: true, done: false },
+    ])
+    // Exactly one terminal (final:true) transcript frame, carrying the complete
+    // utterance; it is the last transcript frame and precedes all AI chunks.
+    const finals = transcriptChunks.filter((c) => c.final === true)
+    expect(finals).toHaveLength(1)
+    expect(transcriptChunks.at(-1)?.final).toBe(true)
+    const firstAiIndex = chunks.findIndex((c) => c.kind === 'text' || c.kind === 'audio')
+    const lastTranscriptIndex =
+      chunks.length - 1 - [...chunks].reverse().findIndex((c) => c.kind === 'transcript')
+    expect(lastTranscriptIndex).toBeLessThan(firstAiIndex)
   })
 
   it('emits NO transcript chunk on a skipped no-speech turn', async () => {

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -14,10 +14,14 @@
  * usage) — it is I/O-free, not side-effect-free. Keeping the orchestration here
  * (no WS, no DO, no clock) makes it unit-testable with three mocked providers.
  *
- * Volcengine ASR note: the current Volcengine ASR adapter returns the
- * *cumulative* full transcript on each chunk (not an incremental delta). So the
- * player's utterance for the turn is the text of the LAST `isFinal` chunk — we
- * take the final cumulative text, not a concatenation of fragments.
+ * Volcengine ASR note: the Volcengine ASR adapter returns the *cumulative* full
+ * transcript on each chunk (not an incremental delta), and marks `isFinal` on the
+ * TERMINAL (last-package) result — the whole utterance, not a mid-utterance
+ * stabilized segment. So the player's complete utterance for the turn is the text
+ * of the last `isFinal` chunk (or, absent a terminal, the last chunk seen before
+ * a clean close). The pipeline streams every interim chunk to the client as a
+ * live-subtitle `transcript` frame (`final: false`), then emits the complete
+ * utterance once as the terminal `transcript` frame (`final: true`).
  */
 
 import type { CompanionContext } from '../../companion-memory/src/types'
@@ -148,24 +152,32 @@ export function splitSentences(buffer: string): { sentences: string[]; remainder
 }
 
 /**
- * Drain an STT transcript stream and return the player's utterance for the
- * turn: the text of the last `isFinal` chunk (cumulative ASR semantics). If no
- * `isFinal` chunk arrives, fall back to the last chunk's text (best effort), or
- * empty string for an empty stream. A clean no-final ASR close (a benign
- * no-speech turn) surfaces here as that empty/partial transcript rather than a
- * throw, so `runTurn` can skip the turn; only a genuine fault (error frame,
- * connect failure, idle stall) throws out of the underlying `transcribe`.
+ * Drain an STT transcript stream, STREAMING each interim result to the client as
+ * a live-subtitle `transcript` chunk (`final: false`, carrying the running
+ * cumulative recognized text), and RETURN the player's complete utterance for
+ * the turn: the text of the terminal `isFinal` chunk (cumulative ASR semantics).
+ * If no `isFinal` (last-package) chunk arrives, fall back to the last chunk's
+ * text (best effort), or empty string for an empty stream. A clean no-final ASR
+ * close (a benign no-speech turn) surfaces here as that empty/partial transcript
+ * rather than a throw, so `runTurn` can skip the turn; only a genuine fault
+ * (error frame, connect failure, idle stall) throws out of `transcribe`.
  *
- * Also reports `audioBytes`: the total byte length of the inbound audio frames
+ * The terminal chunk is NOT emitted as an interim here: its text is returned as
+ * `transcript` so `runTurn` emits it once as the terminal `final: true` frame
+ * after the no-speech gate (an empty utterance is skipped — never surfaced).
+ * Interim chunks whose trimmed text is empty are suppressed, so a whitespace-only
+ * stream that resolves to a skip emits no frame at all.
+ *
+ * Also returns `audioBytes`: the total byte length of the inbound audio frames
  * the STT provider actually pulled, tapped via a counting passthrough. The
  * caller uses this as the fallback STT metering path when the adapter exposes
  * no structured usage of its own. The passthrough forwards every frame
  * unchanged, so STT behaviour is unaffected.
  */
-async function collectFinalTranscript(
+async function* collectFinalTranscript(
   stt: SttProvider,
   audio: AsyncIterable<AudioChunk>
-): Promise<{ transcript: string; audioBytes: number }> {
+): AsyncGenerator<AiResponseChunk, { transcript: string; audioBytes: number }> {
   let audioBytes = 0
   const counted: AsyncIterable<AudioChunk> = {
     async *[Symbol.asyncIterator]() {
@@ -180,7 +192,18 @@ async function collectFinalTranscript(
   let lastAny = ''
   for await (const chunk of stt.transcribe(counted)) {
     lastAny = chunk.text
-    if (chunk.isFinal) lastFinal = chunk.text
+    if (chunk.isFinal) {
+      // Terminal/last-package result — the complete utterance. Don't stream it as
+      // an interim; `runTurn` emits it once as the terminal `final: true` frame
+      // (and only when non-empty, preserving the no-speech skip).
+      lastFinal = chunk.text
+      continue
+    }
+    // Interim running text — stream it live as a non-final subtitle update. The
+    // text is the cumulative recognized-so-far, not a delta.
+    if (chunk.text.trim().length > 0) {
+      yield { kind: 'transcript', text: chunk.text, final: false, done: false }
+    }
   }
   return { transcript: (lastFinal ?? lastAny).trim(), audioBytes }
 }
@@ -467,18 +490,21 @@ export async function* runTurn(
   state: SessionState,
   audio: AsyncIterable<AudioChunk>
 ): AsyncIterable<AiResponseChunk> {
-  // 1. STT: transcribe the player's audio; take the final cumulative transcript.
-  //    `audioBytes` is the inbound-frame byte total — the fallback STT metering
-  //    source at turn settle when the adapter reports no structured usage.
+  // 1. STT: transcribe the player's audio, streaming each interim cumulative
+  //    result to the client as a live-subtitle `transcript` chunk (final: false)
+  //    as it arrives, and capturing the complete utterance (the terminal
+  //    last-package result) as the generator's return. `audioBytes` is the
+  //    inbound-frame byte total — the fallback STT metering source at turn settle
+  //    when the adapter reports no structured usage.
   const turnStart = Date.now()
   traceTurn('turn', 'pipeline-start', {
     turnCount: state.turnCount,
   })
-  const { transcript: playerText, audioBytes: sttAudioBytes } = await collectFinalTranscript(
+  const { transcript: playerText, audioBytes: sttAudioBytes } = yield* collectFinalTranscript(
     providers.stt,
     audio
   )
-  // ASR hop boundary: the final cumulative transcript is in hand (length only —
+  // ASR hop boundary: the complete cumulative transcript is in hand (length only —
   // never the text). An empty transcript here explains a downstream LLM no-op.
   traceTurn('asr', 'final-transcript', {
     transcriptChars: playerText.length,
@@ -502,14 +528,17 @@ export async function* runTurn(
     return
   }
 
-  // 1b. Surface the player's recognized utterance to the client BEFORE the AI
-  //     reply streams, so the UI can show a subtitle of what the AI heard.
-  //     Emitted exactly once per turn and only for a NON-empty transcript (the
-  //     no-speech skip above already returned, so a skipped turn yields nothing).
+  // 1b. The complete utterance — the TERMINAL transcript frame (final: true),
+  //     surfaced BEFORE the AI reply streams so the client can lock in the live
+  //     subtitle of what the AI heard. Interim frames (final: false) for this
+  //     utterance already streamed during STT above; this is the single final
+  //     frame. Emitted only for a NON-empty transcript — the no-speech skip above
+  //     already returned (and a skip emits no interim either, since empty /
+  //     whitespace interims are suppressed), so a skipped turn yields nothing.
   //     This is the player's OWN speech returned to that same client — never
   //     prompt or secret material; it carries `done: false` (the AI reply's last
   //     text chunk is still the turn's terminal `done`).
-  yield { kind: 'transcript', text: playerText, done: false }
+  yield { kind: 'transcript', text: playerText, final: true, done: false }
 
   // 2. Inject: deterministic system message (role + rules + manual subset),
   //    then the rolling history, then this turn's player utterance.


### PR DESCRIPTION
## Summary

Two ASR defects from a live device test, both from ending recognition at the first stabilized segment:
- **Truncation** — recognition stopped at the FIRST `definite` segment, cutting any utterance to its opening few words. 火山 marks segments `definite` progressively; the real end is the protocol last-package bit (`flags & 0x02`) on the final response (`text` is cumulative — triangulated from 火山's first-party clients). `parseSttResponse` now derives `isFinal` from the last-package bit → the **full** transcript. **Verified live**: a 5.3s multi-segment fixture now returns the full text, not just the head.
- **Late subtitle** — the transcript was sent once after STT. `collectFinalTranscript` is now an async generator streaming interim `{type:'transcript', text, final:false}` then `{final:true}`; the `你：…` caption streams live as you speak.

Fail-loud guards + the benign no-speech skip unchanged.

## Test plan
- [x] tsc/build/lint clean; platform-ai 321 + game-bombsquad 392
- [x] **Live-verified**: multi-segment fixture returns full transcript + streaming interims (probe)
- [ ] device re-test (natural speech accuracy + live caption feel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)