### PR TITLE
feat(bombsquad): join run memory identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② memory: one run now carries one join key** - Change. A daily
+run now gets a stable `gameRunId` when the run starts, and that same id is passed
+to the platform-AI voice session, reused as the leaderboard `run_id`, and written
+as the logged-in companion-memory settlement join key after a successful score
+submission. This lets a voice session summary and the finished run settle into
+one memory event. Anonymous leaderboard submissions still work the same way and
+do not write memory.
+
 **Sign out, and a login page that knows you're already in** - New. Signed-in
 players now have a 退出登录 action on their 我的 account page, and opening the
 login page while already signed in shows your email with two clear next steps —

--- a/functions/api/leaderboard.ts
+++ b/functions/api/leaderboard.ts
@@ -3,6 +3,7 @@ import { handlePostScore } from '../../packages/api/src/handlers/post-score'
 import { applyCorsHeaders, buildCorsHeaders } from '../../packages/api/src/cors'
 import { extractClaimedUserId } from '../../packages/api/src/auth/extract-claim'
 import { guardClaimedUserId } from '../../packages/api/src/auth/guard'
+import type { CompanionDb } from '../../packages/companion-memory/src/db'
 
 interface Env {
   LEADERBOARD: KVNamespace
@@ -11,6 +12,7 @@ interface Env {
   // submissions claim none, so the guard never touches `AUTH` for them and the
   // existing anonymous flow is unaffected even before `AUTH` is provisioned.
   AUTH?: KVNamespace
+  COMPANION_DB?: CompanionDb
 }
 
 interface Context {
@@ -54,7 +56,13 @@ export async function onRequest(context: Context): Promise<Response> {
         )
       }
     }
-    return applyCorsHeaders(await handlePostScore(request, env.LEADERBOARD), corsHeaders)
+    return applyCorsHeaders(
+      await handlePostScore(request, env.LEADERBOARD, {
+        auth: env.AUTH,
+        companionDb: env.COMPANION_DB,
+      }),
+      corsHeaders
+    )
   }
 
   if (request.method === 'GET') {

--- a/packages/api/src/handlers/post-score.test.ts
+++ b/packages/api/src/handlers/post-score.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { LeaderboardEntry, ScoreSubmission } from '../../../../shared/leaderboard-types'
+import { createTestDb } from '../../../companion-memory/src/test-support/sqlite-db'
+import type {
+  CaptureEventRecord,
+  SettlementCaptureInput,
+} from '../../../companion-memory/src/types'
 import { handlePostScore } from './post-score'
 
 const VALID_DEVICE_ID = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee'
@@ -15,6 +20,10 @@ class FakeKV {
 
   async put(key: string, value: string): Promise<void> {
     this.store.set(key, value)
+  }
+
+  asKV(): KVNamespace {
+    return this as unknown as KVNamespace
   }
 }
 
@@ -33,10 +42,10 @@ function submission(overrides: Partial<ScoreSubmission> = {}): ScoreSubmission {
   }
 }
 
-function request(body: unknown): Request {
+function request(body: unknown, headers: Record<string, string> = {}): Request {
   return new Request('https://claw.amio.fans/api/leaderboard', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
     body: JSON.stringify(body),
   })
 }
@@ -102,6 +111,78 @@ describe('handlePostScore — leaderboard AI metadata', () => {
       expect.objectContaining({ rank: 1, nickname: '小明', ai_tool: 'chatgpt' }),
       expect.objectContaining({ rank: 2, nickname: 'Legacy' }),
     ])
+  })
+})
+
+describe('handlePostScore — authenticated settlement capture', () => {
+  it('captures a logged-in score settlement with the same run_id as game_run_id', async () => {
+    const leaderboardKv = new FakeKV()
+    const authKv = new FakeKV()
+    await authKv.put(
+      'session:sess-a',
+      JSON.stringify({
+        user_id: 'user-a',
+        email: 'a@example.com',
+        created_at: '2026-07-04T00:00:00.000Z',
+      })
+    )
+    const db = createTestDb()
+
+    const response = await handlePostScore(
+      request(submission({ run_id: 'run-123' }), { Cookie: 'amiclaw_session=sess-a' }),
+      leaderboardKv.asKV(),
+      {
+        auth: authKv.asKV(),
+        companionDb: db,
+        now: () => '2026-07-04T12:00:00.000Z',
+      }
+    )
+
+    expect(response.status).toBe(200)
+    const row = await db
+      .prepare(
+        `SELECT event_id, user_id, kind, game_id, game_run_id, payload, occurred_at
+         FROM capture_event`
+      )
+      .bind()
+      .first<CaptureEventRecord>()
+    expect(row).toMatchObject({
+      event_id: 'settlement:run-123',
+      user_id: 'user-a',
+      kind: 'settlement',
+      game_id: 'bombsquad',
+      game_run_id: 'run-123',
+      occurred_at: '2026-07-04T12:00:00.000Z',
+    })
+    const payload = JSON.parse(row?.payload ?? '{}') as SettlementCaptureInput
+    expect(payload).toMatchObject({
+      settlementId: 'run-123',
+      userId: 'user-a',
+      gameId: 'bombsquad',
+      gameRunId: 'run-123',
+      outcome: 'win',
+      durationSeconds: 130,
+      occurredAt: '2026-07-04T12:00:00.000Z',
+    })
+  })
+
+  it('keeps anonymous submissions successful and memory-free', async () => {
+    const leaderboardKv = new FakeKV()
+    const authKv = new FakeKV()
+    const db = createTestDb()
+
+    const response = await handlePostScore(
+      request(submission({ run_id: 'run-anon' })),
+      leaderboardKv.asKV(),
+      {
+        auth: authKv.asKV(),
+        companionDb: db,
+      }
+    )
+
+    expect(response.status).toBe(200)
+    const rows = await db.prepare('SELECT event_id FROM capture_event').bind().all()
+    expect(rows.results).toHaveLength(0)
   })
 })
 

--- a/packages/api/src/handlers/post-score.ts
+++ b/packages/api/src/handlers/post-score.ts
@@ -3,11 +3,10 @@ import type {
   LeaderboardEntry,
   ScoreSubmissionResponse,
 } from '../../../../shared/leaderboard-types'
-
-// Internal KV shape: LeaderboardEntry plus the dedup key, which is never
-// exposed through the public GET response (stripped in get-leaderboard.ts).
-type StoredEntry = LeaderboardEntry & { run_id?: string }
 import { computeBestRecord, type BestRecord } from '../../../../shared/personal-best'
+import { captureSettlementEvent } from '../../../companion-memory/src/capture'
+import type { CompanionDb } from '../../../companion-memory/src/db'
+import { readSessionFromRequest } from '../auth/session'
 import {
   MAX_AI_MODEL_LEN,
   MAX_AI_TOOL_LEN,
@@ -16,11 +15,25 @@ import {
   validateSubmission,
 } from '../validation'
 
+// Internal KV shape: LeaderboardEntry plus the dedup key, which is never
+// exposed through the public GET response (stripped in get-leaderboard.ts).
+type StoredEntry = LeaderboardEntry & { run_id?: string }
+
 const RATE_LIMIT_MS = 10_000
 const MAX_ENTRIES = 100
 const KV_TTL_SECONDS = 48 * 60 * 60 // 48 hours
 
-export async function handlePostScore(request: Request, kv: KVNamespace): Promise<Response> {
+export interface PostScoreOptions {
+  auth?: KVNamespace
+  companionDb?: CompanionDb
+  now?: () => string
+}
+
+export async function handlePostScore(
+  request: Request,
+  kv: KVNamespace,
+  options: PostScoreOptions = {}
+): Promise<Response> {
   let body: ScoreSubmission
   try {
     body = (await request.json()) as ScoreSubmission
@@ -96,7 +109,37 @@ export async function handlePostScore(request: Request, kv: KVNamespace): Promis
       ? { personal_best_attempt: bestRecord.attempt_number }
       : {}),
   }
+  await captureAuthenticatedSettlement(request, body, options)
   return jsonResponse(response, 200)
+}
+
+async function captureAuthenticatedSettlement(
+  request: Request,
+  body: ScoreSubmission,
+  options: PostScoreOptions
+): Promise<void> {
+  if (!body.run_id || !options.auth || !options.companionDb) return
+
+  try {
+    const session = await readSessionFromRequest(options.auth, request)
+    if (session === null) return
+    const now = options.now ?? (() => new Date().toISOString())
+    await captureSettlementEvent(
+      options.companionDb,
+      {
+        settlementId: body.run_id,
+        userId: session.user_id,
+        gameId: 'bombsquad',
+        gameRunId: body.run_id,
+        outcome: 'win',
+        durationSeconds: body.time_ms / 1000,
+        occurredAt: now(),
+      },
+      { now, newId: () => crypto.randomUUID() }
+    )
+  } catch {
+    console.warn('score settlement capture failed')
+  }
 }
 
 function jsonResponse(body: unknown, status: number): Response {

--- a/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
@@ -65,6 +65,7 @@ const STALE_RESULT_STATE: GameState = {
   mode: 'daily',
   manual: null,
   manualUrl: 'https://claw.amio.fans/manual/2026-05-22',
+  gameRunId: 'run-stale-result',
   sceneInfo: { sceneTongueTwister: '四是四十是十', batteryCount: 2, indicators: [] },
   moduleSequence: ['wire', 'dial', 'button', 'keypad'],
   moduleConfigs: [null, null, null, null],

--- a/packages/game-bombsquad/src/pages/GamePage.timer.test.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.timer.test.tsx
@@ -26,7 +26,7 @@ vi.mock('@/modules/keypad/KeypadModule', () => ({
 import GamePage from './GamePage'
 import { GameProvider, type GameState, TIME_BUDGET_MS } from '@/store/game-context'
 
-const PERSISTENCE_KEY = 'bombsquad:game-state:v3'
+const PERSISTENCE_KEY = 'bombsquad:game-state:v4'
 const T0 = 1_700_000_000_000
 
 // The old daily countdown ended at 10 minutes. The stopwatch must sail past
@@ -41,6 +41,7 @@ function playingState(mode: GameState['mode'], overrides: Partial<GameState> = {
     mode,
     manual: {} as GameState['manual'],
     manualUrl: `https://claw.amio.fans/manual/${mode}`,
+    gameRunId: `run-${mode}`,
     sceneInfo: { sceneTongueTwister: '四是四十是十', batteryCount: 2, indicators: [] },
     moduleSequence: sequence,
     moduleConfigs: sequence.map(() => ({})) as GameState['moduleConfigs'],

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -33,7 +33,12 @@ import ButtonModule from '@/modules/button/ButtonModule'
 import KeypadModule from '@/modules/keypad/KeypadModule'
 import practiceYamlRaw from '../../../manual/data/practice.yaml?raw'
 import { generateSceneInfo } from '@/engine/scene-info'
-import { commitAttemptNumberForMode, getAttemptNumberForMode, getRunSeed } from '@/utils/session'
+import {
+  commitAttemptNumberForMode,
+  createGameRunId,
+  getAttemptNumberForMode,
+  getRunSeed,
+} from '@/utils/session'
 import { getAudioContext, setSfxSuppressed } from '@/audio/audio-context'
 import VoicePanel, { type VoicePanelHandle } from '@/voice/VoicePanel'
 import { deriveVoicePanelInputs, isPlatformVoicePartner } from '@/voice/voice-panel-inputs'
@@ -219,7 +224,7 @@ export default function GamePage() {
   const resultNavigationArmedRef = useRef(state.status !== 'RESULT')
 
   // Voice-session inputs for the current module, recomputed only when the loaded
-  // manual or the current module changes (NOT on every timer-frame re-render).
+  // manual, run identity, or the current module changes (NOT on every timer-frame re-render).
   // Advancing modules changes `gameState.relevantSections` but keeps the same
   // run-stable `sessionKey`, so the panel does NOT remount — the hook steers the
   // live session with one `update-gamestate` instead of reconnecting (one
@@ -236,7 +241,13 @@ export default function GamePage() {
       return deriveVoicePanelInputs({ ...state, currentModuleIndex: clampedIdx })
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [usePlatformVoice, state.manual, state.currentModuleIndex, state.moduleSequence.length]
+    [
+      usePlatformVoice,
+      state.manual,
+      state.gameRunId,
+      state.currentModuleIndex,
+      state.moduleSequence.length,
+    ]
   )
 
   // Mute every game SFX while the mode② voice partner is mounted. The stopwatch
@@ -381,8 +392,9 @@ export default function GamePage() {
         ? `${origin}/manual/practice`
         : toManualDataUrl(customUrl ?? `${origin}/manual/${new Date().toISOString().slice(0, 10)}`)
     const attemptNumber = getAttemptNumberForMode(mode)
+    const gameRunId = createGameRunId()
 
-    dispatch({ type: 'START_LOADING', mode, manualUrl, attemptNumber })
+    dispatch({ type: 'START_LOADING', mode, manualUrl, attemptNumber, gameRunId })
 
     const load = async () => {
       try {
@@ -750,6 +762,7 @@ export default function GamePage() {
           key={voiceInputs.sessionKey}
           manualData={voiceInputs.manualData}
           gameState={voiceInputs.gameState}
+          gameRunId={voiceInputs.gameRunId}
         />
       )}
 

--- a/packages/game-bombsquad/src/pages/ResultPage.feedback.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.feedback.test.tsx
@@ -33,7 +33,7 @@ import ResultPage from './ResultPage'
 import { GameProvider, type GameState, type GameOutcome } from '@/store/game-context'
 import { playSfx } from '@/audio/useSfx'
 
-const PERSISTENCE_KEY = 'bombsquad:game-state:v3'
+const PERSISTENCE_KEY = 'bombsquad:game-state:v4'
 
 function finishedState(mode: GameState['mode'], outcome: GameOutcome): GameState {
   const sequence: GameState['moduleSequence'] =
@@ -43,6 +43,7 @@ function finishedState(mode: GameState['mode'], outcome: GameOutcome): GameState
     mode,
     manual: null,
     manualUrl: null,
+    gameRunId: `run-${mode}-${outcome}`,
     sceneInfo: null,
     moduleSequence: sequence,
     moduleConfigs: sequence.map(() => null),

--- a/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
@@ -51,7 +51,7 @@ import ResultPage from './ResultPage'
 import { submitScore } from '@shared/leaderboard-api'
 import { GameProvider, type GameState } from '@/store/game-context'
 
-const PERSISTENCE_KEY = 'bombsquad:game-state:v3'
+const PERSISTENCE_KEY = 'bombsquad:game-state:v4'
 const NICKNAME_KEY = 'bombsquad-nickname'
 const AI_TOOL_KEY = 'bombsquad-leaderboard-ai-tool'
 
@@ -88,6 +88,7 @@ function finishedDailyState(): GameState {
     mode: 'daily',
     manual: null,
     manualUrl: null,
+    gameRunId: 'run-daily-result',
     sceneInfo: null,
     moduleSequence: ['wire', 'dial', 'button', 'keypad'],
     moduleConfigs: [null, null, null, null],
@@ -170,6 +171,7 @@ describe('ResultPage nickname gate', () => {
       nickname: '小明',
       ai_tool: 'claude',
       device_id: STUB_DEVICE_ID,
+      run_id: 'run-daily-result',
     })
 
     // localStorage persisted the nickname; modal is gone.
@@ -190,6 +192,7 @@ describe('ResultPage nickname gate', () => {
       nickname: '小红',
       ai_tool: 'chatgpt',
       device_id: STUB_DEVICE_ID,
+      run_id: 'run-daily-result',
     })
   })
 

--- a/packages/game-bombsquad/src/pages/ResultPage.outcome.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.outcome.test.tsx
@@ -36,7 +36,7 @@ import ResultPage from './ResultPage'
 import { GameProvider, type GameState, type GameOutcome } from '@/store/game-context'
 import { submitScore } from '@shared/leaderboard-api'
 
-const PERSISTENCE_KEY = 'bombsquad:game-state:v3'
+const PERSISTENCE_KEY = 'bombsquad:game-state:v4'
 
 interface FixtureOptions {
   mode: GameState['mode']
@@ -53,6 +53,7 @@ function finishedState({ mode, outcome, moduleStats, strikeCount = 0 }: FixtureO
     mode,
     manual: null,
     manualUrl: null,
+    gameRunId: `run-${mode}-${outcome}`,
     sceneInfo: null,
     moduleSequence: sequence,
     moduleConfigs: sequence.map(() => null),

--- a/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
@@ -72,7 +72,7 @@ import ResultPage from './ResultPage'
 import { GameProvider, type GameState, type GameOutcome } from '@/store/game-context'
 import { submitScore } from '@shared/leaderboard-api'
 
-const PERSISTENCE_KEY = 'bombsquad:game-state:v3'
+const PERSISTENCE_KEY = 'bombsquad:game-state:v4'
 const RESULT_FEEDBACK_SURVEY_DELAY_MS = 1800
 
 interface FixtureOptions {
@@ -88,6 +88,7 @@ function finishedState({ mode, outcome }: FixtureOptions): GameState {
     mode,
     manual: null,
     manualUrl: null,
+    gameRunId: `run-${mode}-${outcome}`,
     sceneInfo: null,
     moduleSequence: sequence,
     moduleConfigs: sequence.map(() => null),

--- a/packages/game-bombsquad/src/pages/ResultPage.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.test.tsx
@@ -72,7 +72,7 @@ vi.mock('@/utils/nickname', () => ({
 import ResultPage from './ResultPage'
 import { GameProvider, type GameState } from '@/store/game-context'
 
-const PERSISTENCE_KEY = 'bombsquad:game-state:v3'
+const PERSISTENCE_KEY = 'bombsquad:game-state:v4'
 
 function finishedPracticeState(): GameState {
   // Seed `attemptNumber` to a non-default value (7), distinct from
@@ -91,6 +91,7 @@ function finishedPracticeState(): GameState {
     mode: 'practice',
     manual: null,
     manualUrl: null,
+    gameRunId: 'run-practice-result',
     sceneInfo: null,
     moduleSequence: ['wire', 'dial', 'button', 'keypad'],
     moduleConfigs: [null, null, null, null],

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -118,7 +118,8 @@ export default function ResultPage() {
     state.mode === 'daily' &&
     outcome === 'defused' &&
     totalMs !== null &&
-    state.moduleStats.length > 0
+    state.moduleStats.length > 0 &&
+    state.gameRunId !== null
 
   // Lazy initializers: read the stored nickname once on mount. Subsequent
   // useState calls reuse the captured value so the pieces of mount
@@ -179,25 +180,8 @@ export default function ResultPage() {
   const buildSubmission = useCallback(
     (nicknameValue: string, metadataValue: LeaderboardPlayerMetadata): ScoreSubmission | null => {
       if (totalMs === null) return null
+      if (state.gameRunId === null) return null
       const date = getTodayString()
-      // Generate a UUID once per run and persist it so a page-refresh retry
-      // sends the same run_id, enabling backend dedup to collapse duplicates.
-      let run_id: string | undefined
-      try {
-        const storageKey = `run-id:${date}:${state.attemptNumber}`
-        const stored = sessionStorage.getItem(storageKey)
-        if (stored) {
-          run_id = stored
-        } else {
-          run_id = crypto.randomUUID()
-          sessionStorage.setItem(storageKey, run_id)
-        }
-      } catch {
-        // sessionStorage unavailable (e.g. private-browsing restrictions) —
-        // fall back to a per-call UUID; the backend rate limit still provides
-        // a weak guard and the frontend latch covers within-mount doubles.
-        run_id = crypto.randomUUID()
-      }
       return {
         date,
         nickname: nicknameValue,
@@ -208,10 +192,10 @@ export default function ResultPage() {
         ai_tool: metadataValue.aiTool,
         ...(metadataValue.aiModel ? { ai_model: metadataValue.aiModel } : {}),
         device_id: getDeviceId(),
-        run_id,
+        run_id: state.gameRunId,
       }
     },
-    [totalMs, state.attemptNumber, state.moduleStats]
+    [totalMs, state.attemptNumber, state.gameRunId, state.moduleStats]
   )
 
   const recordOptimistic = useCallback(

--- a/packages/game-bombsquad/src/store/game-context.test.ts
+++ b/packages/game-bombsquad/src/store/game-context.test.ts
@@ -30,6 +30,7 @@ function baseState(overrides: Partial<GameState> = {}): GameState {
     mode: 'daily',
     manual: null,
     manualUrl: null,
+    gameRunId: 'run-test',
     sceneInfo: null,
     moduleSequence: ['wire', 'dial', 'button', 'keypad'],
     moduleConfigs: [null, null, null, null],
@@ -58,6 +59,7 @@ describe('gameReducer — START_LOADING', () => {
       mode: 'daily',
       manualUrl: 'u',
       attemptNumber: 1,
+      gameRunId: 'run-daily',
     })
     expect(daily.moduleSequence).toEqual(MODULE_SEQUENCE.daily)
     expect(daily.moduleConfigs).toHaveLength(MODULE_SEQUENCE.daily.length)
@@ -68,9 +70,21 @@ describe('gameReducer — START_LOADING', () => {
       mode: 'practice',
       manualUrl: 'u',
       attemptNumber: 1,
+      gameRunId: 'run-practice',
     })
     expect(practice.moduleSequence).toEqual(MODULE_SEQUENCE.practice)
     expect(practice.moduleConfigs).toHaveLength(2)
+  })
+
+  it('stores a stable run identity before the manual is loaded', () => {
+    const state = gameReducer(baseState(), {
+      type: 'START_LOADING',
+      mode: 'daily',
+      manualUrl: 'u',
+      attemptNumber: 1,
+      gameRunId: 'run-identity',
+    })
+    expect(state.gameRunId).toBe('run-identity')
   })
 })
 

--- a/packages/game-bombsquad/src/store/game-context.tsx
+++ b/packages/game-bombsquad/src/store/game-context.tsx
@@ -76,6 +76,8 @@ export interface GameState {
   mode: GameMode
   manual: Manual | null
   manualUrl: string | null
+  /** Stable identity for this run, generated before the manual is loaded. */
+  gameRunId: string | null
   sceneInfo: SceneInfo | null
   /** Module kinds for this run, in order. Derived from MODULE_SEQUENCE[mode]. */
   moduleSequence: ModuleKind[]
@@ -112,7 +114,13 @@ export interface GameState {
 // ---------------------------------------------------------------------------
 
 export type GameAction =
-  | { type: 'START_LOADING'; mode: GameMode; manualUrl: string; attemptNumber: number }
+  | {
+      type: 'START_LOADING'
+      mode: GameMode
+      manualUrl: string
+      attemptNumber: number
+      gameRunId: string
+    }
   | {
       type: 'MANUAL_LOADED'
       manual: Manual
@@ -140,6 +148,7 @@ const INITIAL_STATE: GameState = {
   mode: 'practice',
   manual: null,
   manualUrl: null,
+  gameRunId: null,
   sceneInfo: null,
   moduleSequence: [],
   moduleConfigs: [],
@@ -172,6 +181,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         status: 'LOADING',
         mode: action.mode,
         manualUrl: action.manualUrl,
+        gameRunId: action.gameRunId,
         attemptNumber: action.attemptNumber,
         moduleSequence: sequence,
         moduleConfigs: sequence.map(() => null),

--- a/packages/game-bombsquad/src/store/persistence.test.ts
+++ b/packages/game-bombsquad/src/store/persistence.test.ts
@@ -7,6 +7,7 @@ const sampleState: GameState = {
   mode: 'practice',
   manual: null,
   manualUrl: 'https://claw.amio.fans/manual/practice',
+  gameRunId: 'run-practice',
   sceneInfo: { sceneTongueTwister: '四是四十是十', batteryCount: 2, indicators: [] },
   moduleSequence: ['wire', 'keypad'],
   moduleConfigs: [null, null],
@@ -42,24 +43,15 @@ describe('persistence', () => {
   })
 
   it('returns null when the stored value is corrupt JSON', () => {
-    sessionStorage.setItem('bombsquad:game-state:v3', '{broken json')
+    sessionStorage.setItem('bombsquad:game-state:v4', '{broken json')
     expect(loadPersistedState()).toBeNull()
   })
 
-  it('ignores a stale v2 blob so the timeBudgetMs semantics change cannot leak in', () => {
-    // The stopwatch rework reused `timeBudgetMs` but flipped its meaning from a
-    // per-mode countdown budget (600000 / 300000) to the 1-hour positive-count
-    // hard cap (3600000). A v2 blob persisted by the previous build still
-    // carries the old 600000 value — if it were restored, the new count-up
-    // timer would end a daily run the instant elapsed ≥ 600000 (10 minutes)
-    // instead of running on. The key bump to v3 must make any v2 entry invisible
-    // to loadPersistedState so the player gets a clean fresh run with the
-    // correct 1-hour cap, never the stale 10-minute value.
-    const staleV2State = { ...sampleState, mode: 'daily' as const, timeBudgetMs: 600_000 }
-    sessionStorage.setItem('bombsquad:game-state:v2', JSON.stringify(staleV2State))
+  it('ignores a stale v3 blob so a run without gameRunId cannot leak in', () => {
+    const staleV3State = { ...sampleState, gameRunId: undefined }
+    sessionStorage.setItem('bombsquad:game-state:v3', JSON.stringify(staleV3State))
     expect(loadPersistedState()).toBeNull()
-    // And nothing leaked the old budget back to a caller.
-    expect(loadPersistedState()?.timeBudgetMs).toBeUndefined()
+    expect(loadPersistedState()?.gameRunId).toBeUndefined()
   })
 
   it('round-trips an EXPLODING state so a refresh mid-explosion is recoverable', () => {

--- a/packages/game-bombsquad/src/store/persistence.ts
+++ b/packages/game-bombsquad/src/store/persistence.ts
@@ -27,7 +27,10 @@ import type { GameState } from './game-context'
 //        therefore neutrally end at 10 minutes instead of running on. Bumping
 //        the key forces any stale v2 entry to be ignored so the player gets a
 //        clean fresh run carrying the correct 1-hour cap.
-const KEY = 'bombsquad:game-state:v3'
+//   v4 — the run identity moved into GameState as `gameRunId`. Restoring an
+//        older v3 blob would produce a live run whose voice session and score
+//        settlement cannot share the same id, so stale v3 state is ignored.
+const KEY = 'bombsquad:game-state:v4'
 
 export function loadPersistedState(): GameState | null {
   if (typeof sessionStorage === 'undefined') return null

--- a/packages/game-bombsquad/src/utils/session.test.ts
+++ b/packages/game-bombsquad/src/utils/session.test.ts
@@ -3,6 +3,7 @@ import {
   PRACTICE_SEED,
   commitAttemptNumberForMode,
   commitDailyAttemptNumber,
+  createGameRunId,
   getAttemptNumberForMode,
   getRunSeed,
   readEntryRecoveryState,
@@ -27,6 +28,10 @@ describe('session utilities', () => {
   it('uses a fixed seed for practice mode', () => {
     expect(getRunSeed('practice')).toBe(PRACTICE_SEED)
     expect(getRunSeed('daily', 123456)).toBe(123456)
+  })
+
+  it('creates a non-empty run identity', () => {
+    expect(createGameRunId()).toMatch(/^[a-z0-9-]+$/i)
   })
 
   it('reserves and reads daily attempts from storage', () => {

--- a/packages/game-bombsquad/src/utils/session.ts
+++ b/packages/game-bombsquad/src/utils/session.ts
@@ -15,6 +15,13 @@ export function getRunSeed(mode: SessionMode, now = Date.now()): number {
   return mode === 'practice' ? PRACTICE_SEED : now
 }
 
+export function createGameRunId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `run-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
 export function getDailyAttemptKey(date = getTodayString()): string {
   return `attempt-${date}`
 }

--- a/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
@@ -31,10 +31,11 @@ function hookState(partial: Partial<UseVoiceSessionResult> = {}): UseVoiceSessio
 
 const manualData: ManualData = { version: 'v1', sections: { button: { rule: 'hold' } } }
 const gameState: GameState = { relevantSections: ['button'] }
+const gameRunId = 'run-panel'
 
 function renderPanel(partial: Partial<UseVoiceSessionResult> = {}) {
   mockHook.mockReturnValue(hookState(partial))
-  return render(<VoicePanel manualData={manualData} gameState={gameState} />)
+  return render(<VoicePanel gameRunId={gameRunId} manualData={manualData} gameState={gameState} />)
 }
 
 beforeEach(() => {
@@ -105,17 +106,17 @@ describe('VoicePanel — cues and content', () => {
     const props = () => ({ manualData: { ...manualData }, gameState: { ...gameState } })
 
     mockHook.mockReturnValue(hookState({ playerTranscript: '红' }))
-    const { rerender } = render(<VoicePanel {...props()} />)
+    const { rerender } = render(<VoicePanel gameRunId={gameRunId} {...props()} />)
     expect(screen.getByLabelText('你说的话')).toHaveTextContent('你：红')
 
     // An interim grows: the subtitle builds up to the latest cumulative text.
     mockHook.mockReturnValue(hookState({ playerTranscript: '红色的线' }))
-    rerender(<VoicePanel {...props()} />)
+    rerender(<VoicePanel gameRunId={gameRunId} {...props()} />)
     expect(screen.getByLabelText('你说的话')).toHaveTextContent('你：红色的线')
 
     // The next utterance's first interim replaces the prior subtitle, not appends.
     mockHook.mockReturnValue(hookState({ playerTranscript: '第' }))
-    rerender(<VoicePanel {...props()} />)
+    rerender(<VoicePanel gameRunId={gameRunId} {...props()} />)
     const subtitle = screen.getByLabelText('你说的话')
     expect(subtitle).toHaveTextContent('你：第')
     expect(subtitle).not.toHaveTextContent('红色的线')
@@ -142,6 +143,15 @@ describe('VoicePanel — cues and content', () => {
 })
 
 describe('VoicePanel — hands-free (no push-to-talk)', () => {
+  it('passes the run identity into the voice-session hook', () => {
+    renderPanel({ status: 'ready' })
+    expect(mockHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gameRunId,
+      })
+    )
+  })
+
   it('renders no push-to-talk button', () => {
     renderPanel({ status: 'ready' })
     expect(screen.queryByRole('button')).not.toBeInTheDocument()

--- a/packages/game-bombsquad/src/voice/VoicePanel.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.tsx
@@ -5,6 +5,8 @@ import type { ConversationPhase, VoiceStatus } from './voice-session-protocol'
 import styles from './VoicePanel.module.css'
 
 interface VoicePanelProps {
+  /** Stable per-run join key shared by voice summary and score settlement. */
+  gameRunId: string
   /** Per-run manual payload (`null` while the manual is still loading). */
   manualData: ManualData | null
   /** Game state driving the manual-subset selection for this module. */
@@ -65,7 +67,7 @@ function placeholderFor(status: VoiceStatus, phase: ConversationPhase): string {
 }
 
 function VoicePanelImpl(
-  { manualData, gameState, gameId }: VoicePanelProps,
+  { gameRunId, manualData, gameState, gameId }: VoicePanelProps,
   ref: React.ForwardedRef<VoicePanelHandle>
 ) {
   const {
@@ -77,6 +79,7 @@ function VoicePanelImpl(
     error,
     requestClosing,
   } = useVoiceSession({
+    gameRunId,
     manualData,
     gameState,
     gameId,

--- a/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
@@ -191,7 +191,7 @@ function lastSocket(): MockWebSocket {
 /** Bring a hook to a live session with the mic streaming. */
 async function ready() {
   const rendered = renderHook(() =>
-    useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    useVoiceSession({ gameRunId: 'run-voice', manualData: manualData(), gameState: gameState() })
   )
   const ws = lastSocket()
   act(() => ws.fireOpen())
@@ -213,7 +213,7 @@ describe('useVoiceSession — connection', () => {
 
   it('connects same-origin and sends create with no userId/prompt', () => {
     const { result } = renderHook(() =>
-      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+      useVoiceSession({ gameRunId: 'run-voice', manualData: manualData(), gameState: gameState() })
     )
     expect(result.current.status).toBe('connecting')
     const ws = lastSocket()
@@ -224,6 +224,7 @@ describe('useVoiceSession — connection', () => {
     expect(create).toMatchObject({
       type: 'create',
       gameId: 'bombsquad',
+      gameRunId: 'run-voice',
       manualData: { version: 'v1' },
       gameState: { relevantSections: ['button'] },
     })

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -26,9 +26,10 @@
  * (listening / thinking / speaking).
  *
  * Security invariant (load-bearing, mirrors the demo): this hook connects ONLY to
- * the same-origin Worker WS and sends ONLY `{gameId, manualData, gameState}` plus
- * binary audio. It carries NO provider key, NO system prompt, and NO userId — the
- * session cookie authenticates same-origin and the server holds every secret.
+ * the same-origin Worker WS and sends ONLY `{gameId, manualData, gameState,
+ * gameRunId}` plus binary audio. It carries NO provider key, NO system prompt,
+ * and NO userId — the session cookie authenticates same-origin and the server
+ * holds every secret.
  *
  * Audio formats (both 16 kHz mono PCM16):
  *  - mic capture: `AudioContext({ sampleRate: 16000 })` + `ScriptProcessorNode`,
@@ -106,6 +107,8 @@ function closeAudioContext(ctx: AudioContext | null): void {
 }
 
 export interface UseVoiceSessionOptions {
+  /** Stable per-run join key shared by voice summary and score settlement. */
+  gameRunId?: string
   /**
    * The per-run manual payload (built via `bombsquadManualToManualData`). `null`
    * while the manual is still loading — the hook stays `idle` and connects once a
@@ -163,7 +166,7 @@ export interface UseVoiceSessionResult {
  * and only after the session is `created`; an unchanged re-render sends nothing.
  */
 export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessionResult {
-  const { manualData, gameState, gameId = 'bombsquad' } = options
+  const { gameRunId, manualData, gameState, gameId = 'bombsquad' } = options
 
   const [state, dispatch] = useReducer(voiceReducer, initialVoiceState)
   const [isAiSpeaking, setIsAiSpeaking] = useState(false)
@@ -185,10 +188,12 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
   const manualDataRef = useRef<ManualData | null>(manualData)
   const gameStateRef = useRef<GameState>(gameState)
   const gameIdRef = useRef<string>(gameId)
+  const gameRunIdRef = useRef<string | undefined>(gameRunId)
   useEffect(() => {
     manualDataRef.current = manualData
     gameStateRef.current = gameState
     gameIdRef.current = gameId
+    gameRunIdRef.current = gameRunId
   })
 
   // Side-effect handles (never trigger re-render).
@@ -558,6 +563,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         gameId: gameIdRef.current,
         manualData: manualDataRef.current,
         gameState: gameStateRef.current,
+        ...(gameRunIdRef.current ? { gameRunId: gameRunIdRef.current } : {}),
       }
       try {
         ws.send(JSON.stringify(create))

--- a/packages/game-bombsquad/src/voice/voice-panel-inputs.test.ts
+++ b/packages/game-bombsquad/src/voice/voice-panel-inputs.test.ts
@@ -38,6 +38,7 @@ function makeState(overrides: Partial<GameState> = {}): GameState {
     mode: 'daily',
     manual: makeManual(),
     manualUrl: 'https://claw.amio.fans/manual/2026-06-28',
+    gameRunId: 'run-default',
     sceneInfo: null,
     moduleSequence: ['wire', 'dial', 'button', 'keypad'],
     moduleConfigs: [],
@@ -97,27 +98,38 @@ describe('deriveVoicePanelInputs (current module -> hook inputs)', () => {
   })
 
   it('keeps a run-stable sessionKey across module advances so the panel never remounts', () => {
-    const first = deriveVoicePanelInputs(makeState({ currentModuleIndex: 0, rngSeed: 42 }))
-    const second = deriveVoicePanelInputs(makeState({ currentModuleIndex: 1, rngSeed: 42 }))
-    // Same run (same seed) → identical key as the module advances → one session.
-    expect(first?.sessionKey).toBe('run-42')
-    expect(second?.sessionKey).toBe('run-42')
+    const first = deriveVoicePanelInputs({
+      ...makeState({ currentModuleIndex: 0 }),
+      gameRunId: 'shared',
+    })
+    const second = deriveVoicePanelInputs({
+      ...makeState({ currentModuleIndex: 1 }),
+      gameRunId: 'shared',
+    })
+    // Same run (same gameRunId) → identical key as the module advances → one session.
+    expect(first?.sessionKey).toBe('run-shared')
+    expect(second?.sessionKey).toBe('run-shared')
     expect(first?.sessionKey).toBe(second?.sessionKey)
+    expect(first?.gameRunId).toBe('shared')
     // But the per-module sections still change, so the hook can steer the session.
     expect(first?.gameState.relevantSections).toEqual(['wire_routing'])
     expect(second?.gameState.relevantSections).toEqual(['symbol_dial'])
   })
 
   it('gives a different run a different sessionKey (a genuinely new session)', () => {
-    const runA = deriveVoicePanelInputs(makeState({ rngSeed: 1 }))
-    const runB = deriveVoicePanelInputs(makeState({ rngSeed: 2 }))
-    expect(runA?.sessionKey).toBe('run-1')
-    expect(runB?.sessionKey).toBe('run-2')
+    const runA = deriveVoicePanelInputs(makeState({ gameRunId: 'a' }))
+    const runB = deriveVoicePanelInputs(makeState({ gameRunId: 'b' }))
+    expect(runA?.sessionKey).toBe('run-a')
+    expect(runB?.sessionKey).toBe('run-b')
     expect(runA?.sessionKey).not.toBe(runB?.sessionKey)
   })
 
   it('returns null until a manual is loaded', () => {
     expect(deriveVoicePanelInputs(makeState({ manual: null }))).toBeNull()
+  })
+
+  it('returns null until the run identity is available', () => {
+    expect(deriveVoicePanelInputs(makeState({ gameRunId: null }))).toBeNull()
   })
 
   it('returns null when there is no current module kind', () => {

--- a/packages/game-bombsquad/src/voice/voice-panel-inputs.ts
+++ b/packages/game-bombsquad/src/voice/voice-panel-inputs.ts
@@ -28,16 +28,18 @@ export function isPlatformVoicePartner(mode: GameMode, partnerParam: string | nu
 }
 
 export interface VoicePanelInputs {
+  /** Stable per-run join key shared by voice summary and score settlement. */
+  gameRunId: string
   /** Per-run manual payload for the voice session. */
   manualData: ManualData
   /** Drives the platform's manual-subset selection for the current module. */
   gameState: VoiceGameState
   /**
    * Stable per-RUN identity. Used as the `VoicePanel` React `key`. It is keyed on
-   * the run (the run's `rngSeed`), NOT the module, so it stays constant as the
-   * player advances modules — the panel mounts ONCE and keeps one continuous WS /
-   * mic / conversation for the whole run (the AI greets once and remembers it).
-   * A genuinely new run gets a new seed and therefore a fresh session.
+   * the run's `gameRunId`, NOT the module, so it stays constant as the player
+   * advances modules — the panel mounts ONCE and keeps one continuous WS / mic /
+   * conversation for the whole run (the AI greets once and remembers it). A
+   * genuinely new run gets a new id and therefore a fresh session.
    */
   sessionKey: string
   /** The current module kind (surfaced for labelling / callers). */
@@ -52,11 +54,12 @@ export interface VoicePanelInputs {
  */
 export function deriveVoicePanelInputs(state: BombSquadGameState): VoicePanelInputs | null {
   const moduleKind = state.moduleSequence[state.currentModuleIndex]
-  if (!moduleKind || state.manual === null) return null
+  if (!moduleKind || state.manual === null || state.gameRunId === null) return null
   return {
+    gameRunId: state.gameRunId,
     manualData: bombsquadManualToManualData(state.manual, state.manual.meta.version),
     gameState: { relevantSections: moduleKindToRelevantSections(moduleKind) },
-    sessionKey: `run-${state.rngSeed}`,
+    sessionKey: `run-${state.gameRunId}`,
     moduleKind,
   }
 }


### PR DESCRIPTION
## Summary

- Generate a stable BombSquad `gameRunId` at run start and persist it through refresh recovery.
- Pass the same id into platform AI voice session creation and reuse it as the leaderboard `run_id`.
- Capture logged-in score settlements into companion memory with the same join key while preserving anonymous leaderboard submissions.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [ ] Tested manually and documented below

Test plan:

- [x] `pnpm --filter @amiclaw/game-bombsquad test:run src/store/game-context.test.ts src/store/persistence.test.ts src/utils/session.test.ts src/voice/voice-panel-inputs.test.ts src/voice/useVoiceSession.test.ts src/voice/VoicePanel.test.tsx src/pages/ResultPage.nickname.test.tsx src/pages/ConnectPage.test.tsx`
- [x] `pnpm --filter api test:run src/handlers/post-score.test.ts`
- [x] `pnpm --filter @amiclaw/game-bombsquad typecheck`
- [x] `pnpm --filter api typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter @amiclaw/game-bombsquad build`
- [x] `pnpm test:run`

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

## Attribution

- Built by Codex thread `019f2b75-e9dd-7a21-afcb-7ea0ffdc3dfc`.