### PR TITLE
Fix BombSquad daily entry feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ homepage copy, legal pages, auth emails, README, and canonical docs. Existing
 `claw.amio.fans` URLs and `amiclaw` internal identifiers stay in place as
 compatibility infrastructure.
 
+**BombSquad daily entry no longer looks broken when you need to restart** - Fix.
+The result recovery surface no longer says the run has "no data"; it now presents
+itself as a restart path, with the daily action clearly saying it will hand the
+manual to the AI before starting the challenge. If clipboard copy fails on the
+connect screen, the page now says the visible manual URL is the same supported
+handoff path as copy-and-paste. The button module also separates the small static
+preview light from the hold-time release strip, so the strip only comes alive
+while holding and still gives away nothing about the correct release color.
+
 **Meet your AI companion** - New. Signed-in players can now give their platform
 AI partner a name and choose its voice, so it feels like theirs from the first
 hello. The companion card counts how many days you've been together from the day

--- a/packages/game-bombsquad/src/game-flow.test.tsx
+++ b/packages/game-bombsquad/src/game-flow.test.tsx
@@ -58,6 +58,19 @@ vi.mock('@shared/leaderboard-api', () => ({
   fetchLeaderboard: vi.fn().mockResolvedValue({ date: '2026-03-16', entries: [] }),
 }))
 
+vi.mock('./utils/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('./audio/audio-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./audio/audio-context')>()
+  return {
+    ...actual,
+    getAudioContext: vi.fn().mockReturnValue(null),
+    setSfxSuppressed: vi.fn(),
+  }
+})
+
 // Daily mode loads its manual over the network. Mock the loader to resolve
 // the practice manual (it carries all four module rule sections), so a daily
 // run can be exercised end to end without a real fetch. Keep the typed error
@@ -141,5 +154,28 @@ describe('full game flow', () => {
       () => expect(screen.getByRole('heading', { name: /拆弹成功/ })).toBeInTheDocument(),
       { timeout: 5000 }
     )
+  }, 12000)
+
+  it('daily connect entry: 进入游戏 reaches the first module, not result recovery', async () => {
+    vi.mocked(loadManual).mockResolvedValue(yaml.load(practiceYamlRaw) as Manual)
+
+    render(
+      <MemoryRouter initialEntries={['/bombsquad/connect?mode=daily']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '复制手册' }))
+    await waitFor(() => expect(screen.getByText('切到语音模式')).toBeInTheDocument(), {
+      timeout: 3000,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /进入游戏/ }))
+
+    await waitFor(() => expect(screen.getByTestId('mock-wire-complete')).toBeInTheDocument(), {
+      timeout: 3000,
+    })
+    expect(screen.queryByRole('heading', { name: '重新开始一局' })).not.toBeInTheDocument()
+    expect(screen.queryByText(/这一局没有数据/)).not.toBeInTheDocument()
   }, 12000)
 })

--- a/packages/game-bombsquad/src/modules/button/ButtonModule.module.css
+++ b/packages/game-bombsquad/src/modules/button/ButtonModule.module.css
@@ -43,7 +43,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 26px;
+  gap: 24px;
   padding: 32px 28px;
   border-radius: var(--radius-2xl);
   border: 1px solid var(--hairline);
@@ -54,75 +54,104 @@
   backdrop-filter: blur(20px);
 }
 
-/* Indicator well — hosts the status pip and, while holding, a continuous
-   sweep ring. The ring gives the player a target-agnostic "still cycling"
-   signal so a held color is never misread as a settled answer. The well is
-   slightly larger than the pip to leave room for the surrounding ring. */
-.indicatorWell {
-  position: relative;
-  display: flex;
+/* Light panel — keeps the static preview pip and hold-time release strip on
+   separate surfaces. The preview light is deliberately small and stable; the
+   release strip is dark until the player has held long enough for cycling. */
+.lightPanel {
+  display: grid;
+  grid-template-columns: 26px minmax(160px, 1fr);
+  gap: 12px;
   align-items: center;
-  justify-content: center;
-  width: 38px;
-  height: 38px;
+  width: min(100%, 230px);
+  padding: 10px 12px;
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.035);
 }
 
-/* Sweep ring — a thin yellow-brand arc that orbits the pip, completing one
-   revolution per full 4-color cycle (4 x 800ms = 3.2s). It is rendered as a
-   masked conic-gradient annulus on a pseudo element so the pip itself never
-   rotates. Motion, color, and geometry are identical for every indicator
-   color — it never reads answer.releaseOnColor, so it leaks no target. */
-.indicatorWell::before {
-  content: '';
-  position: absolute;
-  inset: 0;
+.previewLight {
+  width: 18px;
+  height: 18px;
+  justify-self: center;
   border-radius: 50%;
-  background: conic-gradient(from 0deg, transparent 0deg, var(--y-glow-50) 300deg, var(--y) 360deg);
-  /* Mask to a thin ring: opaque outside the inner radius, transparent inside. */
-  -webkit-mask: radial-gradient(circle, transparent 13px, #000 14px);
-  mask: radial-gradient(circle, transparent 13px, #000 14px);
-  opacity: 0;
-  transition: opacity 0.2s ease;
+  border: 1px solid rgba(255, 255, 255, 0.3);
 }
 
-.indicatorWell.cycling::before {
-  opacity: 1;
-  animation: button-cycle-sweep 3200ms linear infinite;
-}
-
-/* Status indicator pip — color + glow are supplied inline. */
-.indicator {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+.releaseStrip {
+  position: relative;
+  height: 18px;
+  overflow: hidden;
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.015)),
+    rgba(0, 0, 0, 0.34);
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.45);
   transition:
-    background-color 0.2s ease,
+    border-color 0.2s ease,
     box-shadow 0.2s ease;
 }
 
-/* Per-color-change tick — a brief uniform scale pulse replayed on every cycle
-   step (the pip is keyed on the color index, so it remounts each change). The
-   pulse is identical for white/yellow/blue/red and reveals no target. */
-.indicator.advancePulse {
-  animation: button-cycle-tick 320ms ease-out;
+.releaseStrip::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.16) 0,
+    rgba(255, 255, 255, 0.16) 1px,
+    transparent 1px,
+    transparent 22px
+  );
+  opacity: 0.35;
 }
 
-@keyframes button-cycle-sweep {
-  to {
-    transform: rotate(360deg);
-  }
+.releaseStripFill {
+  position: absolute;
+  inset: 2px;
+  border-radius: inherit;
+  background: var(--release-color);
+  box-shadow: 0 0 18px var(--release-color);
+  opacity: 0;
+  transform: scaleX(0.12);
+  transform-origin: left center;
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease,
+    opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
-@keyframes button-cycle-tick {
+.releaseStripActive {
+  border-color: rgba(255, 255, 255, 0.32);
+  box-shadow:
+    inset 0 0 10px rgba(0, 0, 0, 0.35),
+    0 0 18px var(--release-color);
+}
+
+.releaseStripActive .releaseStripFill {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+/* Per-color-change tick — a brief uniform pulse replayed on every cycle step.
+   The fill is keyed on the color index, so the cue is identical for each
+   release target and reveals no answer. */
+.releaseStripFill.advancePulse {
+  animation: button-strip-tick 320ms ease-out;
+}
+
+@keyframes button-strip-tick {
   0% {
-    transform: scale(1);
+    transform: scaleX(0.9);
   }
-  40% {
-    transform: scale(1.22);
+  45% {
+    transform: scaleX(1);
+    filter: brightness(1.25);
   }
   100% {
-    transform: scale(1);
+    transform: scaleX(1);
+    filter: brightness(1);
   }
 }
 
@@ -214,12 +243,9 @@
   .buttonOrbit::before {
     animation: none;
   }
-  /* Drop the per-change pulse and the sweep rotation, but keep the ring
-     visible while holding so the "cycling" affordance survives motion-off. */
-  .indicator.advancePulse {
-    animation: none;
-  }
-  .indicatorWell.cycling::before {
+  /* Drop the per-change pulse, but keep the release strip visible while
+     holding so the affordance survives motion-off. */
+  .releaseStripFill.advancePulse {
     animation: none;
   }
 }

--- a/packages/game-bombsquad/src/modules/button/ButtonModule.test.tsx
+++ b/packages/game-bombsquad/src/modules/button/ButtonModule.test.tsx
@@ -89,18 +89,15 @@ describe('ButtonModule', () => {
   })
 })
 
-describe('ButtonModule cycle-legibility cue is target-agnostic', () => {
+describe('ButtonModule release-strip cue is target-agnostic', () => {
   const RELEASE_COLORS = ['white', 'yellow', 'blue', 'red'] as const
 
-  // The indicator pip lives inside the cue-bearing "indicator well" (the
-  // element that carries the sweep ring + the .cycling activation class). The
-  // well is the pip's parent. Returning its outerHTML captures the FULL cue
-  // markup — the well's class set, the pip's class set, and inline styles —
-  // which is exactly what a viewer could read off the screen.
-  function indicatorWellHtml(): string {
-    const well = screen.getByTestId('button-indicator').parentElement
-    if (!well) throw new Error('indicator pip has no parent well')
-    return well.outerHTML
+  // Returning the release strip's outerHTML captures the cue-bearing surface:
+  // its class set, active flag, current cycle color, and fill markup. The
+  // static preview light is a separate surface and is intentionally excluded
+  // so this guard isolates the hold-time release cue.
+  function releaseStripHtml(): string {
+    return screen.getByTestId('button-release-strip').outerHTML
   }
 
   // The spec's hardest constraint: for any target color X, the rendered
@@ -108,12 +105,12 @@ describe('ButtonModule cycle-legibility cue is target-agnostic', () => {
   // answer from the screen. We drive a `hold` attempt for each of the four
   // `releaseOnColor` targets into the holding state and advance every render by
   // the SAME number of cycle steps, so all four sit at the same cycle index.
-  // The cue markup (ring structure + class sets) must then be byte-identical
+  // The cue markup (strip structure + class sets) must then be byte-identical
   // across all four targets. This fails loudly if anyone later keys the
-  // ring/pulse on answer.releaseOnColor (the well/pip class set or structure
-  // would then diverge by target).
-  it('renders an identical indicator-well cue for every release-on-light target', () => {
-    const renderedWells = RELEASE_COLORS.map((releaseOnColor) => {
+  // strip/fill on answer.releaseOnColor (the class set or structure would then
+  // diverge by target).
+  it('renders an identical release-strip cue for every release-on-light target', () => {
+    const renderedStrips = RELEASE_COLORS.map((releaseOnColor) => {
       vi.useFakeTimers()
       // Hold the per-target inputs (config color / label / preview color) FIXED
       // across all four renders, so the ONLY thing that varies is the answer's
@@ -138,29 +135,30 @@ describe('ButtonModule cycle-legibility cue is target-agnostic', () => {
         vi.advanceTimersByTime(500) // HOLD_THRESHOLD_MS -> holding
         vi.advanceTimersByTime(800 * 2) // INDICATOR_CYCLE_MS * 2 -> same index
       })
-      const html = indicatorWellHtml()
+      const html = releaseStripHtml()
       unmount()
       vi.useRealTimers()
       return html
     })
 
     // Sanity: the cue must actually be present (guards against an empty-string
-    // tautology where every well happens to be identically blank).
-    expect(renderedWells[0]).toContain('button-indicator')
-    expect(renderedWells[0].length).toBeGreaterThan(0)
+    // tautology where every strip happens to be identically blank).
+    expect(renderedStrips[0]).toContain('button-release-strip')
+    expect(renderedStrips[0]).toContain('data-active="true"')
+    expect(renderedStrips[0].length).toBeGreaterThan(0)
 
     // Every target's cue markup must equal white's — identical for all colors.
     for (let i = 1; i < RELEASE_COLORS.length; i++) {
       expect(
-        renderedWells[i],
+        renderedStrips[i],
         `cue markup for releaseOnColor="${RELEASE_COLORS[i]}" differs from "white" — the cue leaks the target`
-      ).toBe(renderedWells[0])
+      ).toBe(renderedStrips[0])
     }
     // Collapsing to a unique set must yield exactly one variant.
-    expect(new Set(renderedWells).size).toBe(1)
+    expect(new Set(renderedStrips).size).toBe(1)
   })
 
-  it('marks the indicator well as cycling only while holding (not idle or pressed)', () => {
+  it('activates the release strip only while holding, while the preview light stays static', () => {
     vi.useFakeTimers()
     const config = { color: 'blue', label: 'ABORT', indicatorColor: 'red', displayNumber: 1 }
     const answer = { type: 'button' as const, action: 'hold' as const, releaseOnColor: 'yellow' }
@@ -174,29 +172,28 @@ describe('ButtonModule cycle-legibility cue is target-agnostic', () => {
       />
     )
     const btn = screen.getByTestId('big-button')
-    const wellTestId = 'button-indicator' // pip parent carries the cycling class
+    const releaseStrip = () => screen.getByTestId('button-release-strip')
+    const previewLight = screen.getByTestId('button-preview-light')
+    const isActive = () => releaseStrip().getAttribute('data-active') === 'true'
 
-    // The .cycling class is the well's class minus the pip's class. We read the
-    // well's classList directly off the pip's parent.
-    const wellClasses = () => {
-      const well = screen.getByTestId(wellTestId).parentElement
-      if (!well) throw new Error('indicator pip has no parent well')
-      return Array.from(well.classList)
-    }
-    const isCycling = () => wellClasses().some((c) => c.toLowerCase().includes('cycling'))
+    expect(previewLight).toHaveAttribute('data-color', 'red')
 
-    // idle: not cycling.
-    expect(isCycling(), 'must not be cycling in idle state').toBe(false)
+    // idle: release strip inactive.
+    expect(isActive(), 'must not activate the release strip in idle state').toBe(false)
+    expect(releaseStrip()).toHaveAttribute('data-color', 'inactive')
 
-    // pressed (before the hold threshold): still not cycling.
+    // pressed (before the hold threshold): release strip still inactive.
     fireEvent.pointerDown(btn)
-    expect(isCycling(), 'must not be cycling in pressed state').toBe(false)
+    expect(isActive(), 'must not activate the release strip in pressed state').toBe(false)
+    expect(releaseStrip()).toHaveAttribute('data-color', 'inactive')
 
-    // holding (after the hold threshold): now cycling.
+    // holding (after the hold threshold): release strip activates.
     act(() => {
       vi.advanceTimersByTime(500) // HOLD_THRESHOLD_MS -> holding
     })
-    expect(isCycling(), 'must be cycling in holding state').toBe(true)
+    expect(isActive(), 'must activate the release strip in holding state').toBe(true)
+    expect(releaseStrip()).toHaveAttribute('data-color', 'white')
+    expect(previewLight).toHaveAttribute('data-color', 'red')
 
     vi.useRealTimers()
   })

--- a/packages/game-bombsquad/src/modules/button/ButtonModule.tsx
+++ b/packages/game-bombsquad/src/modules/button/ButtonModule.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, type KeyboardEvent } from 'react'
+import { useState, useRef, useEffect, type CSSProperties, type KeyboardEvent } from 'react'
 import type { ButtonConfig, ButtonAnswer } from '@shared/manual-schema'
 import type { ModuleProps } from '../types'
 import { playSfx } from '@/audio/useSfx'
@@ -115,15 +115,19 @@ export default function ButtonModule({
     handlePointerUp()
   }
 
-  const indicatorColor = CSS_COLORS[INDICATOR_COLORS[indicatorColorIdx]] ?? '#888'
+  const releaseColorName = INDICATOR_COLORS[indicatorColorIdx]
+  const releaseColor = CSS_COLORS[releaseColorName] ?? '#888'
+  const previewColor = CSS_COLORS[config.indicatorColor] ?? '#888'
   const buttonBg = CSS_COLORS[config.color] ?? '#444'
   const isPressed = buttonState === 'pressed' || buttonState === 'holding'
   const isHolding = buttonState === 'holding'
-  const litColor = isHolding ? indicatorColor : (CSS_COLORS[config.indicatorColor] ?? '#888')
   const buttonAccessibleName = `${config.color} ${config.label} button, display ${config.displayNumber}`
   const lightAccessibleState = isHolding
-    ? `Hold light is ${INDICATOR_COLORS[indicatorColorIdx]}.`
+    ? `Release strip is ${releaseColorName}. Preview light is ${config.indicatorColor}.`
     : `Preview light is ${config.indicatorColor}.`
+  const releaseStripStyle = {
+    '--release-color': releaseColor,
+  } as CSSProperties
 
   return (
     <div
@@ -131,24 +135,34 @@ export default function ButtonModule({
       data-testid="button-module"
     >
       <div className={styles.stage}>
-        {/* The sweep ring runs continuously while holding — one revolution per
-            full 4-color cycle — so a held color reads as "still cycling" rather
-            than "settled". The ring is target-agnostic: its motion and color are
-            identical for every indicator color and never reference the answer. */}
-        <div className={`${styles.indicatorWell} ${isHolding ? styles.cycling : ''}`}>
-          {/* Keyed on the color index so every color change remounts and replays
-              the same brief pulse — a uniform "the light just advanced" tick.
-              The key only changes while holding, so the pulse fires per cycle
-              step and the cue is the same for white/yellow/blue/red. */}
+        <div className={styles.lightPanel}>
           <div
-            key={isHolding ? indicatorColorIdx : 'idle'}
-            className={`${styles.indicator} ${isHolding ? styles.advancePulse : ''}`}
+            className={styles.previewLight}
             style={{
-              backgroundColor: litColor,
-              boxShadow: `0 0 14px ${litColor}`,
+              backgroundColor: previewColor,
+              boxShadow: `0 0 10px ${previewColor}`,
             }}
-            data-testid="button-indicator"
+            data-color={config.indicatorColor}
+            data-testid="button-preview-light"
+            aria-hidden="true"
           />
+          {/* The release strip is a separate surface from the static preview
+              light. It activates only after the hold threshold and cycles the
+              same four colors for every answer target, so it does not encode
+              answer.releaseOnColor. */}
+          <div
+            className={`${styles.releaseStrip} ${isHolding ? styles.releaseStripActive : ''}`}
+            style={releaseStripStyle}
+            data-active={isHolding ? 'true' : 'false'}
+            data-color={isHolding ? releaseColorName : 'inactive'}
+            data-testid="button-release-strip"
+            aria-hidden="true"
+          >
+            <div
+              key={isHolding ? indicatorColorIdx : 'idle'}
+              className={`${styles.releaseStripFill} ${isHolding ? styles.advancePulse : ''}`}
+            />
+          </div>
         </div>
         <div className={styles.buttonOrbit}>
           <span id="button-module-state" className={styles.srOnly} aria-live="polite">

--- a/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
@@ -182,13 +182,14 @@ describe('ConnectPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '复制手册' }))
 
     await waitFor(() => {
-      expect(screen.getByText('复制失败，可手动发送')).toBeInTheDocument()
+      expect(screen.getByText('复制失败，链接仍可用')).toBeInTheDocument()
     })
-    expect(screen.getByText(/你可以重试复制/)).toBeInTheDocument()
+    expect(screen.getByText(/上面的链接就是同一份手册/)).toBeInTheDocument()
+    expect(screen.getByText(/和复制后粘贴完全一样/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '重试复制' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '重试复制手册链接' })).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /我已发给 AI/ }))
+    fireEvent.click(screen.getByRole('button', { name: /我已手动发给 AI/ }))
 
     expect(screen.getByText('第 2/2 步')).toBeInTheDocument()
     expect(screen.getByText(SYNC_PROMPT)).toBeInTheDocument()

--- a/packages/game-bombsquad/src/pages/ConnectPage.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.tsx
@@ -181,7 +181,7 @@ export default function ConnectPage() {
               >
                 <div className={styles.copyCardText}>
                   <div className={styles.copyCardLabel}>
-                    {copied ? '已复制到剪贴板' : copyFailed ? '复制失败，可手动发送' : '手册链接'}
+                    {copied ? '已复制到剪贴板' : copyFailed ? '复制失败，链接仍可用' : '手册链接'}
                   </div>
                   <div className={styles.copyCardUrl}>{manualUrl}</div>
                 </div>
@@ -217,7 +217,7 @@ export default function ConnectPage() {
 
               <p className={styles.hint}>
                 {copyFailed
-                  ? '浏览器没有允许自动复制。你可以重试复制，或手动选择上面的链接发给 AI，等它读完手册后继续。'
+                  ? '浏览器没有允许自动复制，但上面的链接就是同一份手册。手动把它发给 AI，和复制后粘贴完全一样；等它读完后继续。'
                   : '粘贴到你常用的 AI，让它读完手册后说「好了」。'}
               </p>
               {/* /compatibility discovery link — re-homed here from the
@@ -285,7 +285,7 @@ export default function ConnectPage() {
                 </Button>
                 {copyFailed && !copied && (
                   <Button variant="ghost" full onClick={continueAfterManualHandoff}>
-                    我已发给 AI，继续 →
+                    我已手动发给 AI，继续 →
                   </Button>
                 )}
               </>

--- a/packages/game-bombsquad/src/pages/ResultPage.module.css
+++ b/packages/game-bombsquad/src/pages/ResultPage.module.css
@@ -347,6 +347,14 @@
   text-align: center;
 }
 
+.noDataTitle {
+  margin: 0;
+  font: 400 32px/1.1 var(--font-display);
+  font-style: italic;
+  color: #fff;
+  text-shadow: 0 0 20px var(--y-glow-25);
+}
+
 .noDataText {
   margin: 0;
   font: 400 15px/1.6 var(--font-body);

--- a/packages/game-bombsquad/src/pages/ResultPage.recovery.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.recovery.test.tsx
@@ -3,9 +3,9 @@
  *
  * When the result page is opened with no live run in memory (a direct link to
  * /bombsquad/result, a refresh that cleared the run context, or an odd
- * back-navigation), the `noRunData` branch used to render a dead-end
- * "暂无数据。返回主页" link that forced the player out of the game. It now
- * renders a recoverable empty state with three landing-page entry points.
+ * back-navigation), the `noRunData` branch used to render a broken-sounding
+ * no-data message. It now renders an explicit restart surface that sends daily
+ * players back through the manual handoff before the run starts.
  *
  * These tests assert the three recovery actions are present with the correct
  * destinations, and that clicking the primary CTA navigates to the daily
@@ -81,25 +81,27 @@ describe('ResultPage no-run-data recovery', () => {
     sessionStorage.clear()
   })
 
-  it('renders the recovery empty state, not the dead "暂无数据" link', () => {
+  it('renders an explicit restart surface, not a scary no-data message', () => {
     renderRecovery()
 
     expect(screen.queryByText(/暂无数据/)).not.toBeInTheDocument()
-    expect(screen.getByText(/这一局没有数据/)).toBeInTheDocument()
+    expect(screen.queryByText(/这一局没有数据/)).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: '重新开始一局' })).toBeInTheDocument()
+    expect(screen.getByText(/先把手册交给 AI/)).toBeInTheDocument()
   })
 
   it('shows the three recovery actions', () => {
     renderRecovery()
 
-    expect(screen.getByRole('button', { name: /开始今日挑战/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /先交手册，再开始每日挑战/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '练习一局' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '返回主页' })).toBeInTheDocument()
   })
 
-  it('「开始今日挑战」navigates to the daily connect funnel', () => {
+  it('the primary daily CTA navigates to the daily connect funnel', () => {
     renderRecovery()
 
-    fireEvent.click(screen.getByRole('button', { name: /开始今日挑战/ }))
+    fireEvent.click(screen.getByRole('button', { name: /先交手册，再开始每日挑战/ }))
 
     expect(screen.getByTestId('location')).toHaveTextContent('/bombsquad/connect?mode=daily')
   })
@@ -125,7 +127,7 @@ describe('ResultPage no-run-data recovery', () => {
   it('the connect CTAs do not deep-link into /bombsquad/run', () => {
     renderRecovery()
 
-    fireEvent.click(screen.getByRole('button', { name: /开始今日挑战/ }))
+    fireEvent.click(screen.getByRole('button', { name: /先交手册，再开始每日挑战/ }))
 
     expect(screen.getByTestId('location')).not.toHaveTextContent('/bombsquad/run')
   })

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -393,14 +393,17 @@ export default function ResultPage() {
         <Scenery accent="yellow" />
         <div className={styles.stage}>
           <div className={styles.noData}>
-            <p className={styles.noDataText}>这一局没有数据，可能是刷新或直接打开了结算页。</p>
+            <h1 className={styles.noDataTitle}>重新开始一局</h1>
+            <p className={styles.noDataText}>
+              这里没有正在结算的关卡。先把手册交给 AI，等它读完，再进入每日挑战。
+            </p>
             <div className={styles.cta}>
               <Button
                 variant="primary"
                 full
                 onClick={() => navigate('/bombsquad/connect?mode=daily')}
               >
-                开始今日挑战<span aria-hidden="true"> →</span>
+                先交手册，再开始每日挑战<span aria-hidden="true"> →</span>
               </Button>
               <Button
                 variant="ghost"


### PR DESCRIPTION
## Summary

- Reframes BombSquad result recovery as an explicit restart and manual handoff path.
- Clarifies that manual clipboard-copy failure still supports the visible URL handoff.
- Separates the static button preview light from the hold-time release strip and guards the cue against target-color leakage.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [ ] Tested manually and documented below

### Verification run

- `pnpm --filter @amiclaw/game-bombsquad test:run -- ConnectPage ResultPage.recovery ButtonModule game-flow`
- `pnpm --filter @amiclaw/game-bombsquad typecheck`
- `pnpm --filter @amiclaw/game-bombsquad build`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test:run`
- `pnpm build`
- Independent verifier review passed; residual risk is that no browser screenshot or real-device visual pass was performed.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

## Source evidence

- Source TaskNote: pages/projects/amiclaw/tasks/fix-bombsquad-daily-entry-manual-copy-and-button-feedback
- Source report: pages/projects/amiclaw/e2e/reports/bombsquad-e2e-2026-07-01-3

## Attribution

Implemented in Codex Desktop with Codex code-worker and verifier subagents. Claude Code was not used.
