### PR TITLE
fix(bombsquad): inject symbol visual descriptions into the AI manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② voice: the AI can now tell the symbols apart** - Fix. On the
+星盘 (dial) and 星符 (keypad) modules the AI kept asking the player to re-describe
+a symbol — it only received the lookup table of bare symbol names (psi / spiral /
+crescent / …) and never the visual descriptions, so it could not map a player's
+shape description ("海神叉", "咖啡豆") to the right name. Those descriptions live in
+the manual's top-level `symbols` block, which sits outside any single module
+section and so never rode the per-module injection. The two symbol modules now
+embed the visual description of each symbol they reference, so the AI receives
+both the lookup table and what each symbol looks like — including the built-in
+disambiguation for look-alike pairs (psi vs trident, hourglass vs delta).
+
 **BombSquad mode② voice: the AI gives a short closing recap when you win** - Add.
 After a successful daily defuse the results screen used to appear instantly,
 cutting the voice partner off before it could react. Now, on a daily win, the AI

--- a/packages/game-bombsquad/src/voice/manual-data.test.ts
+++ b/packages/game-bombsquad/src/voice/manual-data.test.ts
@@ -28,6 +28,19 @@ function makeManual(): Manual {
         rule: 'keypad rule text',
       },
     },
+    symbols: {
+      delta: { description: '等边三角形' },
+      star: { description: '五角星' },
+      diamond: { description: '菱形' },
+      trident: { description: '三叉戟,易被误描述为叉子' },
+      cross: { description: '十字' },
+      psi: { description: 'U 形碗加竖线,易被误描述为三叉戟' },
+      omega: { description: '马蹄铁形' },
+      lambda: { description: '倒 V 形' },
+      sigma: { description: 'Σ 形' },
+      theta: { description: '椭圆中横线' },
+      phi: { description: '圆加竖线' },
+    },
     decoy_modules: {
       morse_code: { rule: 'a decoy module that must not leak into ManualData' },
     },
@@ -76,13 +89,55 @@ describe('bombsquadManualToManualData', () => {
     )
   })
 
-  it('preserves each module section content verbatim', () => {
+  it('preserves non-symbol module sections verbatim', () => {
     const manual = makeManual()
     const { sections } = bombsquadManualToManualData(manual, 'v1')
     expect(sections.wire_routing).toEqual(manual.modules.wire_routing)
-    expect(sections.symbol_dial).toEqual(manual.modules.symbol_dial)
     expect(sections.button).toEqual(manual.modules.button)
-    expect(sections.keypad).toEqual(manual.modules.keypad)
+  })
+
+  it('preserves symbol module fields and adds symbol_descriptions', () => {
+    const manual = makeManual()
+    const { sections } = bombsquadManualToManualData(manual, 'v1')
+    // Original module fields ride through unchanged…
+    expect(sections.symbol_dial).toMatchObject(manual.modules.symbol_dial)
+    expect(sections.keypad).toMatchObject(manual.modules.keypad)
+    // …plus the referenced symbols' visual descriptions.
+    expect(sections.symbol_dial).toHaveProperty('symbol_descriptions')
+    expect(sections.keypad).toHaveProperty('symbol_descriptions')
+  })
+
+  it('injects descriptions for every symbol referenced by symbol_dial', () => {
+    const manual = makeManual()
+    const { sections } = bombsquadManualToManualData(manual, 'v1')
+    const descriptions = (sections.symbol_dial as { symbol_descriptions: Record<string, string> })
+      .symbol_descriptions
+    // The dial's single column references these five symbols.
+    expect(Object.keys(descriptions).sort()).toEqual(
+      ['cross', 'delta', 'diamond', 'star', 'trident'].sort()
+    )
+    // The disambiguation text (the whole point) survives intact.
+    expect(descriptions.trident).toContain('易被误描述为叉子')
+  })
+
+  it('injects descriptions for every symbol referenced by keypad', () => {
+    const manual = makeManual()
+    const { sections } = bombsquadManualToManualData(manual, 'v1')
+    const descriptions = (sections.keypad as { symbol_descriptions: Record<string, string> })
+      .symbol_descriptions
+    expect(Object.keys(descriptions).sort()).toEqual(
+      ['lambda', 'omega', 'phi', 'psi', 'sigma', 'theta'].sort()
+    )
+    expect(descriptions.psi).toContain('易被误描述为三叉戟')
+  })
+
+  it('tolerates a manual with no top-level symbols block (empty descriptions)', () => {
+    const manual = makeManual()
+    delete manual.symbols
+    const { sections } = bombsquadManualToManualData(manual, 'v1')
+    expect((sections.symbol_dial as { symbol_descriptions: unknown }).symbol_descriptions).toEqual(
+      {}
+    )
   })
 
   it('excludes decoy_modules — only real modules are injected', () => {

--- a/packages/game-bombsquad/src/voice/manual-data.ts
+++ b/packages/game-bombsquad/src/voice/manual-data.ts
@@ -14,6 +14,26 @@ import type { ManualData } from '@amiclaw/platform-ai/contract'
 import type { ModuleKind } from '@/store/game-context'
 
 /**
+ * Build the `{ symbolId: description }` map for the symbol ids referenced by a
+ * symbol-based module, drawn from the manual's top-level `symbols` block. Used
+ * to embed each symbol's visual description alongside its module so the AI can
+ * map a player's shape description (e.g. "海神叉" / "咖啡豆") back to the symbol
+ * name. Returns an empty object when the manual carries no `symbols` block.
+ */
+function symbolDescriptionsFor(
+  symbolIds: Iterable<string>,
+  symbols: Manual['symbols']
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!symbols) return out
+  for (const id of symbolIds) {
+    const entry = symbols[id]
+    if (entry?.description) out[id] = entry.description
+  }
+  return out
+}
+
+/**
  * Map a game `ModuleKind` to the manual section id(s) it grounds on. Section
  * ids match the real manual data keys under `Manual.modules`
  * (`wire_routing` / `symbol_dial` / `button` / `keypad`) and the platform-ai
@@ -46,10 +66,33 @@ export function moduleKindToRelevantSections(kind: ModuleKind): string[] {
  * dropped. The AI grounds on real module rules, and `relevantSections` only
  * ever references real modules (see `moduleKindToRelevantSections`), so decoys
  * would only be unreachable injection weight.
+ *
+ * Symbol-based modules (`symbol_dial`, `keypad`) are enriched with a
+ * `symbol_descriptions` map of the symbols they reference, pulled from the
+ * manual's top-level `symbols` block. Without this the AI only receives the
+ * lookup table of bare symbol names (psi / spiral / …) and cannot map a
+ * player's visual description ("海神叉" / "咖啡豆") to the right name — the
+ * `symbols` block lives at the manual root, outside any single module section,
+ * so per-module injection never reached it. Embedding the referenced
+ * descriptions into the module section makes them ride the existing injection.
  */
 export function bombsquadManualToManualData(manual: Manual, version: string): ManualData {
-  return {
-    version,
-    sections: Object.fromEntries(Object.entries(manual.modules)),
+  const sections: Record<string, unknown> = Object.fromEntries(Object.entries(manual.modules))
+
+  const dial = manual.modules.symbol_dial
+  if (dial?.columns) {
+    const ids = new Set(dial.columns.flat())
+    sections.symbol_dial = {
+      ...dial,
+      symbol_descriptions: symbolDescriptionsFor(ids, manual.symbols),
+    }
   }
+
+  const keypad = manual.modules.keypad
+  if (keypad?.sequences) {
+    const ids = new Set(keypad.sequences.flat())
+    sections.keypad = { ...keypad, symbol_descriptions: symbolDescriptionsFor(ids, manual.symbols) }
+  }
+
+  return { version, sections }
 }


### PR DESCRIPTION
## Summary
On the **星盘 (dial)** and **星符 (keypad)** modules the AI kept asking the player to re-describe a symbol. It only received the lookup table of bare symbol names (`psi` / `spiral` / `crescent` / …) and never the **visual descriptions**, so it couldn't map a player's shape description (e.g. "海神叉" → `psi`, "咖啡豆" → `spiral`) to the symbol name.

Root cause: those descriptions live in the manual's **top-level `symbols` block**, which sits outside any single module section, so the per-module injection (`gameState.relevantSections` only) never reached them.

Fix: `bombsquadManualToManualData` now embeds a `symbol_descriptions` map of the symbols each symbol module references into that module's section, so the existing injection carries them to the AI alongside the lookup table — including the built-in disambiguation for look-alike pairs (psi vs trident, hourglass vs delta).

## Test plan
- [x] game-bombsquad 411 tests (+4: dial/keypad description injection, no-symbols tolerance); typecheck clean
- [ ] CI green
- [ ] Live re-test: AI maps "海神叉"→psi / "咖啡豆"→spiral without looping

Frontend-only (Pages); the platform-ai Worker is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)