### PR TITLE
feat(bombsquad): closing AI recap after a successful daily defuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② voice: the AI gives a short closing recap when you win** - Add.
+After a successful daily defuse the results screen used to appear instantly,
+cutting the voice partner off before it could react. Now, on a daily win, the AI
+plays one short spoken recap — a warm one-to-two-sentence congratulation — and the
+results screen waits until that finishes (with an 8-second hard cap so a TTS hiccup
+never strands you on the win screen). The "拆除成功" burst stays on screen during
+the recap as the celebration beat. Only a successful daily defuse triggers it; a
+loss, a timeout, or practice mode navigates straight to results as before.
+
 **BombSquad leaderboard: a single run can no longer appear twice** - Fix. One
 finished daily run was sometimes posted to the leaderboard more than once
 (showing two identical rows), because the result page had several submit paths

--- a/packages/game-bombsquad/src/game-closing-recap.test.tsx
+++ b/packages/game-bombsquad/src/game-closing-recap.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * GamePage closing-recap gating tests.
+ *
+ * After a successful daily defuse with the platform voice partner active, the
+ * `RESULT` effect in GamePage must:
+ *   1. Call `voicePanelRef.current.requestClosing()` before navigating.
+ *   2. Navigate to `/bombsquad/result` only after the returned promise settles.
+ *   3. Navigate anyway if the promise rejects (error-recovery fallback, covering
+ *      the same `doNavigate` code path as the 8000ms hard-timeout sentinel).
+ *
+ * Approach: mock `useVoiceSession` at the boundary between GamePage → VoicePanel →
+ * hook. The real VoicePanel (with its `forwardRef` + `useImperativeHandle`) is
+ * left intact; only the hook it calls is replaced with a controlled stub. This
+ * threads `requestClosing` through the real ref path so the GamePage effect
+ * exercises the same `voicePanelRef.current.requestClosing()` call it would in
+ * production.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import yaml from 'js-yaml'
+import type { Manual } from '@shared/manual-schema'
+import App from './App'
+import practiceYamlRaw from '../../manual/data/practice.yaml?raw'
+
+// --- Mock: module components (fast, no puzzle logic) -----------------------------
+
+vi.mock('./modules/wire/WireModule', () => ({
+  default: ({ onComplete }: { onComplete: () => void }) => (
+    <button data-testid="mock-wire-complete" onClick={onComplete}>
+      complete-wire
+    </button>
+  ),
+}))
+vi.mock('./modules/dial/DialModule', () => ({
+  default: ({ onComplete }: { onComplete: () => void }) => (
+    <button data-testid="mock-dial-complete" onClick={onComplete}>
+      complete-dial
+    </button>
+  ),
+}))
+vi.mock('./modules/button/ButtonModule', () => ({
+  default: ({ onComplete }: { onComplete: () => void }) => (
+    <button data-testid="mock-button-complete" onClick={onComplete}>
+      complete-button
+    </button>
+  ),
+}))
+vi.mock('./modules/keypad/KeypadModule', () => ({
+  default: ({ onComplete }: { onComplete: () => void }) => (
+    <button data-testid="mock-keypad-complete" onClick={onComplete}>
+      complete-keypad
+    </button>
+  ),
+}))
+
+// --- Mock: leaderboard API -------------------------------------------------------
+
+vi.mock('@shared/leaderboard-api', () => ({
+  submitScore: vi.fn().mockResolvedValue({ ok: true, data: { rank: 1, total_players: 10 } }),
+  fetchLeaderboard: vi.fn().mockResolvedValue({ date: '2026-06-30', entries: [] }),
+}))
+
+// --- Mock: daily manual loader --------------------------------------------------
+
+vi.mock('@/utils/yaml-loader', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/yaml-loader')>()
+  return { ...actual, loadManual: vi.fn() }
+})
+import { loadManual } from '@/utils/yaml-loader'
+
+// --- Mock: event-log (no-op) ----------------------------------------------------
+
+vi.mock('@/utils/event-log', () => ({ logEvent: vi.fn() }))
+
+// --- Mock: useVoiceSession with controllable requestClosing ----------------------
+
+/**
+ * `vi.hoisted` so the mock factory closure below AND the test body both share the
+ * same functions. The factory runs before imports are executed; hoisted values are
+ * the only safe escape hatch.
+ */
+const closingControl = vi.hoisted(() => {
+  let pendingResolve: (() => void) | null = null
+  let pendingReject: ((err: Error) => void) | null = null
+
+  const requestClosing = vi.fn()
+
+  return {
+    requestClosing,
+    /** Resolve the current pending requestClosing promise (recap finished). */
+    resolveClosing: () => {
+      pendingResolve?.()
+      pendingResolve = null
+    },
+    /** Reject the current pending requestClosing promise (recap errored). */
+    rejectClosing: (err: Error) => {
+      pendingReject?.(err)
+      pendingReject = null
+    },
+    /** Install (or re-install) the pending-promise implementation. */
+    setupPending: () => {
+      requestClosing.mockImplementation(
+        () =>
+          new Promise<void>((res, rej) => {
+            pendingResolve = res
+            pendingReject = rej
+          })
+      )
+    },
+  }
+})
+
+vi.mock('@/voice/useVoiceSession', () => ({
+  useVoiceSession: () => ({
+    status: 'ready' as const,
+    conversationPhase: 'listening' as const,
+    playerSpeaking: false,
+    aiText: '',
+    playerTranscript: '',
+    isAiSpeaking: false,
+    error: null,
+    summary: null,
+    endSession: vi.fn(),
+    requestClosing: closingControl.requestClosing,
+  }),
+}))
+
+// --- Helpers -------------------------------------------------------------------
+
+const DAILY_MODULE_TESTIDS = [
+  'mock-wire-complete',
+  'mock-dial-complete',
+  'mock-button-complete',
+  'mock-keypad-complete',
+]
+
+async function completeModules(testIds: string[]) {
+  for (const testId of testIds) {
+    await waitFor(() => expect(screen.getByTestId(testId)).toBeInTheDocument(), { timeout: 3000 })
+    fireEvent.click(screen.getByTestId(testId))
+  }
+}
+
+// --- Tests ---------------------------------------------------------------------
+
+describe('GamePage closing-recap gating', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.mocked(loadManual).mockResolvedValue(yaml.load(practiceYamlRaw) as Manual)
+    closingControl.requestClosing.mockReset()
+    closingControl.setupPending()
+  })
+
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('gates navigation on requestClosing — heading appears only after the promise resolves', async () => {
+    render(
+      <MemoryRouter initialEntries={['/bombsquad/run?mode=daily&partner=platform']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    // Drive all 4 daily modules to completion.
+    await completeModules(DAILY_MODULE_TESTIDS)
+
+    // The RESULT effect should have called requestClosing. Navigation is
+    // blocked while the promise is pending.
+    await waitFor(() => expect(closingControl.requestClosing).toHaveBeenCalled(), {
+      timeout: 3000,
+    })
+    expect(screen.queryByRole('heading', { name: /拆弹成功/ })).toBeNull()
+
+    // Resolve the recap — the .then(doNavigate) handler fires.
+    closingControl.resolveClosing()
+
+    await waitFor(
+      () => expect(screen.getByRole('heading', { name: /拆弹成功/ })).toBeInTheDocument(),
+      { timeout: 3000 }
+    )
+  }, 15000)
+
+  it('fallback: navigates even when requestClosing rejects (error-recovery, same path as timeout)', async () => {
+    // Rejection exercises the `.then(doNavigate, doNavigate)` error handler —
+    // the same `doNavigate` function that the 8000ms timeout sentinel calls.
+    // Testing rejection is structurally equivalent to testing the timeout but
+    // avoids fake-timer complexity.
+    render(
+      <MemoryRouter initialEntries={['/bombsquad/run?mode=daily&partner=platform']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    await completeModules(DAILY_MODULE_TESTIDS)
+
+    await waitFor(() => expect(closingControl.requestClosing).toHaveBeenCalled(), {
+      timeout: 3000,
+    })
+
+    // Simulate a WS drop mid-recap.
+    closingControl.rejectClosing(new Error('WebSocket closed before recap finished'))
+
+    await waitFor(
+      () => expect(screen.getByRole('heading', { name: /拆弹成功/ })).toBeInTheDocument(),
+      { timeout: 3000 }
+    )
+  }, 15000)
+})

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import yaml from 'js-yaml'
 import type { Manual, SceneInfo, ModuleConfig, ModuleAnswer } from '@shared/manual-schema'
@@ -35,7 +35,7 @@ import practiceYamlRaw from '../../../manual/data/practice.yaml?raw'
 import { generateSceneInfo } from '@/engine/scene-info'
 import { getAttemptNumberForMode, getRunSeed } from '@/utils/session'
 import { getAudioContext, setSfxSuppressed } from '@/audio/audio-context'
-import VoicePanel from '@/voice/VoicePanel'
+import VoicePanel, { type VoicePanelHandle } from '@/voice/VoicePanel'
 import { deriveVoicePanelInputs, isPlatformVoicePartner } from '@/voice/voice-panel-inputs'
 import styles from './GamePage.module.css'
 
@@ -53,6 +53,12 @@ const MODULE_LABEL: Record<ModuleKind, string> = {
 // How long the CSS explosion plays before routing to the failure result
 // page — kept in step with the ExplosionOverlay keyframe durations.
 const EXPLOSION_DURATION_MS = 1400
+
+// Hard-max timeout for the closing-recap audio on a successful daily defuse.
+// If the TTS provider does not deliver audio within this window (network hiccup,
+// provider timeout, silent LLM response) we navigate anyway so the player is
+// never stranded on the win screen.
+const CLOSING_RECAP_TIMEOUT_MS = 8000
 
 // Two-line diagnostic copy: line 1 names what just happened locally, line 2
 // names the AI partner's now-stale view. Kept as an array so the two lines
@@ -204,16 +210,32 @@ export default function GamePage() {
   // game state only, never alters game logic.
   const usePlatformVoice = isPlatformVoicePartner(mode, searchParams.get('partner'))
 
+  // Ref to the mounted VoicePanel — used to call requestClosing() imperatively
+  // on a successful daily defuse before navigating to the results screen.
+  const voicePanelRef = useRef<VoicePanelHandle>(null)
+  // Guard: the closing recap fires exactly once per RESULT entry — even if the
+  // effect re-runs (StrictMode double-invoke, unlikely state oscillation).
+  const closingFiredRef = useRef(false)
+
   // Voice-session inputs for the current module, recomputed only when the loaded
   // manual or the current module changes (NOT on every timer-frame re-render).
   // Advancing modules changes `gameState.relevantSections` but keeps the same
   // run-stable `sessionKey`, so the panel does NOT remount — the hook steers the
   // live session with one `update-gamestate` instead of reconnecting (one
   // continuous conversation per run; the AI greets once and remembers it).
+  //
+  // When all modules complete, `currentModuleIndex` advances to moduleSequence.length
+  // (out of bounds) on the ALL_COMPLETE/RESULT transition. We clamp to the last
+  // valid index so VoicePanel stays mounted during RESULT state, allowing the
+  // closing-recap turn to play before navigation.
   const voiceInputs = useMemo(
-    () => (usePlatformVoice ? deriveVoicePanelInputs(state) : null),
+    () => {
+      if (!usePlatformVoice) return null
+      const clampedIdx = Math.min(state.currentModuleIndex, state.moduleSequence.length - 1)
+      return deriveVoicePanelInputs({ ...state, currentModuleIndex: clampedIdx })
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [usePlatformVoice, state.manual, state.currentModuleIndex]
+    [usePlatformVoice, state.manual, state.currentModuleIndex, state.moduleSequence.length]
   )
 
   // Mute every game SFX while the mode② voice partner is mounted. The stopwatch
@@ -446,10 +468,47 @@ export default function GamePage() {
   }, [state.status, dispatch])
 
   useEffect(() => {
-    if (state.status === 'RESULT') {
+    if (state.status !== 'RESULT') return
+
+    // Closing recap only for a successful daily defuse with the voice partner
+    // active. All other outcomes (loss, timeout, practice) navigate immediately.
+    const isDefusedDailyVoice = state.outcome === 'defused' && mode === 'daily' && usePlatformVoice
+
+    if (!isDefusedDailyVoice || closingFiredRef.current) {
       navigate('/bombsquad/result')
+      return
     }
-  }, [state.status, navigate])
+
+    closingFiredRef.current = true
+
+    let settled = false
+    const doNavigate = () => {
+      if (!settled) {
+        settled = true
+        navigate('/bombsquad/result')
+      }
+    }
+
+    // Hard-max timeout: if TTS never delivers (provider hiccup / silence), do
+    // not leave the player waiting. The "拆除成功" burst stays on screen during
+    // the wait — a natural celebration beat.
+    const timeout = setTimeout(doNavigate, CLOSING_RECAP_TIMEOUT_MS)
+
+    const panel = voicePanelRef.current
+    if (!panel) {
+      clearTimeout(timeout)
+      doNavigate()
+      return
+    }
+
+    panel.requestClosing().then(doNavigate, doNavigate)
+
+    return () => {
+      settled = true
+      clearTimeout(timeout)
+    }
+    // voicePanelRef is a stable ref — not a dependency.
+  }, [state.status, state.outcome, mode, usePlatformVoice, navigate])
 
   // Auto-advance from MODULE_COMPLETE after the inter-module transition delay.
   // The constant is shared with the score validator (@shared/game-timing) so
@@ -678,6 +737,7 @@ export default function GamePage() {
 
       {voiceInputs && (
         <VoicePanel
+          ref={voicePanelRef}
           key={voiceInputs.sessionKey}
           manualData={voiceInputs.manualData}
           gameState={voiceInputs.gameState}

--- a/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
@@ -11,6 +11,7 @@ import { useVoiceSession } from './useVoiceSession'
 const mockHook = vi.mocked(useVoiceSession)
 
 const endSession = vi.fn()
+const requestClosing = vi.fn().mockResolvedValue(undefined)
 
 function hookState(partial: Partial<UseVoiceSessionResult> = {}): UseVoiceSessionResult {
   return {
@@ -23,6 +24,7 @@ function hookState(partial: Partial<UseVoiceSessionResult> = {}): UseVoiceSessio
     error: null,
     summary: null,
     endSession,
+    requestClosing,
     ...partial,
   }
 }

--- a/packages/game-bombsquad/src/voice/VoicePanel.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useImperativeHandle, forwardRef } from 'react'
 import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
 import { useVoiceSession } from './useVoiceSession'
 import type { ConversationPhase, VoiceStatus } from './voice-session-protocol'
@@ -11,6 +11,19 @@ interface VoicePanelProps {
   gameState: GameState
   /** Platform game id; defaults to `'bombsquad'` inside the hook. */
   gameId?: string
+}
+
+/**
+ * Imperative handle exposed by VoicePanel via `ref`. GamePage uses this to
+ * trigger the closing-recap turn and gate results-screen navigation on it.
+ */
+export interface VoicePanelHandle {
+  /**
+   * Request the closing-recap turn. Returns a promise that resolves when the
+   * recap audio has finished playing. Resolves immediately if the session is
+   * not live. See `useVoiceSession.requestClosing` for the full contract.
+   */
+  requestClosing: () => Promise<void>
 }
 
 /**
@@ -51,13 +64,25 @@ function placeholderFor(status: VoiceStatus, phase: ConversationPhase): string {
   return '正在接通 AI 语音…'
 }
 
-function VoicePanelImpl({ manualData, gameState, gameId }: VoicePanelProps) {
-  const { status, conversationPhase, aiText, playerTranscript, isAiSpeaking, error } =
-    useVoiceSession({
-      manualData,
-      gameState,
-      gameId,
-    })
+function VoicePanelImpl(
+  { manualData, gameState, gameId }: VoicePanelProps,
+  ref: React.ForwardedRef<VoicePanelHandle>
+) {
+  const {
+    status,
+    conversationPhase,
+    aiText,
+    playerTranscript,
+    isAiSpeaking,
+    error,
+    requestClosing,
+  } = useVoiceSession({
+    manualData,
+    gameState,
+    gameId,
+  })
+
+  useImperativeHandle(ref, () => ({ requestClosing }), [requestClosing])
 
   const isLive = status === 'ready'
   // While live, the prominent indicator is the conversation phase; before that
@@ -118,7 +143,8 @@ function VoicePanelImpl({ manualData, gameState, gameId }: VoicePanelProps) {
 /**
  * Memoized so the ~60fps GamePage timer re-render does not re-render the panel:
  * with the stable, memoized `manualData` / `gameState` props from GamePage it
- * only re-renders on its own hook-state changes.
+ * only re-renders on its own hook-state changes. `forwardRef` wraps first so
+ * the ref flows through the memo boundary to `useImperativeHandle` inside.
  */
-const VoicePanel = memo(VoicePanelImpl)
+const VoicePanel = memo(forwardRef<VoicePanelHandle, VoicePanelProps>(VoicePanelImpl))
 export default VoicePanel

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -143,6 +143,13 @@ export interface UseVoiceSessionResult {
   summary: import('@amiclaw/platform-ai/contract').SessionSummary | null
   /** End the session: send `end`, await the summary, and tear down. */
   endSession: () => void
+  /**
+   * Request the closing-recap turn. Sends `{type:'closing'}` to the DO, which
+   * runs one final LLM+TTS recap and streams it back. The returned promise
+   * resolves when the recap audio has finished playing (all queued TTS frames
+   * drained). Resolves immediately if the socket is not open.
+   */
+  requestClosing: () => Promise<void>
 }
 
 /**
@@ -218,6 +225,16 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
   const turnStreamingRef = useRef(false)
   /** True while dropping the tail of a barged-in turn (until its `done` chunk). */
   const suppressTurnRef = useRef(false)
+  /**
+   * Closing-recap tracking. `closingInProgressRef` is true from the moment
+   * `{type:'closing'}` is sent until the recap audio finishes playing.
+   * `closingDoneRef` flips to true when the recap's terminal `done` chunk
+   * arrives — at that point the promise resolves as soon as all queued audio
+   * frames drain. `closingResolveRef` holds the pending promise resolver.
+   */
+  const closingInProgressRef = useRef(false)
+  const closingDoneRef = useRef(false)
+  const closingResolveRef = useRef<(() => void) | null>(null)
 
   const safeDispatch = useCallback((action: Parameters<typeof dispatch>[0]) => {
     if (mountedRef.current) dispatch(action)
@@ -278,6 +295,18 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
           activeSourcesRef.current.delete(source)
           playingCountRef.current = Math.max(0, playingCountRef.current - 1)
           if (playingCountRef.current === 0 && mountedRef.current) setIsAiSpeaking(false)
+          // If the closing recap's terminal `done` chunk already arrived and
+          // this was the last audio frame, resolve the pending requestClosing
+          // promise so GamePage can navigate to the results screen.
+          if (playingCountRef.current === 0 && closingDoneRef.current) {
+            const resolve = closingResolveRef.current
+            if (resolve) {
+              closingResolveRef.current = null
+              closingInProgressRef.current = false
+              closingDoneRef.current = false
+              resolve()
+            }
+          }
         }
       } catch {
         // A playback failure must never break the turn — text still renders.
@@ -566,6 +595,22 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
           playAudioFrame(base64ToBytes(frame.audio))
         }
         safeDispatch({ type: 'frame', frame })
+        // Closing-recap resolution: when the recap's terminal `done` chunk
+        // arrives, flip `closingDoneRef`. If no audio frames are queued (a
+        // text-only or zero-TTS edge case), resolve the promise immediately;
+        // otherwise `source.onended` resolves it once the last frame drains.
+        if (frame.done && closingInProgressRef.current) {
+          closingDoneRef.current = true
+          if (playingCountRef.current === 0) {
+            const resolve = closingResolveRef.current
+            if (resolve) {
+              closingResolveRef.current = null
+              closingInProgressRef.current = false
+              closingDoneRef.current = false
+              resolve()
+            }
+          }
+        }
         return
       }
       if (frame.type === 'error') {
@@ -621,6 +666,37 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
       safeDispatch({ type: 'closed' })
     }
   }, [stopCapture, closeSocket, safeDispatch])
+
+  /**
+   * Request the closing-recap turn from the DO. Returns a promise that resolves
+   * when the recap audio has finished playing (all queued TTS frames drained
+   * after the terminal `done` chunk), so the caller can gate results-screen
+   * navigation on the player HEARING the recap. Resolves immediately if the
+   * WebSocket is not open (no audio to wait for).
+   *
+   * Called once per successful daily defuse, from GamePage's RESULT effect.
+   * GamePage applies its own hard-max timeout (~8 s) so a TTS hiccup never
+   * strands the player on the win screen.
+   */
+  const requestClosing = useCallback((): Promise<void> => {
+    const ws = wsRef.current
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      return Promise.resolve()
+    }
+    return new Promise<void>((resolve) => {
+      closingResolveRef.current = resolve
+      closingInProgressRef.current = true
+      closingDoneRef.current = false
+      try {
+        ws.send(JSON.stringify({ type: 'closing' }))
+      } catch {
+        // Send failed — resolve immediately so the caller does not hang.
+        closingResolveRef.current = null
+        closingInProgressRef.current = false
+        resolve()
+      }
+    })
+  }, [])
 
   // --- Connect on mount (once the manual is ready); full teardown on unmount ---
 
@@ -680,5 +756,6 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     error: state.error,
     summary: state.summary,
     endSession,
+    requestClosing,
   }
 }

--- a/packages/platform-ai/src/contract.ts
+++ b/packages/platform-ai/src/contract.ts
@@ -162,6 +162,21 @@ export interface SessionSummary {
 }
 
 /**
+ * Client→server control message: request the closing-recap turn.
+ *
+ * Sent by the client on a successful daily defuse BEFORE the results screen
+ * appears. The DO runs one final LLM+TTS recap turn (1-2 sentences, spoken
+ * Chinese, no lists) and streams it back via the normal `AiResponseChunk`
+ * channel, ending with `{kind:'text', done:true}`. The client plays the audio
+ * and navigates to the results screen once it finishes (or after a hard timeout
+ * so a TTS hiccup never strands the player). The `{type:'end'}` message follows
+ * after navigation — the recap does not end the session.
+ */
+export interface ClosingMessage {
+  type: 'closing'
+}
+
+/**
  * The four-method session contract. Implemented by the Durable Object backed
  * server in a later round; defined here as the type-shape SSOT so consumers and
  * the future implementation share one contract.

--- a/packages/platform-ai/src/provider-config.ts
+++ b/packages/platform-ai/src/provider-config.ts
@@ -186,6 +186,11 @@ const PROVIDER_REGISTRY: Record<GameId, ProviderConfig> = {
         'daily 模式下累计三次错误才引爆，前两次只是可见的 strike；时间只计分、不引爆——出错时保持沉着，让玩家把当前局面重新报清再继续（答错时同一道题仍在，原地重试）。',
         '你的回复会被原样朗读给玩家，所以只输出纯口语：不要括号、方括号、星号或任何 markdown，不要把符号名或注释塞进括号里。要指明某个符号时，把它自然说进句子里（说「中间那个三叉戟的轮，往右按一次」，而不是「中间那个轮（三叉戟）按右箭头 1 次」）；次数、方向也用口语（说「按一次」「往右」，不用「1 次」「右箭头」这种书面写法）。',
         '始终用中文，口语、简洁、精确；冷静不慌、不说废话。',
+        // Closing-recap instruction (separate concern — keeps the voice-output rule above intact).
+        // Fires when the server sends the synthetic [game complete] directive at the end of a
+        // successful daily defuse. The prompt directive already constrains length and intent;
+        // this rule reinforces the persona's voice contract for that edge case.
+        '炸弹完全拆除时，用一到两句口语中文热情祝贺玩家，简短温暖；不列清单、不用括号。',
       ],
     },
     // Provider stack mirrors `demo` exactly — the verified DeepSeek + Volcengine

--- a/packages/platform-ai/src/session-closing-recap.test.ts
+++ b/packages/platform-ai/src/session-closing-recap.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Production-class tests for the closing-recap turn on the REAL `VoiceSessionDO`
+ * under the workerd runtime (`@cloudflare/vitest-pool-workers`).
+ *
+ * After the player's bomb is defused the client sends `{ type: 'closing' }`. The
+ * DO runs one AI-only turn (LLM->TTS, NO player audio — mirrors the opening
+ * greeting) to deliver a short spoken recap. This suite covers:
+ *   - The closing turn streams text + audio and completes (done chunk arrives).
+ *   - turnCount is NOT incremented (closing is not a player turn).
+ *   - `end` works cleanly after the closing turn finishes.
+ *   - Sending `closing` before `create` is a silent no-op (no chunks emitted).
+ *
+ * Harness details: see `session-do-test-kit.ts`.
+ */
+
+import {
+  createSessionOverWs,
+  makeSessionDo,
+  messagesOfType,
+  openSocket,
+  sawDoneChunk,
+  settle,
+  waitFor,
+  waitForMessage,
+} from './session-do-test-kit'
+
+const END = JSON.stringify({ type: 'end' })
+const CLOSING = JSON.stringify({ type: 'closing' })
+
+describe('real VoiceSessionDO — closing recap turn', () => {
+  it('streams a complete reply turn after a `closing` control message', async () => {
+    // Real demo-mock providers: the mock LLM replies, the mock TTS synthesizes —
+    // no player audio, just the server-side CLOSING_DIRECTIVE.
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket, 'demo-mock', { opening: false })
+
+    socket.send(CLOSING)
+
+    await waitFor(() => sawDoneChunk(socket), 'closing recap completed')
+    const textChunks = messagesOfType(socket, 'chunk').filter(
+      (c) => c.kind === 'text' && c.text !== ''
+    )
+    expect(textChunks.length).toBeGreaterThan(0)
+  })
+
+  it('does not increment turnCount on closing recap', async () => {
+    // The closing turn is an AI-only epilogue, not a player turn. turnCount
+    // in the summary must stay at 0 regardless of how many closing turns run.
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket, 'demo-mock', { opening: false })
+
+    socket.send(CLOSING)
+    await waitFor(() => sawDoneChunk(socket), 'closing recap completed')
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    const summary = messagesOfType(socket, 'summary')[0].summary as { turnCount: number }
+    expect(summary.turnCount).toBe(0)
+  })
+
+  it('accepts `end` cleanly after closing recap completes', async () => {
+    // The DO must still handle `end` after a closing turn without crashing or
+    // hanging — session teardown must be clean.
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket, 'demo-mock', { opening: false })
+
+    socket.send(CLOSING)
+    await waitFor(() => sawDoneChunk(socket), 'closing recap done before end')
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    expect(messagesOfType(socket, 'summary').length).toBeGreaterThan(0)
+  })
+
+  it('is a no-op (no chunks) if sent before `create`', async () => {
+    // If the client misbehaves and sends `closing` before the session is
+    // initialised, the DO must silently ignore it rather than crash.
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    // Deliberately skip `create` — sessionState is null.
+
+    socket.send(CLOSING)
+    await settle()
+
+    expect(messagesOfType(socket, 'chunk')).toEqual([])
+    expect(sawDoneChunk(socket)).toBe(false)
+  })
+})

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -89,6 +89,7 @@ import type { ProviderEnv } from './providers/factory'
 import { assembleSession } from './session-assembly'
 import { traceTurn, traceTurnError } from './trace'
 import {
+  runClosingTurn,
   runOpeningTurn,
   runReply,
   runUtteranceStt,
@@ -186,12 +187,24 @@ interface UpdateGameStateMessage {
   gameState: GameState
 }
 
+/**
+ * Request the closing-recap turn. Sent by the client on a successful daily
+ * defuse BEFORE the results screen appears. The DO runs one final LLM+TTS recap
+ * turn (1-2 sentences, spoken Chinese, warm) and streams it back via the normal
+ * `AiResponseChunk` channel. The `{type:'end'}` message follows after the client
+ * navigates away — this message does NOT end the session.
+ */
+interface ClosingSessionMessage {
+  type: 'closing'
+}
+
 type ControlMessage =
   | CreateSessionMessage
   | SpeechStartMessage
   | TurnMessage
   | EndSessionMessage
   | UpdateGameStateMessage
+  | ClosingSessionMessage
 
 /**
  * Base64-encode raw bytes for JSON transport of an audio frame. Uses the
@@ -1116,6 +1129,37 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
   }
 
   /**
+   * Fire the closing-recap turn: an LLM+TTS-only turn from the server-side
+   * `CLOSING_DIRECTIVE`, streamed to the socket with NO player audio. Mirrors
+   * `runOpeningGreeting` in structure: background-launched on `closing`
+   * (fire-and-forget), self-fencing via the epoch guard, fail-loud on a provider
+   * error. The closing recap does NOT end the session — `end` follows later when
+   * the client navigates away (the VoicePanel unmount sends `end`).
+   */
+  private async runClosingRecap(ws: Connection): Promise<void> {
+    const myEpoch = this.turnEpoch
+    try {
+      if (!this.sessionState || !this.providers || this.sessionId === undefined) return
+      traceTurn('turn', 'closing-start', { sessionId: this.sessionId })
+      const turn = runClosingTurn(this.providers, this.sessionState)[Symbol.asyncIterator]()
+      await this.streamTurn(ws, turn)
+    } catch (err: unknown) {
+      // Skip the fail-loud close once a teardown has advanced the generation
+      // (the session this recap belonged to is gone; a newer session may own
+      // the socket now). Mirrors the opening-greeting error path exactly.
+      if (this.turnEpoch === myEpoch) {
+        const reason = err instanceof Error ? err.message : 'closing recap failed'
+        traceTurnError('turn', 'closing-error', { messageChars: reason.length })
+        try {
+          ws.close(1008, safeCloseReason(reason))
+        } catch {
+          // socket already gone — nothing to fail loud on.
+        }
+      }
+    }
+  }
+
+  /**
    * Reject cross-session / cross-user access. Delegates to the pure
    * `assertSessionOwnership` predicate (the L2 ownership invariant — the `turn`
    * and `end` paths verify ownership against the bound session).
@@ -1353,6 +1397,32 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
           ws.send(JSON.stringify({ type: 'summary', summary }))
         }
         ws.close(1000, safeCloseReason('session ended'))
+        return
+      }
+      case 'closing': {
+        // Closing-recap trigger: run one final LLM+TTS turn (the post-win
+        // recap) and stream it back. Must have a live session + the owner
+        // socket; a non-owner or pre-create signal is a silent no-op (NOT a
+        // 1008 close — the session remains alive; `end` follows when the client
+        // navigates away). A turn in flight is rejected with `turn_in_flight` so
+        // the serial-turn guard is not violated; the client falls back to its
+        // hard timeout and navigates without waiting for the recap.
+        if (
+          !this.sessionState ||
+          !socketUserId ||
+          this.sessionId === undefined ||
+          !this.providers
+        ) {
+          return
+        }
+        if (!socketIsBoundSessionOwner(ws, this.ownerSocket, this.boundIdentity())) {
+          return
+        }
+        if (this.turnInFlight) {
+          this.sendError(ws, 'turn_in_flight', 'a turn is already in progress')
+          return
+        }
+        void this.runClosingRecap(ws)
         return
       }
       case 'update-gamestate': {

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -654,6 +654,63 @@ export async function* runTurn(
 }
 
 /**
+ * Server-side closing directive for the post-win recap turn.
+ *
+ * Seeded as a synthetic `user` message (like `OPENING_DIRECTIVE`) so the LLM
+ * has a turn to respond to; NEVER client-provided and NEVER persisted into
+ * history (the recap text it elicits is). The persona's own voice rule (spoken
+ * Chinese, no brackets/markdown, etc.) governs the reply; this only constrains
+ * LENGTH and INTENT so the recap stays short and warm.
+ */
+export const CLOSING_DIRECTIVE =
+  '[game complete] The bomb has been fully defused. ' +
+  'In the language you have been speaking (Chinese), congratulate the player warmly in ' +
+  'one short sentence, then give a one-sentence spoken recap of the defusal. ' +
+  'Two sentences total. Spoken naturally. No lists, no brackets, no markdown.'
+
+/**
+ * Run the closing-recap turn — an LLM+TTS-only turn the DO fires after the
+ * player wins a daily defuse, with NO player-audio STT step. Mirrors
+ * {@link runOpeningTurn}: the server-side {@link CLOSING_DIRECTIVE} stands in
+ * for the (absent) player utterance so the LLM speaks a short warm recap before
+ * the results screen appears.
+ *
+ * The synthetic directive is NEVER persisted to history; only the recap text it
+ * produces is. The recap does NOT count toward `turnCount` — it is not a player
+ * turn. LLM/TTS usage IS metered (the turn consumes real provider resources).
+ * I/O-free beyond driving the injected LLM/TTS providers. Mutates `state`
+ * (history, LLM/TTS usage).
+ */
+export async function* runClosingTurn(
+  providers: Pick<TurnProviders, 'llm' | 'tts'>,
+  state: SessionState
+): AsyncIterable<AiResponseChunk> {
+  const turnStart = Date.now()
+  const userMessage: ChatMessage = { role: 'user', content: CLOSING_DIRECTIVE }
+  const messages: ChatMessage[] = [...assembleSystem(state), ...state.history, userMessage]
+
+  const result = yield* streamLlmTts(providers, state.config.llm.model, messages, turnStart)
+
+  // Settle: the closing directive is synthetic and must never leak into history
+  // (the recap it elicits is the only thing remembered). turnCount tracks
+  // player->AI turns, so the closing recap does not increment it.
+  state.history.push({ role: 'assistant', content: result.assistantText })
+  const { outputTokens } = applyLlmTtsUsage(providers, state, result)
+
+  traceTurn('turn', 'closing-settle', {
+    turnCount: state.turnCount,
+    llmDeltaCount: result.llmDeltaCount,
+    llmOutputTokens: outputTokens,
+    sentenceCount: result.sentenceCount,
+    ttsFrameCount: result.ttsFrameCount,
+    ttsAudioBytes: result.ttsAudioBytes,
+    elapsedMs: Date.now() - turnStart,
+  })
+
+  yield { kind: 'text', text: '', done: true }
+}
+
+/**
  * Run the AI-first opening greeting — an LLM+TTS-only turn the DO fires on
  * session establishment, with NO player-audio STT step. The server-side
  * {@link OPENING_DIRECTIVE} stands in for the (absent) player utterance so the


### PR DESCRIPTION
## Summary
- On a successful **daily defuse**, the AI voice partner now plays a short spoken recap (1-2 warm sentences) before the results screen — previously results popped instantly and cut the AI off.
- Results navigation waits for the recap audio to finish, with an **8s hard timeout** so a TTS hiccup never strands the player. The "拆除成功" burst stays on screen during the wait.
- Only a daily `defused` win triggers it; loss / timeout / practice navigate immediately.

## How it works
- New `{type:'closing'}` control message → DO runs one LLM+TTS-only recap turn (`runClosingTurn`, owner-gated, epoch-fenced, `turn_in_flight`-guarded; does NOT end the session).
- `CLOSING_DIRECTIVE` is a synthetic server-side directive (never persisted; mirrors the opening greeting).
- `useVoiceSession.requestClosing()` resolves when recap audio drains; `GamePage` gates `navigate()` on it or the timeout (navigates on resolve/reject/timeout, single-fire). Clamps the module index so `VoicePanel` stays mounted through RESULT.

## Test plan
- [x] platform-ai 333 tests (+4); game-bombsquad 407 (+2); typecheck clean
- [ ] CI green
- [ ] Live probe: `{type:'closing'}` streams a recap turn
- [ ] Live play-test: hear the recap on a daily win before results

🤖 Generated with [Claude Code](https://claude.com/claude-code)