### PR TITLE
fix(bombsquad): keep the voice indicator on "思考中" through a suppressed VAD blip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② voice: the indicator no longer flips back to "聆听中" mid-think** -
+Fix. After you finished speaking, the indicator would show "思考中" and then snap
+straight back to "聆听中" without the AI answering. A breath or room-noise tail
+crossing the voice-detection threshold for a moment while the AI was still
+thinking was being treated as the start of a new utterance for the indicator
+only — the server request was already suppressed, but the on-screen phase was
+flipped before that same guard ran. The indicator now stays "思考中" until the AI
+replies (or the no-response fallback fires); a genuine interruption while the AI
+is speaking still works.
+
 **BombSquad mode② voice: the AI can now tell the symbols apart** - Fix. On the
 星盘 (dial) and 星符 (keypad) modules the AI kept asking the player to re-describe
 a symbol — it only received the lookup table of bare symbol names (psi / spiral /

--- a/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
@@ -378,6 +378,35 @@ describe('useVoiceSession — client VAD', () => {
     expect(ws.controlMessages().some((m) => m.type === 'turn')).toBe(true)
   })
 
+  it('stays thinking when noise crosses the VAD threshold while awaiting the reply', async () => {
+    const { result, ws } = await ready()
+    finishGreeting(ws)
+    // A real player utterance: speech then silence -> turn sent -> thinking.
+    act(() => {
+      fireFrame(0.5)
+      fireFrame(0.5)
+    })
+    act(() => {
+      for (let i = 0; i < 10; i += 1) fireFrame(0.0)
+    })
+    expect(result.current.conversationPhase).toBe('thinking')
+    const speechStartsBefore = ws.controlMessages().filter((m) => m.type === 'speech-start').length
+
+    // Still awaiting the reply (no chunk yet). The open mic picks up a breath /
+    // room-noise tail crossing the threshold for >= minSpeechMs. This must NOT
+    // yank the indicator from `thinking` back to `listening`, nor open a spurious
+    // server utterance — the AI still holds the floor.
+    act(() => {
+      fireFrame(0.5)
+      fireFrame(0.5)
+    })
+    expect(result.current.playerSpeaking).toBe(false)
+    expect(result.current.conversationPhase).toBe('thinking')
+    expect(ws.controlMessages().filter((m) => m.type === 'speech-start').length).toBe(
+      speechStartsBefore
+    )
+  })
+
   it('sends speech-start then turn, in order, for a real player utterance', async () => {
     const { ws } = await ready()
     finishGreeting(ws)

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -410,7 +410,6 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
 
   /** A VAD `speech-start`: the player began an utterance (incl. barge-in). */
   const onSpeechStart = useCallback(() => {
-    setPlayerSpeaking(true)
     // Barge-in: the player is talking while the AI's audio is playing. Stop the
     // playback at once and drop the rest of the interrupted turn's streamed
     // chunks (text + audio) — the server keeps streaming them (it cancels nothing
@@ -436,6 +435,15 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
       !bargeIn &&
       (awaitingResponseRef.current || (turnStreamingRef.current && !suppressTurnRef.current))
     if (aiHoldsFloor) return
+    // Only a REAL utterance (a fresh turn, or a genuine barge-in) flips the phase
+    // to `listening`. Setting this BEFORE the guard made a suppressed speech-start
+    // — a breath / room-noise tail crossing the VAD threshold for 400ms while the
+    // AI is still `thinking` (awaitingResponse) — yank the indicator straight from
+    // `thinking` back to `listening`, reading as "it heard me finish, then ignored
+    // me". The server-side send is already suppressed for this case; the UI phase
+    // must be suppressed in lockstep, so it stays `thinking` until the reply lands
+    // (or the no-response watchdog fires).
+    setPlayerSpeaking(true)
     const ws = wsRef.current
     if (ws && ws.readyState === WebSocket.OPEN) {
       try {


### PR DESCRIPTION
## Summary
After the player finished speaking, the 3-state indicator showed **思考中 (thinking)** then snapped straight back to **聆听中 (listening)** with no AI reply.

`onSpeechStart` set `playerSpeaking = true` **unconditionally**, before the `aiHoldsFloor` guard — so a breath / room-noise tail crossing the VAD threshold for ≥ `minSpeechMs` while the AI was still awaiting/streaming the reply flipped the phase to `listening` (via `deriveConversationPhase: playerSpeaking → listening`), even though the server-side `speech-start` was already suppressed for exactly that case.

Fix: move `setPlayerSpeaking(true)` **after** the guard, so a suppressed speech-start no longer flips the UI phase — the indicator stays `思考中` until the reply lands or the no-response watchdog fires, in lockstep with the server-side suppression. A genuine barge-in (player speaks over the AI's audio) makes `aiHoldsFloor` false, so it still flips to listening and signals the server as before.

## Test plan
- [x] game-bombsquad 408 tests (+1: phase stays thinking through a mid-think VAD blip); typecheck clean
- [ ] CI green
- [ ] Live re-test: indicator holds 思考中 until the AI answers

Frontend-only (Pages); the platform-ai Worker is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)