### PR TITLE
feat(platform): close login session UI loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Sign out, and a login page that knows you're already in** - New. Signed-in
+players now have a 退出登录 action on their 我的 account page, and opening the
+login page while already signed in shows your email with two clear next steps —
+continue into the platform, or sign out — instead of the bare sign-in form.
+Signing out returns the whole site to the anonymous state.
+
 **AMIO Arcade brand rename** — The active product surfaces now use AMIO Arcade /
 AMIO 游乐场 instead of AmiClaw, including the shared wordmark, page titles,
 homepage copy, legal pages, auth emails, README, and canonical docs. Existing

--- a/packages/platform/src/hooks/useAuth.ts
+++ b/packages/platform/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { AuthIdentity, SessionResponse } from '@shared/auth-types'
 import { API_BASE } from '@shared/api-base'
 
@@ -30,6 +30,16 @@ export type AuthState =
   | { status: 'loading'; user: null }
   | { status: 'authed'; user: DisplayUser }
   | { status: 'anon'; user: null }
+
+/**
+ * What `useAuth` returns: the read-only session state plus `logout`. `logout`
+ * is stable across renders (`status`/`user` still narrow as before), so every
+ * consumer can destructure it without breaking the existing state branches.
+ */
+export type UseAuthResult = AuthState & {
+  /** Revoke the session server-side, then return the whole UI to anonymous. */
+  logout: () => Promise<void>
+}
 
 function deriveDisplayUser(identity: AuthIdentity): DisplayUser {
   const localPart = identity.email.split('@')[0] ?? identity.email
@@ -63,9 +73,27 @@ function devBypassState(): AuthState | undefined {
  * always legal), so any non-`authenticated` response — including a network
  * failure — resolves to `anon`, never an error UI.
  */
-export function useAuth(): AuthState {
+export function useAuth(): UseAuthResult {
   const bypass = devBypassState()
   const [state, setState] = useState<AuthState>(bypass ?? { status: 'loading', user: null })
+
+  /**
+   * Log out: POST `/api/auth/logout` (idempotent — always clears the cookie),
+   * then hard-navigate home. There is no shared auth store — TopNav, the
+   * account page and each `useAuth` caller hold their own copy of the session
+   * state — so a full navigation is the only reliable way to return every
+   * surface to anonymous at once, and it re-reads the now-cleared session on
+   * the fresh load. A failed request still falls through to the navigation; the
+   * session endpoint is the source of truth on the next load.
+   */
+  const logout = useCallback(async () => {
+    try {
+      await fetch(`${API_BASE}/api/auth/logout`, { method: 'POST', credentials: 'include' })
+    } catch {
+      // Network failure — navigate anyway; the reloaded session read decides.
+    }
+    window.location.assign('/')
+  }, [])
 
   useEffect(() => {
     // Dev bypass is resolved synchronously above; skip the network read.
@@ -92,5 +120,5 @@ export function useAuth(): AuthState {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return state
+  return { ...state, logout }
 }

--- a/packages/platform/src/pages/AccountPage.module.css
+++ b/packages/platform/src/pages/AccountPage.module.css
@@ -63,6 +63,12 @@
   word-break: break-all;
 }
 
+/* Sign-out action — a full-width ghost button under the identity. */
+.logout {
+  margin-top: 20px;
+  width: 100%;
+}
+
 /* ----------  right — detail column  ---------- */
 .detail {
   display: flex;

--- a/packages/platform/src/pages/AccountPage.test.tsx
+++ b/packages/platform/src/pages/AccountPage.test.tsx
@@ -159,4 +159,37 @@ describe('AccountPage /me', () => {
     // The voice is represented by name, not fabricated audio playback.
     expect(screen.getByText('暖声')).toBeInTheDocument()
   })
+
+  it('signs out via POST /api/auth/logout and returns to the anonymous state', async () => {
+    const assignSpy = vi.fn()
+    vi.stubGlobal('location', { ...window.location, assign: assignSpy })
+    const fetchSpy = vi.fn((input: RequestInfo | URL) => {
+      const url = urlOf(input)
+      if (url.includes('/api/companion')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'no companion set up' }), { status: 404 })
+        )
+      }
+      if (url.includes('/api/auth/logout')) {
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      }
+      return Promise.resolve(new Response(JSON.stringify(AUTHED), { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+    renderAccount('/me')
+
+    // The sign-out action lives on the signed-in profile card.
+    fireEvent.click(await screen.findByRole('button', { name: '退出登录' }))
+
+    // The whole UI is reset to anonymous via a hard navigation home, and the
+    // sign-out POST hit /api/auth/logout.
+    await vi.waitFor(() => expect(assignSpy).toHaveBeenCalledWith('/'))
+    const logoutCall = fetchSpy.mock.calls.find(([input]) =>
+      urlOf(input as RequestInfo | URL).includes('/api/auth/logout')
+    )
+    expect(logoutCall).toBeDefined()
+    const [, init] = logoutCall as unknown as [string, RequestInit]
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('include')
+  })
 })

--- a/packages/platform/src/pages/AccountPage.tsx
+++ b/packages/platform/src/pages/AccountPage.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { ConicAvatar, EyebrowTag, GlassCard } from '@amiclaw/ui'
+import { Button, ConicAvatar, EyebrowTag, GlassCard } from '@amiclaw/ui'
 import { useAuth, type DisplayUser } from '@/hooks/useAuth'
 import CompanionCard from '@/components/companion/CompanionCard'
 import { companionSeedEnabled } from '@/lib/companion-seed'
@@ -13,7 +13,7 @@ import styles from './AccountPage.module.css'
 
    Platform chrome — every accent is brand yellow; no BombSquad cyan here. */
 export default function AccountPage() {
-  const { status, user } = useAuth()
+  const { status, user, logout } = useAuth()
   // The dev seed lets a Cloudflare preview feel the companion surfaces without a
   // live session; treat it as enough to show the companion entry here too.
   const seeded = companionSeedEnabled()
@@ -22,7 +22,7 @@ export default function AccountPage() {
     <div className={styles.page}>
       <EyebrowTag variant="section">我的 · ACCOUNT</EyebrowTag>
       {status === 'loading' && !seeded ? null : status === 'authed' && user ? (
-        <SignedInProfile user={user} />
+        <SignedInProfile user={user} onLogout={logout} />
       ) : seeded ? (
         <SeededCompanionPreview />
       ) : (
@@ -55,7 +55,7 @@ function SeededCompanionPreview() {
    fake-data problem PR #133 fixed for the signed-out state. So the detail
    column is an honest empty state — "还没有成绩，去玩一局" with a play CTA —
    not mock numbers and not a「即将推出」placeholder. */
-function SignedInProfile({ user }: { user: DisplayUser }) {
+function SignedInProfile({ user, onLogout }: { user: DisplayUser; onLogout: () => void }) {
   return (
     <>
       <h2 className={styles.title}>
@@ -70,6 +70,9 @@ function SignedInProfile({ user }: { user: DisplayUser }) {
           </div>
           <div className={styles.name}>{user.displayName}</div>
           <div className={styles.rank}>{user.email}</div>
+          <Button variant="ghost" size="sm" className={styles.logout} onClick={onLogout}>
+            退出登录
+          </Button>
         </GlassCard>
 
         <div className={styles.detail}>

--- a/packages/platform/src/pages/LoginPage.module.css
+++ b/packages/platform/src/pages/LoginPage.module.css
@@ -86,6 +86,29 @@
   text-align: center;
 }
 
+/* ----------  signed-in notice (an authenticated visitor on /login)  ---------- */
+.identityLabel {
+  margin: 0;
+  font: 500 12px var(--font-body);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.identityEmail {
+  margin: 8px 0 0;
+  font: 400 18px var(--font-body);
+  color: var(--text-1);
+  word-break: break-all;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 24px;
+}
+
 /* "或" divider between the email form and the Google button. */
 .divider {
   display: flex;

--- a/packages/platform/src/pages/LoginPage.test.tsx
+++ b/packages/platform/src/pages/LoginPage.test.tsx
@@ -13,11 +13,36 @@
  *      of whether the email is known (the page never reveals which addresses can
  *      sign in).
  *   3. a network failure surfaces a retry message, not the confirmation.
+ *   4. an already-authenticated visitor sees their identity and the continue /
+ *      sign-out actions instead of the bare form; signing out POSTs
+ *      /api/auth/logout and returns the site to the anonymous state.
  */
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import type { SessionResponse } from '@shared/auth-types'
 import LoginPage from './LoginPage'
+
+/** Resolve any fetch input to its URL string. */
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.toString()
+  return (input as Request).url
+}
+
+const ANON: SessionResponse = { authenticated: false, identity: null }
+const AUTHED: SessionResponse = {
+  authenticated: true,
+  identity: { user_id: 'u_1', email: 'nova@amio.fans' },
+}
+
+/** Stub GET /api/auth/session (read by useAuth on mount) with a given body. */
+function stubSession(session: SessionResponse) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(new Response(JSON.stringify(session), { status: 200 })))
+  )
+}
 
 function renderLogin() {
   return render(
@@ -28,6 +53,12 @@ function renderLogin() {
 }
 
 describe('LoginPage /login', () => {
+  beforeEach(() => {
+    // useAuth reads GET /api/auth/session on mount. Default to anonymous so the
+    // sign-in form renders; tests needing a session or POST override this stub.
+    stubSession(ANON)
+  })
+
   afterEach(() => {
     vi.unstubAllGlobals()
   })
@@ -74,9 +105,16 @@ describe('LoginPage /login', () => {
   })
 
   it('shows the unified confirmation after submitting an email', async () => {
-    const fetchSpy = vi.fn(() =>
-      Promise.resolve(new Response(JSON.stringify({ ok: true, message: 'x' }), { status: 200 }))
-    )
+    // useAuth reads the session (anonymous here); the form submit POSTs the
+    // magic-link request. One URL-aware spy answers both.
+    const fetchSpy = vi.fn((input: RequestInfo | URL) => {
+      if (urlOf(input).includes('/api/auth/session')) {
+        return Promise.resolve(new Response(JSON.stringify(ANON), { status: 200 }))
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: true, message: 'x' }), { status: 200 })
+      )
+    })
     vi.stubGlobal('fetch', fetchSpy)
     renderLogin()
 
@@ -84,10 +122,12 @@ describe('LoginPage /login', () => {
     fireEvent.click(screen.getByRole('button', { name: '发送登录链接' }))
 
     expect(await screen.findByText('如果该邮箱可用，你会收到一封登录邮件。')).toBeInTheDocument()
-    // The POST hit the magic-link request endpoint with the typed email.
-    expect(fetchSpy).toHaveBeenCalledTimes(1)
-    const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit]
-    expect(url).toContain('/api/auth/magic-link/request')
+    // The POST hit the magic-link request endpoint exactly once, with the email.
+    const magicCalls = fetchSpy.mock.calls.filter(([input]) =>
+      urlOf(input as RequestInfo | URL).includes('/api/auth/magic-link/request')
+    )
+    expect(magicCalls).toHaveLength(1)
+    const [, init] = magicCalls[0] as unknown as [string, RequestInit]
     expect(JSON.parse(init.body as string)).toEqual({ email: 'nova@amio.fans' })
   })
 
@@ -104,5 +144,44 @@ describe('LoginPage /login', () => {
     expect(await screen.findByText('发送失败，请检查网络后重试。')).toBeInTheDocument()
     // The unified confirmation must NOT appear on a true network failure.
     expect(screen.queryByText('如果该邮箱可用，你会收到一封登录邮件。')).not.toBeInTheDocument()
+  })
+
+  it('shows the signed-in identity and continue / sign-out actions, not the form', async () => {
+    stubSession(AUTHED)
+    renderLogin()
+
+    // Identity: the session email, with continue + sign-out actions.
+    expect(await screen.findByText('nova@amio.fans')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '继续' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '退出登录' })).toBeInTheDocument()
+    // The bare sign-in form must NOT render for an already-authenticated visitor.
+    expect(screen.queryByLabelText('邮箱')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '发送登录链接' })).not.toBeInTheDocument()
+  })
+
+  it('signs out via POST /api/auth/logout and returns to the anonymous state', async () => {
+    const assignSpy = vi.fn()
+    vi.stubGlobal('location', { ...window.location, assign: assignSpy })
+    const fetchSpy = vi.fn((input: RequestInfo | URL) => {
+      if (urlOf(input).includes('/api/auth/logout')) {
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      }
+      return Promise.resolve(new Response(JSON.stringify(AUTHED), { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+    renderLogin()
+
+    fireEvent.click(await screen.findByRole('button', { name: '退出登录' }))
+
+    // The sign-out POST hit /api/auth/logout, and the whole UI is reset to
+    // anonymous via a hard navigation home.
+    await vi.waitFor(() => expect(assignSpy).toHaveBeenCalledWith('/'))
+    const logoutCall = fetchSpy.mock.calls.find(([input]) =>
+      urlOf(input as RequestInfo | URL).includes('/api/auth/logout')
+    )
+    expect(logoutCall).toBeDefined()
+    const [, init] = logoutCall as unknown as [string, RequestInit]
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('include')
   })
 })

--- a/packages/platform/src/pages/LoginPage.tsx
+++ b/packages/platform/src/pages/LoginPage.tsx
@@ -1,7 +1,9 @@
 import { useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Button, EyebrowTag, GlassCard } from '@amiclaw/ui'
 import type { MagicLinkRequestBody } from '@shared/auth-types'
 import { API_BASE } from '@shared/api-base'
+import { useAuth, type DisplayUser } from '@/hooks/useAuth'
 import styles from './LoginPage.module.css'
 
 /* Google sign-in start endpoint. A plain navigational link, NOT a fetch: the
@@ -32,6 +34,7 @@ function startWithOwnAI() {
      free anonymous play.
    Platform chrome — brand yellow, dark-only, CSS-only transitions. */
 export default function LoginPage() {
+  const { status, user, logout } = useAuth()
   const [email, setEmail] = useState('')
   const [phase, setPhase] = useState<Phase>('idle')
 
@@ -55,6 +58,13 @@ export default function LoginPage() {
       setPhase('error')
     }
   }
+
+  // An already-authenticated visitor on /login gets their identity and the two
+  // honest next steps, not the bare form. Loading and anonymous both fall
+  // through to the sign-in form: /login is anonymous-by-default, so the form is
+  // shown optimistically rather than holding the page blank while the session
+  // read is in flight.
+  if (status === 'authed' && user) return <AuthedNotice user={user} onLogout={logout} />
 
   return (
     <div className={styles.page}>
@@ -126,6 +136,37 @@ export default function LoginPage() {
           带自己的 AI 直接开始玩
         </button>
       </p>
+    </div>
+  )
+}
+
+/* An already-authenticated visitor who lands on /login should not see the bare
+   sign-in form. Show who they are and the two honest next steps: continue into
+   the platform, or sign out. Same one-card layout and page-load reveal as the
+   sign-in state. */
+function AuthedNotice({ user, onLogout }: { user: DisplayUser; onLogout: () => void }) {
+  const navigate = useNavigate()
+  return (
+    <div className={styles.page}>
+      <div className={styles.head}>
+        <EyebrowTag variant="section">已登录 · SIGNED IN</EyebrowTag>
+        <h2 className={styles.title}>
+          你已<span className={styles.accent}>登录</span>。
+        </h2>
+      </div>
+
+      <GlassCard radius="2xl" className={styles.card}>
+        <p className={styles.identityLabel}>当前登录</p>
+        <p className={styles.identityEmail}>{user.email}</p>
+        <div className={styles.actions}>
+          <Button variant="primary" onClick={() => navigate('/')}>
+            继续
+          </Button>
+          <Button variant="ghost" onClick={onLogout}>
+            退出登录
+          </Button>
+        </div>
+      </GlassCard>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Add a 退出登录 (sign out) affordance on the signed-in AccountPage profile card, wired to POST /api/auth/logout with credentials, then a hard navigation home so every per-page session copy resets to anonymous
- Render a signed-in notice (identity email + 继续 + 退出登录) on /login instead of the bare form when the session resolves to authenticated
- useAuth gains a backward-compatible logout() helper; unit tests cover both new states including POST method and credentials assertions

## Type of change

- [x] New feature

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [ ] Tested manually and documented below

Full recursive test suite green (platform 76, api 168, platform-ai 333, bombsquad 423, manual 71, companion-memory 46, ui 8, yijing 21); typecheck, eslint, prettier, markdownlint clean; full build OK. Logged-in states cannot be play-tested on the Pages preview (session cookie is production-origin), so manual verification happens on production after merge.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MsPPUB6CiTcpbrDXK7t4F