### PR TITLE
Rename product brand to AMIO Arcade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # .github/workflows/ci.yml
-# CI pipeline for AmiClaw (pnpm monorepo, React + Vite web app)
+# CI pipeline for AMIO Arcade (amiclaw pnpm monorepo, React + Vite web app)
 # Runs on push/PR to main: install, test, build
 
 name: CI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@ project instructions.
 
 ## Project Overview
 
-**AmiClaw** (`claw.amio.fans`) is a human-AI collaborative gaming platform.
+**AMIO Arcade** (`claw.amio.fans`, formerly AmiClaw) is a human-AI
+collaborative gaming platform. The repository/package namespace and Cloudflare
+Pages project remain `amiclaw` for compatibility.
 **BombSquad** (`claw.amio.fans/bombsquad`) is the first game: a voice-based
 bomb-defusal challenge inspired by _Keep Talking and Nobody Explodes_, where the
 human player and an AI expert communicate only through voice.
@@ -15,7 +17,7 @@ Key docs:
 
 - System architecture (C4 model): `docs/architecture/architecture.md`
 - BombSquad gameplay, player guide: `docs/bombsquad-player-guide.md`
-- AmiClaw platform overview, player guide: `docs/amiclaw-platform-guide.md`
+- AMIO Arcade platform overview, player guide: `docs/amiclaw-platform-guide.md`
 - Design system: `docs/DesignSystem.md`
 - Changelog authoring guide: `docs/changelog-style-guide.md`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**AMIO Arcade brand rename** — The active product surfaces now use AMIO Arcade /
+AMIO 游乐场 instead of AmiClaw, including the shared wordmark, page titles,
+homepage copy, legal pages, auth emails, README, and canonical docs. Existing
+`claw.amio.fans` URLs and `amiclaw` internal identifiers stay in place as
+compatibility infrastructure.
+
 **Meet your AI companion** - New. Signed-in players can now give their platform
 AI partner a name and choose its voice, so it feels like theirs from the first
 hello. The companion card counts how many days you've been together from the day

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to AmiClaw
+# Contributing to AMIO Arcade
 
 Thank you for your interest in contributing!
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-# AmiClaw
+# AMIO Arcade
 
-**AmiClaw** (`claw.amio.fans`) is a platform for human-AI collaborative games,
-where you and your AI work together in real time to solve challenges.
+**AMIO Arcade** (`claw.amio.fans`, formerly AmiClaw) is a platform for
+human-AI collaborative games, where you and your AI work together in real time
+to solve challenges. The repository, workspace package scope, Cloudflare Pages
+project, and current production host still use the `amiclaw` / `claw.amio.fans`
+compatibility identifiers.
 
 > **"Keep Us Human"** — The fun is not in the AI solving problems alone. It is
 > in the two of you figuring them out together.
 
 ## BombSquad
 
-**BombSquad** (`claw.amio.fans/bombsquad`) is the first AmiClaw game, inspired by
-_Keep Talking and Nobody Explodes_.
+**BombSquad** (`claw.amio.fans/bombsquad`) is the first AMIO Arcade game,
+inspired by _Keep Talking and Nobody Explodes_.
 
 You are the bomb defuser. Your AI is the manual expert.
 
@@ -66,7 +69,10 @@ amiclaw/
 ├── docs/                    # Design documents and plans
 ├── packages/
 │   ├── api/                 # Leaderboard handler module (Pages Functions)
-│   ├── game/                # BombSquad React SPA
+│   ├── platform/            # Platform shell and deploy root
+│   ├── game-bombsquad/      # BombSquad React SPA
+│   ├── game-yijing/         # Yijing Oracle React SPA
+│   ├── ui/                  # Shared Atlas UI primitives
 │   └── manual/              # Manual static pages and YAML data
 ├── prompts/                 # Prompt and skill templates
 ├── scripts/                 # Release and maintenance scripts
@@ -98,7 +104,7 @@ pnpm dev
 Operational notes:
 
 - Manual sources live in `packages/manual/data/`
-- `pnpm build` assembles the manual assets into `packages/game/dist/manual/`
+- `pnpm build` assembles all game and manual assets into `packages/platform/dist/`
   for Cloudflare Pages
 - The current UI keeps leaderboard nickname anonymous by default
 - `ai_tool` is supported by the schema but not collected by the current UI yet
@@ -117,7 +123,9 @@ pnpm build
 
 Workspace notes:
 
-- `packages/game` contains the React + Vite game client
+- `packages/platform` contains the React + Vite platform shell and deploy root
+- `packages/game-bombsquad` contains the BombSquad React + Vite game client
+- `packages/game-yijing` contains the Yijing Oracle React + Vite game client
 - `packages/manual` builds the static manual pages and YAML data
 - `packages/api` contains the leaderboard handler module imported by Pages Functions
 
@@ -126,6 +134,6 @@ See [`docs/plans/`](./docs/plans/) for implementation plans and
 
 ## Links
 
-- Platform: [claw.amio.fans](https://claw.amio.fans)
+- AMIO Arcade: [claw.amio.fans](https://claw.amio.fans)
 - BombSquad: [claw.amio.fans/bombsquad](https://claw.amio.fans/bombsquad)
 - Part of the [AMIO](https://amio.fans) ecosystem

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -1,4 +1,4 @@
-# e2e/flow-inventory.yaml — BombSquad + Amiclaw platform user-flow SSOT
+# e2e/flow-inventory.yaml — BombSquad + AMIO Arcade platform user-flow SSOT
 #
 # This file is the single source of truth for all user-facing flows the e2e
 # journey scenarios cover. Every journey Gherkin scenario in e2e/*.gherkin MUST

--- a/e2e/homepage.gherkin
+++ b/e2e/homepage.gherkin
@@ -1,4 +1,4 @@
-# Amiclaw platform homepage — the `/` route is a 4-tab platform shell
+# AMIO Arcade platform homepage — the `/` route is a 4-tab platform shell
 # (游戏 / 排行榜 / 社区 / 我的). It shows an anonymous hero or a signed-in welcome
 # strip per login state, and a featured BombSquad overview with the live
 # daily challenge countdown.
@@ -10,9 +10,9 @@
 # landing-overflow scenario; the mobile no-horizontal-overflow check is merged
 # into the hero scenario below.
 
-Feature: Amiclaw platform homepage
+Feature: AMIO Arcade platform homepage
   As a visitor to claw.amio.fans
-  I want the homepage to present Amiclaw as a multi-game platform
+  I want the homepage to present AMIO Arcade as a multi-game platform
   And let me reach the BombSquad game and the other platform tabs
   So that I understand the platform vision and can start playing
 
@@ -26,7 +26,7 @@ Feature: Amiclaw platform homepage
     When the `/` route renders
     Then I see the anonymous hero with a single「开始玩 →」CTA
     And I see the featured BombSquad overview
-    And I see the "什么是 Amiclaw" section
+    And I see the "什么是 AMIO Arcade" section
     And I see the upcoming-games section
     And I see the footer pitch
     And the page is dark-only with no light-mode variant
@@ -70,7 +70,7 @@ Feature: Amiclaw platform homepage
     Then I see the welcome strip greeting me by name
     And the welcome strip shows an honest no-scores prompt and a play CTA
     And the anonymous hero is not shown
-    And the "什么是 Amiclaw" section and the footer pitch are not shown
+    And the "什么是 AMIO Arcade" section and the footer pitch are not shown
     And I can still reach the featured BombSquad overview
 
   # Source: bombsquad-zone-styling

--- a/e2e/privacy-terms-pages.gherkin
+++ b/e2e/privacy-terms-pages.gherkin
@@ -22,7 +22,7 @@ Feature: Platform privacy and terms pages
     When I click "隐私"
     Then the URL path is /privacy
     And I see the heading "隐私政策 · PRIVACY"
-    And I see the subtitle "本政策说明 AmiClaw 收集哪些信息、为什么收集、如何使用与保存，以及你对这些信息拥有的权利。"
+    And I see the subtitle "本政策说明 AMIO 游乐场收集哪些信息、为什么收集、如何使用与保存，以及你对这些信息拥有的权利。"
 
   # Source: footer-to-terms
   @playwright
@@ -30,4 +30,4 @@ Feature: Platform privacy and terms pages
     When I click "条款"
     Then the URL path is /terms
     And I see the heading "用户条款 · TERMS"
-    And I see the subtitle "本条款是你与运营方就使用 AmiClaw 平台达成的协议。请在使用本服务前阅读并接受。"
+    And I see the subtitle "本条款是你与运营方就使用 AMIO 游乐场达成的协议。请在使用本服务前阅读并接受。"

--- a/e2e/regression/fix-bombsquad-deep-link-refresh-blank.gherkin
+++ b/e2e/regression/fix-bombsquad-deep-link-refresh-blank.gherkin
@@ -61,7 +61,7 @@ Feature: bombsquad-deep-link-refresh-blank regression coverage
   #   200 rewrite resolved to a redirect rather than serving the SPA, and the
   #   follow-up request fell through to the /* platform-shell catch-all. Every
   #   hard-load / refresh of a BombSquad deep route rendered the blank platform
-  #   shell (HTTP 200, title "AmiClaw — 和 AI 一起玩点新的") instead of the game.
+  #   shell (HTTP 200, title "AMIO Arcade — 和 AI 一起玩点新的") instead of the game.
   # fix: target the directory /bombsquad/ instead of /bombsquad/index.html, so
   #   Pages serves /bombsquad/index.html cleanly with no canonicalization bounce.
   # retire-when: BombSquad stops being a BrowserRouter sub-app under /bombsquad/

--- a/e2e/steps/homepage.steps.ts
+++ b/e2e/steps/homepage.steps.ts
@@ -101,8 +101,8 @@ Then('I see the featured BombSquad overview', async ({ page }) => {
   await expect(featured.getByText('每日挑战 · DAILY DROP')).toHaveCount(0)
 })
 
-Then('I see the "什么是 Amiclaw" section', async ({ page }) => {
-  await expect(page.getByText('关于 · What is AmiClaw')).toBeVisible()
+Then('I see the "什么是 AMIO Arcade" section', async ({ page }) => {
+  await expect(page.getByText('关于 · What is AMIO Arcade')).toBeVisible()
 })
 
 Then('I see the upcoming-games section', async ({ page }) => {
@@ -226,8 +226,8 @@ Then('the anonymous hero is not shown', async ({ page }) => {
   await expect(page.getByRole('button', { name: '开始玩 →' })).toHaveCount(0)
 })
 
-Then('the "什么是 Amiclaw" section and the footer pitch are not shown', async ({ page }) => {
-  await expect(page.getByText('关于 · What is AmiClaw')).toHaveCount(0)
+Then('the "什么是 AMIO Arcade" section and the footer pitch are not shown', async ({ page }) => {
+  await expect(page.getByText('关于 · What is AMIO Arcade')).toHaveCount(0)
   await expect(page.getByText('永久免费，不存档也不出售你的对话。')).toHaveCount(0)
 })
 

--- a/e2e/steps/result.steps.ts
+++ b/e2e/steps/result.steps.ts
@@ -201,7 +201,7 @@ Then('no row mentions a required browser or "Clipboard API"', async ({ page }) =
 
 Then('I am back on the BombSquad landing page', async ({ page }) => {
   // The compatibility page's 返回 link lands on the BombSquad landing (/bombsquad),
-  // not the Amiclaw platform homepage — the landing carries the mode CTAs.
+  // not the AMIO Arcade platform homepage — the landing carries the mode CTAs.
   // BombSquad is served at /bombsquad/, so the landing may carry a trailing
   // slash; normalize it away before comparing.
   await expect.poll(() => new URL(page.url()).pathname.replace(/\/$/, '')).toBe('/bombsquad')

--- a/functions/api/auth/PROVISIONING.md
+++ b/functions/api/auth/PROVISIONING.md
@@ -41,11 +41,11 @@ wrangler pages secret put RESEND_API_KEY
 Optional environment variables (plain vars, not secrets — set in the Pages
 dashboard or via config):
 
-| Variable          | Purpose                                   | Default (dev fallback)            |
-| ----------------- | ----------------------------------------- | --------------------------------- |
-| `RESEND_API_KEY`  | Resend API key (secret)                   | unset → link logged, not emailed  |
-| `AUTH_EMAIL_FROM` | Verified `From` address                   | `AmiClaw <onboarding@resend.dev>` |
-| `AUTH_BASE_URL`   | Origin for verify URL + post-login target | `https://claw.amio.fans`          |
+| Variable          | Purpose                                   | Default (dev fallback)                |
+| ----------------- | ----------------------------------------- | ------------------------------------- |
+| `RESEND_API_KEY`  | Resend API key (secret)                   | unset → link logged, not emailed      |
+| `AUTH_EMAIL_FROM` | Verified `From` address                   | `AMIO Arcade <onboarding@resend.dev>` |
+| `AUTH_BASE_URL`   | Origin for verify URL + post-login target | `https://claw.amio.fans`              |
 
 When `RESEND_API_KEY` is unset the request endpoint still returns its normal
 unified response, but no email is sent — the magic link is written to the
@@ -58,7 +58,7 @@ Create an OAuth 2.0 client in Google Cloud so the Google sign-in path can run.
 1. Open the [Google Cloud Console](https://console.cloud.google.com/) and select
    (or create) a project.
 2. Configure the **OAuth consent screen** (APIs & Services → OAuth consent
-   screen): External user type, app name (e.g. `AmiClaw`), support email, and
+   screen): External user type, app name (e.g. `AMIO Arcade`), support email, and
    the `openid` + `email` scopes (the only scopes the code requests).
 3. Create credentials → **OAuth client ID** → application type **Web
    application**.

--- a/packages/api/src/auth/config.ts
+++ b/packages/api/src/auth/config.ts
@@ -16,7 +16,7 @@ export interface AuthEnv {
   AUTH: KVNamespace
   /** Resend API key (secret). When unset, email send is logged, not sent. */
   RESEND_API_KEY?: string
-  /** Verified Resend sending address, e.g. `AmiClaw <login@claw.amio.fans>`. */
+  /** Verified Resend sending address, e.g. `AMIO Arcade <login@claw.amio.fans>`. */
   AUTH_EMAIL_FROM?: string
   /**
    * Origin used to build the magic-link verify URL and the post-login redirect
@@ -57,7 +57,7 @@ export const OAUTH_STATE_TTL_SECONDS = 10 * 60 // 10 minutes
 // --- Dev fallbacks ----------------------------------------------------------
 
 const DEFAULT_BASE_URL = 'https://claw.amio.fans'
-const DEFAULT_EMAIL_FROM = 'AmiClaw <onboarding@resend.dev>'
+const DEFAULT_EMAIL_FROM = 'AMIO Arcade <onboarding@resend.dev>'
 
 export function resolveBaseUrl(env: AuthEnv): string {
   return env.AUTH_BASE_URL && env.AUTH_BASE_URL.length > 0 ? env.AUTH_BASE_URL : DEFAULT_BASE_URL

--- a/packages/api/src/auth/email.test.ts
+++ b/packages/api/src/auth/email.test.ts
@@ -25,7 +25,7 @@ describe('createResendSender', () => {
     const sender = createResendSender({
       AUTH: {} as unknown as KVNamespace,
       RESEND_API_KEY: 'test_key',
-      AUTH_EMAIL_FROM: 'AmiClaw <login@claw.amio.fans>',
+      AUTH_EMAIL_FROM: 'AMIO Arcade <login@claw.amio.fans>',
     })
 
     const result = await sender({ to: 'a@example.com', verifyUrl: 'https://x/verify?token=t' })
@@ -38,7 +38,7 @@ describe('createResendSender', () => {
     expect(headers.Authorization).toBe('Bearer test_key')
     const body = JSON.parse((init as RequestInit).body as string)
     expect(body.to).toBe('a@example.com')
-    expect(body.from).toBe('AmiClaw <login@claw.amio.fans>')
+    expect(body.from).toBe('AMIO Arcade <login@claw.amio.fans>')
     expect(body.html).toContain('https://x/verify?token=t')
   })
 

--- a/packages/api/src/auth/email.ts
+++ b/packages/api/src/auth/email.ts
@@ -28,13 +28,13 @@ export interface SendResult {
 export type EmailSender = (email: MagicLinkEmail) => Promise<SendResult>
 
 const RESEND_ENDPOINT = 'https://api.resend.com/emails'
-const EMAIL_SUBJECT = 'Your AmiClaw sign-in link'
+const EMAIL_SUBJECT = 'Your AMIO Arcade sign-in link'
 
 function renderHtml(verifyUrl: string): string {
   // Minimal, plain HTML. The link is the only actionable element.
   return [
-    '<p>Click the link below to sign in to AmiClaw. It expires in 15 minutes and can be used once.</p>',
-    `<p><a href="${verifyUrl}">Sign in to AmiClaw</a></p>`,
+    '<p>Click the link below to sign in to AMIO Arcade. It expires in 15 minutes and can be used once.</p>',
+    `<p><a href="${verifyUrl}">Sign in to AMIO Arcade</a></p>`,
     `<p>If the link does not work, paste this URL into your browser:</p>`,
     `<p>${verifyUrl}</p>`,
     '<p>If you did not request this, you can ignore this email.</p>',
@@ -43,7 +43,7 @@ function renderHtml(verifyUrl: string): string {
 
 function renderText(verifyUrl: string): string {
   return [
-    'Click the link below to sign in to AmiClaw. It expires in 15 minutes and can be used once.',
+    'Click the link below to sign in to AMIO Arcade. It expires in 15 minutes and can be used once.',
     '',
     verifyUrl,
     '',

--- a/packages/game-bombsquad/index.html
+++ b/packages/game-bombsquad/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BombSquad — AmiClaw</title>
+    <title>BombSquad — AMIO Arcade</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/game-yijing/index.html
+++ b/packages/game-yijing/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>易经签卜 — AmiClaw Oracle</title>
+    <title>易经签卜 — AMIO Arcade</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/game-yijing/src/pages/PageSign.tsx
+++ b/packages/game-yijing/src/pages/PageSign.tsx
@@ -64,7 +64,7 @@ export function PageSign() {
 
         <div className={styles.card}>
           <div className={styles.cardHead}>
-            <span className={styles.cardLbl}>amiclaw oracle · 卦签</span>
+            <span className={styles.cardLbl}>AMIO 游乐场 · 卦签</span>
             <span className={styles.cardDate}>{todayCN()}</span>
           </div>
 

--- a/packages/platform/index.html
+++ b/packages/platform/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AmiClaw — 和 AI 一起玩点新的</title>
+    <title>AMIO Arcade — 和 AI 一起玩点新的</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/platform/src/components/home/AnonHero.tsx
+++ b/packages/platform/src/components/home/AnonHero.tsx
@@ -35,9 +35,10 @@ export default function AnonHero({ onStart, board }: AnonHeroProps) {
         </h1>
         <p className={styles.sub}>
           <span className={styles.subLine}>
-            <Wordmark /> 是 AMIO 的人机协作游戏平台。
+            <Wordmark language="zh" />
+            是你和 AI 伙伴的轻量体验入口。
           </span>
-          <span className={styles.subLine}>带上你的 AI，一起进入不同小游戏。</span>
+          <span className={styles.subLine}>带上你的 AI 伙伴，来玩一局。</span>
         </p>
         <div className={styles.cta}>
           <Button variant="primary" onClick={onStart}>

--- a/packages/platform/src/components/home/WhatIsAmiclaw.module.css
+++ b/packages/platform/src/components/home/WhatIsAmiclaw.module.css
@@ -1,4 +1,4 @@
-/* What-is-Amiclaw value props — handoff §6.5; pixel values mirror
+/* What-is-AMIO-Arcade value props — handoff §6.5; pixel values mirror
    prototype/atlas/atlas.html (.pitch-*). The cards consume the
    GlassCard primitive — its base + `interactive` hover match the
    prototype's .pitch-card exactly. The responsive @media tier (≤768px)
@@ -9,8 +9,8 @@
   padding: 24px 0 0;
 }
 
-/* The brand name in the eyebrow keeps its prose case (`AmiClaw`) instead of
-   inheriting the eyebrow's `text-transform: uppercase` — never `AMICLAW`
+/* The brand name in the eyebrow keeps its prose case instead of
+   inheriting the eyebrow's `text-transform: uppercase`
    (DesignSystem.md §Brand → Product Name). */
 .brandToken {
   text-transform: none;

--- a/packages/platform/src/components/home/WhatIsAmiclaw.tsx
+++ b/packages/platform/src/components/home/WhatIsAmiclaw.tsx
@@ -26,7 +26,7 @@ const VALUE_PROPS: ValueProp[] = [
   },
 ]
 
-/* What-is-Amiclaw section — handoff §6.5. Anonymous-only; a three-up
+/* What-is-AMIO-Arcade section — handoff §6.5. Anonymous-only; a three-up
    grid of interactive glass value-prop cards. Platform chrome — no
    cyan; the giant italic numbers are Latin, so ABeeZee italic is fine. */
 export default function WhatIsAmiclaw() {

--- a/packages/platform/src/pages/GamesPage.test.tsx
+++ b/packages/platform/src/pages/GamesPage.test.tsx
@@ -1,7 +1,7 @@
 /**
  * GamesPage (platform homepage) integration tests.
  *
- * Covers the `/` route — the Amiclaw「星图 / Atlas」homepage:
+ * Covers the `/` route — the AMIO Arcade「星图 / Atlas」homepage:
  *   1. anonymous `/` renders the AnonHero
  *   2. the anonymous hero「开始玩」CTA routes to /bombsquad
  *   3. a signed-in visitor renders the WelcomeStrip (greeting by the
@@ -100,7 +100,7 @@ describe('GamesPage homepage', () => {
       screen.getByText(
         (_, el) =>
           el?.textContent ===
-          'AmiClaw 是 AMIO 的人机协作游戏平台。带上你的 AI，一起进入不同小游戏。'
+          'AMIO 游乐场是你和 AI 伙伴的轻量体验入口。带上你的 AI 伙伴，来玩一局。'
       )
     ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /开始玩/ })).toBeInTheDocument()

--- a/packages/platform/src/pages/GamesPage.tsx
+++ b/packages/platform/src/pages/GamesPage.tsx
@@ -7,7 +7,7 @@ import FooterPitch from '@/components/home/FooterPitch'
 import { useAuth } from '@/hooks/useAuth'
 import { useDailyBoard } from '@/hooks/useDailyBoard'
 
-/* The `/` route — the Amiclaw platform homepage. Renders the anonymous
+/* The `/` route — the AMIO Arcade platform homepage. Renders the anonymous
    hero or the signed-in welcome strip per useAuth(), then the homepage
    sections. The homepage carries the anonymous play entry into the BombSquad
    landing page (/bombsquad): the AnonHero primary「开始玩」CTA (the TopNav now

--- a/packages/platform/src/pages/PrivacyPage.test.tsx
+++ b/packages/platform/src/pages/PrivacyPage.test.tsx
@@ -25,7 +25,7 @@ describe('PrivacyPage', () => {
   it('renders the policy with its title and lead', () => {
     renderPage()
     expect(screen.getByRole('heading', { name: /我们如何对待你的数据/ })).toBeInTheDocument()
-    expect(screen.getByText(/本政策说明 AmiClaw 收集哪些信息/)).toBeInTheDocument()
+    expect(screen.getByText(/本政策说明 AMIO 游乐场收集哪些信息/)).toBeInTheDocument()
   })
 
   it('states the 48-hour leaderboard and 30-day telemetry retention windows', () => {

--- a/packages/platform/src/pages/PrivacyPage.tsx
+++ b/packages/platform/src/pages/PrivacyPage.tsx
@@ -4,8 +4,8 @@ import styles from './PrivacyPage.module.css'
 const CONTACT_EMAIL = 'hi@amio.love'
 const EFFECTIVE_DATE = '2026-06-07'
 
-/* Privacy policy page — a production-grade Chinese privacy policy for the
-   AmiClaw platform (claw.amio.fans). The collected-data inventory is kept
+/* Privacy policy page — a production-grade Chinese privacy policy for
+   AMIO Arcade (claw.amio.fans). The collected-data inventory is kept
    faithful to the real submission and telemetry contracts (validation.ts /
    post-event.ts / leaderboard-types.ts / event-types.ts) and the real KV
    retention windows (leaderboard 48h, telemetry 30d). Platform chrome —
@@ -18,7 +18,7 @@ export default function PrivacyPage() {
         我们如何对待<span className={styles.accent}>你的数据</span>。
       </h2>
       <p className={styles.lead}>
-        本政策说明 AmiClaw 收集哪些信息、为什么收集、如何使用与保存，以及你对这些信息拥有的权利。
+        本政策说明 AMIO 游乐场收集哪些信息、为什么收集、如何使用与保存，以及你对这些信息拥有的权利。
         请在使用本服务前阅读。
       </p>
 
@@ -27,8 +27,9 @@ export default function PrivacyPage() {
           <section className={styles.section}>
             <h3 className={styles.heading}>一、适用范围与运营方</h3>
             <p>
-              本政策适用于你访问与使用 AmiClaw 平台（claw.amio.fans，含 BombSquad
-              等其上的游戏）时，运营方对你个人信息的处理。本服务的运营方为 AMIO 团队。
+              {
+                '本政策适用于你访问与使用 AMIO 游乐场（AMIO Arcade，原 AmiClaw，claw.amio.fans，含 BombSquad 等其上的游戏）时，运营方对你个人信息的处理。本服务的运营方为 AMIO 团队。'
+              }
             </p>
             <p>
               本服务不设账号体系，无须注册，也无须提供邮箱、手机号或真实姓名即可游玩。

--- a/packages/platform/src/pages/TermsPage.test.tsx
+++ b/packages/platform/src/pages/TermsPage.test.tsx
@@ -23,7 +23,7 @@ describe('TermsPage', () => {
   it('renders the agreement with its title and lead', () => {
     renderPage()
     expect(screen.getByRole('heading', { name: /使用本服务的约定/ })).toBeInTheDocument()
-    expect(screen.getByText(/本条款是你与运营方就使用 AmiClaw 平台达成的协议/)).toBeInTheDocument()
+    expect(screen.getByText(/本条款是你与运营方就使用 AMIO 游乐场达成的协议/)).toBeInTheDocument()
   })
 
   it('covers the applicable-law and dispute-resolution section', () => {

--- a/packages/platform/src/pages/TermsPage.tsx
+++ b/packages/platform/src/pages/TermsPage.tsx
@@ -4,8 +4,8 @@ import styles from './TermsPage.module.css'
 const CONTACT_EMAIL = 'hi@amio.love'
 const EFFECTIVE_DATE = '2026-06-07'
 
-/* Terms-of-service page — a production-grade Chinese user agreement for the
-   AmiClaw platform (claw.amio.fans). Mirrors the real service shape: no
+/* Terms-of-service page — a production-grade Chinese user agreement for
+   AMIO Arcade (claw.amio.fans). Mirrors the real service shape: no
    accounts (device-id identity), the player-supplied AI tool is an
    uncontrolled third party, nicknames + AI tool are publicly displayed.
    Platform chrome — every accent is brand yellow; no BombSquad cyan here. */
@@ -17,7 +17,7 @@ export default function TermsPage() {
         使用本服务的<span className={styles.accent}>约定</span>。
       </h2>
       <p className={styles.lead}>
-        本条款是你与运营方就使用 AmiClaw 平台达成的协议。请在使用本服务前阅读并接受。
+        本条款是你与运营方就使用 AMIO 游乐场达成的协议。请在使用本服务前阅读并接受。
       </p>
 
       <GlassCard radius="2xl" className={styles.card}>
@@ -25,9 +25,9 @@ export default function TermsPage() {
           <section className={styles.section}>
             <h3 className={styles.heading}>一、接受条款</h3>
             <p>
-              当你访问或使用 AmiClaw 平台（claw.amio.fans，含 BombSquad
-              等其上的游戏，下称「本服务」）时，即表示你已阅读、理解并同意受本条款约束。
-              如你不同意本条款，请勿使用本服务。本服务的运营方为 AMIO 团队。
+              {
+                '当你访问或使用 AMIO 游乐场（AMIO Arcade，原 AmiClaw，claw.amio.fans，含 BombSquad 等其上的游戏，下称「本服务」）时，即表示你已阅读、理解并同意受本条款约束。如你不同意本条款，请勿使用本服务。本服务的运营方为 AMIO 团队。'
+              }
             </p>
           </section>
 

--- a/packages/ui/src/SectionHeader/SectionHeader.tsx
+++ b/packages/ui/src/SectionHeader/SectionHeader.tsx
@@ -16,7 +16,7 @@ interface SectionHeaderAction {
 interface SectionHeaderProps {
   /* Plain string for the usual uppercase eyebrow, or a ReactNode when a
      fragment must opt out of the eyebrow's `text-transform: uppercase` —
-     e.g. a `<Wordmark />` keeping the brand name in prose case (`AmiClaw`). */
+     e.g. a `<Wordmark />` keeping the brand name in prose case. */
   eyebrow: ReactNode
   title: ReactNode
   action?: SectionHeaderAction

--- a/packages/ui/src/Wordmark/Wordmark.module.css
+++ b/packages/ui/src/Wordmark/Wordmark.module.css
@@ -1,18 +1,21 @@
-/* lockup — the AMIO·claw brand mark, lifted verbatim from the canonical
-   TopNav brand mark. Size is set by the consumer via font-size / className
-   (the nav uses 22px desktop / 19px mobile); the recipe scales with it. The
-   two raw rgba literals (the 0.35 yellow glow and the 0.45 white middot) carry
-   over from the TopNav mark — no exact token exists and they add no new hue. */
+/* Lockup — the AMIO Arcade brand mark. Size is set by the consumer via
+   font-size / className (the nav uses 22px desktop / 19px mobile); the recipe
+   scales with it. The raw yellow glow carries over from the previous TopNav
+   mark; no exact token exists and it adds no new hue. */
 .lockup {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.28em;
   font-family: var(--font-display);
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.02em;
   color: var(--amio-yellow);
   text-shadow: 0 0 18px rgba(255, 229, 62, 0.35);
 }
 
-.dot {
-  color: rgba(255, 255, 255, 0.45);
-  margin: 0 2px;
-  font-weight: 300;
+.arcade {
+  color: var(--text-1);
+  font-weight: 600;
+  letter-spacing: 0;
+  text-shadow: none;
 }

--- a/packages/ui/src/Wordmark/Wordmark.tsx
+++ b/packages/ui/src/Wordmark/Wordmark.tsx
@@ -1,24 +1,26 @@
 import styles from './Wordmark.module.css'
 
 interface WordmarkProps {
-  /* `text` → the plain prose name `AmiClaw` (inherits surrounding type, so it
-     drops into running copy). `lockup` → the `AMIO·claw` brand mark. */
+  /* `text` → the plain prose name (inherits surrounding type, so it drops into
+     running copy). `lockup` → the AMIO Arcade brand mark. */
   variant?: 'text' | 'lockup'
+  language?: 'en' | 'zh'
   className?: string
 }
 
 /* The single source for how the product name renders. Prose copy, titles and
-   alt text use the `text` variant (`AmiClaw`); the TopNav brand link and any
-   logo placement use the `lockup` variant (`AMIO·claw`). The two forms are
+   alt text use the `text` variant (`AMIO Arcade` / `AMIO 游乐场`); the TopNav
+   brand link and any logo placement use the `lockup` variant. The two forms are
    never mixed — see DesignSystem.md §Brand → Product Name. */
-export default function Wordmark({ variant = 'text', className }: WordmarkProps) {
+export default function Wordmark({ variant = 'text', language = 'en', className }: WordmarkProps) {
   if (variant === 'lockup') {
     const classes = [styles.lockup, className].filter(Boolean).join(' ')
     return (
-      <span className={classes}>
-        AMIO<span className={styles.dot}>·</span>claw
+      <span className={classes} aria-label="AMIO Arcade">
+        <span>AMIO</span>
+        <span className={styles.arcade}>Arcade</span>
       </span>
     )
   }
-  return <span className={className}>AmiClaw</span>
+  return <span className={className}>{language === 'zh' ? 'AMIO 游乐场' : 'AMIO Arcade'}</span>
 }

--- a/packages/ui/src/styles/animations.css
+++ b/packages/ui/src/styles/animations.css
@@ -1,5 +1,5 @@
 /* ============================================================
-   Amiclaw Atlas — Global Keyframes
+   AMIO Arcade Atlas — Global Keyframes
    ============================================================
    Named keyframes for the Atlas platform surface, with exact
    definitions from prototype/atlas/atlas.html. These live in a


### PR DESCRIPTION
## Summary

- Rename active public product surfaces from AmiClaw / AMIO.claw to AMIO Arcade / AMIO 游乐场.
- Update shared Wordmark rendering, page titles, home/legal/auth email copy, README, tests, and changelog.
- Preserve compatibility identifiers for packages, hostnames, cookies, Cloudflare resources, and history.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or cleanup
- [x] Documentation
- [x] CI or configuration

## Testing

- [x] Existing tests pass
- [ ] New tests added if behavior changed
- [x] Tested manually and documented below

Manual testing:

- pnpm lint
- pnpm test:run
- pnpm build
- git diff --check
- Local browser preview checked /, /privacy, /terms, /bombsquad/, and /oracle/ for updated AMIO Arcade titles and absence of stale homepage copy.
- Independent verifier-codex review passed with no blocking or medium-severity findings.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

Attribution: Prepared by Codex.