### PR TITLE
feat(bombsquad): one continuous mode② voice conversation per run + clearer ASR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② voice: one conversation per run, clearer recognition, longer
+pauses** - Change. The AI partner is now a single continuous conversation for the
+whole daily run: it greets you once and remembers the whole game, and when you
+move to the next module it just gets that module's manual — it no longer
+restarts and re-introduces itself each module. Recognition no longer inserts a
+period at every pause (which had been chopping words apart when you spoke
+slowly), so your speech reads as continuous text. And it now waits 2.5s (up from
+1.5s) before taking its turn, giving you more room to think and gather your words.
+
 **BombSquad mode② voice: full speech recognition + live captions** - Fix. Two
 problems: the recognizer cut off after your first few words, and your subtitle
 only showed up late. Both came from ending recognition at the first stabilized

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -205,8 +205,10 @@ export default function GamePage() {
 
   // Voice-session inputs for the current module, recomputed only when the loaded
   // manual or the current module changes (NOT on every timer-frame re-render).
-  // `moduleKey` keys the panel's remount so advancing modules tears down the old
-  // session and reconnects with the new module's `relevantSections`.
+  // Advancing modules changes `gameState.relevantSections` but keeps the same
+  // run-stable `sessionKey`, so the panel does NOT remount — the hook steers the
+  // live session with one `update-gamestate` instead of reconnecting (one
+  // continuous conversation per run; the AI greets once and remembers it).
   const voiceInputs = useMemo(
     () => (usePlatformVoice ? deriveVoicePanelInputs(state) : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -218,7 +220,8 @@ export default function GamePage() {
   // disturbs the conversation and bleeds back in as false speech. Only the SOUND
   // is gated — the stopwatch keeps counting (the elapsed time IS the score). A
   // mode① run never mounts the panel (`voiceInputs === null`), so it keeps all
-  // SFX. Cleanup restores audio on exit / module change.
+  // SFX. `voiceActive` stays true for the whole mode② run (the panel no longer
+  // remounts per module), so cleanup restores audio on exit / unmount.
   const voiceActive = voiceInputs !== null
   useEffect(() => {
     setSfxSuppressed(voiceActive)
@@ -668,7 +671,7 @@ export default function GamePage() {
 
       {voiceInputs && (
         <VoicePanel
-          key={voiceInputs.moduleKey}
+          key={voiceInputs.sessionKey}
           manualData={voiceInputs.manualData}
           gameState={voiceInputs.gameState}
         />

--- a/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
@@ -369,14 +369,9 @@ describe('useVoiceSession — client VAD', () => {
     expect(result.current.playerSpeaking).toBe(true)
     expect(result.current.conversationPhase).toBe('listening')
 
-    // Six 256ms silence frames (1536ms >= 1500ms hangover) end it -> a turn is sent.
+    // Ten 256ms silence frames (2560ms >= 2500ms hangover) end it -> a turn is sent.
     act(() => {
-      fireFrame(0.0)
-      fireFrame(0.0)
-      fireFrame(0.0)
-      fireFrame(0.0)
-      fireFrame(0.0)
-      fireFrame(0.0)
+      for (let i = 0; i < 10; i += 1) fireFrame(0.0)
     })
     expect(result.current.playerSpeaking).toBe(false)
     expect(result.current.conversationPhase).toBe('thinking')
@@ -421,6 +416,89 @@ describe('useVoiceSession — client VAD', () => {
     )
     expect(result.current.error).toBeNull()
     expect(result.current.status).toBe('ready')
+  })
+})
+
+describe('useVoiceSession — module advance steers one session', () => {
+  /** Render with a controllable gameState prop, then bring it to a live session. */
+  async function readyWithGameState(initial: GameState) {
+    const rendered = renderHook(
+      ({ gs }: { gs: GameState }) => useVoiceSession({ manualData: manualData(), gameState: gs }),
+      { initialProps: { gs: initial } }
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    await act(async () => {
+      ws.fireMessage({ type: 'created', sessionId: 'sess-1' })
+    })
+    await waitFor(() => captureProcessor())
+    return { ...rendered, ws }
+  }
+
+  it('sends the first module via create and never an update for it', async () => {
+    const { ws } = await readyWithGameState({ relevantSections: ['wire_routing'] })
+    const create = ws.controlMessages().find((m) => m.type === 'create')
+    expect(create).toMatchObject({ gameState: { relevantSections: ['wire_routing'] } })
+    expect(ws.controlMessages().some((m) => m.type === 'update-gamestate')).toBe(false)
+  })
+
+  it('advancing a module sends ONE update-gamestate on the SAME socket (no reconnect/re-greet)', async () => {
+    const { ws, rerender } = await readyWithGameState({ relevantSections: ['wire_routing'] })
+    const socketsBefore = MockWebSocket.instances.length
+
+    // Player advances to the next module: relevantSections change.
+    act(() => rerender({ gs: { relevantSections: ['symbol_dial'] } }))
+
+    const updates = ws.controlMessages().filter((m) => m.type === 'update-gamestate')
+    expect(updates).toHaveLength(1)
+    expect(updates[0]).toMatchObject({
+      type: 'update-gamestate',
+      gameState: { relevantSections: ['symbol_dial'] },
+    })
+    // Same live socket — no fresh WebSocket constructed (no reconnect), and no
+    // second `create` (no re-greet).
+    expect(MockWebSocket.instances.length).toBe(socketsBefore)
+    expect(ws.controlMessages().filter((m) => m.type === 'create')).toHaveLength(1)
+  })
+
+  it('sends one update per module across several advances', async () => {
+    const { ws, rerender } = await readyWithGameState({ relevantSections: ['wire_routing'] })
+    act(() => rerender({ gs: { relevantSections: ['symbol_dial'] } }))
+    act(() => rerender({ gs: { relevantSections: ['button'] } }))
+    act(() => rerender({ gs: { relevantSections: ['keypad'] } }))
+    const updates = ws.controlMessages().filter((m) => m.type === 'update-gamestate')
+    expect(updates.map((m) => (m.gameState as GameState).relevantSections)).toEqual([
+      ['symbol_dial'],
+      ['button'],
+      ['keypad'],
+    ])
+  })
+
+  it('does not send an update when a re-render leaves the sections unchanged', async () => {
+    const { ws, rerender } = await readyWithGameState({ relevantSections: ['wire_routing'] })
+    // A new object with identical sections (e.g. a stopwatch-frame re-render).
+    act(() => rerender({ gs: { relevantSections: ['wire_routing'] } }))
+    expect(ws.controlMessages().some((m) => m.type === 'update-gamestate')).toBe(false)
+  })
+
+  it('does not send an update before the session is created', async () => {
+    const rendered = renderHook(
+      ({ gs }: { gs: GameState }) => useVoiceSession({ manualData: manualData(), gameState: gs }),
+      { initialProps: { gs: { relevantSections: ['wire_routing'] } as GameState } }
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    // Section change while connecting (no `created` yet) — must not steer a
+    // not-yet-existing session, and must not duplicate a `create`.
+    act(() => rendered.rerender({ gs: { relevantSections: ['symbol_dial'] } }))
+    expect(ws.controlMessages().some((m) => m.type === 'update-gamestate')).toBe(false)
+    // Once created, the latest sections are reconciled with exactly one steer.
+    await act(async () => {
+      ws.fireMessage({ type: 'created', sessionId: 'sess-1' })
+    })
+    const updates = ws.controlMessages().filter((m) => m.type === 'update-gamestate')
+    expect(updates).toHaveLength(1)
+    expect(updates[0]).toMatchObject({ gameState: { relevantSections: ['symbol_dial'] } })
   })
 })
 

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -76,6 +76,16 @@ const NO_RESPONSE_TIMEOUT_MS = 12000
  * so a leaked context across turns / panel remounts eventually starves the next
  * `new AudioContext(...)` — which is the failure this hardening guards against.
  */
+/**
+ * Stable signature of the manual-subset selection, for change detection across
+ * renders. A new selection (the player advanced modules) yields a different
+ * string; an unchanged selection (a timer-frame re-render) yields the same one,
+ * so the `update-gamestate` steer fires exactly once per real module change.
+ */
+function sectionsSignature(gameState: GameState): string {
+  return JSON.stringify(gameState.relevantSections ?? [])
+}
+
 function closeAudioContext(ctx: AudioContext | null): void {
   if (!ctx) return
   try {
@@ -99,8 +109,10 @@ export interface UseVoiceSessionOptions {
   manualData: ManualData | null
   /**
    * The game state driving manual-subset selection (`relevantSections` via
-   * `moduleKindToRelevantSections`). Applied at session-create time; see the
-   * module-change note on the return type.
+   * `moduleKindToRelevantSections`). The FIRST value rides the `create` message;
+   * a later change (the player advanced modules within one run) is steered on the
+   * live socket with a single `update-gamestate` — see the module-change note on
+   * the return type.
    */
   gameState: GameState
   /** Platform game id. Defaults to `'bombsquad'`. */
@@ -129,13 +141,14 @@ export interface UseVoiceSessionResult {
 }
 
 /**
- * Module-change / `gameState` updates: the wire protocol exposes no mid-session
- * `gameState` update message (only `create` / `end`, and a re-`create` is
- * rejected `already_created`), so `relevantSections` are pinned at the value
- * captured when the session is created. The hook keeps the LATEST `gameState`/
- * `manualData` in refs and applies them at create time; to inject a new module's
- * sections the consumer creates a fresh session (remount via the `VoicePanel`
- * key). Within one live session, turns reuse the created sections.
+ * Module-change / `gameState` updates: ONE continuous session spans the whole
+ * run. The FIRST `gameState.relevantSections` rides the `create` message; when
+ * the player advances modules the sections change and the hook steers the LIVE
+ * session with a single `{type:'update-gamestate', gameState}` on the same open
+ * socket — it does NOT reconnect, so the WS, the mic, the conversation history,
+ * and the AI-first greeting all persist (the AI just gets the new module's manual
+ * subset for subsequent turns). The update is sent exactly once per actual change
+ * and only after the session is `created`; an unchanged re-render sends nothing.
  */
 export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessionResult {
   const { manualData, gameState, gameId = 'bombsquad' } = options
@@ -170,6 +183,13 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
   const wsRef = useRef<WebSocket | null>(null)
   const endedRef = useRef(false)
   const mountedRef = useRef(true)
+  /**
+   * The `relevantSections` signature already communicated to the live session —
+   * set when `create` is sent (the first selection rides that message) and after
+   * each `update-gamestate`. A module advance whose new signature differs from
+   * this sends exactly one steer; `null` until the session is being created.
+   */
+  const sentSectionsRef = useRef<string | null>(null)
 
   const mediaStreamRef = useRef<MediaStream | null>(null)
   const captureCtxRef = useRef<AudioContext | null>(null)
@@ -454,6 +474,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     const data = manualDataRef.current
     if (!data) return
     endedRef.current = false
+    sentSectionsRef.current = null
     safeDispatch({ type: 'connecting' })
 
     let ws: WebSocket
@@ -474,6 +495,10 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
       }
       try {
         ws.send(JSON.stringify(create))
+        // The first module's sections rode this `create`; record them so a later
+        // module advance sends ONE `update-gamestate` (and the module the session
+        // was created with never triggers a redundant steer).
+        sentSectionsRef.current = sectionsSignature(gameStateRef.current)
       } catch {
         safeDispatch({ type: 'transport-error', message: 'failed to create voice session' })
       }
@@ -586,6 +611,30 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
       closeSocket(true)
     }
   }, [hasManual, connect, stopCapture, teardownPlayback, closeSocket])
+
+  // --- Module advance within one run: steer the live session, never reconnect ---
+  //
+  // When `relevantSections` change AFTER the session is created (the player moved
+  // to a new module), send ONE `update-gamestate` on the open socket so the
+  // server injects the new module's manual subset for subsequent turns. The first
+  // selection already rode the `create` message (`onopen` set `sentSectionsRef`),
+  // so only a genuine later change sends here, exactly once. Gated on the `ready`
+  // status (set on the `created` frame) so nothing is sent before the session
+  // exists — never as a second `create`. The conversation, history, and greeting
+  // are untouched; this only re-selects which manual sections the next turn sees.
+  const liveSectionsSignature = sectionsSignature(gameState)
+  useEffect(() => {
+    if (state.status !== 'ready') return
+    if (sentSectionsRef.current === liveSectionsSignature) return
+    const ws = wsRef.current
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+    sentSectionsRef.current = liveSectionsSignature
+    try {
+      ws.send(JSON.stringify({ type: 'update-gamestate', gameState: gameStateRef.current }))
+    } catch {
+      /* non-fatal — a dropped steer just leaves the next turn on the old sections */
+    }
+  }, [liveSectionsSignature, state.status])
 
   const conversationPhase = useMemo(
     () => deriveConversationPhase({ isAiSpeaking, playerSpeaking, awaitingResponse }),

--- a/packages/game-bombsquad/src/voice/voice-panel-inputs.test.ts
+++ b/packages/game-bombsquad/src/voice/voice-panel-inputs.test.ts
@@ -96,12 +96,24 @@ describe('deriveVoicePanelInputs (current module -> hook inputs)', () => {
     expect(inputs?.manualData.sections).not.toHaveProperty('morse_code')
   })
 
-  it('produces a distinct moduleKey per module so the panel remounts on advance', () => {
-    const first = deriveVoicePanelInputs(makeState({ currentModuleIndex: 0 }))
-    const second = deriveVoicePanelInputs(makeState({ currentModuleIndex: 1 }))
-    expect(first?.moduleKey).toBe('0-wire')
-    expect(second?.moduleKey).toBe('1-dial')
-    expect(first?.moduleKey).not.toBe(second?.moduleKey)
+  it('keeps a run-stable sessionKey across module advances so the panel never remounts', () => {
+    const first = deriveVoicePanelInputs(makeState({ currentModuleIndex: 0, rngSeed: 42 }))
+    const second = deriveVoicePanelInputs(makeState({ currentModuleIndex: 1, rngSeed: 42 }))
+    // Same run (same seed) → identical key as the module advances → one session.
+    expect(first?.sessionKey).toBe('run-42')
+    expect(second?.sessionKey).toBe('run-42')
+    expect(first?.sessionKey).toBe(second?.sessionKey)
+    // But the per-module sections still change, so the hook can steer the session.
+    expect(first?.gameState.relevantSections).toEqual(['wire_routing'])
+    expect(second?.gameState.relevantSections).toEqual(['symbol_dial'])
+  })
+
+  it('gives a different run a different sessionKey (a genuinely new session)', () => {
+    const runA = deriveVoicePanelInputs(makeState({ rngSeed: 1 }))
+    const runB = deriveVoicePanelInputs(makeState({ rngSeed: 2 }))
+    expect(runA?.sessionKey).toBe('run-1')
+    expect(runB?.sessionKey).toBe('run-2')
+    expect(runA?.sessionKey).not.toBe(runB?.sessionKey)
   })
 
   it('returns null until a manual is loaded', () => {

--- a/packages/game-bombsquad/src/voice/voice-panel-inputs.ts
+++ b/packages/game-bombsquad/src/voice/voice-panel-inputs.ts
@@ -3,7 +3,10 @@
  * hook inputs. Side-effect-free (no React, no I/O) so the mode②-gating and the
  * current-module -> `relevantSections` derivation are unit-testable without a
  * browser. `GamePage` consumes these to mount `VoicePanel` only for an opted-in
- * daily run, and to remount it (fresh session) on every module advance.
+ * daily run. The panel is keyed on the RUN (`sessionKey`), not the module, so it
+ * mounts once and stays mounted across module advances — one continuous voice
+ * session per run. Only `gameState.relevantSections` changes per module, which
+ * the hook steers on the live socket; advancing modules never remounts.
  */
 
 import type { GameState as BombSquadGameState, GameMode, ModuleKind } from '@/store/game-context'
@@ -30,12 +33,13 @@ export interface VoicePanelInputs {
   /** Drives the platform's manual-subset selection for the current module. */
   gameState: VoiceGameState
   /**
-   * Stable per-module identity. Used as the `VoicePanel` React `key`, so when
-   * the player advances modules the panel tears down (WS/mic/AudioContext) and
-   * reconnects with the new module's `relevantSections` — the locked
-   * per-module-session model.
+   * Stable per-RUN identity. Used as the `VoicePanel` React `key`. It is keyed on
+   * the run (the run's `rngSeed`), NOT the module, so it stays constant as the
+   * player advances modules — the panel mounts ONCE and keeps one continuous WS /
+   * mic / conversation for the whole run (the AI greets once and remembers it).
+   * A genuinely new run gets a new seed and therefore a fresh session.
    */
-  moduleKey: string
+  sessionKey: string
   /** The current module kind (surfaced for labelling / callers). */
   moduleKind: ModuleKind
 }
@@ -52,7 +56,7 @@ export function deriveVoicePanelInputs(state: BombSquadGameState): VoicePanelInp
   return {
     manualData: bombsquadManualToManualData(state.manual, state.manual.meta.version),
     gameState: { relevantSections: moduleKindToRelevantSections(moduleKind) },
-    moduleKey: `${state.currentModuleIndex}-${moduleKind}`,
+    sessionKey: `run-${state.rngSeed}`,
     moduleKind,
   }
 }

--- a/packages/game-bombsquad/src/voice/voice-vad.ts
+++ b/packages/game-bombsquad/src/voice/voice-vad.ts
@@ -56,11 +56,11 @@ export interface VadConfig {
  */
 export const DEFAULT_VAD_CONFIG: VadConfig = {
   speechThreshold: 0.07,
-  // 1500ms of trailing silence before an utterance is considered finished. A
-  // generous pause so the player can think and gather their words mid-sentence
+  // 2500ms of trailing silence before an utterance is considered finished. A
+  // long pause so the player can think and gather their words mid-sentence
   // without the turn firing prematurely (a defuse player describes a device, then
   // pauses to read the next part). Tunable per device feedback.
-  silenceHangoverMs: 1500,
+  silenceHangoverMs: 2500,
   minSpeechMs: 400,
 }
 

--- a/packages/platform-ai/src/providers/volcengine.test.ts
+++ b/packages/platform-ai/src/providers/volcengine.test.ts
@@ -228,7 +228,7 @@ describe('STT frame codec', () => {
     expect(body).toEqual({
       user: { uid: 'user-9' },
       audio: { format: 'pcm', rate: 24000, bits: 16, channel: 1 },
-      request: { model_name: 'bigmodel', enable_punc: true, enable_itn: true },
+      request: { model_name: 'bigmodel', enable_punc: false, enable_itn: true },
     })
   })
 

--- a/packages/platform-ai/src/providers/volcengine.ts
+++ b/packages/platform-ai/src/providers/volcengine.ts
@@ -400,7 +400,13 @@ export function buildSttConfigFrame(config: {
       },
       request: {
         model_name: config.model,
-        enable_punc: true,
+        // Punctuation OFF: with it on, slow / deliberate speech (a player
+        // describing symbols one at a time, pausing between each) gets a period
+        // inserted at every pause, which fragments words ("沙漏" -> "沙。漏").
+        // Off yields continuous text the LLM and the caption both read better.
+        enable_punc: false,
+        // ITN ON: keeps spoken numbers as digits ("三个" -> "3 个"), which reads
+        // cleaner and matches how the manual phrases counts.
         enable_itn: true,
       },
     })

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -138,7 +138,26 @@ interface EndSessionMessage {
   type: 'end'
 }
 
-type ControlMessage = CreateSessionMessage | TurnMessage | EndSessionMessage
+/**
+ * Steer the live session's manual injection mid-conversation. Sent by the client
+ * when the player advances modules within ONE continuous run: the whole-run
+ * voice session stays a single conversation (history + the AI-first greeting
+ * persist), and only WHICH manual subset is injected changes. The DO updates the
+ * stored session `gameState.relevantSections` so the NEXT turn injects the new
+ * module's manual; it does NOT create a new session, reset history, re-run the
+ * greeting, or disturb an in-flight turn. `manualData` (the whole manual) was
+ * already provided at `create` — this only re-selects sections from it.
+ */
+interface UpdateGameStateMessage {
+  type: 'update-gamestate'
+  gameState: GameState
+}
+
+type ControlMessage =
+  | CreateSessionMessage
+  | TurnMessage
+  | EndSessionMessage
+  | UpdateGameStateMessage
 
 /**
  * Base64-encode raw bytes for JSON transport of an audio frame. Uses the
@@ -1080,6 +1099,42 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
           ws.send(JSON.stringify({ type: 'summary', summary }))
         }
         ws.close(1000, safeCloseReason('session ended'))
+        return
+      }
+      case 'update-gamestate': {
+        // Steer the live session's manual injection for SUBSEQUENT turns. This
+        // is fire-and-forget session metadata: it adjusts which manual subset
+        // the next turn injects, and must NEVER tear down or interrupt the
+        // running conversation (the whole point of one continuous session across
+        // modules is that history + the AI-first greeting persist). So every
+        // rejection path here is a benign no-op, NOT a 1008 close: no live
+        // session, a non-owner socket, or a malformed payload all just return
+        // without mutating anything.
+        //
+        // Owner-socket gated, mirroring `end`'s teardown gate (only the creator
+        // socket may steer its own session — a same-user duplicate tab / a
+        // second authenticated socket on this DO must not redirect the owner's
+        // injected manual). The non-owner consequence is downgraded from `end`'s
+        // 1008 close to a silent no-op: this message only re-selects sections,
+        // so ignoring a stray one is strictly safer than killing a socket.
+        if (!this.sessionState) return
+        if (!socketIsBoundSessionOwner(ws, this.ownerSocket, this.boundIdentity())) return
+        // Validate the untrusted payload defensively (the `JSON.parse` cast is
+        // unchecked): a missing `gameState`, a non-array `relevantSections`, or a
+        // non-string element is a benign no-op rather than a throw — a throw would
+        // be caught by `onMessage` and 1008-close the owner's socket, losing the
+        // whole conversation.
+        const incoming = (msg.gameState as { relevantSections?: unknown } | undefined)
+          ?.relevantSections
+        if (!Array.isArray(incoming) || !incoming.every((id) => typeof id === 'string')) return
+        // Reassign the FIELD (not the whole `sessionState` object) so history,
+        // turnCount, usage, and any in-flight turn's already-captured `messages`
+        // are untouched; only `assembleSystem`'s NEXT read (at the next turn's
+        // start) picks up the new sections. Copy the array so a later client-side
+        // mutation of the payload can never reach into session state. An in-flight
+        // turn snapshotted its `messages` at its own start, so this update applies
+        // strictly to the next turn — the running turn is never disturbed.
+        this.sessionState.gameState = { relevantSections: [...incoming] }
         return
       }
     }

--- a/packages/platform-ai/src/session-update-gamestate.test.ts
+++ b/packages/platform-ai/src/session-update-gamestate.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Production-class tests for the `update-gamestate` control message, driving the
+ * REAL `VoiceSessionDO` under the workerd runtime (`@cloudflare/vitest-pool-workers`).
+ *
+ * The feature: a BombSquad mode② voice session spans a WHOLE daily run as ONE
+ * continuous conversation. When the player advances modules, the client keeps the
+ * SAME session and sends `{type:'update-gamestate', gameState:{relevantSections}}`
+ * so the DO re-selects which manual subset the NEXT turn injects — WITHOUT
+ * creating a new session, resetting history, re-running the AI-first greeting, or
+ * disturbing an in-flight turn. `manualData` (the whole manual) was already passed
+ * at `create`; only which sections are injected changes.
+ *
+ * Harness (see `session-do-test-kit.ts`): the gated provider bundle captures each
+ * turn's `LlmCompletionRequest`. The request's system message (`messages[0]`)
+ * carries the deterministic manual injection (`assembleLlmContext`), so a test can
+ * assert WHICH sections the turn injected by substring-matching the system text.
+ */
+
+const providerControl = vi.hoisted(() => ({
+  override: undefined as import('./turn-pipeline').TurnProviders | undefined,
+}))
+
+vi.mock('./providers/factory', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./providers/factory')>()
+  return {
+    ...actual,
+    createProviders: (...args: Parameters<typeof actual.createProviders>) =>
+      providerControl.override ?? actual.createProviders(...args),
+  }
+})
+
+import {
+  makeGatedProviders,
+  makeSessionDo,
+  messagesOfType,
+  openSocket,
+  sawDoneChunk,
+  settle,
+  waitFor,
+  waitForMessage,
+  type TestSocket,
+} from './session-do-test-kit'
+
+beforeEach(() => {
+  providerControl.override = undefined
+})
+
+const TURN = JSON.stringify({ type: 'turn' })
+const END = JSON.stringify({ type: 'end' })
+
+// A two-module manual: each section value is an unambiguous marker so a test can
+// tell which subset reached the LLM by substring-matching the system message.
+const ALPHA = 'ALPHA-SECTION-MARKER'
+const BRAVO = 'BRAVO-SECTION-MARKER'
+const MULTI_MANUAL = {
+  version: 'manual-v1',
+  sections: { moduleA: ALPHA, moduleB: BRAVO },
+}
+
+/** Send a `create` with a custom manual + initial gameState; await the ack. */
+async function createWith(socket: TestSocket, relevantSections: string[]): Promise<void> {
+  socket.send(
+    JSON.stringify({
+      type: 'create',
+      gameId: 'demo-mock',
+      manualData: MULTI_MANUAL,
+      gameState: { relevantSections },
+      opening: false,
+    })
+  )
+  await waitForMessage(socket, 'created')
+}
+
+/** The system message text the gated LLM captured for turn index `i`. */
+function systemTextOfTurn(kit: ReturnType<typeof makeGatedProviders>, i: number): string {
+  return kit.llmTurns[i].request.messages[0].content
+}
+
+describe('real VoiceSessionDO — update-gamestate (continuous run, module advance)', () => {
+  it('a mid-session update changes the NEXT turn injection without reset/re-greet/history-loss; the in-flight turn is undisturbed', async () => {
+    const kit = makeGatedProviders()
+    providerControl.override = kit.providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createWith(socket, ['moduleA'])
+
+    // Turn 1 (module A) parks at the gated LLM await. Its captured request injects
+    // module A's manual subset, not module B's.
+    socket.send(TURN)
+    await waitFor(() => kit.llmTurns.length === 1, 'turn 1 reached the LLM')
+    expect(systemTextOfTurn(kit, 0)).toContain(ALPHA)
+    expect(systemTextOfTurn(kit, 0)).not.toContain(BRAVO)
+    // No history yet → system + the current player utterance only.
+    expect(kit.llmTurns[0].request.messages).toHaveLength(2)
+
+    // The player advances to module B WHILE turn 1 is still in flight. This must
+    // not disturb the running turn (it already snapshotted its messages) and must
+    // not error / close the socket.
+    socket.send(
+      JSON.stringify({ type: 'update-gamestate', gameState: { relevantSections: ['moduleB'] } })
+    )
+    await settle()
+    expect(messagesOfType(socket, 'error')).toEqual([])
+    expect(socket.closeEvents).toEqual([])
+    // The in-flight turn's already-captured request is unchanged.
+    expect(systemTextOfTurn(kit, 0)).toContain(ALPHA)
+    expect(systemTextOfTurn(kit, 0)).not.toContain(BRAVO)
+
+    // Finish turn 1.
+    await session.run(() => kit.llmTurns[0].pushDelta('Cut the third wire.'))
+    await session.run(() => kit.llmTurns[0].finishStream())
+    await waitFor(() => kit.llmTurns[0].settled(), 'turn 1 settled')
+    await waitFor(() => sawDoneChunk(socket), 'turn 1 done chunk')
+
+    // Turn 2 (after the update) injects module B's subset, not module A's — proving
+    // the update took effect on the next turn.
+    socket.send(TURN)
+    await waitFor(() => kit.llmTurns.length === 2, 'turn 2 reached the LLM')
+    expect(systemTextOfTurn(kit, 1)).toContain(BRAVO)
+    expect(systemTextOfTurn(kit, 1)).not.toContain(ALPHA)
+    // History PERSISTED across the update: turn 2 carries turn 1's user+assistant
+    // messages (system + 2 history + current player utterance = 4), so the session
+    // was never reset.
+    expect(kit.llmTurns[1].request.messages).toHaveLength(4)
+    expect(kit.llmTurns[1].request.messages[2]).toEqual({
+      role: 'assistant',
+      content: 'Cut the third wire.',
+    })
+
+    // No re-create and no re-greet: exactly one `created` ack, and exactly two
+    // LLM turns total (the two player turns — the update injected no extra turn).
+    expect(messagesOfType(socket, 'created')).toHaveLength(1)
+    expect(kit.llmTurns).toHaveLength(2)
+
+    await session.run(() => kit.llmTurns[1].finishStream())
+    await waitFor(() => kit.llmTurns[1].settled(), 'turn 2 settled')
+
+    // Both turns counted in the one continuous session's summary.
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    const summary = messagesOfType(socket, 'summary')[0].summary as { turnCount: number }
+    expect(summary.turnCount).toBe(2)
+  })
+
+  it('is a benign no-op for an invalid payload and for a non-owner socket (no 1008, no injection change)', async () => {
+    const kit = makeGatedProviders()
+    providerControl.override = kit.providers
+    const session = makeSessionDo()
+    const owner = await openSocket(session, 'user-A')
+    await createWith(owner, ['moduleA'])
+
+    // Malformed update from the OWNER: missing `relevantSections` / wrong types.
+    // Must be ignored, never a 1008 close (that would drop the whole conversation).
+    owner.send(JSON.stringify({ type: 'update-gamestate' }))
+    owner.send(JSON.stringify({ type: 'update-gamestate', gameState: {} }))
+    owner.send(
+      JSON.stringify({ type: 'update-gamestate', gameState: { relevantSections: 'moduleB' } })
+    )
+    owner.send(JSON.stringify({ type: 'update-gamestate', gameState: { relevantSections: [42] } }))
+
+    // A SECOND authenticated socket for the SAME user (a duplicate tab) is not the
+    // owner socket — its update must not redirect the owner's injected manual.
+    const duplicate = await openSocket(session, 'user-A')
+    duplicate.send(
+      JSON.stringify({ type: 'update-gamestate', gameState: { relevantSections: ['moduleB'] } })
+    )
+    await settle()
+    expect(owner.closeEvents).toEqual([])
+    expect(duplicate.closeEvents).toEqual([])
+    expect(messagesOfType(owner, 'error')).toEqual([])
+
+    // The owner's next turn still injects module A — neither the malformed owner
+    // updates nor the non-owner update changed the live selection.
+    owner.send(TURN)
+    await waitFor(() => kit.llmTurns.length === 1, 'owner turn reached the LLM')
+    expect(systemTextOfTurn(kit, 0)).toContain(ALPHA)
+    expect(systemTextOfTurn(kit, 0)).not.toContain(BRAVO)
+  })
+})


### PR DESCRIPTION
## Summary

Three device-test asks:
- **One conversation per run** (not per module): the VoicePanel is keyed on the run, so the session/mic/history/AI-first greeting persist across module advances. On advance, the hook sends one `{type:'update-gamestate', gameState}` on the live socket; the DO updates the injected manual subset for subsequent turns (owner-gated, no reconnect/re-greet, history intact). First module rides `create`.
- **Recognition reads as continuous text**: 火山 ASR `enable_punc` OFF — with it on, slow/deliberate speech got a period at every pause, fragmenting words (沙漏→沙。漏). `enable_itn` stays on.
- **Longer pause**: VAD `silenceHangoverMs` 1.5s→2.5s.

## Test plan
- [x] tsc/build/lint clean; platform-ai 323 + game-bombsquad 398
- [ ] device re-test (one continuous convo across modules, cleaner recognition, 2.5s pause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)