### PR TITLE
fix(bombsquad): live during-speech ASR — captions while speaking, no 8s timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② voice: live captions while you speak** - Change. Recognition
+now runs live as you talk instead of waiting until you stop, so your `你：…`
+caption builds up word by word while you're still speaking, and the connection no
+longer drops with an 8-second recognizer timeout. The client tells the server when
+your utterance starts; the server opens the recognizer, transcribes the live
+audio into streaming captions, and finalizes the full text when you pause —
+verified end to end against the live provider (captions arriving mid-speech, full
+final transcript, clean finish).
+
 **BombSquad daily challenge: "手册格式异常" on start** - Fix. The daily run
 always showed a parse error on load because the game engine was fetching the
 human-readable HTML manual page (`/manual/<date>`) and trying to parse it as

--- a/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
@@ -378,6 +378,58 @@ describe('useVoiceSession — client VAD', () => {
     expect(ws.controlMessages().some((m) => m.type === 'turn')).toBe(true)
   })
 
+  it('sends speech-start then turn, in order, for a real player utterance', async () => {
+    const { ws } = await ready()
+    finishGreeting(ws)
+
+    // Two 256ms speech frames (>= 400ms minSpeechMs) start the utterance.
+    act(() => {
+      fireFrame(0.5)
+      fireFrame(0.5)
+    })
+    // The utterance START is signaled once; the turn waits for utterance-end.
+    expect(ws.controlMessages().filter((m) => m.type === 'speech-start')).toHaveLength(1)
+    expect(ws.controlMessages().some((m) => m.type === 'turn')).toBe(false)
+
+    // Ten 256ms silence frames (2560ms >= 2500ms hangover) end it -> the turn.
+    act(() => {
+      for (let i = 0; i < 10; i += 1) fireFrame(0.0)
+    })
+    const types = ws.controlMessages().map((m) => m.type)
+    // Exactly one speech-start, exactly one turn, speech-start BEFORE the turn.
+    expect(types.filter((t) => t === 'speech-start')).toHaveLength(1)
+    expect(types.filter((t) => t === 'turn')).toHaveLength(1)
+    expect(types.indexOf('turn')).toBeGreaterThan(types.indexOf('speech-start'))
+  })
+
+  it('does not send speech-start while the AI-first opening greeting is in flight', async () => {
+    const { ws } = await ready()
+    // No greeting chunk yet: the hook is awaiting the opening reply. Noise the open
+    // mic picks up (the greeting's own voice / the stopwatch tick) must NOT open an
+    // utterance on the server — that would race the in-flight greeting.
+    act(() => {
+      fireFrame(0.5)
+      fireFrame(0.5)
+      fireFrame(0.0)
+      fireFrame(0.0)
+    })
+    expect(ws.controlMessages().some((m) => m.type === 'speech-start')).toBe(false)
+  })
+
+  it('does not send speech-start while a (non-barged-in) AI turn is still streaming', async () => {
+    const { ws } = await ready()
+    finishGreeting(ws)
+    // A reply turn is streaming text (done:false) with no audio playing yet — the
+    // AI holds the floor, and this is NOT a barge-in.
+    act(() => ws.fireMessage({ type: 'chunk', kind: 'text', text: 'still talking', done: false }))
+    const before = ws.controlMessages().filter((m) => m.type === 'speech-start').length
+    act(() => {
+      fireFrame(0.5)
+      fireFrame(0.5)
+    })
+    expect(ws.controlMessages().filter((m) => m.type === 'speech-start').length).toBe(before)
+  })
+
   it('does not send a turn while the AI-first opening greeting is in flight', async () => {
     const { result, ws } = await ready()
     // No greeting chunk yet: the hook is awaiting the opening reply. Noise the
@@ -513,6 +565,7 @@ describe('useVoiceSession — barge-in', () => {
     })
     expect(result.current.isAiSpeaking).toBe(true)
     const playing = playbackSources().at(-1)
+    const speechStartsBefore = ws.controlMessages().filter((m) => m.type === 'speech-start').length
 
     // Player barges in (2 frames >= the 400ms minSpeechMs).
     act(() => {
@@ -523,6 +576,11 @@ describe('useVoiceSession — barge-in', () => {
     expect(result.current.isAiSpeaking).toBe(false)
     expect(result.current.playerSpeaking).toBe(true)
     expect(result.current.aiText).toBe('') // interrupted turn's text dropped
+    // A genuine barge-in IS a real utterance start: it stops playback AND signals
+    // speech-start so the server transcribes the interrupting utterance live.
+    expect(ws.controlMessages().filter((m) => m.type === 'speech-start').length).toBe(
+      speechStartsBefore + 1
+    )
 
     // The interrupted turn's tail keeps streaming from the server — drop it.
     act(() => ws.fireMessage({ type: 'chunk', kind: 'text', text: ' on and on', done: true }))

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -10,15 +10,20 @@
  *
  * Turn model (important): the CLIENT runs the VAD. On `create` the server fires
  * the AI-first opening greeting (no client input). Thereafter the hook streams the
- * mic continuously and the client-side VAD detects end-of-utterance (the player
- * went silent after speaking) and sends `{type:'turn'}`, which the server runs as
- * a normal STT->LLM->TTS turn over the audio buffered since the last turn. Turns
- * are SERIAL server-side: a `turn` sent while one is in flight is rejected with a
- * benign `turn_in_flight`, so the hook only sends when the AI is idle (not
- * speaking, not awaiting, not mid-stream) — otherwise the open mic picking up the
- * AI's own greeting / the stopwatch tick would fire spurious, rejected turns. The
- * VAD additionally drives the 3-state conversation phase (listening / thinking /
- * speaking) and barge-in (stop local playback when the player talks over the AI).
+ * mic continuously; the client-side VAD detects utterance START (the player began
+ * speaking) and sends `{type:'speech-start'}`, which opens the server recognizer
+ * so it transcribes LIVE while the player talks, then detects end-of-utterance
+ * (the player went silent) and sends `{type:'turn'}`, which finalizes that turn as
+ * a normal STT->LLM->TTS turn over the audio buffered since the last turn. One
+ * speech-start per utterance, paired with the one turn. Turns are SERIAL
+ * server-side: a `turn` sent while one is in flight is rejected with a benign
+ * `turn_in_flight`, so BOTH sends fire only when the AI is idle (not speaking, not
+ * awaiting, not mid-stream) — otherwise the open mic picking up the AI's own
+ * greeting / the stopwatch tick would open a spurious utterance / fire a rejected
+ * turn. The one mid-stream exception is a genuine barge-in (the player talks over
+ * the AI): it stops local playback AND signals speech-start, since the player has
+ * taken the floor. The VAD additionally drives the 3-state conversation phase
+ * (listening / thinking / speaking).
  *
  * Security invariant (load-bearing, mirrors the demo): this hook connects ONLY to
  * the same-origin Worker WS and sends ONLY `{gameId, manualData, gameState}` plus
@@ -381,10 +386,34 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     // playback at once and drop the rest of the interrupted turn's streamed
     // chunks (text + audio) — the server keeps streaming them (it cancels nothing
     // in v1), so the client must locally discard them until that turn's `done`.
-    if (playingCountRef.current > 0) {
+    const bargeIn = playingCountRef.current > 0
+    if (bargeIn) {
       interruptPlayback()
       if (turnStreamingRef.current) suppressTurnRef.current = true
       safeDispatch({ type: 'barge-in' })
+    }
+    // Signal the utterance START to the server so it opens the recognizer and
+    // transcribes LIVE while the player speaks; the matching `turn` on
+    // utterance-end finalizes it (one speech-start per utterance, paired with the
+    // one turn). Guard it the SAME way the `turn` send in `onUtteranceEnd` is
+    // guarded — only signal a REAL utterance. A genuine barge-in (the player took
+    // the floor over the AI's own audio) IS a real utterance, so it signals after
+    // the interrupt above; otherwise suppress while the AI holds the floor (the
+    // AI-first opening greeting / a pending reply — `awaitingResponse`, set until
+    // the first reply chunk — or a non-barged-in turn still streaming), so the
+    // greeting's own voice or a leaked stopwatch tick cannot open a spurious
+    // utterance. The mic only opens on `created`, so this never fires pre-session.
+    const aiHoldsFloor =
+      !bargeIn &&
+      (awaitingResponseRef.current || (turnStreamingRef.current && !suppressTurnRef.current))
+    if (aiHoldsFloor) return
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      try {
+        ws.send(JSON.stringify({ type: 'speech-start' }))
+      } catch {
+        /* non-fatal — a dropped speech-start just defers live transcription to the turn */
+      }
     }
   }, [interruptPlayback, safeDispatch])
 

--- a/packages/platform-ai/demo/live-asr-probe.mjs
+++ b/packages/platform-ai/demo/live-asr-probe.mjs
@@ -1,0 +1,95 @@
+/* eslint-disable no-console -- stdout CLI probe for the live during-speech ASR. */
+// Verifies the live (during-speech) ASR against the deployed Worker: connect →
+// AI-first greeting → `speech-start` → stream audio in REAL-TIME-paced frames →
+// expect interim `{type:'transcript'}` captions WHILE streaming → `turn` →
+// expect a FULL final transcript + the AI reply, with NO 8s ASR timeout.
+import { readFileSync } from 'node:fs'
+
+const FRAME_BYTES = 8192 // ~256ms at 16kHz PCM16
+const url = process.argv.includes('--url')
+  ? process.argv[process.argv.indexOf('--url') + 1]
+  : 'wss://claw.amio.fans'
+const gameId = process.argv.includes('--gameId')
+  ? process.argv[process.argv.indexOf('--gameId') + 1]
+  : 'bombsquad'
+const fixturePath = process.argv.includes('--fixture')
+  ? process.argv[process.argv.indexOf('--fixture') + 1]
+  : 'demo/fixture-long.pcm'
+const audio = new Uint8Array(readFileSync(fixturePath))
+
+const ws = new WebSocket(`${url}/ai-ws/lasr-${Math.random().toString(36).slice(2, 8)}`)
+const t0 = () => `${((Date.now() - start) / 1000).toFixed(1)}s`
+let start = 0
+let greetingDone = false
+let interimCount = 0
+let finalTranscript = ''
+let replyText = ''
+
+ws.addEventListener('open', () => {
+  start = Date.now()
+  ws.send(
+    JSON.stringify({
+      type: 'create',
+      gameId,
+      manualData: {
+        version: 'fdx',
+        sections: { button: { rule: 'Describe the button color and label.' } },
+      },
+      gameState: { relevantSections: ['button'] },
+    })
+  )
+})
+
+async function speakLive() {
+  console.log(`[${t0()}] speech-start → streaming audio in real-time-paced frames…`)
+  ws.send(JSON.stringify({ type: 'speech-start' }))
+  for (let off = 0; off < audio.byteLength; off += FRAME_BYTES) {
+    if (ws.readyState !== WebSocket.OPEN) return
+    ws.send(audio.slice(off, Math.min(off + FRAME_BYTES, audio.byteLength)).buffer)
+    await new Promise((r) => setTimeout(r, 250)) // ~real-time: one 256ms frame / 250ms
+  }
+  console.log(`[${t0()}] audio done → turn (finalize)`)
+  ws.send(JSON.stringify({ type: 'turn' }))
+}
+
+ws.addEventListener('message', (event) => {
+  if (typeof event.data !== 'string') return
+  let m
+  try {
+    m = JSON.parse(event.data)
+  } catch {
+    return
+  }
+  if (m.type === 'created') {
+    console.log(`[${t0()}] created — awaiting AI-first greeting…`)
+    setTimeout(() => {
+      greetingDone = true
+      speakLive()
+    }, 7000) // give the greeting time, then speak
+  } else if (m.type === 'transcript') {
+    if (greetingDone) {
+      interimCount += m.final ? 0 : 1
+      if (m.final) finalTranscript = m.text
+      console.log(`[${t0()}] caption ${m.final ? 'FINAL' : 'interim'}: "${m.text}"`)
+    }
+  } else if (m.type === 'chunk') {
+    if (greetingDone && m.kind === 'text' && m.text) replyText += m.text
+    if (greetingDone && m.done) {
+      console.log(`\n=== RESULT ===`)
+      console.log(
+        `interims-during-speech: ${interimCount}  (want > 1 and arriving BEFORE the turn)`
+      )
+      console.log(`final transcript: "${finalTranscript}"`)
+      console.log(`AI reply: "${replyText}"`)
+      ws.send(JSON.stringify({ type: 'end' }))
+      setTimeout(() => process.exit(0), 1500)
+    }
+  } else if (m.type === 'error') {
+    console.log(`[${t0()}] server error: ${m.code} — ${m.message}`)
+  }
+})
+ws.addEventListener('close', (e) => {
+  console.log(`\n[${t0()}] close code=${e.code} reason="${e.reason || ''}"`)
+  process.exit(0)
+})
+ws.addEventListener('error', () => console.log('[error] websocket error'))

--- a/packages/platform-ai/src/index.ts
+++ b/packages/platform-ai/src/index.ts
@@ -85,9 +85,12 @@ export {
   DEV_AUTH_USER_ID,
 } from './auth-seam'
 
-// Testable turn-pipeline orchestration (DO is a thin shell over this).
-export type { UsageCounters, SessionState, TurnProviders } from './turn-pipeline'
-export { runTurn, splitSentences } from './turn-pipeline'
+// Testable turn-pipeline orchestration (DO is a thin shell over this). The live
+// WS transport drives the two phases separately — `runUtteranceStt` on
+// `speech-start` (interim captions WHILE the player speaks) and `runReply` on
+// `turn`; `runTurn` is their end-to-end composition (the buffered primitive).
+export type { UsageCounters, SessionState, TurnProviders, UtteranceResult } from './turn-pipeline'
+export { runTurn, runUtteranceStt, runReply, splitSentences } from './turn-pipeline'
 
 // Session-terminal usage metering flush (the DO is a thin shell over this).
 export type { UsageKvWriter, UsageRecord, SessionUsageSnapshot } from './usage-flush'

--- a/packages/platform-ai/src/session-binary-audio.test.ts
+++ b/packages/platform-ai/src/session-binary-audio.test.ts
@@ -44,6 +44,7 @@ import {
   messagesOfType,
   openSocket,
   sawDoneChunk,
+  SPEECH_START,
   waitFor,
   waitForMessage,
 } from './session-do-test-kit'
@@ -66,13 +67,16 @@ describe('real VoiceSessionDO — binary audio reaches STT byte-intact (P1)', ()
     // A genuine binary audio frame: distinct non-zero bytes so an empty (the
     // Blob-conversion bug) or garbage view is unmistakable in the assertion.
     const AUDIO = new Uint8Array([0x10, 0x20, 0x30, 0x40, 0x50, 0x60])
+    // speech-start opens the live recognizer; only THEN is the audio frame
+    // forwarded to it (frames with no open utterance are dropped).
+    socket.send(SPEECH_START)
     socket.send(AUDIO.slice().buffer)
 
-    // Run the turn; STT drains the buffered bridge and captures the frames it
-    // pulled. WS delivery is ordered, so the binary frame is pushed onto the
-    // bridge before the turn closes it.
+    // Finalize the utterance; the live STT drains the bridge and captures the
+    // frames it pulled. WS delivery is ordered, so the binary frame is pushed onto
+    // the open bridge before the turn closes it.
     socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'turn ran STT once')
+    await waitFor(() => kit.sttCalls() === 1, 'utterance opened STT')
     await waitFor(() => sawDoneChunk(socket), 'turn emitted its terminal done chunk')
 
     // The crux: the bytes that reached STT are non-empty AND exactly the bytes
@@ -96,11 +100,12 @@ describe('real VoiceSessionDO — binary audio reaches STT byte-intact (P1)', ()
 
     const FRAME_1 = new Uint8Array([0x01, 0x02, 0x03])
     const FRAME_2 = new Uint8Array([0xfa, 0xfb, 0xfc, 0xfd])
+    socket.send(SPEECH_START)
     socket.send(FRAME_1.slice().buffer)
     socket.send(FRAME_2.slice().buffer)
 
     socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'turn ran STT once')
+    await waitFor(() => kit.sttCalls() === 1, 'utterance opened STT')
     await waitFor(() => sawDoneChunk(socket), 'turn emitted its terminal done chunk')
 
     // Both frames reach STT, in order, byte-for-byte — the concatenation equals

--- a/packages/platform-ai/src/session-do-test-kit.ts
+++ b/packages/platform-ai/src/session-do-test-kit.ts
@@ -227,6 +227,31 @@ export async function createSessionOverWs(
   return created.sessionId
 }
 
+/** A `speech-start` control frame: opens the per-utterance live recognizer. */
+export const SPEECH_START = JSON.stringify({ type: 'speech-start' })
+
+/** A `turn` control frame: finalizes the open utterance into the reply. */
+export const TURN = JSON.stringify({ type: 'turn' })
+
+/**
+ * Drive one full utterance over the socket the live way: `speech-start` opens the
+ * recognizer (the STT phase starts), then `turn` closes the bridge to finalize it
+ * into the reply. The two control frames ride back-to-back (WS-ordered), so the
+ * recognizer opens, the STT finalizes on the close, and the reply runs. Resolves
+ * once that reply reaches the gated LLM (`kit.llmTurns.length === expected`) — the
+ * live-model replacement for the prior "wait until `sttCalls === n`" signal, which
+ * now fires at `speech-start` (recognizer open), BEFORE the reply parks.
+ */
+export async function driveUtteranceToLlm(
+  socket: TestSocket,
+  kit: { llmTurns: GatedTurnHandle[] },
+  expected: number
+): Promise<void> {
+  socket.send(SPEECH_START)
+  socket.send(TURN)
+  await waitFor(() => kit.llmTurns.length === expected, `reply ${expected} reached the gated LLM`)
+}
+
 /** The socket's outbound messages of one protocol type (free-function form). */
 export function messagesOfType(socket: TestSocket, type: string): WsMessage[] {
   return socket.messagesOfType(type)
@@ -434,6 +459,75 @@ export function makeStreamingTranscriptProviders(transcripts: SttTranscriptChunk
   return {
     providers: { stt, llm, tts: createMockTtsProvider() },
     sttCalls: () => calls,
+  }
+}
+
+/**
+ * Provider bundle whose STT transcribes LIVE: it yields one CUMULATIVE interim
+ * transcript per audio frame it PULLS (so a test can assert interim caption frames
+ * surface WHILE audio arrives — between `speech-start` and `turn`), then a terminal
+ * `isFinal` chunk on the bridge close. The LLM completes immediately so the reply
+ * runs end-to-end. This is the DO-level analog of the real 火山 live-stream cadence
+ * (the real adapter is the manager's live-probe surface; the mock proves the DO's
+ * speech-start -> live-feed -> interim-stream wiring).
+ */
+export function makeLiveStreamingAsrProviders(): {
+  providers: TurnProviders
+  sttCalls(): number
+} {
+  let calls = 0
+  const stt: SttProvider = {
+    async *transcribe(audio): AsyncIterable<SttTranscriptChunk> {
+      calls += 1
+      let cumulative = ''
+      for await (const frame of audio) {
+        cumulative += `[${frame.byteLength}]`
+        yield { text: cumulative, isFinal: false }
+      }
+      yield { text: `${cumulative} done`, isFinal: true }
+    },
+  }
+  const llm: LlmProvider = {
+    async *streamCompletion() {
+      yield { content: 'ok.', done: true }
+    },
+  }
+  return {
+    providers: { stt, llm, tts: createMockTtsProvider() },
+    sttCalls: () => calls,
+  }
+}
+
+/**
+ * Provider bundle whose STT yields one interim transcript then throws a REAL ASR
+ * error (an error frame surfaces as a throw out of `transcribe` — NOT a benign
+ * no-speech close). The live DO must fail loud (1008) even before `turn`, and the
+ * LLM is never reached.
+ */
+export function makeErroringAsrProviders(message = 'Volcengine ASR error: boom'): {
+  providers: TurnProviders
+  sttCalls(): number
+  llmCalls(): number
+} {
+  let sttCalls = 0
+  let llmCalls = 0
+  const stt: SttProvider = {
+    async *transcribe(): AsyncIterable<SttTranscriptChunk> {
+      sttCalls += 1
+      yield { text: '部分', isFinal: false }
+      throw new Error(message)
+    },
+  }
+  const llm: LlmProvider = {
+    async *streamCompletion() {
+      llmCalls += 1
+      yield { content: '', done: true }
+    },
+  }
+  return {
+    providers: { stt, llm, tts: createMockTtsProvider() },
+    sttCalls: () => sttCalls,
+    llmCalls: () => llmCalls,
   }
 }
 

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -4,18 +4,26 @@
  * It is a thin shell over the testable orchestration in `turn-pipeline.ts`:
  *   - It holds the session state (gameId/userId binding, conversation history,
  *     game state, usage counters) created in `createSession`.
- *   - It implements the four-method contract semantics
- *     (`createSession` / `onPlayerAudio` / `onAiResponse` / `endSession`),
+ *   - It binds and tears down the session (`createSession` / `endSession`),
  *     enforcing `sessionId <-> userId` ownership on every operation.
- *   - It drives `runTurn` over the WebSocket: the player pushes binary audio
- *     frames, then a client `turn` control message fires the turn; outbound
- *     `AiResponseChunk`s are serialized back to the player. The client owns turn
- *     detection (its VAD sends `turn` when the player stops speaking).
+ *   - It drives LIVE, per-utterance ASR over the WebSocket. The client owns turn
+ *     detection (its VAD): on `speech-start` the DO opens a 火山 recognizer and
+ *     feeds the live incoming audio frames to it immediately, streaming interim
+ *     `{type:'transcript', final:false}` frames back so the caption builds WHILE
+ *     the player speaks; on `turn` it finalizes (negative-sequence end packet ->
+ *     last-package final), emits the terminal `{type:'transcript', final:true}`,
+ *     then runs the LLM+TTS reply, serializing outbound `AiResponseChunk`s back to
+ *     the player. The two phases are `runUtteranceStt` (speech-start) and
+ *     `runReply` (turn); their end-to-end composition `runTurn` backs the
+ *     unit-tested pipeline. Audio is streamed to 火山 continuously DURING the
+ *     utterance and end-of-audio is signaled promptly on `turn`, so 火山's 8s
+ *     inter-packet timeout cannot fire on a normal utterance.
  *   - On `create` it also fires an AI-first opening greeting (`runOpeningTurn`,
  *     LLM->TTS, no player audio) so the AI speaks first, when enabled (default).
  *
- * The orchestration logic itself lives in `runTurn` / `runOpeningTurn` (pure,
- * provider-mocked unit tests); this class is the DO/WS adapter around them.
+ * The orchestration logic itself lives in `runUtteranceStt` / `runReply` (and
+ * their composition `runTurn`) / `runOpeningTurn` (pure, provider-mocked unit
+ * tests); this class is the DO/WS adapter that drives the two phases live.
  *
  * The class extends the Cloudflare Agents SDK `Agent` base (over `partyserver`),
  * with hibernation deliberately OFF (`static options = { hibernate: false }`).
@@ -51,9 +59,10 @@
  * frame, not just control messages.
  *
  * Two ownership grains coexist, split by what the operation does:
- *  - DRIVE operations (`turn`, binary audio) are gated on the owner USER id: the
- *    operating socket's authenticated user must equal the bound owner. They run a
- *    turn / feed audio; they never clear the session.
+ *  - DRIVE operations (`speech-start`, `turn`, binary audio) are gated on the
+ *    owner USER id: the operating socket's authenticated user must equal the bound
+ *    owner. They open / finalize an utterance and feed audio; they never clear the
+ *    session.
  *  - TEARDOWN operations (`end`, owner socket close) are gated on the owner
  *    SOCKET reference — the exact socket recorded at `createSession`
  *    (`ownerSocket` / `socketIsBoundSessionOwner`). A user-id grain is too coarse
@@ -79,7 +88,14 @@ import type { GameState } from './manual-injection'
 import type { ProviderEnv } from './providers/factory'
 import { assembleSession } from './session-assembly'
 import { traceTurn, traceTurnError } from './trace'
-import { runOpeningTurn, runTurn, type SessionState, type TurnProviders } from './turn-pipeline'
+import {
+  runOpeningTurn,
+  runReply,
+  runUtteranceStt,
+  type SessionState,
+  type TurnProviders,
+  type UtteranceResult,
+} from './turn-pipeline'
 import { flushSessionUsage, type UsageKvWriter } from './usage-flush'
 import {
   assertSessionOwnership,
@@ -125,10 +141,27 @@ interface CreateSessionMessage {
 }
 
 /**
- * Run one turn: close the current audio bridge so STT terminates, drive
- * `runTurn`, and stream the resulting `AiResponseChunk`s back to the client.
- * The player pushes binary audio frames, then sends this control message to
- * signal "that's my utterance, respond now".
+ * The player began an utterance (the client VAD detected speech start). The DO
+ * OPENS a per-utterance 火山 ASR connection and starts feeding the live incoming
+ * audio frames to it immediately, streaming interim `{type:'transcript',
+ * final:false}` frames back as the recognizer stabilizes more text — so the
+ * caption builds WHILE the player speaks. Paired with exactly one later `turn`.
+ * A second `speech-start` (or one while the AI is replying — a barge-in)
+ * supersedes the prior utterance / cancels the in-flight reply and opens a fresh
+ * recognizer.
+ */
+interface SpeechStartMessage {
+  type: 'speech-start'
+}
+
+/**
+ * The player stopped (the client VAD detected utterance end). The DO finalizes
+ * the open utterance — closing the audio bridge so the ASR pump sends the
+ * negative-sequence end-of-audio packet and 火山 returns the last-package final —
+ * emits the terminal `{type:'transcript', final:true}` frame, then runs the
+ * existing LLM+TTS reply over the complete transcript. A `turn` with no open
+ * utterance (no prior `speech-start`, or it was already finalized / barged-in
+ * away) is a benign no-op.
  */
 interface TurnMessage {
   type: 'turn'
@@ -155,6 +188,7 @@ interface UpdateGameStateMessage {
 
 type ControlMessage =
   | CreateSessionMessage
+  | SpeechStartMessage
   | TurnMessage
   | EndSessionMessage
   | UpdateGameStateMessage
@@ -238,9 +272,12 @@ const textEncoderForReason = new TextEncoder()
 const textDecoderForReason = new TextDecoder()
 
 /**
- * Async audio bridge: binary WS frames are pushed in; `runTurn`'s STT step
- * pulls them via `for await`. One bridge backs one in-flight turn; `end` closes
- * it so the STT stream terminates.
+ * Async audio bridge: binary WS frames are pushed in; the STT step pulls them via
+ * `for await`. One bridge backs one live utterance: it is created on
+ * `speech-start` (the recognizer opens and starts pulling LIVE while the player
+ * speaks) and `close()`d on `turn` (so the ASR pump sends the negative-sequence
+ * end-of-audio packet and the stream terminates). A teardown / barge-in also
+ * closes it.
  */
 class AudioBridge {
   private buffer: AudioChunk[] = []
@@ -278,6 +315,26 @@ class AudioBridge {
       yield next.value
     }
   }
+}
+
+/**
+ * One live, per-utterance ASR session: the bridge audio frames are pushed into,
+ * the background STT driver's completion promise, and the captured outcome / a
+ * genuine ASR fault. Opened on `speech-start`, consumed on `turn`, fenced by its
+ * own `epoch` so a barge-in / teardown that advanced the session generation
+ * stops its late interim frames and swallows its late faults.
+ */
+interface LiveUtterance {
+  /** The audio bridge live frames are pushed into; closed on `turn` to finalize. */
+  bridge: AudioBridge
+  /** The session generation this utterance belongs to (epoch-fencing). */
+  epoch: number
+  /** Resolves when the background STT driver settled (populating `outcome`/`error`). */
+  done: Promise<void>
+  /** The captured complete utterance + audio byte total, once STT finalized cleanly. */
+  outcome?: UtteranceResult
+  /** A genuine ASR fault (error frame / connect failure / idle stall), if STT failed. */
+  error?: unknown
 }
 
 export class VoiceSessionDO extends Agent<SessionDoEnv> {
@@ -319,26 +376,32 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
   private usageFlushed = false
   /** Wired providers for the session. */
   private providers: TurnProviders | undefined
-  /** Audio bridge for the in-flight turn, if any. */
-  private audio: AudioBridge | undefined
   /**
-   * Turn in-flight guard. A voice turn is a single serial round; a DO event can
-   * interleave across the many `await`s inside one turn (STT/LLM/TTS all await),
-   * so a second `turn` message arriving mid-flight would start a second
-   * `onAiResponse`/`runTurn` over the SAME `state`/`providers`/socket — racing
-   * the shared `history`/`usage` and interleaving two response streams on one
-   * socket. This flag is `true` for exactly the window one turn is running; a
-   * second `turn` while set is rejected (fail-loud), and it is cleared in the
-   * turn loop's `finally` so success / failure / cancel all release it (an
-   * exception can never wedge the guard shut).
+   * The live, in-progress utterance, if any: set on `speech-start` (the
+   * recognizer opens and starts feeding on live audio), consumed + cleared on
+   * `turn` (finalize), and discarded on barge-in / teardown. `undefined` between
+   * utterances. Incoming binary audio frames are forwarded to its bridge ONLY
+   * while it is set; frames arriving with no live utterance (between utterances,
+   * during the AI-first greeting) are dropped.
+   */
+  private liveUtterance: LiveUtterance | undefined
+  /**
+   * Reply in-flight guard. A voice reply is a single serial round; a DO event can
+   * interleave across the many `await`s inside one reply (LLM/TTS all await), so a
+   * second `turn` message arriving mid-reply would start a second `runReply` over
+   * the SAME `state`/`providers`/socket — racing the shared `history`/`usage` and
+   * interleaving two response streams on one socket. This flag is `true` for
+   * exactly the window one reply is running; a second `turn` while set is rejected
+   * (fail-loud), and it is cleared in the reply loop's `finally` so success /
+   * failure / cancel all release it (an exception can never wedge the guard shut).
    */
   private turnInFlight = false
   /**
-   * The in-flight turn's async iterator, held so a mid-turn `end` (or the
-   * owner's socket close) can cancel it cleanly: closing the audio bridge
-   * terminates STT, and `return()` on this iterator runs `runTurn`'s `finally`
-   * (closes the sentence queue, returns the live LLM/TTS iterators) so no
-   * provider stream is left dangling. `undefined` when no turn is running.
+   * The in-flight reply's async iterator, held so a mid-reply `end` (or the
+   * owner's socket close, or a barge-in `speech-start`) can cancel it cleanly:
+   * `return()` on this iterator runs `runReply`'s `finally` (closes the sentence
+   * queue, returns the live LLM/TTS iterators) so no provider stream is left
+   * dangling. `undefined` when no reply is running.
    */
   private activeTurn: AsyncIterator<AiResponseChunk> | undefined
   /**
@@ -439,17 +502,25 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
       // Binary frame: player audio. Gate it through the SAME per-socket ownership
       // predicate the control path uses — a binary frame must come from the
       // connection whose user owns the bound session. Without this, a second
-      // authenticated connection on the same DO could push frames the owner's
-      // next `turn` transcribes, forging the owner's utterance. The throw on a
-      // non-owner frame is caught below and closes THAT connection with 1008
-      // (fail loud, control-path-consistent) — the owner's bridge is never
-      // touched. The frame's bytes are recovered defensively for whatever shape
-      // the runtime delivers (`ArrayBuffer` / `ArrayBufferView` / `Blob`), so
-      // audio fidelity never depends on partyserver's post-accept
-      // `binaryType = 'arraybuffer'` assignment (see `audioFrameToBytes`).
+      // authenticated connection on the same DO could push frames into the owner's
+      // live recognizer, forging the owner's utterance. The throw on a non-owner
+      // frame is caught below and closes THAT connection with 1008 (fail loud,
+      // control-path-consistent) — the owner's utterance is never touched. The
+      // frame's bytes are recovered defensively for whatever shape the runtime
+      // delivers (`ArrayBuffer` / `ArrayBufferView` / `Blob`), so audio fidelity
+      // never depends on partyserver's post-accept `binaryType = 'arraybuffer'`
+      // assignment (see `audioFrameToBytes`).
+      //
+      // The mic streams continuously, so frames arrive between utterances and
+      // during the AI-first greeting too; they are forwarded to the recognizer
+      // ONLY while a live utterance is open (between `speech-start` and `turn`)
+      // and otherwise dropped. Feeding the open recognizer live — rather than
+      // buffering for a transcribe-at-`turn` — is what keeps 火山's 8s
+      // inter-packet timeout from firing and surfaces the caption WHILE the player
+      // speaks.
       this.assertSocketOwner(connection)
-      const bridge = this.ensureAudioBridge()
-      bridge.push(await audioFrameToBytes(message))
+      const bytes = await audioFrameToBytes(message)
+      this.liveUtterance?.bridge.push(bytes)
     } catch (err: unknown) {
       const reason = err instanceof Error ? err.message : 'message handling failed'
       // Byte-safe truncation: `reason` is a provider error string of unbounded
@@ -541,10 +612,11 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
    * published fields, so observers only ever see a session that is fully
    * constructed or entirely absent — never half-bound. The prior interleaving
    * (`this.userId = userId` BEFORE `createProviders`) let a failed create leave
-   * the DO bound to a user with NO `state`/`providers`: that user's binary
-   * frames then passed the ownership gate, lazily created an audio bridge, and
-   * the leaked pre-create frames survived into the next SUCCESSFUL session's
-   * first turn (create does not reset `this.audio`).
+   * the DO bound to a user with NO `state`/`providers`: that user's frames then
+   * passed the ownership gate. In the live model frames are only ever forwarded
+   * to an OPEN utterance (set on `speech-start`, never on a bare `create`), so
+   * the publish-after-success ordering still matters for the gate but no longer
+   * risks a leaked-frame carry-over.
    */
   createSession(
     gameId: string,
@@ -564,42 +636,16 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
   }
 
   /**
-   * Feed one player audio frame. Validates `sessionId <-> userId` ownership,
-   * then pushes the frame onto the in-flight turn's audio bridge.
-   */
-  onPlayerAudio(sessionId: string, userId: string, audioChunk: AudioChunk): void {
-    this.assertOwner(sessionId, userId)
-    this.ensureAudioBridge().push(audioChunk)
-  }
-
-  /**
-   * Run a turn over the current audio and yield the AI response stream.
-   * Validates ownership, then delegates to `runTurn`. The caller is expected to
-   * have finished pushing the turn's audio (or to close the bridge) so STT can
-   * terminate.
-   */
-  async *onAiResponse(sessionId: string, userId: string): AsyncIterable<AiResponseChunk> {
-    this.assertOwner(sessionId, userId)
-    if (!this.sessionState || !this.providers) {
-      throw new Error('session-do: onAiResponse before createSession')
-    }
-    const bridge = this.ensureAudioBridge()
-    bridge.close()
-    this.audio = undefined
-    yield* runTurn(this.providers, this.sessionState, bridge)
-  }
-
-  /**
    * End the session: validate ownership, settle, flush the session's usage to
    * the USAGE KV, and return the summary with the turn count and usage mount
    * point.
    *
-   * The flush lives HERE — in the contract method — because `endSession` is
-   * the single implementation boundary every `end`-shaped termination goes
-   * through: the WS `end` branch calls this method, and a direct consumer
-   * driving the four-method contract over the DO stub reaches it without any
-   * WS framing. Hanging the flush on the WS branch instead would let a direct
-   * contract call end a session unmetered. The owner-socket close path keeps
+   * The flush lives HERE — in the session-teardown method — because `endSession`
+   * is the single implementation boundary every `end`-shaped termination goes
+   * through: the WS `end` branch calls this method, and a direct consumer driving
+   * the session contract over the DO stub reaches it without any WS framing.
+   * Hanging the flush on the WS branch instead would let a direct teardown call
+   * end a session unmetered. The owner-socket close path keeps
    * its own `flushUsage()` — an abrupt drop never reaches `endSession` (see
    * `onSocketClose`). State is still live at this point, so the flush
    * naturally precedes any `clearSession` the caller performs. A mid-flight
@@ -613,8 +659,10 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
     if (!this.sessionState) {
       throw new Error('session-do: endSession before createSession')
     }
-    this.audio?.close()
-    this.audio = undefined
+    // Terminate any open live utterance's recognizer (closing its bridge ends the
+    // STT stream); `clearSession` discards the handle. A reply in flight is
+    // canceled separately by the `end` path's `cancelActiveTurn`.
+    this.discardLiveUtterance()
     const summary: SessionSummary = {
       sessionId,
       gameId: this.sessionState.config.gameId,
@@ -661,9 +709,127 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
     }
   }
 
-  private ensureAudioBridge(): AudioBridge {
-    if (this.audio === undefined) this.audio = new AudioBridge()
-    return this.audio
+  /**
+   * Open a fresh live utterance on `speech-start`: discard any prior live
+   * utterance (a second `speech-start` without an intervening `turn`), cancel an
+   * in-flight AI reply and free the serial-turn guard (barge-in — the player took
+   * the floor while the AI was replying / greeting), then start the per-utterance
+   * STT driver over a new bridge. Incoming audio frames feed this bridge LIVE, so
+   * 火山 transcribes WHILE the player speaks and the DO streams interim caption
+   * frames; `turn` closes the bridge to finalize.
+   *
+   * The new utterance captures the CURRENT generation (post-`supersedeActiveTurn`
+   * bump) as its epoch, so a later barge-in / teardown that advances the epoch
+   * fences this utterance's late interim frames and swallows its late faults
+   * (see `runLiveStt` / the `turn` finalize guard).
+   */
+  private beginUtterance(ws: Connection): void {
+    this.discardLiveUtterance()
+    this.supersedeActiveTurn()
+    const bridge = new AudioBridge()
+    const myEpoch = this.turnEpoch
+    const utterance: LiveUtterance = {
+      bridge,
+      epoch: myEpoch,
+      // Replaced synchronously below; the placeholder keeps `done` non-optional.
+      done: Promise.resolve(),
+    }
+    utterance.done = this.runLiveStt(ws, bridge, myEpoch).then(
+      (outcome) => {
+        utterance.outcome = outcome
+      },
+      (err) => {
+        utterance.error = err
+        // Fail loud on a GENUINE ASR fault that surfaced mid-utterance (before
+        // `turn`) — but only while this utterance is still the live generation. A
+        // barge-in / teardown that advanced the epoch already moved on; its late
+        // ASR fault must not 1008-close a socket the new generation owns. A
+        // benign no-speech close is NOT a fault (it resolves with an empty
+        // transcript, not a rejection), so it never reaches here.
+        if (this.turnEpoch === myEpoch) {
+          const reason = err instanceof Error ? err.message : 'live ASR failed'
+          traceTurnError('asr', 'live-error', { messageChars: reason.length })
+          try {
+            ws.close(1008, safeCloseReason(reason))
+          } catch {
+            // socket already gone — nothing to fail loud on.
+          }
+        }
+      }
+    )
+    this.liveUtterance = utterance
+  }
+
+  /**
+   * Drive the per-utterance STT phase: pull the player's audio off `bridge`,
+   * stream each interim cumulative transcript to the client as a live caption
+   * frame (`{type:'transcript', final:false}`) AS IT ARRIVES, and resolve to the
+   * complete utterance + audio byte total once the stream ends (bridge close on
+   * `turn`, or a benign no-speech close). A genuine ASR fault throws out (handled
+   * fail-loud by `beginUtterance` / the `turn` finalize). Interim frames are
+   * suppressed once the epoch advances (barge-in / teardown), so a superseded
+   * utterance never paints stale caption text onto the new generation's socket.
+   */
+  private async runLiveStt(
+    ws: Connection,
+    bridge: AudioBridge,
+    myEpoch: number
+  ): Promise<UtteranceResult> {
+    if (!this.providers) throw new Error('session-do: speech-start before createSession')
+    const gen = runUtteranceStt(this.providers, bridge)[Symbol.asyncIterator]()
+    try {
+      for (;;) {
+        const next = await gen.next()
+        if (next.done) return next.value
+        const chunk = next.value
+        if (this.turnEpoch === myEpoch && chunk.kind === 'transcript') {
+          ws.send(
+            JSON.stringify({
+              type: 'transcript',
+              text: chunk.text ?? '',
+              final: chunk.final ?? false,
+            })
+          )
+        }
+      }
+    } finally {
+      // Defensive cleanup on an early (throwing) exit: terminate the STT
+      // generator so its upstream is returned. A no-op on the normal done path
+      // (the generator already completed). The return value is discarded — the
+      // cast satisfies the generator's typed `TReturn`.
+      await gen.return(undefined as unknown as UtteranceResult)
+    }
+  }
+
+  /**
+   * Discard the live utterance, if any: close its bridge so its STT stream
+   * terminates (a benign no-speech close — the captured outcome / late frames are
+   * fenced by the epoch). Idempotent; a no-op when no utterance is open.
+   */
+  private discardLiveUtterance(): void {
+    const utterance = this.liveUtterance
+    if (utterance === undefined) return
+    this.liveUtterance = undefined
+    utterance.bridge.close()
+  }
+
+  /**
+   * Free the serial-turn guard for a NEW turn in the SAME session — the barge-in
+   * case (the player speaks while the AI is replying / greeting). Mirrors
+   * `clearSession`'s epoch mechanism WITHOUT clearing the session: capture the
+   * in-flight turn, bump `turnEpoch` (so the superseded turn's late `finally` is a
+   * no-op against the new generation — it cannot reopen the guard or null the new
+   * `activeTurn`), reset the guard synchronously, then `return()` the captured
+   * iterator (fire-and-forget — `return()` cannot interrupt a pending provider
+   * `await`, so it must not block). A no-op (beyond a harmless epoch bump) when no
+   * turn is in flight.
+   */
+  private supersedeActiveTurn(): void {
+    const turn = this.activeTurn
+    this.turnEpoch += 1
+    this.turnInFlight = false
+    this.activeTurn = undefined
+    if (turn !== undefined) void turn.return?.(undefined)
   }
 
   /**
@@ -709,7 +875,10 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
     this.userId = undefined
     this.sessionId = undefined
     this.providers = undefined
-    this.audio = undefined
+    // Discard any open live utterance (closes its bridge -> STT terminates). The
+    // epoch bump above fences its late interim frames / faults from this just-torn
+    // generation, exactly as it fences a stale turn `finally`.
+    this.discardLiveUtterance()
     this.turnInFlight = false
     this.activeTurn = undefined
     this.ownerSocket = undefined
@@ -797,17 +966,21 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
   }
 
   /**
-   * Stream one turn's `AiResponseChunk`s to the socket under the serial-turn
-   * guard, shared by the client-`turn` path (STT->LLM->TTS via `runTurn`) and
-   * the AI-first opening greeting (LLM->TTS via `runOpeningTurn`).
+   * Stream one reply's `AiResponseChunk`s to the socket under the serial-turn
+   * guard, shared by the client-`turn` reply path (the terminal transcript frame +
+   * LLM->TTS via `runReply`) and the AI-first opening greeting (LLM->TTS via
+   * `runOpeningTurn`). The live INTERIM transcript frames are NOT streamed here —
+   * they stream from `runLiveStt` during the utterance (between `speech-start` and
+   * `turn`); `runReply` yields only the single terminal `final: true` transcript
+   * frame, which this relays before the AI reply chunks.
    *
-   * Holds the iterator explicitly (so a mid-turn `end` / owner close can cancel
-   * it via `return()`) and captures this turn's generation (`myEpoch`) at the
-   * same synchronous point the shared `turnInFlight`/`activeTurn` fields are set,
-   * so the `finally` clears the guard on every exit (normal end, provider error,
-   * cancellation) — but ONLY while this turn is still the live generation: a
-   * stale `finally` whose session was already ended/dropped must not null out a
-   * newer session's `turnInFlight`/`activeTurn` (see `turnEpoch`).
+   * Holds the iterator explicitly (so a mid-reply `end` / owner close / barge-in
+   * can cancel it via `return()`) and captures this reply's generation (`myEpoch`)
+   * at the same synchronous point the shared `turnInFlight`/`activeTurn` fields are
+   * set, so the `finally` clears the guard on every exit (normal end, provider
+   * error, cancellation) — but ONLY while this reply is still the live generation:
+   * a stale `finally` whose session was already ended/dropped/superseded must not
+   * null out a newer generation's `turnInFlight`/`activeTurn` (see `turnEpoch`).
    */
   private async streamTurn(ws: Connection, turn: AsyncIterator<AiResponseChunk>): Promise<void> {
     const myEpoch = this.turnEpoch
@@ -820,13 +993,13 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
         const chunk = next.value
         if (chunk.kind === 'transcript') {
           // The player's recognized utterance — its OWN wire frame, NOT a
-          // `chunk`: `{type:'transcript', text, final}`. Streamed as a series
-          // before the AI reply chunks so the client can build a live subtitle:
-          // zero or more interim frames (`final:false`, running cumulative text)
-          // then one terminal frame (`final:true`, the complete utterance).
-          // `runTurn` only yields these for a non-empty transcript (a no-speech
-          // turn sends none). They carry no `done` — the AI reply's terminal
-          // `chunk` still closes the turn.
+          // `chunk`: `{type:'transcript', text, final}`. Here this is the single
+          // terminal frame (`final:true`, the complete utterance) `runReply`
+          // yields before the AI reply chunks; the interim frames (`final:false`,
+          // running cumulative text) already streamed live from `runLiveStt` while
+          // the player spoke. `runReply` yields the terminal frame only for a
+          // non-empty transcript (a no-speech turn sends none). It carries no
+          // `done` — the AI reply's terminal `chunk` still closes the turn.
           ws.send(
             JSON.stringify({
               type: 'transcript',
@@ -898,8 +1071,8 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
 
   /**
    * Reject cross-session / cross-user access. Delegates to the pure
-   * `assertSessionOwnership` predicate (the L2 ownership invariant —
-   * `onPlayerAudio` / `onAiResponse` / `endSession` verify ownership).
+   * `assertSessionOwnership` predicate (the L2 ownership invariant — the `turn`
+   * and `end` paths verify ownership against the bound session).
    */
   private assertOwner(sessionId: string, userId: string): void {
     assertSessionOwnership(this.boundIdentity(), sessionId, userId)
@@ -928,7 +1101,7 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
     }
   }
 
-  /** WS control-message dispatch driving the four-method semantics. */
+  /** WS control-message dispatch: create / speech-start / turn / end / update-gamestate. */
   private async handleControl(ws: Connection, msg: ControlMessage): Promise<void> {
     // The operating user is THIS socket's authenticated identity, resolved per
     // message — never a shared field a later upgrade could have overwritten.
@@ -991,39 +1164,74 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
         if (msg.opening ?? true) void this.runOpeningGreeting(ws)
         return
       }
+      case 'speech-start': {
+        // The player began an utterance: OPEN a live recognizer and start feeding
+        // audio. A DRIVE op (owner-USER grain, same as binary audio): the
+        // operating socket's authenticated user must own the bound session. A
+        // non-owner / unauthenticated / pre-create signal throws -> the listener
+        // fail-louds with 1008, exactly as the binary-audio gate does. (The mic
+        // only opens on `created`, so a pre-create signal is defense-in-depth.)
+        this.assertSocketOwner(ws)
+        this.beginUtterance(ws)
+        return
+      }
       case 'turn': {
         const sessionId = this.sessionId
-        if (!this.sessionState || !socketUserId || sessionId === undefined) {
+        if (!this.sessionState || !socketUserId || sessionId === undefined || !this.providers) {
           ws.close(1008, safeCloseReason('turn before create'))
           return
         }
-        // Turn in-flight guard: voice turns are serial. A second `turn` while
-        // one is running (owner double-click / retry) would start a second
-        // `runTurn` over the shared `state`/`providers` and interleave two
-        // response streams on this one socket — DO events interleave across the
-        // turn's STT/LLM/TTS `await`s. Reject the overlap with an explicit
-        // signal on THIS socket (NOT a 1008 close — the first turn is streaming
-        // on the same socket and a close would truncate it). No second
-        // `onAiResponse`/`runTurn` is started; the live turn is untouched.
+        // Cross-user / cross-session turn -> fail loud (1008 via the listener).
+        // Preserves the prior `onAiResponse` ownership assertion (DRIVE op, owner-
+        // USER grain), so a second authenticated user on this DO cannot finalize
+        // the owner's utterance.
+        this.assertOwner(sessionId, socketUserId)
+        // Turn in-flight guard: voice turns are serial. A second `turn` while a
+        // reply is running (owner double-click / retry) would start a second reply
+        // over the shared `state`/`providers` and interleave two response streams
+        // on this one socket — DO events interleave across the reply's LLM/TTS
+        // `await`s. Reject the overlap with an explicit signal on THIS socket (NOT
+        // a 1008 close — the first reply is streaming on the same socket and a
+        // close would truncate it). The live reply is untouched.
         if (this.turnInFlight) {
           this.sendError(ws, 'turn_in_flight', 'a turn is already in progress')
           return
         }
-        // Turn-trace: the first hop boundary — a turn was accepted and is about
-        // to drive STT->LLM->TTS. Greppable park-point anchor (see `trace.ts`).
-        traceTurn('turn', 'start', {
-          sessionId,
-        })
-        // Stream the AI response chunks back under the serial-turn guard. Text
-        // rides as JSON; audio is base64-encoded so the whole turn stays on the
-        // JSON text channel and the binary frame direction remains
-        // player-audio-only. Ownership is checked against THIS socket's user (in
-        // `onAiResponse`), so a second client on the same DO cannot drive the
-        // first user's session. `streamTurn` owns the `turnInFlight`/`activeTurn`/
-        // `turnEpoch` machinery (see its docstring), so a mid-turn `end`/owner
-        // close cancels cleanly and a stale `finally` cannot clobber a newer
-        // session's guard.
-        const turn = this.onAiResponse(sessionId, socketUserId)[Symbol.asyncIterator]()
+        const utterance = this.liveUtterance
+        if (utterance === undefined) {
+          // A `turn` with no open utterance: no prior `speech-start`, or it was
+          // already finalized / barged-in away. Benign no-op — nothing to
+          // finalize, no reply (the player effectively said nothing this turn).
+          return
+        }
+        // Finalize THIS utterance: detach it so a stray later `turn` is benign,
+        // then close its bridge so the ASR pump sends the negative-sequence
+        // end-of-audio packet and 火山 returns the last-package final.
+        this.liveUtterance = undefined
+        const myEpoch = this.turnEpoch
+        utterance.bridge.close()
+        // Turn-trace: the finalize boundary — the utterance is closing and the
+        // reply is about to drive LLM->TTS. Greppable park-point anchor.
+        traceTurn('turn', 'start', { sessionId })
+        // Await the live STT finalization (it drains on the bridge close above).
+        await utterance.done
+        // A barge-in / teardown during the finalize await advanced the generation:
+        // abandon this reply (a newer utterance owns the floor, or the session is
+        // gone). Also re-check the session is still bound (teardown nulls it).
+        if (this.turnEpoch !== myEpoch || !this.sessionState || !this.providers) return
+        if (utterance.error !== undefined) {
+          // A genuine ASR fault already fail-loud-closed the socket in
+          // `beginUtterance` (epoch-fenced) — nothing more to do here.
+          return
+        }
+        const result: UtteranceResult = utterance.outcome ?? { transcript: '', audioBytes: 0 }
+        // Run the reply (terminal transcript frame + LLM+TTS over the complete
+        // utterance) under the serial-turn guard. A no-speech utterance (empty
+        // transcript) is skipped inside `runReply` — no chunks, no state, benign.
+        // `streamTurn` owns the `turnInFlight`/`activeTurn`/`turnEpoch` machinery
+        // (see its docstring), so a mid-reply `end`/owner close cancels cleanly and
+        // a stale `finally` cannot clobber a newer session's guard.
+        const turn = runReply(this.providers, this.sessionState, result)[Symbol.asyncIterator]()
         await this.streamTurn(ws, turn)
         return
       }
@@ -1048,11 +1256,11 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
           // `endSession` re-validates ownership (a cross-user `end` throws before
           // any teardown — the throw closes THAT socket with 1008 via the
           // listener, so a non-owner cannot end / cancel the owner's turn),
-          // closes the audio bridge (the NEXT turn's bridge, which buffered any
-          // frames that arrived during this turn — the in-flight turn already
-          // detached + closed its own bridge at `onAiResponse` start, so its STT
-          // has already terminated), flushes the session's usage to the USAGE
-          // KV (exactly once — the flush boundary lives in the contract method,
+          // terminates any open live utterance's recognizer (`discardLiveUtterance`
+          // closes its bridge so its STT stream ends; a reply in flight already
+          // detached + closed its own utterance bridge at `turn` finalize),
+          // flushes the session's usage to the USAGE KV (exactly once — the flush
+          // boundary lives in the teardown method,
           // not in this branch; see `endSession` / `flushUsage`), and returns
           // the summary.
           const summary = this.endSession(sessionId, socketUserId)

--- a/packages/platform-ai/src/session-end-cleanup.test.ts
+++ b/packages/platform-ai/src/session-end-cleanup.test.ts
@@ -39,6 +39,7 @@ vi.mock('./providers/factory', async (importOriginal) => {
 
 import {
   createSessionOverWs,
+  driveUtteranceToLlm,
   makeGatedProviders,
   makeSessionDo,
   messagesOfType,
@@ -140,8 +141,7 @@ describe('real VoiceSessionDO — end mid-turn clears, late settle does not revi
     const socket = await openSocket(session, 'user-A')
     const firstId = await createSessionOverWs(socket)
 
-    socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'turn parked')
+    await driveUtteranceToLlm(socket, kit, 1)
     await session.run(() => kit.llmTurns[0].pushDelta('partial'))
     await settle()
 
@@ -176,8 +176,7 @@ describe('real VoiceSessionDO — end mid-turn clears, late settle does not revi
     const reconnect2 = await openSocket(session, 'user-A')
     const secondId = await createSessionOverWs(reconnect2)
     expect(secondId).not.toBe(firstId)
-    reconnect2.send(TURN)
-    await waitFor(() => kit.sttCalls() === 2, 'fresh turn started')
+    await driveUtteranceToLlm(reconnect2, kit, 2)
     const freshHistory = kit.llmTurns[1].request.messages.filter((m) => m.role === 'assistant')
     expect(freshHistory).toEqual([])
     await session.run(() => kit.llmTurns[1].finishStream())
@@ -196,8 +195,7 @@ describe('real VoiceSessionDO — owner abrupt close clears the session like end
     const socket = await openSocket(session, 'user-A')
     const firstId = await createSessionOverWs(socket)
 
-    socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'turn parked')
+    await driveUtteranceToLlm(socket, kit, 1)
     await session.run(() => kit.llmTurns[0].pushDelta('x'))
     await settle()
 
@@ -225,8 +223,7 @@ describe('real VoiceSessionDO — owner abrupt close clears the session like end
     const reconnect2 = await openSocket(session, 'user-A')
     const secondId = await createSessionOverWs(reconnect2)
     expect(secondId).not.toBe(firstId)
-    reconnect2.send(TURN)
-    await waitFor(() => kit.sttCalls() === 2, 'fresh turn started')
+    await driveUtteranceToLlm(reconnect2, kit, 2)
     await session.run(() => kit.llmTurns[1].finishStream())
     await waitFor(() => kit.llmTurns[1].settled(), 'fresh turn settled')
     expect(kit.llmTurns[1].settled()).toBe(true)
@@ -275,8 +272,7 @@ describe('real VoiceSessionDO — end teardown gate, only the owner socket ends 
     await createSessionOverWs(owner)
     const duplicate = await openSocket(session, 'user-A')
 
-    owner.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'owner turn parked')
+    await driveUtteranceToLlm(owner, kit, 1)
     await session.run(() => kit.llmTurns[0].pushDelta('partial'))
     await settle()
 

--- a/packages/platform-ai/src/session-epoch-guard.test.ts
+++ b/packages/platform-ai/src/session-epoch-guard.test.ts
@@ -44,6 +44,7 @@ vi.mock('./providers/factory', async (importOriginal) => {
 
 import {
   createSessionOverWs,
+  driveUtteranceToLlm,
   makeGatedProviders,
   makeSessionDo,
   messagesOfType,
@@ -72,8 +73,7 @@ describe('real VoiceSessionDO — epoch guard, stale finally is a no-op (P2)', (
     // Generation 1: an owner session with a turn parked at a provider await.
     const socket1 = await openSocket(session, 'user-A')
     await createSessionOverWs(socket1)
-    socket1.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'gen-1 turn parked')
+    await driveUtteranceToLlm(socket1, kit, 1)
     expect(kit.sttCalls()).toBe(1)
 
     // Owner ends mid-turn: fire-and-forget cancel + clearSession (epoch bump).
@@ -88,8 +88,7 @@ describe('real VoiceSessionDO — epoch guard, stale finally is a no-op (P2)', (
     // starts a NEW turn. This is generation 2.
     const socket2 = await openSocket(session, 'user-B')
     await createSessionOverWs(socket2)
-    socket2.send(TURN)
-    await waitFor(() => kit.sttCalls() === 2, 'gen-2 turn started')
+    await driveUtteranceToLlm(socket2, kit, 2)
     expect(kit.sttCalls()).toBe(2)
     expect(kit.llmTurns).toHaveLength(2)
 
@@ -132,8 +131,7 @@ describe('real VoiceSessionDO — epoch guard, stale finally is a no-op (P2)', (
     // Generation 1 parks mid-turn, then the owner socket drops WITHOUT `end`.
     const socket1 = await openSocket(session, 'user-A')
     await createSessionOverWs(socket1)
-    socket1.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'gen-1 turn parked')
+    await driveUtteranceToLlm(socket1, kit, 1)
     socket1.disconnect()
     await settle()
     expect(kit.llmTurns[0].finallyRan()).toBe(false)
@@ -141,8 +139,7 @@ describe('real VoiceSessionDO — epoch guard, stale finally is a no-op (P2)', (
     // Reconnect: fresh session + new turn (generation 2).
     const socket2 = await openSocket(session, 'user-A')
     await createSessionOverWs(socket2)
-    socket2.send(TURN)
-    await waitFor(() => kit.sttCalls() === 2, 'gen-2 turn started')
+    await driveUtteranceToLlm(socket2, kit, 2)
     expect(kit.sttCalls()).toBe(2)
 
     // gen-1's late `finally` runs after gen 2 is live: must be a no-op.

--- a/packages/platform-ai/src/session-live-asr.test.ts
+++ b/packages/platform-ai/src/session-live-asr.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Production-class tests for the LIVE, per-utterance ASR path on the REAL
+ * `VoiceSessionDO` under the workerd runtime (`@cloudflare/vitest-pool-workers`).
+ *
+ * The live model (the fix this suite covers): the client VAD sends
+ * `{type:'speech-start'}` when the player begins talking; the DO OPENS a 火山
+ * recognizer and feeds the live incoming audio frames to it immediately, streaming
+ * `{type:'transcript', final:false}` caption frames back WHILE the player speaks.
+ * On `{type:'turn'}` the DO closes the bridge (the ASR pump sends the
+ * negative-sequence end-of-audio packet), emits the terminal
+ * `{type:'transcript', final:true}` frame, then runs the LLM+TTS reply. A genuine
+ * ASR fault fails loud (1008); a barge-in (`speech-start` while the AI is replying)
+ * cancels the in-flight reply and opens a fresh utterance.
+ *
+ * Harness limits (load-bearing): the STT here is MOCKED, so it proves the DO's
+ * speech-start -> live-feed -> interim-stream -> turn-finalize WIRING, not the real
+ * 火山 streaming / last-package finalization / 8s-timeout behaviour. The manager
+ * must LIVE-VERIFY those against the real adapter (speech-start -> stream a fixture
+ * -> turn; assert interim frames DURING the utterance, a full final, and that the
+ * `[Timeout waiting next packet] ... 8 seconds` fault no longer fires).
+ */
+
+const providerControl = vi.hoisted(() => ({
+  override: undefined as import('./turn-pipeline').TurnProviders | undefined,
+}))
+
+vi.mock('./providers/factory', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./providers/factory')>()
+  return {
+    ...actual,
+    createProviders: (...args: Parameters<typeof actual.createProviders>) =>
+      providerControl.override ?? actual.createProviders(...args),
+  }
+})
+
+import {
+  createSessionOverWs,
+  driveUtteranceToLlm,
+  makeErroringAsrProviders,
+  makeGatedProviders,
+  makeLiveStreamingAsrProviders,
+  makeSessionDo,
+  messagesOfType,
+  openSocket,
+  sawDoneChunk,
+  settle,
+  SPEECH_START,
+  TURN,
+  waitFor,
+  waitForMessage,
+} from './session-do-test-kit'
+
+beforeEach(() => {
+  providerControl.override = undefined
+})
+
+const END = JSON.stringify({ type: 'end' })
+
+describe('real VoiceSessionDO — live per-utterance ASR', () => {
+  it('opens the recognizer on speech-start and streams interim caption frames as audio arrives, before turn', async () => {
+    const kit = makeLiveStreamingAsrProviders()
+    providerControl.override = kit.providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    // speech-start OPENS the live recognizer — no `turn` yet.
+    socket.send(SPEECH_START)
+    await waitFor(() => kit.sttCalls() === 1, 'recognizer opened on speech-start')
+
+    // Audio frames stream WHILE the player speaks; each yields a live interim
+    // caption frame BEFORE any `turn` is sent.
+    socket.send(new Uint8Array([1, 2, 3]).buffer)
+    socket.send(new Uint8Array([4, 5]).buffer)
+    await waitFor(
+      () => messagesOfType(socket, 'transcript').length >= 2,
+      'interim caption frames streamed during speech'
+    )
+
+    const duringSpeech = messagesOfType(socket, 'transcript')
+    expect(duringSpeech.length).toBeGreaterThanOrEqual(2)
+    // All caption frames so far are interim (final:false) — the utterance is still
+    // open. No AI reply chunk and no terminal transcript before `turn`.
+    expect(duringSpeech.every((t) => t.final === false)).toBe(true)
+    expect(duringSpeech.some((t) => t.final === true)).toBe(false)
+    expect(messagesOfType(socket, 'chunk')).toEqual([])
+
+    // `turn` finalizes: exactly one terminal final transcript frame, then the reply.
+    socket.send(TURN)
+    await waitFor(() => sawDoneChunk(socket), 'reply completed after turn')
+    const finals = messagesOfType(socket, 'transcript').filter((t) => t.final === true)
+    expect(finals).toHaveLength(1)
+    expect(messagesOfType(socket, 'chunk').length).toBeGreaterThan(0)
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    const summary = messagesOfType(socket, 'summary')[0].summary as { turnCount: number }
+    expect(summary.turnCount).toBe(1)
+  })
+
+  it('fails loud (1008) on a real ASR error during the utterance, never a benign skip', async () => {
+    const kit = makeErroringAsrProviders('Volcengine ASR error: boom')
+    providerControl.override = kit.providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    // The recognizer yields one interim then throws a genuine ASR fault — the DO
+    // must fail loud with a 1008 close (NOT a benign skip), even before `turn`.
+    socket.send(SPEECH_START)
+    await waitFor(
+      () => socket.closeEvents.some((c) => c.code === 1008),
+      'live ASR fault closed the socket 1008'
+    )
+    expect(socket.closeEvents).toContainEqual({ code: 1008, reason: 'Volcengine ASR error: boom' })
+    // The fault is upstream of the reply, so the LLM is never reached.
+    expect(kit.llmCalls()).toBe(0)
+  })
+
+  it('a barge-in speech-start cancels the in-flight reply and opens a fresh utterance', async () => {
+    const kit = makeGatedProviders()
+    providerControl.override = kit.providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    // Utterance 1: its reply parks mid-stream at the gated LLM (the AI is talking).
+    await driveUtteranceToLlm(socket, kit, 1)
+    await session.run(() => kit.llmTurns[0].pushDelta('the AI is talking'))
+    await settle()
+    expect(kit.llmTurns[0].settled()).toBe(false)
+
+    // The player talks over the AI: a barge-in `speech-start` OPENS a fresh
+    // recognizer and cancels the in-flight reply (freeing the serial guard).
+    socket.send(SPEECH_START)
+    await waitFor(() => kit.sttCalls() === 2, 'barge-in opened a fresh recognizer')
+
+    // The barged-in reply unwinds (its `finally` runs once its parked provider
+    // settles) WITHOUT settling — it never completed, so it does not count.
+    await session.run(() => kit.llmTurns[0].pushDelta('late'))
+    await waitFor(() => kit.llmTurns[0].finallyRan(), 'barged-in reply unwound')
+    expect(kit.llmTurns[0].finallyRan()).toBe(true)
+    expect(kit.llmTurns[0].settled()).toBe(false)
+
+    // The new utterance finalizes into a fresh reply that runs to completion — the
+    // guard was freed by the barge-in, so this `turn` is accepted (not rejected).
+    socket.send(TURN)
+    await waitFor(() => kit.llmTurns.length === 2, 'fresh reply reached the LLM')
+    expect(messagesOfType(socket, 'error')).toEqual([])
+    await session.run(() => kit.llmTurns[1].finishStream())
+    await waitFor(() => kit.llmTurns[1].settled(), 'fresh reply settled')
+    expect(kit.llmTurns[1].settled()).toBe(true)
+    await waitFor(() => sawDoneChunk(socket), 'fresh reply done chunk')
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    // Only the completed second reply counts; the barged-in first never settled.
+    const summary = messagesOfType(socket, 'summary')[0].summary as { turnCount: number }
+    expect(summary.turnCount).toBe(1)
+  })
+
+  it('a turn with no prior speech-start is a benign no-op (no reply, no error, session stays usable)', async () => {
+    const kit = makeLiveStreamingAsrProviders()
+    providerControl.override = kit.providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    // A `turn` with no open utterance: nothing to finalize — benign no-op.
+    socket.send(TURN)
+    await settle()
+    expect(kit.sttCalls()).toBe(0)
+    expect(messagesOfType(socket, 'transcript')).toEqual([])
+    expect(messagesOfType(socket, 'chunk')).toEqual([])
+    expect(messagesOfType(socket, 'error')).toEqual([])
+    expect(socket.closeEvents).toEqual([])
+
+    // The session stays usable: a real utterance afterwards runs normally.
+    socket.send(SPEECH_START)
+    socket.send(new Uint8Array([7, 8]).buffer)
+    socket.send(TURN)
+    await waitFor(() => sawDoneChunk(socket), 'a real utterance still runs after the benign turn')
+    expect(kit.sttCalls()).toBe(1)
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    const summary = messagesOfType(socket, 'summary')[0].summary as { turnCount: number }
+    expect(summary.turnCount).toBe(1)
+  })
+})

--- a/packages/platform-ai/src/session-transcript.test.ts
+++ b/packages/platform-ai/src/session-transcript.test.ts
@@ -39,6 +39,7 @@ import {
   openSocket,
   sawDoneChunk,
   settle,
+  SPEECH_START,
   waitFor,
   waitForMessage,
 } from './session-do-test-kit'
@@ -58,8 +59,9 @@ describe('real VoiceSessionDO — player transcript wire frame', () => {
     const socket = await openSocket(session, 'user-A')
     await createSessionOverWs(socket)
 
+    socket.send(SPEECH_START)
     socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'turn ran STT once')
+    await waitFor(() => kit.sttCalls() === 1, 'utterance opened STT')
     await waitFor(() => sawDoneChunk(socket), 'turn emitted its terminal done chunk')
 
     // Exactly one transcript frame — the terminal (final:true) complete utterance
@@ -100,8 +102,9 @@ describe('real VoiceSessionDO — player transcript wire frame', () => {
     const socket = await openSocket(session, 'user-A')
     await createSessionOverWs(socket)
 
+    socket.send(SPEECH_START)
     socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'turn ran STT once')
+    await waitFor(() => kit.sttCalls() === 1, 'utterance opened STT')
     await waitFor(() => sawDoneChunk(socket), 'turn emitted its terminal done chunk')
 
     // The running cumulative interims stream first (final:false), then exactly one
@@ -136,8 +139,9 @@ describe('real VoiceSessionDO — player transcript wire frame', () => {
     const socket = await openSocket(session, 'user-A')
     await createSessionOverWs(socket)
 
+    socket.send(SPEECH_START)
     socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'turn ran STT once')
+    await waitFor(() => kit.sttCalls() === 1, 'utterance opened STT')
     // The no-speech skip emits nothing; let any (absent) frames drain so the
     // "nothing was sent" assertion is meaningful.
     await settle()

--- a/packages/platform-ai/src/session-turn-guard.test.ts
+++ b/packages/platform-ai/src/session-turn-guard.test.ts
@@ -34,6 +34,7 @@ vi.mock('./providers/factory', async (importOriginal) => {
 
 import {
   createSessionOverWs,
+  driveUtteranceToLlm,
   makeGatedProviders,
   makeSessionDo,
   makeStuckLlm,
@@ -43,6 +44,7 @@ import {
   openSocket,
   sawDoneChunk,
   settle,
+  SPEECH_START,
   waitFor,
   waitForMessage,
 } from './session-do-test-kit'
@@ -64,13 +66,13 @@ describe('real VoiceSessionDO — turn in-flight guard (P1)', () => {
     const socket = await openSocket(session, 'user-A')
     await createSessionOverWs(socket)
 
-    // First turn starts and parks at the gated LLM await (a real turn mid-flight).
-    socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'first turn parked at provider await')
+    // First utterance: speech-start opens STT, turn finalizes -> the reply parks
+    // at the gated LLM await (a real reply mid-flight).
+    await driveUtteranceToLlm(socket, kit, 1)
     expect(kit.sttCalls()).toBe(1)
     expect(kit.llmTurns).toHaveLength(1)
 
-    // Owner double-clicks: a second `turn` arrives while the first is parked.
+    // Owner double-clicks: a second `turn` arrives while the first reply is parked.
     socket.send(TURN)
     await waitForMessage(socket, 'error')
 
@@ -105,15 +107,13 @@ describe('real VoiceSessionDO — turn in-flight guard (P1)', () => {
     const socket = await openSocket(session, 'user-A')
     await createSessionOverWs(socket)
 
-    socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'first turn parked')
+    await driveUtteranceToLlm(socket, kit, 1)
     await session.run(() => kit.llmTurns[0].finishStream())
-    await waitFor(() => kit.llmTurns[0].settled(), 'first turn settled')
+    await waitFor(() => kit.llmTurns[0].settled(), 'first reply settled')
     expect(kit.llmTurns[0].settled()).toBe(true)
 
-    // A fresh turn after the first completes is accepted (a real second runTurn).
-    socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 2, 'second turn started')
+    // A fresh utterance after the first completes is accepted (a real second reply).
+    await driveUtteranceToLlm(socket, kit, 2)
     expect(kit.sttCalls()).toBe(2)
     expect(kit.llmTurns).toHaveLength(2)
     await session.run(() => kit.llmTurns[1].finishStream())
@@ -139,6 +139,7 @@ describe('real VoiceSessionDO — turn in-flight guard (P1)', () => {
     // Under the real runtime that 1008 close of the OWNER socket also tears the
     // session down (`onSocketClose`) — so proving the guard is not wedged uses a
     // fresh session, exactly as a reconnecting client would.
+    socket.send(SPEECH_START)
     socket.send(TURN)
     await waitFor(() => throwing.calls() === 1, 'provider reached once')
     await waitFor(() => socket.closeEvents.some((c) => c.code === 1008), '1008 fail-loud close')
@@ -149,6 +150,7 @@ describe('real VoiceSessionDO — turn in-flight guard (P1)', () => {
     // provider again instead of bouncing off a wedged turn_in_flight guard.
     const reconnect = await openSocket(session, 'user-A')
     await createSessionOverWs(reconnect)
+    reconnect.send(SPEECH_START)
     reconnect.send(TURN)
     await waitFor(() => throwing.calls() === 2, 'provider reached again (guard released)')
     expect(throwing.calls()).toBe(2)
@@ -168,8 +170,7 @@ describe('real VoiceSessionDO — end during a turn (matrix: end)', () => {
     const socket = await openSocket(session, 'user-A')
     await createSessionOverWs(socket)
 
-    socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'turn parked')
+    await driveUtteranceToLlm(socket, kit, 1)
     // Let one chunk through so the turn is genuinely mid-stream.
     await session.run(() => kit.llmTurns[0].pushDelta('partial'))
     await settle()
@@ -226,10 +227,13 @@ describe('real VoiceSessionDO — end during a turn (matrix: end)', () => {
     const socket = await openSocket(session, 'user-A')
     await createSessionOverWs(socket)
 
+    socket.send(SPEECH_START)
     socket.send(TURN)
-    await waitFor(() => bundle.sttCalls() === 1, 'turn parked at stuck provider')
+    await waitFor(() => bundle.sttCalls() === 1, 'utterance opened STT')
+    // Let the reply reach (and park at) the never-settling stuck LLM.
+    await settle()
 
-    // `end` lands even though the turn's cancel can never settle.
+    // `end` lands even though the reply's cancel can never settle.
     socket.send(END)
     await waitForMessage(socket, 'summary')
     expect(messagesOfType(socket, 'summary')).toHaveLength(1)
@@ -253,8 +257,7 @@ describe('real VoiceSessionDO — create during a turn (matrix: create)', () => 
     const socket = await openSocket(session, 'user-A')
     const sessionId = await createSessionOverWs(socket)
 
-    socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'turn parked')
+    await driveUtteranceToLlm(socket, kit, 1)
 
     // A second `create` arrives mid-turn: explicit reject, no socket close (a
     // close would truncate the turn streaming on this same socket).
@@ -295,8 +298,7 @@ describe('real VoiceSessionDO — owner close during a turn (matrix: close)', ()
     const socket = await openSocket(session, 'user-A')
     await createSessionOverWs(socket)
 
-    socket.send(TURN)
-    await waitFor(() => kit.sttCalls() === 1, 'turn parked')
+    await driveUtteranceToLlm(socket, kit, 1)
     await session.run(() => kit.llmTurns[0].pushDelta('x'))
     await settle()
 

--- a/packages/platform-ai/src/session-update-gamestate.test.ts
+++ b/packages/platform-ai/src/session-update-gamestate.test.ts
@@ -32,6 +32,7 @@ vi.mock('./providers/factory', async (importOriginal) => {
 })
 
 import {
+  driveUtteranceToLlm,
   makeGatedProviders,
   makeSessionDo,
   messagesOfType,
@@ -47,7 +48,6 @@ beforeEach(() => {
   providerControl.override = undefined
 })
 
-const TURN = JSON.stringify({ type: 'turn' })
 const END = JSON.stringify({ type: 'end' })
 
 // A two-module manual: each section value is an unambiguous marker so a test can
@@ -86,10 +86,9 @@ describe('real VoiceSessionDO — update-gamestate (continuous run, module advan
     const socket = await openSocket(session, 'user-A')
     await createWith(socket, ['moduleA'])
 
-    // Turn 1 (module A) parks at the gated LLM await. Its captured request injects
-    // module A's manual subset, not module B's.
-    socket.send(TURN)
-    await waitFor(() => kit.llmTurns.length === 1, 'turn 1 reached the LLM')
+    // Turn 1 (module A): speech-start opens STT, turn finalizes -> the reply parks
+    // at the gated LLM. Its captured request injects module A's subset, not B's.
+    await driveUtteranceToLlm(socket, kit, 1)
     expect(systemTextOfTurn(kit, 0)).toContain(ALPHA)
     expect(systemTextOfTurn(kit, 0)).not.toContain(BRAVO)
     // No history yet → system + the current player utterance only.
@@ -116,8 +115,7 @@ describe('real VoiceSessionDO — update-gamestate (continuous run, module advan
 
     // Turn 2 (after the update) injects module B's subset, not module A's — proving
     // the update took effect on the next turn.
-    socket.send(TURN)
-    await waitFor(() => kit.llmTurns.length === 2, 'turn 2 reached the LLM')
+    await driveUtteranceToLlm(socket, kit, 2)
     expect(systemTextOfTurn(kit, 1)).toContain(BRAVO)
     expect(systemTextOfTurn(kit, 1)).not.toContain(ALPHA)
     // History PERSISTED across the update: turn 2 carries turn 1's user+assistant
@@ -173,8 +171,7 @@ describe('real VoiceSessionDO — update-gamestate (continuous run, module advan
 
     // The owner's next turn still injects module A — neither the malformed owner
     // updates nor the non-owner update changed the live selection.
-    owner.send(TURN)
-    await waitFor(() => kit.llmTurns.length === 1, 'owner turn reached the LLM')
+    await driveUtteranceToLlm(owner, kit, 1)
     expect(systemTextOfTurn(kit, 0)).toContain(ALPHA)
     expect(systemTextOfTurn(kit, 0)).not.toContain(BRAVO)
   })

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -113,6 +113,19 @@ export interface TurnProviders {
 }
 
 /**
+ * The captured outcome of one utterance's STT phase ({@link runUtteranceStt}),
+ * consumed by the reply phase ({@link runReply}). In the live WS transport the
+ * DO runs the STT phase on `speech-start` (so interim captions stream WHILE the
+ * player speaks) and the reply phase on `turn`, threading this between them.
+ */
+export interface UtteranceResult {
+  /** The player's complete recognized utterance (empty string for no-speech). */
+  transcript: string
+  /** Total inbound audio bytes the STT provider pulled — the fallback metering source. */
+  audioBytes: number
+}
+
+/**
  * LLM provider instances may expose a `lastUsage` after a stream is drained
  * (the DeepSeek adapter does). We read it structurally so the pipeline does not
  * depend on the concrete adapter type.
@@ -303,6 +316,30 @@ function applyLlmTtsUsage(
 }
 
 /**
+ * Apply a settled turn's STT input-seconds to state. Prefers the adapter's
+ * structured usage report (the Volcengine adapter exposes the server's
+ * `audio_info.duration` when reported, or its own exact bytes->duration
+ * conversion when not). When the adapter exposes nothing at all, falls back to
+ * the pipeline's byte tap over the inbound frames the STT provider actually
+ * pulled — and latches the session's STT metering annotation to
+ * `derived-from-bytes` (see `SessionState.sttSource`).
+ */
+function applySttUsage(
+  providers: Pick<TurnProviders, 'stt'>,
+  state: SessionState,
+  sttAudioBytes: number
+): void {
+  const sttUsage = (providers.stt as MaybeSttUsageProvider).lastUsage
+  if (sttUsage) {
+    state.usage.sttInputSeconds += sttUsage.durationMs / 1000
+    if (sttUsage.source === 'derived-from-bytes') state.sttSource = 'derived-from-bytes'
+  } else {
+    state.usage.sttInputSeconds += audioSecondsFromBytes(sttAudioBytes)
+    state.sttSource = 'derived-from-bytes'
+  }
+}
+
+/**
  * The shared LLM->TTS half of a turn: given the fully-assembled `messages`, run
  * the LLM stream and TTS concurrently and yield the interleaved `text`/`audio`
  * chunks (NO terminal `done` — the caller emits that after its own settle). It
@@ -475,51 +512,67 @@ async function* streamLlmTts(
 }
 
 /**
- * Run one player turn end to end (player audio -> STT -> LLM -> TTS).
+ * STT phase of a turn — driven LIVE during the player's utterance.
  *
- * Yields the turn's `AiResponseChunk`s in order: incremental `text` chunks as
- * the LLM streams, `audio` chunks as TTS synthesizes the segmented sentences,
- * and exactly one terminal chunk with `done: true`. Mutates `state` (history,
- * turnCount, usage) as a side effect so the next turn sees this turn's context.
+ * Consumes the inbound audio stream, streaming each interim CUMULATIVE result to
+ * the client as a live-subtitle `transcript` chunk (final: false) AS IT ARRIVES,
+ * and returns the player's COMPLETE utterance (the terminal last-package result)
+ * plus the inbound-frame byte total (the fallback STT metering source). The
+ * generator yields ONLY interim frames; the terminal complete utterance is
+ * returned, not yielded (the reply phase emits it once as the `final: true`
+ * frame, after the no-speech gate).
  *
- * I/O-free beyond driving the injected providers (it never touches the network,
- * a clock, or a socket directly) — fully unit-testable with mocked STT/LLM/TTS.
+ * In the live WS transport the DO calls this on `speech-start` over the STILL-OPEN
+ * audio bridge, so frames pushed while the player speaks feed the recognizer
+ * immediately and the interim captions surface WHILE they talk; the DO closes the
+ * bridge on `turn` to terminate the stream and capture the final. A benign
+ * no-speech utterance surfaces as an empty/partial transcript (no throw); only a
+ * genuine ASR fault throws out of here (fail loud upstream).
  */
-export async function* runTurn(
-  providers: TurnProviders,
-  state: SessionState,
+export async function* runUtteranceStt(
+  providers: Pick<TurnProviders, 'stt'>,
   audio: AsyncIterable<AudioChunk>
-): AsyncIterable<AiResponseChunk> {
-  // 1. STT: transcribe the player's audio, streaming each interim cumulative
-  //    result to the client as a live-subtitle `transcript` chunk (final: false)
-  //    as it arrives, and capturing the complete utterance (the terminal
-  //    last-package result) as the generator's return. `audioBytes` is the
-  //    inbound-frame byte total — the fallback STT metering source at turn settle
-  //    when the adapter reports no structured usage.
-  const turnStart = Date.now()
-  traceTurn('turn', 'pipeline-start', {
-    turnCount: state.turnCount,
-  })
-  const { transcript: playerText, audioBytes: sttAudioBytes } = yield* collectFinalTranscript(
-    providers.stt,
-    audio
-  )
+): AsyncGenerator<AiResponseChunk, UtteranceResult> {
+  const sttStart = Date.now()
+  const { transcript, audioBytes } = yield* collectFinalTranscript(providers.stt, audio)
   // ASR hop boundary: the complete cumulative transcript is in hand (length only —
   // never the text). An empty transcript here explains a downstream LLM no-op.
   traceTurn('asr', 'final-transcript', {
-    transcriptChars: playerText.length,
-    elapsedMs: Date.now() - turnStart,
+    transcriptChars: transcript.length,
+    elapsedMs: Date.now() - sttStart,
   })
+  return { transcript, audioBytes }
+}
 
-  // Benign no-speech turn: the player's buffered audio held nothing
-  // transcribable (a false-positive VAD trigger — a stopwatch tick, a cough,
-  // ambient noise — surfacing as a clean ASR close with no final transcript).
-  // Skip the turn: emit NO response chunks, mutate NO state (history, turnCount,
-  // usage all untouched), and meter nothing — the player effectively spoke
-  // nothing this turn (undercount-only, consistent with the session metering
-  // stance). The session stays ready and the next `turn` runs normally. This is
-  // NOT an error: a real ASR error frame / connect failure / mid-stream stall
-  // still throws out of `collectFinalTranscript` above and fails the turn loud.
+/**
+ * Reply phase of a turn — run on `turn`, after the utterance's STT finalized.
+ *
+ * Given the captured complete utterance, emits the terminal `transcript`
+ * (final: true) frame, assembles the deterministic context, runs LLM+TTS, and
+ * settles state (history, turnCount, LLM/TTS/STT usage). Yields the ordered AI
+ * reply chunks ending in exactly one terminal `done: true` chunk.
+ *
+ * The STT stream was already drained by {@link runUtteranceStt}, so
+ * `providers.stt.lastUsage` is settled by the time this reads it. Mutates `state`;
+ * I/O-free beyond driving the injected LLM/TTS providers.
+ */
+export async function* runReply(
+  providers: TurnProviders,
+  state: SessionState,
+  utterance: UtteranceResult
+): AsyncIterable<AiResponseChunk> {
+  const turnStart = Date.now()
+  const { transcript: playerText, audioBytes: sttAudioBytes } = utterance
+
+  // Benign no-speech turn: the player's utterance held nothing transcribable (a
+  // false-positive VAD trigger — a stopwatch tick, a cough, ambient noise —
+  // surfacing as a clean ASR close with no final transcript). Skip the turn: emit
+  // NO response chunks, mutate NO state (history, turnCount, usage all untouched),
+  // and meter nothing — the player effectively spoke nothing this turn
+  // (undercount-only, consistent with the session metering stance). The session
+  // stays ready and the next `turn` runs normally. This is NOT an error: a real
+  // ASR error frame / connect failure / mid-stream stall throws out of
+  // `runUtteranceStt` (fail loud), never reaching here with a transcript.
   if (playerText.trim().length === 0) {
     traceTurn('turn', 'skip-no-speech', {
       turnCount: state.turnCount,
@@ -528,47 +581,31 @@ export async function* runTurn(
     return
   }
 
-  // 1b. The complete utterance — the TERMINAL transcript frame (final: true),
-  //     surfaced BEFORE the AI reply streams so the client can lock in the live
-  //     subtitle of what the AI heard. Interim frames (final: false) for this
-  //     utterance already streamed during STT above; this is the single final
-  //     frame. Emitted only for a NON-empty transcript — the no-speech skip above
-  //     already returned (and a skip emits no interim either, since empty /
-  //     whitespace interims are suppressed), so a skipped turn yields nothing.
-  //     This is the player's OWN speech returned to that same client — never
-  //     prompt or secret material; it carries `done: false` (the AI reply's last
-  //     text chunk is still the turn's terminal `done`).
+  // The complete utterance — the TERMINAL transcript frame (final: true), surfaced
+  // BEFORE the AI reply streams so the client can lock in the live subtitle of
+  // what the AI heard. Interim frames (final: false) for this utterance already
+  // streamed during the STT phase; this is the single final frame. This is the
+  // player's OWN speech returned to that same client — never prompt or secret
+  // material; it carries `done: false` (the AI reply's last text chunk is still
+  // the turn's terminal `done`).
   yield { kind: 'transcript', text: playerText, final: true, done: false }
 
-  // 2. Inject: deterministic system message (role + rules + manual subset),
-  //    then the rolling history, then this turn's player utterance.
+  // Inject: deterministic system message (role + rules + manual subset), then the
+  // rolling history, then this turn's player utterance.
   const userMessage: ChatMessage = { role: 'user', content: playerText }
   const messages: ChatMessage[] = [...assembleSystem(state), ...state.history, userMessage]
 
-  // 3. LLM + 4. TTS run concurrently via the shared half.
+  // LLM + TTS run concurrently via the shared half.
   const result = yield* streamLlmTts(providers, state.config.llm.model, messages, turnStart)
 
-  // 5. Settle turn state: record history, count, and usage; emit the terminal
-  //    chunk so the consumer can close out the turn.
+  // Settle turn state: record history, count, and usage; emit the terminal chunk
+  // so the consumer can close out the turn.
   state.history.push(userMessage)
   state.history.push({ role: 'assistant', content: result.assistantText })
   state.turnCount += 1
 
   const { outputTokens } = applyLlmTtsUsage(providers, state, result)
-  // STT seconds: prefer the adapter's structured usage report (the Volcengine
-  // adapter exposes the server's `audio_info.duration` when reported, or its
-  // own exact bytes->duration conversion when not). When the adapter exposes
-  // nothing at all, fall back to the pipeline's byte tap over the inbound
-  // frames the STT provider actually pulled — and latch the session's STT
-  // metering annotation to `derived-from-bytes` (see `SessionState.sttSource`).
-  const sttUsage = (providers.stt as MaybeSttUsageProvider).lastUsage
-  if (sttUsage) {
-    state.usage.sttInputSeconds += sttUsage.durationMs / 1000
-    if (sttUsage.source === 'derived-from-bytes') state.sttSource = 'derived-from-bytes'
-  } else {
-    state.usage.sttInputSeconds += audioSecondsFromBytes(sttAudioBytes)
-    state.sttSource = 'derived-from-bytes'
-  }
+  applySttUsage(providers, state, sttAudioBytes)
 
   // Turn settle: the per-turn accounting boundary. The counts here are the
   // single most diagnostic line for the silent-park — e.g. llmDeltaCount:0 +
@@ -585,6 +622,35 @@ export async function* runTurn(
   })
 
   yield { kind: 'text', text: '', done: true }
+}
+
+/**
+ * Run one player turn end to end (player audio -> STT -> LLM -> TTS) as the
+ * composition of its two phases: {@link runUtteranceStt} (STT, streaming interim
+ * captions) then {@link runReply} (LLM+TTS over the captured utterance).
+ *
+ * This is the BUFFERED single-call form — the live WS transport drives the two
+ * phases separately (STT on `speech-start` over the open audio bridge so the
+ * caption builds WHILE the player speaks, reply on `turn`), but the end-to-end
+ * form keeps the whole pipeline unit-testable with mocked providers and is the
+ * canonical primitive exported by the package.
+ *
+ * Yields the turn's `AiResponseChunk`s in order: interim `transcript` chunks, the
+ * terminal `transcript` (final: true), incremental `text` chunks as the LLM
+ * streams, `audio` chunks as TTS synthesizes, and exactly one terminal `done`
+ * chunk. Mutates `state` (history, turnCount, usage). I/O-free beyond driving the
+ * injected providers.
+ */
+export async function* runTurn(
+  providers: TurnProviders,
+  state: SessionState,
+  audio: AsyncIterable<AudioChunk>
+): AsyncIterable<AiResponseChunk> {
+  traceTurn('turn', 'pipeline-start', {
+    turnCount: state.turnCount,
+  })
+  const utterance = yield* runUtteranceStt(providers, audio)
+  yield* runReply(providers, state, utterance)
 }
 
 /**


### PR DESCRIPTION
## Summary

Reworks the ASR timing from transcribe-after-the-player-stops to transcribe **live while they speak**. Fixes two live-device problems: the `你：…` caption only appeared after the player finished, and a `1008: Volcengine ASR [Timeout waiting next packet] 8s` dropped the session.

- Client sends `{type:'speech-start'}` on VAD speech-start, streams audio continuously, then `{type:'turn'}` on utterance-end.
- Backend (`session-do.ts` + `turn-pipeline.ts` split into `runUtteranceStt` / `runReply` / `runTurn`): speech-start opens the recognizer + live-feeds the audio, streaming interim `{type:'transcript', text, final:false}` captions; turn finalizes the full transcript (last-package bit) and runs the LLM+TTS reply. Barge-in + epoch fencing preserved; buffered path removed. Volcengine adapter untouched (its `transcribe` already consumes a push stream) — only DO timing changed.

## Test plan
- [x] tsc/build/lint clean; platform-ai 327 + game-bombsquad 401
- [x] **Live-verified** against the deployed Worker (`demo/live-asr-probe.mjs`): interim captions arrive mid-speech (6 before the turn), full final transcript, no 8s timeout, clean finish, sensible reply
- [ ] device re-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)