### PR TITLE
fix: repair BombSquad entry recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ handoff path as copy-and-paste. The button module also separates the small stati
 preview light from the hold-time release strip, so the strip only comes alive
 while holding and still gives away nothing about the correct release color.
 
+**BombSquad entry recovery keeps your mode** - Fix. Starting a new run now clears
+stale finished-run state before the game page opens, so a completed result can no
+longer bounce practice or daily players back to the restart screen. Recovery copy
+now follows the last selected mode: practice recovery stays practice-specific,
+daily recovery after a completed manual handoff can go straight back into the
+challenge, pre-module daily failures no longer reserve an attempt, copy-failure
+retry has one clear action, and the button's static preview light is visually
+quieter than the active release strip.
+
 **Meet your AI companion** - New. Signed-in players can now give their platform
 AI partner a name and choose its voice, so it feels like theirs from the first
 hello. The companion card counts how many days you've been together from the day

--- a/packages/game-bombsquad/src/modules/button/ButtonModule.module.css
+++ b/packages/game-bombsquad/src/modules/button/ButtonModule.module.css
@@ -59,27 +59,32 @@
    release strip is dark until the player has held long enough for cycling. */
 .lightPanel {
   display: grid;
-  grid-template-columns: 26px minmax(160px, 1fr);
-  gap: 12px;
+  grid-template-columns: 22px minmax(176px, 1fr);
+  gap: 14px;
   align-items: center;
-  width: min(100%, 230px);
-  padding: 10px 12px;
+  width: min(100%, 254px);
+  padding: 12px 14px;
   border-radius: var(--radius-xl);
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.035);
 }
 
 .previewLight {
-  width: 18px;
-  height: 18px;
+  width: 12px;
+  height: 12px;
   justify-self: center;
   border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  opacity: 0.46;
+  filter: saturate(0.72);
+  box-shadow:
+    inset 0 0 0 2px rgba(5, 5, 17, 0.5),
+    0 0 5px var(--preview-color);
 }
 
 .releaseStrip {
   position: relative;
-  height: 18px;
+  height: 24px;
   overflow: hidden;
   border-radius: var(--radius-pill);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -108,10 +113,12 @@
 
 .releaseStripFill {
   position: absolute;
-  inset: 2px;
+  inset: 3px;
   border-radius: inherit;
   background: var(--release-color);
-  box-shadow: 0 0 18px var(--release-color);
+  box-shadow:
+    0 0 20px var(--release-color),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.24);
   opacity: 0;
   transform: scaleX(0.12);
   transform-origin: left center;
@@ -123,10 +130,11 @@
 }
 
 .releaseStripActive {
-  border-color: rgba(255, 255, 255, 0.32);
+  border-color: rgba(255, 255, 255, 0.46);
   box-shadow:
     inset 0 0 10px rgba(0, 0, 0, 0.35),
-    0 0 18px var(--release-color);
+    0 0 0 2px rgba(255, 255, 255, 0.08),
+    0 0 22px var(--release-color);
 }
 
 .releaseStripActive .releaseStripFill {

--- a/packages/game-bombsquad/src/modules/button/ButtonModule.test.tsx
+++ b/packages/game-bombsquad/src/modules/button/ButtonModule.test.tsx
@@ -177,15 +177,18 @@ describe('ButtonModule release-strip cue is target-agnostic', () => {
     const isActive = () => releaseStrip().getAttribute('data-active') === 'true'
 
     expect(previewLight).toHaveAttribute('data-color', 'red')
+    expect(previewLight).toHaveAttribute('data-visual-priority', 'context')
 
     // idle: release strip inactive.
     expect(isActive(), 'must not activate the release strip in idle state').toBe(false)
     expect(releaseStrip()).toHaveAttribute('data-color', 'inactive')
+    expect(releaseStrip()).toHaveAttribute('data-visual-priority', 'inactive-release')
 
     // pressed (before the hold threshold): release strip still inactive.
     fireEvent.pointerDown(btn)
     expect(isActive(), 'must not activate the release strip in pressed state').toBe(false)
     expect(releaseStrip()).toHaveAttribute('data-color', 'inactive')
+    expect(releaseStrip()).toHaveAttribute('data-visual-priority', 'inactive-release')
 
     // holding (after the hold threshold): release strip activates.
     act(() => {
@@ -193,7 +196,40 @@ describe('ButtonModule release-strip cue is target-agnostic', () => {
     })
     expect(isActive(), 'must activate the release strip in holding state').toBe(true)
     expect(releaseStrip()).toHaveAttribute('data-color', 'white')
+    expect(releaseStrip()).toHaveAttribute('data-visual-priority', 'active-release')
     expect(previewLight).toHaveAttribute('data-color', 'red')
+    expect(previewLight).toHaveAttribute('data-visual-priority', 'context')
+
+    vi.useRealTimers()
+  })
+
+  it('keeps a blue preview light structurally subordinate to the active blue strip phase', () => {
+    vi.useFakeTimers()
+    const config = { color: 'red', label: 'ABORT', indicatorColor: 'blue', displayNumber: 5 }
+    const answer = { type: 'button' as const, action: 'hold' as const, releaseOnColor: 'white' }
+    render(
+      <ButtonModule
+        config={config}
+        answer={answer}
+        onComplete={vi.fn()}
+        onError={vi.fn()}
+        sceneInfo={sceneInfo}
+      />
+    )
+    const btn = screen.getByTestId('big-button')
+    const previewLight = screen.getByTestId('button-preview-light')
+    const releaseStrip = screen.getByTestId('button-release-strip')
+
+    fireEvent.pointerDown(btn)
+    act(() => {
+      vi.advanceTimersByTime(500)
+      vi.advanceTimersByTime(800 * 2)
+    })
+
+    expect(previewLight).toHaveAttribute('data-color', 'blue')
+    expect(previewLight).toHaveAttribute('data-visual-priority', 'context')
+    expect(releaseStrip).toHaveAttribute('data-color', 'blue')
+    expect(releaseStrip).toHaveAttribute('data-visual-priority', 'active-release')
 
     vi.useRealTimers()
   })

--- a/packages/game-bombsquad/src/modules/button/ButtonModule.tsx
+++ b/packages/game-bombsquad/src/modules/button/ButtonModule.tsx
@@ -128,6 +128,10 @@ export default function ButtonModule({
   const releaseStripStyle = {
     '--release-color': releaseColor,
   } as CSSProperties
+  const previewLightStyle = {
+    '--preview-color': previewColor,
+    backgroundColor: previewColor,
+  } as CSSProperties
 
   return (
     <div
@@ -138,11 +142,9 @@ export default function ButtonModule({
         <div className={styles.lightPanel}>
           <div
             className={styles.previewLight}
-            style={{
-              backgroundColor: previewColor,
-              boxShadow: `0 0 10px ${previewColor}`,
-            }}
+            style={previewLightStyle}
             data-color={config.indicatorColor}
+            data-visual-priority="context"
             data-testid="button-preview-light"
             aria-hidden="true"
           />
@@ -155,6 +157,7 @@ export default function ButtonModule({
             style={releaseStripStyle}
             data-active={isHolding ? 'true' : 'false'}
             data-color={isHolding ? releaseColorName : 'inactive'}
+            data-visual-priority={isHolding ? 'active-release' : 'inactive-release'}
             data-testid="button-release-strip"
             aria-hidden="true"
           >

--- a/packages/game-bombsquad/src/pages/ConnectPage.module.css
+++ b/packages/game-bombsquad/src/pages/ConnectPage.module.css
@@ -177,7 +177,8 @@
 }
 
 /* ----------  manual-URL copy card  ----------
-   The whole card copies the manual link, matching the bottom CTA. */
+   The whole card copies the manual link until clipboard access fails; then it
+   becomes a read-only fallback so there is only one retry action. */
 .urlPreview {
   display: flex;
   align-items: center;
@@ -235,6 +236,25 @@
 
 .urlPreviewDone .copyCardLabel {
   color: var(--green);
+}
+
+.urlPreviewFailed {
+  cursor: text;
+  border-color: rgba(255, 107, 157, 0.28);
+}
+
+.urlPreviewFailed:hover {
+  background: var(--glass);
+  border-color: rgba(255, 107, 157, 0.28);
+}
+
+.urlPreviewFailed .copyCardLabel {
+  color: var(--rose);
+}
+
+.urlPreviewFailed .copyCardIcon {
+  background: rgba(255, 107, 157, 0.12);
+  color: var(--rose);
 }
 
 .copyCardUrl {

--- a/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
@@ -54,9 +54,35 @@ vi.mock('@/audio/audio-context', () => ({
 import ConnectPage from './ConnectPage'
 import { copyToClipboard } from '@/utils/clipboard'
 import { getAudioContext } from '@/audio/audio-context'
+import { GameProvider, type GameState } from '@/store/game-context'
+import { loadPersistedState, savePersistedState } from '@/store/persistence'
 
 /** The exact AI-readiness sync prompt copy rendered on step 2. */
 const SYNC_PROMPT = '等 AI 说完「好了」，点「进入游戏」就开始，计时随即启动。'
+
+const STALE_RESULT_STATE: GameState = {
+  status: 'RESULT',
+  mode: 'daily',
+  manual: null,
+  manualUrl: 'https://claw.amio.fans/manual/2026-05-22',
+  sceneInfo: { sceneTongueTwister: '四是四十是十', batteryCount: 2, indicators: [] },
+  moduleSequence: ['wire', 'dial', 'button', 'keypad'],
+  moduleConfigs: [null, null, null, null],
+  moduleAnswers: [null, null, null, null],
+  currentModuleIndex: 4,
+  moduleStats: [{ moduleType: 'wire', timeMs: 1000, errorCount: 0 }],
+  totalStartTime: 1_700_000_000_000,
+  totalEndTime: 1_700_000_001_000,
+  currentModuleStartTime: null,
+  currentModuleErrorCount: 0,
+  strikeCount: 0,
+  timeBudgetMs: 3_600_000,
+  outcome: 'defused',
+  errorMessage: null,
+  errorKind: null,
+  attemptNumber: 2,
+  rngSeed: 123,
+}
 
 /* Renders the current location so the run-handoff target is assertable
    without mounting the real GamePage. */
@@ -69,7 +95,14 @@ function renderConnect(mode: 'daily' | 'practice') {
   return render(
     <MemoryRouter initialEntries={[`/bombsquad/connect?mode=${mode}`]}>
       <Routes>
-        <Route path="/bombsquad/connect" element={<ConnectPage />} />
+        <Route
+          path="/bombsquad/connect"
+          element={
+            <GameProvider>
+              <ConnectPage />
+            </GameProvider>
+          }
+        />
         <Route path="/bombsquad/run" element={<LocationProbe />} />
       </Routes>
     </MemoryRouter>
@@ -89,6 +122,7 @@ async function copyAndReachStep2() {
 
 describe('ConnectPage', () => {
   beforeEach(() => {
+    sessionStorage.clear()
     vi.mocked(copyToClipboard).mockReset()
     vi.mocked(copyToClipboard).mockResolvedValue(true)
     vi.mocked(getAudioContext).mockReset()
@@ -187,7 +221,7 @@ describe('ConnectPage', () => {
     expect(screen.getByText(/上面的链接就是同一份手册/)).toBeInTheDocument()
     expect(screen.getByText(/和复制后粘贴完全一样/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '重试复制' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '重试复制手册链接' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '重试复制手册链接' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /我已手动发给 AI/ }))
 
@@ -225,6 +259,19 @@ describe('ConnectPage', () => {
     // iOS Safari only permits audio to start from inside a user gesture, so the
     // 进入游戏 tap is where the shared AudioContext gets unlocked.
     expect(getAudioContext).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears stale persisted result state before entering a new run', async () => {
+    savePersistedState(STALE_RESULT_STATE)
+    expect(loadPersistedState()?.status).toBe('RESULT')
+
+    renderConnect('practice')
+
+    await copyAndReachStep2()
+    fireEvent.click(screen.getByRole('button', { name: /进入游戏/ }))
+
+    expect(loadPersistedState()).toBeNull()
+    expect(screen.getByTestId('location')).toHaveTextContent('/bombsquad/run?mode=practice')
   })
 
   it('unlocks the AudioContext when 进入游戏 is tapped (practice)', async () => {

--- a/packages/game-bombsquad/src/pages/ConnectPage.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.tsx
@@ -6,6 +6,9 @@ import Button from '@/components/bombsquad/Button'
 import { useDailyChallenge } from '@/hooks/useDailyChallenge'
 import { copyToClipboard } from '@/utils/clipboard'
 import { getAudioContext } from '@/audio/audio-context'
+import { useGame } from '@/store/game-context'
+import { clearPersistedState } from '@/store/persistence'
+import { saveEntryRecoveryState } from '@/utils/session'
 import styles from './ConnectPage.module.css'
 
 type ConnectMode = 'daily' | 'practice'
@@ -21,6 +24,7 @@ type ConnectMode = 'daily' | 'practice'
 export default function ConnectPage() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
+  const { dispatch } = useGame()
   const mode: ConnectMode = searchParams.get('mode') === 'practice' ? 'practice' : 'daily'
   const modeLabel = mode === 'daily' ? '每日挑战' : '练习'
 
@@ -30,6 +34,10 @@ export default function ConnectPage() {
   const [step, setStep] = useState<1 | 2>(1)
   const [copied, setCopied] = useState(false)
   const [copyFailed, setCopyFailed] = useState(false)
+
+  useEffect(() => {
+    saveEntryRecoveryState({ mode, manualUrl, manualHandoffComplete: false })
+  }, [mode, manualUrl])
 
   /* Once the manual link is copied, the card turns green and the flow
      auto-advances to step 2 after ~0.7s. The timer is owned by an effect
@@ -66,6 +74,9 @@ export default function ConnectPage() {
      outside one. getAudioContext() is idempotent; the run calls it again at
      game start as a fallback. */
   const confirmStart = () => {
+    saveEntryRecoveryState({ mode, manualUrl, manualHandoffComplete: true })
+    clearPersistedState()
+    dispatch({ type: 'RESET' })
     getAudioContext()
     if (mode === 'daily') {
       navigate(`/bombsquad/run?mode=daily&url=${encodeURIComponent(dailyUrl)}`)
@@ -165,40 +176,19 @@ export default function ConnectPage() {
             </div>
           </div>
 
-          {/* Step 1 — copy the manual link. The full URL card and the bottom
-              primary CTA share the same copy action: the card keeps the link
-              visible and trustworthy, while the CTA remains the strongest
-              explicit command for players scanning fast. */}
+          {/* Step 1 — copy the manual link. Before a copy failure, the URL card
+              and bottom primary CTA share the same copy action. After failure,
+              the card becomes a stable manual-link fallback while the CTA is
+              the single retry surface. */}
           {step === 1 && (
             <div className={styles.action}>
-              <button
-                type="button"
-                className={`${styles.urlPreview} ${copied ? styles.urlPreviewDone : ''}`}
-                onClick={handleCopy}
-                aria-label={
-                  copied ? '已复制手册链接' : copyFailed ? '重试复制手册链接' : '复制手册链接'
-                }
-              >
-                <div className={styles.copyCardText}>
-                  <div className={styles.copyCardLabel}>
-                    {copied ? '已复制到剪贴板' : copyFailed ? '复制失败，链接仍可用' : '手册链接'}
+              {copyFailed && !copied ? (
+                <div className={`${styles.urlPreview} ${styles.urlPreviewFailed}`}>
+                  <div className={styles.copyCardText}>
+                    <div className={styles.copyCardLabel}>复制失败，链接仍可用</div>
+                    <div className={styles.copyCardUrl}>{manualUrl}</div>
                   </div>
-                  <div className={styles.copyCardUrl}>{manualUrl}</div>
-                </div>
-                <div className={styles.copyCardIcon} aria-hidden="true">
-                  {copied ? (
-                    <svg
-                      viewBox="0 0 24 24"
-                      width="20"
-                      height="20"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                    >
-                      <path d="M5 12 L10 17 L19 7" />
-                    </svg>
-                  ) : (
+                  <div className={styles.copyCardIcon} aria-hidden="true">
                     <svg
                       viewBox="0 0 24 24"
                       width="20"
@@ -211,9 +201,51 @@ export default function ConnectPage() {
                       <rect x="8" y="8" width="12" height="12" rx="2" />
                       <path d="M16 8 V5 a2 2 0 0 0 -2 -2 H6 a2 2 0 0 0 -2 2 v9 a2 2 0 0 0 2 2 h3" />
                     </svg>
-                  )}
+                  </div>
                 </div>
-              </button>
+              ) : (
+                <button
+                  type="button"
+                  className={`${styles.urlPreview} ${copied ? styles.urlPreviewDone : ''}`}
+                  onClick={handleCopy}
+                  aria-label={copied ? '已复制手册链接' : '复制手册链接'}
+                >
+                  <div className={styles.copyCardText}>
+                    <div className={styles.copyCardLabel}>
+                      {copied ? '已复制到剪贴板' : '手册链接'}
+                    </div>
+                    <div className={styles.copyCardUrl}>{manualUrl}</div>
+                  </div>
+                  <div className={styles.copyCardIcon} aria-hidden="true">
+                    {copied ? (
+                      <svg
+                        viewBox="0 0 24 24"
+                        width="20"
+                        height="20"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.8"
+                        strokeLinecap="round"
+                      >
+                        <path d="M5 12 L10 17 L19 7" />
+                      </svg>
+                    ) : (
+                      <svg
+                        viewBox="0 0 24 24"
+                        width="20"
+                        height="20"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                      >
+                        <rect x="8" y="8" width="12" height="12" rx="2" />
+                        <path d="M16 8 V5 a2 2 0 0 0 -2 -2 H6 a2 2 0 0 0 -2 2 v9 a2 2 0 0 0 2 2 h3" />
+                      </svg>
+                    )}
+                  </div>
+                </button>
+              )}
 
               <p className={styles.hint}>
                 {copyFailed

--- a/packages/game-bombsquad/src/pages/GamePage.attempt.test.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.attempt.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('@/utils/event-log', () => ({ logEvent: vi.fn() }))
+vi.mock('@/audio/audio-context', () => ({
+  getAudioContext: vi.fn().mockReturnValue(null),
+  isSfxSuppressed: vi.fn().mockReturnValue(false),
+  setMasterMuted: vi.fn(),
+  setSfxSuppressed: vi.fn(),
+}))
+vi.mock('@/voice/VoicePanel', () => ({ default: () => null }))
+
+const {
+  loadManualMock,
+  generateWireMock,
+  generateDialMock,
+  generateButtonMock,
+  generateKeypadMock,
+} = vi.hoisted(() => ({
+  loadManualMock: vi.fn(),
+  generateWireMock: vi.fn(() => ({ config: {}, answer: {} })),
+  generateDialMock: vi.fn(() => ({ config: {}, answer: {} })),
+  generateButtonMock: vi.fn(() => ({ config: {}, answer: {} })),
+  generateKeypadMock: vi.fn(() => ({ config: {}, answer: {} })),
+}))
+
+vi.mock('@/utils/yaml-loader', async (importOriginal) => {
+  const real = await importOriginal<typeof import('@/utils/yaml-loader')>()
+  return {
+    ...real,
+    loadManual: loadManualMock,
+  }
+})
+
+vi.mock('@/modules/wire/generator', () => ({ generateWire: generateWireMock }))
+vi.mock('@/modules/dial/generator', () => ({ generateDial: generateDialMock }))
+vi.mock('@/modules/button/generator', () => ({ generateButton: generateButtonMock }))
+vi.mock('@/modules/keypad/generator', () => ({ generateKeypad: generateKeypadMock }))
+
+vi.mock('@/modules/wire/WireModule', () => ({ default: () => <div data-testid="wire-module" /> }))
+vi.mock('@/modules/dial/DialModule', () => ({ default: () => <div data-testid="dial-module" /> }))
+vi.mock('@/modules/button/ButtonModule', () => ({
+  default: () => <div data-testid="button-module" />,
+}))
+vi.mock('@/modules/keypad/KeypadModule', () => ({
+  default: () => <div data-testid="keypad-module" />,
+}))
+
+import GamePage from './GamePage'
+import { GameProvider } from '@/store/game-context'
+import { getDailyAttemptKey } from '@/utils/session'
+
+const MINIMAL_MANUAL = {
+  modules: {
+    wire_routing: { rules: [] },
+    symbol_dial: { columns: [] },
+    button: { rules: [] },
+    keypad: { sequences: [] },
+  },
+}
+
+function renderDailyRun() {
+  return render(
+    <MemoryRouter initialEntries={['/bombsquad/run?mode=daily']}>
+      <GameProvider>
+        <GamePage />
+      </GameProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('GamePage daily attempt persistence', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    loadManualMock.mockReset()
+    generateWireMock.mockClear()
+    generateDialMock.mockClear()
+    generateButtonMock.mockClear()
+    generateKeypadMock.mockClear()
+  })
+
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('does not persist a daily attempt when manual loading fails before the first module', async () => {
+    loadManualMock.mockRejectedValueOnce(new Error('offline'))
+
+    renderDailyRun()
+
+    await waitFor(() => {
+      expect(screen.getByText(/加载失败/)).toBeInTheDocument()
+    })
+
+    expect(sessionStorage.getItem(getDailyAttemptKey())).toBeNull()
+  })
+
+  it('persists the previewed daily attempt only once the run reaches the first module', async () => {
+    loadManualMock.mockResolvedValueOnce(MINIMAL_MANUAL as never)
+
+    renderDailyRun()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wire-module')).toBeInTheDocument()
+    })
+
+    expect(sessionStorage.getItem(getDailyAttemptKey())).toBe('1')
+  })
+})

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -33,7 +33,7 @@ import ButtonModule from '@/modules/button/ButtonModule'
 import KeypadModule from '@/modules/keypad/KeypadModule'
 import practiceYamlRaw from '../../../manual/data/practice.yaml?raw'
 import { generateSceneInfo } from '@/engine/scene-info'
-import { getAttemptNumberForMode, getRunSeed } from '@/utils/session'
+import { commitAttemptNumberForMode, getAttemptNumberForMode, getRunSeed } from '@/utils/session'
 import { getAudioContext, setSfxSuppressed } from '@/audio/audio-context'
 import VoicePanel, { type VoicePanelHandle } from '@/voice/VoicePanel'
 import { deriveVoicePanelInputs, isPlatformVoicePartner } from '@/voice/voice-panel-inputs'
@@ -216,6 +216,7 @@ export default function GamePage() {
   // Guard: the closing recap fires exactly once per RESULT entry — even if the
   // effect re-runs (StrictMode double-invoke, unlikely state oscillation).
   const closingFiredRef = useRef(false)
+  const resultNavigationArmedRef = useRef(state.status !== 'RESULT')
 
   // Voice-session inputs for the current module, recomputed only when the loaded
   // manual or the current module changes (NOT on every timer-frame re-render).
@@ -285,6 +286,12 @@ export default function GamePage() {
   useEffect(() => {
     if (showSceneNudge) markSceneNudgeSeen()
   }, [showSceneNudge])
+
+  useEffect(() => {
+    if (state.status !== 'RESULT') {
+      resultNavigationArmedRef.current = true
+    }
+  }, [state.status])
 
   // Consume the one-shot refresh flag from a commit-phase effect rather than
   // from inside `detectRefresh`. This keeps the detector pure so StrictMode's
@@ -457,8 +464,9 @@ export default function GamePage() {
   useEffect(() => {
     if (state.status !== 'READY') return
     getAudioContext()
+    commitAttemptNumberForMode(state.mode, state.attemptNumber)
     dispatch({ type: 'START_GAME' })
-  }, [state.status, dispatch])
+  }, [state.status, state.mode, state.attemptNumber, dispatch])
 
   // Navigate to result when ALL_COMPLETE transitions to RESULT
   useEffect(() => {
@@ -469,6 +477,7 @@ export default function GamePage() {
 
   useEffect(() => {
     if (state.status !== 'RESULT') return
+    if (!resultNavigationArmedRef.current) return
 
     // Closing recap only for a successful daily defuse with the voice partner
     // active. All other outcomes (loss, timeout, practice) navigate immediately.

--- a/packages/game-bombsquad/src/pages/ResultPage.recovery.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.recovery.test.tsx
@@ -4,18 +4,14 @@
  * When the result page is opened with no live run in memory (a direct link to
  * /bombsquad/result, a refresh that cleared the run context, or an odd
  * back-navigation), the `noRunData` branch used to render a broken-sounding
- * no-data message. It now renders an explicit restart surface that sends daily
- * players back through the manual handoff before the run starts.
+ * no-data message. It now renders an explicit restart surface keyed to the last
+ * selected entry mode when available.
  *
- * These tests assert the three recovery actions are present with the correct
- * destinations, and that clicking the primary CTA navigates to the daily
- * connect funnel. Setup mirrors the other ResultPage tests but leaves
- * sessionStorage empty so `GameProvider` hydrates to INITIAL_STATE
- * (moduleStats: [], outcome: null), which is exactly the `noRunData` case.
- *
- * Also includes the GamePage manual-URL regression guard (Optional ①): a daily
- * run launched with NO `url` query param must derive the manual URL from the
- * UTC current date, not crash or fall back to a stale hostname.
+ * These tests assert the default recovery actions, the completed daily handoff
+ * direct-run path, and the practice-specific recovery copy. Setup mirrors the
+ * other ResultPage tests but leaves sessionStorage without a game-state seed so
+ * `GameProvider` hydrates to INITIAL_STATE (moduleStats: [], outcome: null),
+ * which is exactly the `noRunData` case.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
@@ -44,6 +40,7 @@ vi.mock('@/utils/nickname', () => ({
 
 import ResultPage from './ResultPage'
 import { GameProvider } from '@/store/game-context'
+import { saveEntryRecoveryState } from '@/utils/session'
 
 // Renders the current pathname + search so navigation destinations can be
 // asserted after a CTA click.
@@ -130,5 +127,41 @@ describe('ResultPage no-run-data recovery', () => {
     fireEvent.click(screen.getByRole('button', { name: /先交手册，再开始每日挑战/ }))
 
     expect(screen.getByTestId('location')).not.toHaveTextContent('/bombsquad/run')
+  })
+
+  it('daily recovery after manual handoff goes straight back to the daily run', () => {
+    const manualUrl = 'https://claw.amio.fans/manual/2026-07-01'
+    saveEntryRecoveryState({
+      mode: 'daily',
+      manualUrl,
+      manualHandoffComplete: true,
+    })
+    renderRecovery()
+
+    expect(screen.getByRole('heading', { name: '重新进入每日挑战' })).toBeInTheDocument()
+    expect(screen.getByText(/手册对接已经完成/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /直接进入每日挑战/ }))
+
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      `/bombsquad/run?mode=daily&url=${encodeURIComponent(manualUrl)}`
+    )
+  })
+
+  it('practice recovery uses practice-specific copy and never points to daily challenge', () => {
+    saveEntryRecoveryState({
+      mode: 'practice',
+      manualUrl: 'https://claw.amio.fans/manual/practice',
+      manualHandoffComplete: true,
+    })
+    renderRecovery()
+
+    expect(screen.getByRole('heading', { name: '重新进入练习' })).toBeInTheDocument()
+    expect(screen.getByText(/练习关卡/)).toBeInTheDocument()
+    expect(screen.queryByText(/每日挑战/)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /直接进入练习/ }))
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/bombsquad/run?mode=practice')
   })
 })

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -17,6 +17,7 @@ import {
   type LeaderboardPlayerMetadata,
 } from '@/utils/leaderboard-player-metadata'
 import { hasAnsweredSurvey, markSurveyAnswered } from '@/utils/survey'
+import { readEntryRecoveryState } from '@/utils/session'
 import { playSfx } from '@/audio/useSfx'
 import type { ScoreSubmission, ScoreSubmissionResponse } from '@shared/leaderboard-types'
 import styles from './ResultPage.module.css'
@@ -83,6 +84,7 @@ export default function ResultPage() {
   // the failure copy can be honest. `null` while no failure is showing.
   const [submitFailKind, setSubmitFailKind] = useState<'network' | 'rejected' | null>(null)
   const [submitFailMessage, setSubmitFailMessage] = useState<string | null>(null)
+  const [entryRecovery] = useState(() => readEntryRecoveryState())
 
   // Fall back to `defused` for any legacy RESULT state persisted before the
   // game-modes rework added the `outcome` field.
@@ -382,36 +384,71 @@ export default function ResultPage() {
   // modules (an exploded run, which still carries an `outcome`). Reached when
   // the result page is opened with no live run: a direct link to
   // /bombsquad/result, a refresh that cleared the run context, or an odd
-  // back-navigation. Instead of a dead "返回主页" link, offer the same three
-  // entry points the landing page funnels through, so the player is never
-  // pushed out of the game. Daily is the primary CTA; both connect entries go
-  // through /bombsquad/connect (not a deep link into /bombsquad/run) so the
-  // copy-manual handoff still runs.
+  // back-navigation. Recover from the last selected entry mode when available.
+  // If the player already completed the connect-page handoff, the primary CTA
+  // returns directly to the matching run; otherwise it goes back through the
+  // connect flow and explains why the manual step is still required.
   if (noRunData) {
+    const recoveryMode = entryRecovery?.mode ?? 'daily'
+    const manualHandoffComplete = entryRecovery?.manualHandoffComplete === true
+    const recoveryRunTarget =
+      recoveryMode === 'daily'
+        ? `/bombsquad/run?mode=daily${
+            entryRecovery?.manualUrl ? `&url=${encodeURIComponent(entryRecovery.manualUrl)}` : ''
+          }`
+        : '/bombsquad/run?mode=practice'
+    const recoveryConnectTarget = `/bombsquad/connect?mode=${recoveryMode}`
+    const recoveryTitle =
+      recoveryMode === 'practice'
+        ? '重新进入练习'
+        : manualHandoffComplete
+          ? '重新进入每日挑战'
+          : '重新开始一局'
+    const recoveryText =
+      recoveryMode === 'practice'
+        ? manualHandoffComplete
+          ? '这里没有正在结算的练习关卡。手册对接已经完成，可以直接重新进入练习。'
+          : '这里没有正在结算的练习关卡。先把练习手册交给 AI，等它读完，再进入练习。'
+        : manualHandoffComplete
+          ? '手册对接已经完成，但这一局还没真正开始。可以直接重新进入每日挑战；如果 AI 没读完，再回到对接页。'
+          : '这里没有正在结算的关卡。先把手册交给 AI，等它读完，再进入每日挑战。'
+    const primaryLabel =
+      recoveryMode === 'practice'
+        ? manualHandoffComplete
+          ? '直接进入练习'
+          : '先交练习手册，再开始'
+        : manualHandoffComplete
+          ? '直接进入每日挑战'
+          : '先交手册，再开始每日挑战'
+    const secondaryAction = manualHandoffComplete
+      ? { label: '重新对接手册', target: recoveryConnectTarget }
+      : recoveryMode === 'daily'
+        ? { label: '练习一局', target: '/bombsquad/connect?mode=practice' }
+        : null
+
     return (
       <main className={styles.page}>
         <Scenery accent="yellow" />
         <div className={styles.stage}>
           <div className={styles.noData}>
-            <h1 className={styles.noDataTitle}>重新开始一局</h1>
-            <p className={styles.noDataText}>
-              这里没有正在结算的关卡。先把手册交给 AI，等它读完，再进入每日挑战。
-            </p>
+            <h1 className={styles.noDataTitle}>{recoveryTitle}</h1>
+            <p className={styles.noDataText}>{recoveryText}</p>
             <div className={styles.cta}>
               <Button
                 variant="primary"
                 full
-                onClick={() => navigate('/bombsquad/connect?mode=daily')}
+                onClick={() =>
+                  navigate(manualHandoffComplete ? recoveryRunTarget : recoveryConnectTarget)
+                }
               >
-                先交手册，再开始每日挑战<span aria-hidden="true"> →</span>
+                {primaryLabel}
+                <span aria-hidden="true"> →</span>
               </Button>
-              <Button
-                variant="ghost"
-                full
-                onClick={() => navigate('/bombsquad/connect?mode=practice')}
-              >
-                练习一局
-              </Button>
+              {secondaryAction && (
+                <Button variant="ghost" full onClick={() => navigate(secondaryAction.target)}>
+                  {secondaryAction.label}
+                </Button>
+              )}
               <Button variant="ghost" full onClick={() => navigate('/bombsquad')}>
                 返回主页
               </Button>

--- a/packages/game-bombsquad/src/utils/session.test.ts
+++ b/packages/game-bombsquad/src/utils/session.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
   PRACTICE_SEED,
+  commitAttemptNumberForMode,
+  commitDailyAttemptNumber,
   getAttemptNumberForMode,
   getRunSeed,
+  readEntryRecoveryState,
   readDailyAttemptCount,
   reserveDailyAttempt,
+  saveEntryRecoveryState,
 } from './session'
 
 function createStorageStub(initialEntries: Record<string, string> = {}) {
@@ -33,9 +37,60 @@ describe('session utilities', () => {
     expect(readDailyAttemptCount(storage, '2026-03-27')).toBe(2)
   })
 
-  it('returns mode-specific attempt numbers', () => {
+  it('returns mode-specific preview attempt numbers without reserving daily storage', () => {
     const storage = createStorageStub({ 'attempt-2026-03-27': '3' })
     expect(getAttemptNumberForMode('practice', storage, '2026-03-27')).toBe(1)
     expect(getAttemptNumberForMode('daily', storage, '2026-03-27')).toBe(4)
+    expect(readDailyAttemptCount(storage, '2026-03-27')).toBe(3)
+  })
+
+  it('commits a previewed daily attempt idempotently when a run starts', () => {
+    const storage = createStorageStub({ 'attempt-2026-03-27': '3' })
+    const previewAttempt = getAttemptNumberForMode('daily', storage, '2026-03-27')
+    expect(previewAttempt).toBe(4)
+
+    expect(commitDailyAttemptNumber(previewAttempt, storage, '2026-03-27')).toBe(4)
+    expect(readDailyAttemptCount(storage, '2026-03-27')).toBe(4)
+
+    expect(commitDailyAttemptNumber(previewAttempt, storage, '2026-03-27')).toBe(4)
+    expect(readDailyAttemptCount(storage, '2026-03-27')).toBe(4)
+  })
+
+  it('commits attempts by mode', () => {
+    const storage = createStorageStub()
+    expect(commitAttemptNumberForMode('practice', 9, storage, '2026-03-27')).toBe(1)
+    expect(readDailyAttemptCount(storage, '2026-03-27')).toBe(0)
+
+    expect(commitAttemptNumberForMode('daily', 1, storage, '2026-03-27')).toBe(1)
+    expect(readDailyAttemptCount(storage, '2026-03-27')).toBe(1)
+  })
+
+  it('round-trips the entry recovery state', () => {
+    const storage = createStorageStub()
+    saveEntryRecoveryState(
+      {
+        mode: 'practice',
+        manualUrl: 'https://claw.amio.fans/manual/practice',
+        manualHandoffComplete: true,
+      },
+      storage
+    )
+
+    expect(readEntryRecoveryState(storage)).toEqual({
+      mode: 'practice',
+      manualUrl: 'https://claw.amio.fans/manual/practice',
+      manualHandoffComplete: true,
+    })
+  })
+
+  it('ignores invalid entry recovery state', () => {
+    const storage = createStorageStub({
+      'bombsquad:entry-recovery': JSON.stringify({
+        mode: 'weekly',
+        manualUrl: 'https://claw.amio.fans/manual/practice',
+      }),
+    })
+
+    expect(readEntryRecoveryState(storage)).toBeNull()
   })
 })

--- a/packages/game-bombsquad/src/utils/session.ts
+++ b/packages/game-bombsquad/src/utils/session.ts
@@ -3,6 +3,13 @@ import { getTodayString } from '@shared/date'
 export type SessionMode = 'practice' | 'daily'
 
 export const PRACTICE_SEED = 42
+const ENTRY_RECOVERY_KEY = 'bombsquad:entry-recovery'
+
+export interface EntryRecoveryState {
+  mode: SessionMode
+  manualUrl: string
+  manualHandoffComplete: boolean
+}
 
 export function getRunSeed(mode: SessionMode, now = Date.now()): number {
   return mode === 'practice' ? PRACTICE_SEED : now
@@ -30,10 +37,64 @@ export function reserveDailyAttempt(
   return nextAttempt
 }
 
-export function getAttemptNumberForMode(
-  mode: SessionMode,
+export function previewDailyAttemptNumber(
+  storage: Pick<Storage, 'getItem'> = sessionStorage,
+  date = getTodayString()
+): number {
+  return readDailyAttemptCount(storage, date) + 1
+}
+
+export function commitDailyAttemptNumber(
+  attemptNumber: number,
   storage: Pick<Storage, 'getItem' | 'setItem'> = sessionStorage,
   date = getTodayString()
 ): number {
-  return mode === 'daily' ? reserveDailyAttempt(storage, date) : 1
+  const safeAttemptNumber = Number.isFinite(attemptNumber) && attemptNumber > 0 ? attemptNumber : 1
+  const currentAttemptCount = readDailyAttemptCount(storage, date)
+  const committedAttempt = Math.max(currentAttemptCount, safeAttemptNumber)
+  storage.setItem(getDailyAttemptKey(date), String(committedAttempt))
+  return committedAttempt
+}
+
+export function getAttemptNumberForMode(
+  mode: SessionMode,
+  storage: Pick<Storage, 'getItem'> = sessionStorage,
+  date = getTodayString()
+): number {
+  return mode === 'daily' ? previewDailyAttemptNumber(storage, date) : 1
+}
+
+export function commitAttemptNumberForMode(
+  mode: SessionMode,
+  attemptNumber: number,
+  storage: Pick<Storage, 'getItem' | 'setItem'> = sessionStorage,
+  date = getTodayString()
+): number {
+  return mode === 'daily' ? commitDailyAttemptNumber(attemptNumber, storage, date) : 1
+}
+
+export function saveEntryRecoveryState(
+  state: EntryRecoveryState,
+  storage: Pick<Storage, 'setItem'> = sessionStorage
+): void {
+  storage.setItem(ENTRY_RECOVERY_KEY, JSON.stringify(state))
+}
+
+export function readEntryRecoveryState(
+  storage: Pick<Storage, 'getItem'> = sessionStorage
+): EntryRecoveryState | null {
+  const raw = storage.getItem(ENTRY_RECOVERY_KEY)
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Partial<EntryRecoveryState>
+    if (parsed.mode !== 'daily' && parsed.mode !== 'practice') return null
+    if (typeof parsed.manualUrl !== 'string') return null
+    return {
+      mode: parsed.mode,
+      manualUrl: parsed.manualUrl,
+      manualHandoffComplete: parsed.manualHandoffComplete === true,
+    }
+  } catch {
+    return null
+  }
 }


### PR DESCRIPTION
## Summary

- Preserve BombSquad no-run recovery state so practice recovery stays in practice and completed daily handoff can resume the daily run.
- Delay daily attempt commitment until the run starts, preventing pre-module recovery from appearing as a consumed attempt.
- Consolidate copy-failure retry UI and make the button preview light subordinate to the active release strip without target-color leakage.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Local checks:

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm build`
- `pnpm test:regression`
- `pnpm e2e:audit`
- `pnpm e2e:build-answers`
- `git diff --exit-code e2e/fixtures/answers.json`
- `pnpm test:e2e`

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

## Claude Code attribution

- Implemented by OpenAI Codex in Codex Desktop; no Claude Code runtime was used.