### PR TITLE
fix(bombsquad): daily challenge loads YAML manual data, not the HTML share page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad daily challenge: "手册格式异常" on start** - Fix. The daily run
+always showed a parse error on load because the game engine was fetching the
+human-readable HTML manual page (`/manual/<date>`) and trying to parse it as
+YAML. The engine now fetches the machine-readable YAML data file
+(`/manual/data/<date>.yaml`). The player→AI share link that ConnectPage copies
+to the clipboard is unchanged — it still points to the HTML page at
+`/manual/<date>`, which is what the AI partner reads.
+
 **BombSquad mode② voice: one conversation per run, clearer recognition, longer
 pauses** - Change. The AI partner is now a single continuous conversation for the
 whole daily run: it greets you once and remembers the whole game, and when you

--- a/packages/game-bombsquad/src/pages/GamePage.manual-url.test.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.manual-url.test.tsx
@@ -1,18 +1,14 @@
 /**
- * GamePage manual-URL derivation regression guard (Optional ① from the
- * fix-daily-run-missing-url-param task).
+ * GamePage manual-URL derivation regression guard.
  *
- * A daily run launched with NO `url` query param must derive the manual URL
- * from the UTC current date — `${origin}/manual/<UTC-today>` — rather than
- * crashing, loading nothing, or falling back to a stale hostname. This is the
- * root mechanism the ResultPage recovery fix sits downstream of: when the
- * connect funnel forwards into /bombsquad/run?mode=daily without a `url`
- * param, the manual still resolves.
+ * A daily run launched with NO `url` query param must fetch from the YAML
+ * data endpoint — `${origin}/manual/data/<UTC-today>.yaml` — rather than the
+ * HTML share page (`/manual/<date>`). Fetching the HTML page caused the daily
+ * challenge to always show "手册格式异常" because yaml.load(htmlText) throws
+ * ManualParseError (root bug: fix-daily-manual-fetch-url).
  *
- * The slice(0,10) of an ISO string is the UTC date by construction
- * (Date.prototype.toISOString always renders in UTC / Zulu), so this also
- * pins the UTC-0-safe behavior. We mock the manual loader and capture the URL
- * it is called with on a fresh (unseeded) daily mount.
+ * Also pins the UTC-0-safe date behaviour: Date.toISOString() always renders
+ * in UTC/Zulu, so slice(0,10) is stable even near local midnight.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, act } from '@testing-library/react'
@@ -26,14 +22,15 @@ vi.mock('@/utils/event-log', () => ({ logEvent: vi.fn() }))
 const { loadManualMock } = vi.hoisted(() => ({
   loadManualMock: vi.fn(),
 }))
-vi.mock('@/utils/yaml-loader', () => ({
-  loadManual: loadManualMock,
-  // GamePage imports these error classes for instanceof checks; provide real
-  // class stubs so the module's import binding resolves.
-  ManualNetworkError: class ManualNetworkError extends Error {},
-  ManualNotFoundError: class ManualNotFoundError extends Error {},
-  ManualParseError: class ManualParseError extends Error {},
-}))
+vi.mock('@/utils/yaml-loader', async (importOriginal) => {
+  // Spread the real module so toManualDataUrl (and any future exports) stay
+  // functional — only loadManual is replaced with a capture mock.
+  const real = await importOriginal<typeof import('@/utils/yaml-loader')>()
+  return {
+    ...real,
+    loadManual: loadManualMock,
+  }
+})
 
 import GamePage from './GamePage'
 import { GameProvider } from '@/store/game-context'
@@ -76,8 +73,10 @@ describe('GamePage manual-URL derivation', () => {
 
     expect(loadManualMock).toHaveBeenCalledTimes(1)
     const calledUrl = loadManualMock.mock.calls[0][0] as string
-    // The path segment must be the pinned UTC date, regardless of origin.
-    expect(calledUrl).toMatch(new RegExp(`/manual/${PINNED_UTC_DATE}$`))
+    // Engine must fetch the YAML data file, not the HTML share page.
+    expect(calledUrl).toMatch(new RegExp(`/manual/data/${PINNED_UTC_DATE}\\.yaml$`))
+    // Must NOT fetch the HTML share page (the root bug).
+    expect(calledUrl).not.toMatch(new RegExp(`/manual/${PINNED_UTC_DATE}$`))
     // And it must NOT silently fall back to practice or an empty path.
     expect(calledUrl).not.toContain('/manual/practice')
   })

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -7,6 +7,7 @@ import { useTimer } from '@/hooks/useTimer'
 import { createRng, type Rng } from '@/engine/rng'
 import {
   loadManual,
+  toManualDataUrl,
   ManualNetworkError,
   ManualNotFoundError,
   ManualParseError,
@@ -340,10 +341,16 @@ export default function GamePage() {
       typeof window !== 'undefined' && window.location?.origin
         ? window.location.origin
         : 'https://claw.amio.fans'
+    // Daily: the engine fetches the machine-readable YAML data file
+    // (`/manual/data/<date>.yaml`), NOT the HTML share page (`/manual/<date>`).
+    // The player→AI share URL stays at `/manual/<date>` (ConnectPage sources it
+    // independently from useDailyChallenge — it never reads state.manualUrl).
+    // `customUrl` arrives as the HTML share URL from the `?url=` param; convert
+    // it to its YAML equivalent so the engine always fetches parseable YAML.
     const manualUrl =
       mode === 'practice'
         ? `${origin}/manual/practice`
-        : (customUrl ?? `${origin}/manual/${new Date().toISOString().slice(0, 10)}`)
+        : toManualDataUrl(customUrl ?? `${origin}/manual/${new Date().toISOString().slice(0, 10)}`)
     const attemptNumber = getAttemptNumberForMode(mode)
 
     dispatch({ type: 'START_LOADING', mode, manualUrl, attemptNumber })

--- a/packages/game-bombsquad/src/utils/yaml-loader.test.ts
+++ b/packages/game-bombsquad/src/utils/yaml-loader.test.ts
@@ -4,6 +4,7 @@ import {
   ManualNotFoundError,
   ManualParseError,
   loadManual,
+  toManualDataUrl,
 } from './yaml-loader'
 
 const SAMPLE_MANUAL_YAML = `
@@ -22,6 +23,47 @@ modules:
 // a YAMLException ("undefined alias"), which is the parse-failure path we
 // want to distinguish from network failures at the loader boundary.
 const INVALID_YAML = '*missing'
+
+// ---------------------------------------------------------------------------
+// toManualDataUrl — regression: daily engine must fetch YAML, not HTML page
+// ---------------------------------------------------------------------------
+// Pre-fix: GamePage passed the HTML share URL (/manual/<date>) directly to
+// loadManual, which returned HTML text that yaml.load() could not parse →
+// ManualParseError → "手册格式异常". The fix routes the engine through
+// toManualDataUrl so it always fetches /manual/data/<date>.yaml.
+
+describe('toManualDataUrl', () => {
+  it('converts the HTML share URL to the YAML data URL (root regression)', () => {
+    // This is the exact transform the daily engine now applies on every start.
+    // Red before fix: GamePage called loadManual('/manual/2026-06-30') directly.
+    // Green after fix: GamePage calls loadManual(toManualDataUrl('/manual/2026-06-30')).
+    expect(toManualDataUrl('https://claw.amio.fans/manual/2026-06-30')).toBe(
+      'https://claw.amio.fans/manual/data/2026-06-30.yaml'
+    )
+  })
+
+  it('preserves an arbitrary origin (preview / staging deployments)', () => {
+    expect(toManualDataUrl('https://amiclaw.pages.dev/manual/2026-01-15')).toBe(
+      'https://amiclaw.pages.dev/manual/data/2026-01-15.yaml'
+    )
+  })
+
+  it('returns a data URL unchanged (idempotent — already correct path)', () => {
+    const already = 'https://claw.amio.fans/manual/data/2026-06-30.yaml'
+    expect(toManualDataUrl(already)).toBe(already)
+  })
+
+  it('does not transform the player→AI share URL shape (HTML page stays at /manual/<date>)', () => {
+    // ConnectPage copies /manual/<date> to the clipboard — that URL must NOT
+    // become the data URL. ConnectPage never calls toManualDataUrl; this test
+    // confirms the two URL shapes are distinct after the conversion.
+    const shareUrl = 'https://claw.amio.fans/manual/2026-06-30'
+    const dataUrl = toManualDataUrl(shareUrl)
+    expect(dataUrl).not.toBe(shareUrl)
+    expect(dataUrl).toContain('/manual/data/')
+    expect(dataUrl.endsWith('.yaml')).toBe(true)
+  })
+})
 
 describe('loadManual', () => {
   const originalFetch = globalThis.fetch

--- a/packages/game-bombsquad/src/utils/yaml-loader.ts
+++ b/packages/game-bombsquad/src/utils/yaml-loader.ts
@@ -53,6 +53,22 @@ export class ManualNetworkError extends Error {
   }
 }
 
+/**
+ * Converts a daily manual HTML share URL (`/manual/<date>`) to its
+ * machine-readable YAML data URL (`/manual/data/<date>.yaml`).
+ *
+ * The engine always fetches the YAML data file for puzzle generation; the HTML
+ * page at `/manual/<date>` is the human/AI-readable share link. This helper
+ * lets callers normalise the URL before fetching regardless of which form
+ * they receive. If the URL is already a data URL (contains `/manual/data/`)
+ * it is returned unchanged. URLs that do not match the expected pattern are
+ * also returned unchanged (no silent data loss).
+ */
+export function toManualDataUrl(shareUrl: string): string {
+  if (shareUrl.includes('/manual/data/')) return shareUrl
+  return shareUrl.replace(/(\/manual\/)([0-9]{4}-[0-9]{2}-[0-9]{2})$/, '$1data/$2.yaml')
+}
+
 export async function loadManual(url: string): Promise<Manual> {
   if (CACHE.has(url)) return CACHE.get(url)!
 


### PR DESCRIPTION
## Summary

- Daily challenge showed **"手册格式异常"** on entry and could not start (practice was fine). The game engine fetched `/manual/<date>`, which serves the human/AI-readable **HTML** manual page, so `yaml.load(html)` threw `ManualParseError`. The machine-readable YAML is published at `/manual/data/<date>.yaml`.
- Added a pure `toManualDataUrl()` helper and routed the **daily engine fetch** through it. The **player→AI share link** (ConnectPage, sourced independently from `useDailyChallenge` — it never reads `state.manualUrl`) is unchanged and still points to the HTML page `/manual/<date>`, which is what the AI partner reads.
- Practice mode untouched (build-time import). Added unit regression on the URL transform (pure-function tests + updated GamePage integration assertion).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass (full repo suite green via pre-commit; game-bombsquad 402/402)
- [x] New tests added if behavior changed (`toManualDataUrl` unit suite + GamePage daily-URL assertion)
- [x] Tested manually and documented below

Manual / empirical verification:
- Prod `GET /manual/2026-06-30` → `200 text/html` (the HTML page — the bug); `GET /manual/data/2026-06-30.yaml` → `200 text/yaml`.
- Fetched the prod data YAML and confirmed it carries the engine-required schema: `modules.wire_routing.rules` (16), `modules.symbol_dial`, `modules.button.rules` (12), `modules.keypad` — so the engine loads **and** generates from it (no swap to "谜题生成失败").
- Confirmed ConnectPage share link is independent of `state.manualUrl` (hard constraint: AI-readable page stays the HTML page).

⚠️ **Hold merge** — pending real-device confirmation that the daily challenge now opens on iOS Safari + Android Chrome (use the Cloudflare Pages preview).

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed (CHANGELOG under Unreleased)
- [x] Breaking changes documented if any (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)