### PR TITLE
fix(bombsquad): dedup leaderboard submissions by stable run_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad leaderboard: a single run can no longer appear twice** - Fix. One
+finished daily run was sometimes posted to the leaderboard more than once
+(showing two identical rows), because the result page had several submit paths
+that could each fire and the backend appended a new row on every POST. The fix
+adds two layers: the result page now latches submission so a run is sent at most
+once per page lifecycle (the retry button still works after a real failure), and
+every run carries a stable client-generated `run_id` so the backend replaces any
+existing row with that id instead of appending — a refresh or network race
+collapses to one row. `run_id` is internal and never exposed in the public
+leaderboard response.
+
 **BombSquad mode② voice: your first word is no longer dropped, and the AI speaks
 plain spoken words** - Fix. Two recognition/voice polish fixes. First, the very
 start of each utterance was being clipped: the recognizer only opened once the

--- a/packages/api/src/handlers/get-leaderboard.test.ts
+++ b/packages/api/src/handlers/get-leaderboard.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { LeaderboardResponse } from '../../../../shared/leaderboard-types'
+import { handleGetLeaderboard } from './get-leaderboard'
+
+class FakeKV {
+  private readonly store = new Map<string, string>()
+
+  async get(key: string, type?: 'json'): Promise<unknown> {
+    const value = this.store.get(key)
+    if (value === undefined) return null
+    return type === 'json' ? JSON.parse(value) : value
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    this.store.set(key, value)
+  }
+}
+
+function request(date: string): Request {
+  return new Request(`https://claw.amio.fans/api/leaderboard?date=${date}`, { method: 'GET' })
+}
+
+describe('handleGetLeaderboard — run_id privacy', () => {
+  // run_id is an internal backend dedup key. It must never reach the public
+  // leaderboard response, or it would leak a stable per-run identifier.
+  it('strips the internal run_id from every entry in the public response', async () => {
+    const kv = new FakeKV()
+    const date = '2026-06-30'
+    await kv.put(
+      `leaderboard:${date}`,
+      JSON.stringify([
+        { rank: 1, nickname: '小明', time_ms: 130_000, attempt_number: 1, run_id: 'run-x' },
+        { rank: 2, nickname: '小红', time_ms: 140_000, attempt_number: 1, run_id: 'run-y' },
+      ])
+    )
+
+    const response = await handleGetLeaderboard(request(date), kv as unknown as KVNamespace)
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as LeaderboardResponse
+    expect(body.entries).toHaveLength(2)
+    for (const entry of body.entries) {
+      expect(entry).not.toHaveProperty('run_id')
+    }
+    // The public fields survive intact.
+    expect(body.entries[0]).toMatchObject({ rank: 1, nickname: '小明', time_ms: 130_000 })
+  })
+})

--- a/packages/api/src/handlers/get-leaderboard.ts
+++ b/packages/api/src/handlers/get-leaderboard.ts
@@ -1,5 +1,9 @@
 import type { LeaderboardEntry, LeaderboardResponse } from '../../../../shared/leaderboard-types'
 
+// Internal KV shape includes the dedup key; it must be stripped before the
+// public GET response so run_id is never exposed to leaderboard readers.
+type StoredEntry = LeaderboardEntry & { run_id?: string }
+
 export async function handleGetLeaderboard(request: Request, kv: KVNamespace): Promise<Response> {
   const url = new URL(request.url)
   const date = url.searchParams.get('date') ?? new Date().toISOString().slice(0, 10)
@@ -11,7 +15,14 @@ export async function handleGetLeaderboard(request: Request, kv: KVNamespace): P
     })
   }
 
-  const entries = ((await kv.get(`leaderboard:${date}`, 'json')) as LeaderboardEntry[] | null) ?? []
+  const raw = ((await kv.get(`leaderboard:${date}`, 'json')) as StoredEntry[] | null) ?? []
+  // Strip the internal run_id from every entry — it is a backend dedup key,
+  // not part of the public leaderboard contract.
+  const entries: LeaderboardEntry[] = raw.map((e) => {
+    const entry = { ...e } as Partial<StoredEntry>
+    delete entry.run_id
+    return entry as LeaderboardEntry
+  })
 
   const response: LeaderboardResponse = { date, entries }
   return new Response(JSON.stringify(response), {

--- a/packages/api/src/handlers/post-score.test.ts
+++ b/packages/api/src/handlers/post-score.test.ts
@@ -104,3 +104,53 @@ describe('handlePostScore — leaderboard AI metadata', () => {
     ])
   })
 })
+
+describe('handlePostScore — run_id idempotency', () => {
+  // A run carries a stable client-generated run_id. Re-submitting the same run
+  // (page refresh, retry, or a KV-race double-POST) must REPLACE the existing
+  // row, not append a second one — otherwise the leaderboard shows duplicates.
+  it('replaces an existing entry with the same run_id instead of appending', async () => {
+    const kv = new FakeKV()
+    const date = new Date().toISOString().slice(0, 10)
+    // Pre-seed the same run already on the board (its first, slower submit).
+    await kv.put(
+      `leaderboard:${date}`,
+      JSON.stringify([
+        { rank: 1, nickname: '小明', time_ms: 150_000, attempt_number: 1, run_id: 'run-x' },
+      ])
+    )
+
+    const response = await handlePostScore(
+      request(submission({ time_ms: 130_000, run_id: 'run-x' })),
+      kv as unknown as KVNamespace
+    )
+
+    expect(response.status).toBe(200)
+    const entries = (await kv.get(`leaderboard:${date}`, 'json')) as Array<
+      LeaderboardEntry & { run_id?: string }
+    > | null
+    // Exactly one row for the run — the resubmission replaced the prior one.
+    expect(entries).toHaveLength(1)
+    expect(entries?.[0]).toMatchObject({ rank: 1, time_ms: 130_000, run_id: 'run-x' })
+  })
+
+  it('appends runs that carry distinct run_ids', async () => {
+    const kv = new FakeKV()
+    const date = new Date().toISOString().slice(0, 10)
+    await kv.put(
+      `leaderboard:${date}`,
+      JSON.stringify([
+        { rank: 1, nickname: '小红', time_ms: 120_000, attempt_number: 1, run_id: 'run-x' },
+      ])
+    )
+
+    const response = await handlePostScore(
+      request(submission({ time_ms: 130_000, run_id: 'run-y' })),
+      kv as unknown as KVNamespace
+    )
+
+    expect(response.status).toBe(200)
+    const entries = (await kv.get(`leaderboard:${date}`, 'json')) as LeaderboardEntry[] | null
+    expect(entries).toHaveLength(2)
+  })
+})

--- a/packages/api/src/handlers/post-score.ts
+++ b/packages/api/src/handlers/post-score.ts
@@ -3,6 +3,10 @@ import type {
   LeaderboardEntry,
   ScoreSubmissionResponse,
 } from '../../../../shared/leaderboard-types'
+
+// Internal KV shape: LeaderboardEntry plus the dedup key, which is never
+// exposed through the public GET response (stripped in get-leaderboard.ts).
+type StoredEntry = LeaderboardEntry & { run_id?: string }
 import { computeBestRecord, type BestRecord } from '../../../../shared/personal-best'
 import {
   MAX_AI_MODEL_LEN,
@@ -52,21 +56,27 @@ export async function handlePostScore(request: Request, kv: KVNamespace): Promis
 
   // Read-modify-write leaderboard
   const leaderboardKey = `leaderboard:${body.date}`
-  const existing = ((await kv.get(leaderboardKey, 'json')) as LeaderboardEntry[] | null) ?? []
+  const existing = ((await kv.get(leaderboardKey, 'json')) as StoredEntry[] | null) ?? []
 
-  const newEntry: LeaderboardEntry = {
+  const newEntry: StoredEntry = {
     rank: 0, // assigned below after sort
     nickname: sanitizeNickname(body.nickname),
     time_ms: body.time_ms,
     attempt_number: body.attempt_number,
     ai_tool: sanitizeLeaderboardText(body.ai_tool, MAX_AI_TOOL_LEN),
+    ...(body.run_id ? { run_id: body.run_id } : {}),
   }
   const aiModel = body.ai_model
     ? sanitizeLeaderboardText(body.ai_model, MAX_AI_MODEL_LEN)
     : undefined
   if (aiModel) newEntry.ai_model = aiModel
 
-  const updated = [...existing, newEntry]
+  // Idempotency: when the submission carries a run_id, remove any existing
+  // entry with the same run_id before appending. This makes a double-POST of
+  // the same run (e.g. page refresh or KV race) produce exactly one row.
+  const base = body.run_id ? existing.filter((e) => e.run_id !== body.run_id) : existing
+
+  const updated = [...base, newEntry]
     .sort((a, b) => a.time_ms - b.time_ms)
     .slice(0, MAX_ENTRIES)
     .map((entry, idx) => ({ ...entry, rank: idx + 1 }))

--- a/packages/api/src/validation.ts
+++ b/packages/api/src/validation.ts
@@ -55,6 +55,9 @@ export function validateSubmission(submission: ScoreSubmission): ValidationResul
   if (submission.ai_model !== undefined && typeof submission.ai_model !== 'string') {
     return fail('Invalid ai_model')
   }
+  if (submission.run_id !== undefined && typeof submission.run_id !== 'string') {
+    return fail('Invalid run_id')
+  }
 
   if (submission.time_ms < MIN_GAME_TIME_MS) return fail('Time too short — minimum 15 seconds')
   if (submission.time_ms > MAX_GAME_TIME_MS) return fail('Time exceeds maximum')

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import PostGameModal, { type PostGameModalResult } from '@/components/PostGameModal'
 import { Scenery } from '@amiclaw/ui'
@@ -155,6 +155,15 @@ export default function ResultPage() {
     () => hasFinishedDailyRun && nickname !== null && leaderboardMetadata !== null
   )
 
+  // Idempotency latch: prevents the same run from being submitted more than
+  // once within a single ResultPage lifecycle. Guards all three submit paths
+  // (mount effect, modal-confirm, retry). The latch is released back to 'idle'
+  // on a network failure so the retry button can fire a second attempt.
+  // Across remounts (e.g. page refresh with game state still in sessionStorage),
+  // the per-run stable run_id in buildSubmission + backend dedup provide the
+  // second layer of protection.
+  const submittedRef = useRef<'idle' | 'in-flight' | 'done'>('idle')
+
   // The daily score is still gated while the modal is open with a leaderboard
   // submission section present.
   const leaderboardGatePending = modalPurpose === 'leaderboard'
@@ -168,8 +177,27 @@ export default function ResultPage() {
   const buildSubmission = useCallback(
     (nicknameValue: string, metadataValue: LeaderboardPlayerMetadata): ScoreSubmission | null => {
       if (totalMs === null) return null
+      const date = getTodayString()
+      // Generate a UUID once per run and persist it so a page-refresh retry
+      // sends the same run_id, enabling backend dedup to collapse duplicates.
+      let run_id: string | undefined
+      try {
+        const storageKey = `run-id:${date}:${state.attemptNumber}`
+        const stored = sessionStorage.getItem(storageKey)
+        if (stored) {
+          run_id = stored
+        } else {
+          run_id = crypto.randomUUID()
+          sessionStorage.setItem(storageKey, run_id)
+        }
+      } catch {
+        // sessionStorage unavailable (e.g. private-browsing restrictions) —
+        // fall back to a per-call UUID; the backend rate limit still provides
+        // a weak guard and the frontend latch covers within-mount doubles.
+        run_id = crypto.randomUUID()
+      }
       return {
-        date: getTodayString(),
+        date,
         nickname: nicknameValue,
         time_ms: Math.round(totalMs),
         attempt_number: state.attemptNumber,
@@ -178,6 +206,7 @@ export default function ResultPage() {
         ai_tool: metadataValue.aiTool,
         ...(metadataValue.aiModel ? { ai_model: metadataValue.aiModel } : {}),
         device_id: getDeviceId(),
+        run_id,
       }
     },
     [totalMs, state.attemptNumber, state.moduleStats]
@@ -200,10 +229,13 @@ export default function ResultPage() {
   // Applies a submission outcome to UI state. Centralizes the three-way mapping
   // (success / network failure / server rejection) so the mount, modal-confirm,
   // and retry paths stay in lockstep.
+  // Also manages the idempotency latch: locks it permanently on success so no
+  // further submit can fire; releases it to 'idle' on failure so retry works.
   const applySubmitResult = useCallback(
     (submission: ScoreSubmission, result: SubmitScoreResult) => {
       setSubmitting(false)
       if (result.ok) {
+        submittedRef.current = 'done' // permanently lock — this run is on the board
         setSubmitFailed(false)
         setSubmitFailKind(null)
         setSubmitFailMessage(null)
@@ -215,6 +247,7 @@ export default function ResultPage() {
           /* ignore */
         }
       } else {
+        submittedRef.current = 'idle' // release latch so the retry button can fire
         setSubmitFailed(true)
         setSubmitFailKind(result.kind)
         setSubmitFailMessage(result.kind === 'rejected' ? (result.error ?? null) : null)
@@ -228,10 +261,21 @@ export default function ResultPage() {
   // the modal-confirm path flips it on synchronously before calling here.
   // Keeping `setSubmitting(true)` out of this function lets us call it from
   // inside `useEffect` without tripping react-hooks/set-state-in-effect.
+  //
+  // Idempotency: the submittedRef latch guards against concurrent or double
+  // invocations within a single component lifecycle (e.g. React StrictMode
+  // double-effect invocation). A cross-mount double (page refresh) is handled
+  // by the stable run_id in buildSubmission + backend dedup.
   const performSubmission = useCallback(
     (nicknameValue: string, metadataValue: LeaderboardPlayerMetadata) => {
+      if (submittedRef.current !== 'idle') return // already in-flight or done
+      submittedRef.current = 'in-flight'
+
       const submission = buildSubmission(nicknameValue, metadataValue)
-      if (!submission) return
+      if (!submission) {
+        submittedRef.current = 'idle' // release if build failed (totalMs unavailable)
+        return
+      }
 
       // Persist locally so a retry can succeed even if user navigates back
       try {
@@ -317,13 +361,10 @@ export default function ResultPage() {
     setSubmitFailKind(null)
     setSubmitFailMessage(null)
     setSubmitting(true)
-    const submission = buildSubmission(nickname, leaderboardMetadata)
-    if (!submission) {
-      setSubmitting(false)
-      return
-    }
-    submitScore(submission).then((result) => applySubmitResult(submission, result))
-  }, [buildSubmission, applySubmitResult, nickname, leaderboardMetadata])
+    // applySubmitResult resets submittedRef to 'idle' on failure, so
+    // performSubmission will proceed here on the retry path.
+    performSubmission(nickname, leaderboardMetadata)
+  }, [performSubmission, nickname, leaderboardMetadata])
 
   const handlePlayAgain = () => {
     // Emit BEFORE the RESET so we still capture the just-finished run's mode

--- a/shared/leaderboard-types.ts
+++ b/shared/leaderboard-types.ts
@@ -8,6 +8,7 @@ export interface ScoreSubmission {
   ai_tool: string // required: 'claude' | 'chatgpt' | 'gemini' | string
   ai_model?: string // optional concrete model/version, omitted when blank
   device_id: string // UUID from localStorage
+  run_id?: string // client-generated UUID stable per run; used for backend dedup
 }
 
 export interface ScoreSubmissionResponse {


### PR DESCRIPTION
## Summary
- A single finished daily run could show **twice** on the leaderboard: ResultPage had multiple submit paths and the backend appended on every POST.
- **Frontend**: a `submittedRef` latch makes the submit fire at most once per page lifecycle (retry still works after a real failure); each run carries a stable `run_id` (persisted in sessionStorage by date+attempt) so a refresh resends the same id.
- **Backend**: `post-score` replaces any existing entry with the same `run_id` instead of appending (idempotent); `run_id` is stripped from the public GET response.

## Test plan
- [x] api 166 tests (+3: run_id replace/append dedup, GET strip)
- [x] game-bombsquad 405 tests; typecheck clean
- [ ] CI green
- [ ] Live re-test: one run → one leaderboard row

🤖 Generated with [Claude Code](https://claude.com/claude-code)