### PR TITLE
Harden mode2 launch readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ with every understanding linking back to the exact memory it came from. If you
 haven't met your companion yet, both places guide you to do that first. They
 start out empty, honestly waiting for the story you'll build together.
 
+**AMIO Arcade mode2 launch readiness hardened** - Internal reliability and
+compliance hardening. The privacy policy and terms now describe the real mode1
+versus mode2 data boundary: auth sessions, platform-AI voice sessions, usage
+metering, Companion D1 memory, and third-party AI providers. Auth cookie parsing
+now treats malformed percent-encoding as attacker-controlled input and fails
+closed instead of throwing. Companion `voice_id` resolution now reads
+deploy-configured Volcengine voice tokens from `VOLC_TTS_VOICE_COMPANION_*`,
+keeps runtime sessions fail-open to the provider default voice, and adds a
+fail-loud readiness gate plus post-deploy runbook checks for auth, Companion D1,
+usage KV, observability, and deployed voice secret names.
+
 **BombSquad mode② voice: the indicator no longer flips back to "聆听中" mid-think** -
 Fix. After you finished speaking, the indicator would show "思考中" and then snap
 straight back to "聆听中" without the AI answering. A breath or room-noise tail

--- a/functions/api/companion/PROVISIONING.md
+++ b/functions/api/companion/PROVISIONING.md
@@ -50,17 +50,40 @@ The consolidator reuses the Worker's existing `DEEPSEEK_API_KEY` /
 degrades to settlement-facts-only consolidation — episodes from conversation
 highlights and all profile claims are skipped.
 
-## 5. Voice mapping back-fill (deploy-blocking)
+## 5. Voice mapping configuration (deploy-blocking)
 
 `packages/platform-ai/src/voice-id-mapping.ts` maps the platform-neutral
-`voice_id` catalog to Volcengine `voice_type` tokens, and session assembly
-threads the resolved token into the TTS provider as the companion's speaker.
-The committed values are `PLACEHOLDER_*`: at runtime an unfilled placeholder
-(or a missing mapping) degrades to the provider's default voice with a
-`console.warn` — sessions still assemble, but every companion speaks the
-default voice instead of its chosen one.
+`voice_id` catalog to Volcengine `voice_type` tokens at session assembly time.
+The concrete vendor tokens are deploy configuration, not source code. Configure
+all three Worker env values before exposing the companion feature:
 
-**Back-filling the real `voice_type` tokens is therefore a deploy-blocking
-checklist item**: confirm the tokens against the Volcengine console and fill
-them in before the companion feature ships. The mapping mechanism, its
-completeness test, and the degrade path are already in place.
+- `VOLC_TTS_VOICE_COMPANION_WARM`
+- `VOLC_TTS_VOICE_COMPANION_BRIGHT`
+- `VOLC_TTS_VOICE_COMPANION_CALM`
+
+Confirm the real `voice_type` tokens in the Volcengine console or provider
+dashboard. Do not guess token strings and do not commit token values to source.
+At runtime, a missing value degrades to the provider default voice with a
+`console.warn`; the session still assembles, but the selected companion voice is
+not honored. Launch readiness must fail loud on that condition.
+
+Run the low-side-effect readiness gate after deployment:
+
+```sh
+PLATFORM_AI_BASE_URL=https://claw.amio.fans \
+VOLC_TTS_VOICE_COMPANION_WARM=<real token> \
+VOLC_TTS_VOICE_COMPANION_BRIGHT=<real token> \
+VOLC_TTS_VOICE_COMPANION_CALM=<real token> \
+pnpm --filter @amiclaw/platform-ai smoke:readiness
+```
+
+If the voice values are deployed as Worker secrets, also verify the deployed
+secret names without reading their values:
+
+```sh
+RUN_WORKER_SECRET_NAME_CHECK=1 \
+pnpm --filter @amiclaw/platform-ai smoke:readiness
+```
+
+See `packages/platform-ai/POST_DEPLOY_READINESS.md` for the D1, `USAGE`, auth,
+and log-lookup checks that complete the mode2 launch gate.

--- a/packages/api/src/auth/session.test.ts
+++ b/packages/api/src/auth/session.test.ts
@@ -4,6 +4,7 @@ import { SESSION_COOKIE_NAME } from '../../../../shared/auth-types'
 import { SESSION_TTL_SECONDS } from './config'
 import {
   createSession,
+  readCookie,
   readSession,
   revokeSession,
   readSessionCookie,
@@ -44,9 +45,40 @@ describe('auth session', () => {
     expect(readSessionCookie(req)).toBe('abc123')
   })
 
+  it('percent-decodes a well-formed cookie value', () => {
+    const req = requestWithCookie(`${SESSION_COOKIE_NAME}=abc%20123`)
+    expect(readSessionCookie(req)).toBe('abc 123')
+  })
+
+  it('does not throw on malformed percent escapes in cookie values', () => {
+    for (const value of ['%', '%E', '%ZZ', '%C3%28']) {
+      const req = requestWithCookie(`${SESSION_COOKIE_NAME}=${value}`)
+      expect(() => readSessionCookie(req)).not.toThrow()
+      expect(readSessionCookie(req)).toBe(value)
+    }
+  })
+
+  it('keeps sibling cookie parsing total when one value has a malformed escape', () => {
+    const req = requestWithCookie(`a=ok; bad=%; b=%41`)
+    expect(readCookie(req, 'a')).toBe('ok')
+    expect(readCookie(req, 'bad')).toBe('%')
+    expect(readCookie(req, 'b')).toBe('A')
+  })
+
   it('returns null when no cookie present', () => {
     const req = new Request('https://claw.amio.fans/api/auth/session')
     expect(readSessionCookie(req)).toBeNull()
+  })
+
+  it('malformed session cookies fail closed through readSessionFromRequest', async () => {
+    const kv = new FakeKV()
+    const { sessionId } = await createSession(kv.asKV(), IDENTITY)
+    expect(sessionId).not.toBe('%')
+
+    for (const value of ['%', '%E', '%C3%28']) {
+      const req = requestWithCookie(`${SESSION_COOKIE_NAME}=${value}`)
+      await expect(readSessionFromRequest(kv.asKV(), req)).resolves.toBeNull()
+    }
   })
 
   it('readSessionFromRequest round-trips a real cookie', async () => {

--- a/packages/api/src/auth/session.ts
+++ b/packages/api/src/auth/session.ts
@@ -71,6 +71,19 @@ export async function readSessionFromRequest(
 }
 
 /**
+ * Decode a cookie value without ever throwing on attacker-controlled input.
+ * Malformed percent escapes stay raw, which fails closed downstream because no
+ * real session id should match that raw garbage value.
+ */
+function decodeCookieValue(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+/**
  * Read a single cookie value by name from a request's `Cookie` header, or
  * `null`. Shared by the session reader and the OAuth state-cookie check so the
  * (slightly fiddly) parse loop lives in one place.
@@ -83,7 +96,7 @@ export function readCookie(request: Request, name: string): string | null {
     if (eq === -1) continue
     const cookieName = part.slice(0, eq).trim()
     if (cookieName === name) {
-      return decodeURIComponent(part.slice(eq + 1).trim())
+      return decodeCookieValue(part.slice(eq + 1).trim())
     }
   }
   return null

--- a/packages/platform-ai/POST_DEPLOY_READINESS.md
+++ b/packages/platform-ai/POST_DEPLOY_READINESS.md
@@ -1,0 +1,146 @@
+# Platform AI post-deploy readiness
+
+This runbook is for the mode2 Platform AI Worker and Companion D1 launch gate.
+It is intentionally low-side-effect: the default smoke path performs no live
+writes. Checks that create a session, write `USAGE`, or trigger companion capture
+require explicit opt-in flags.
+
+## Preconditions
+
+- The `platform-ai` Worker is deployed to the canonical route
+  `claw.amio.fans/ai-ws/*`.
+- `packages/platform-ai/wrangler.toml` keeps Workers Logs enabled:
+  `[observability].enabled = true`.
+- The Worker has `AUTH`, `USAGE`, `COMPANION_DB`, `VOICE_SESSION`, and
+  `COMPANION_CONSOLIDATOR` bindings configured.
+- The Pages project has `AUTH` and `COMPANION_DB` bindings configured for the
+  `/api/auth/*` and `/api/companion/*` control plane.
+- The real Volcengine companion voice tokens are configured as Worker env vars
+  or secrets:
+  - `VOLC_TTS_VOICE_COMPANION_WARM`
+  - `VOLC_TTS_VOICE_COMPANION_BRIGHT`
+  - `VOLC_TTS_VOICE_COMPANION_CALM`
+
+Do not commit those token values to source. Confirm them in the Volcengine
+console or provider dashboard, then set them with the same deployment mechanism
+used for the other Worker secrets or vars.
+
+## Default smoke
+
+Run from the repo root:
+
+```sh
+PLATFORM_AI_BASE_URL=https://claw.amio.fans \
+VOLC_TTS_VOICE_COMPANION_WARM=<real token> \
+VOLC_TTS_VOICE_COMPANION_BRIGHT=<real token> \
+VOLC_TTS_VOICE_COMPANION_CALM=<real token> \
+pnpm --filter @amiclaw/platform-ai smoke:readiness
+```
+
+Default checks:
+
+- `voice_id` launch readiness: every platform voice id has a configured
+  Volcengine `voice_type` value in the shell running the check. This proves the
+  resolver will not send guessed or placeholder tokens; use the remote secret
+  check below to verify the deployed Worker has the same names configured.
+- Unauthenticated `wss://claw.amio.fans/ai-ws/*` handshakes reject with `401`.
+- If `PLATFORM_AI_AUTH_COOKIE` is provided, the script also performs a read-only
+  `GET /api/companion/profile`; `200` or `404` means Pages auth and
+  `COMPANION_DB` binding are visible.
+
+## Opt-in checks
+
+### Deployed voice secret names
+
+This is read-only and uses Wrangler to verify that the deployed `platform-ai`
+Worker has the three companion voice secret names. It confirms secret presence,
+not secret values.
+
+```sh
+RUN_WORKER_SECRET_NAME_CHECK=1 \
+pnpm --filter @amiclaw/platform-ai smoke:readiness
+```
+
+Expected result: `wrangler secret list` includes
+`VOLC_TTS_VOICE_COMPANION_WARM`, `VOLC_TTS_VOICE_COMPANION_BRIGHT`, and
+`VOLC_TTS_VOICE_COMPANION_CALM`.
+
+### Login-gated session create shape
+
+This creates and ends one `demo-mock` WebSocket session. It does not call real
+AI providers, but normal teardown can write a zero-usage `USAGE` record and can
+hand the summary to `COMPANION_CONSOLIDATOR`.
+
+```sh
+PLATFORM_AI_AUTH_COOKIE='amiclaw_session=<session id>' \
+RUN_SESSION_CREATE_CHECK=1 \
+pnpm --filter @amiclaw/platform-ai smoke:readiness
+```
+
+Expected result: a `created` frame with a UUID `sessionId`, followed by a
+`summary` frame after the script sends `end`.
+
+### Companion D1 schema read
+
+This is read-only and uses Wrangler against the remote D1 database:
+
+```sh
+RUN_D1_SCHEMA_CHECK=1 \
+COMPANION_D1_DATABASE_NAME=amiclaw-companion \
+pnpm --filter @amiclaw/platform-ai smoke:readiness
+```
+
+Expected result: the remote database exposes the full initial Companion Memory
+schema: `companion`, `episode`, `profile_claim`, `profile_claim_evidence`,
+`asset_entry`, and `capture_event`.
+
+### USAGE write visibility
+
+This writes, reads, and deletes one `readiness-smoke:*` key. Run only when you
+intend to mutate the production `USAGE` namespace for a smoke check.
+
+```sh
+RUN_USAGE_WRITE_CHECK=1 \
+USAGE_KV_NAMESPACE_ID=<USAGE namespace id> \
+pnpm --filter @amiclaw/platform-ai smoke:readiness
+```
+
+Expected result: the key is written, read back, and deleted successfully.
+
+## Manual trace lookup
+
+Workers Logs and Query Builder only have data after observability is enabled in
+Wrangler and the Worker has been redeployed.
+
+- Real-time tail:
+
+  ```sh
+  pnpm exec wrangler --config=packages/platform-ai/wrangler.toml tail platform-ai
+  ```
+
+- Cloudflare dashboard Query Builder:
+  - Dataset: Workers Logs.
+  - Worker: `platform-ai`.
+  - Time window: the smoke run time.
+  - Useful text filters: `turn-trace`, `companion-capture`,
+    `companion-consolidator`, `voice-id-mapping`, `usage flush failed`.
+
+For a session-create opt-in smoke, confirm that the `created`/`summary` path is
+near the logs for that time window and that no provider-secret or binding-missing
+error appears.
+
+## Readiness interpretation
+
+- A missing `VOLC_TTS_VOICE_COMPANION_*` value is launch-blocking. Runtime
+  sessions still fail open to the provider default voice, but launch readiness
+  must fail loud because a chosen companion voice would not be honored.
+- If the voice values are deployed as Worker secrets, run the deployed secret
+  name check before launch. A local shell value alone does not prove production
+  has the binding.
+- A `401` for unauthenticated `/ai-ws/*` is required. A successful unauthenticated
+  WebSocket upgrade is a blocker.
+- `GET /api/companion/profile` returning `500` with a valid auth cookie usually
+  means Pages cannot see `COMPANION_DB`, the schema is missing, or the auth
+  binding is misconfigured.
+- A failed `USAGE` smoke does not block the player path at runtime, but it blocks
+  launch readiness because usage visibility is required for mode2 exposure.

--- a/packages/platform-ai/package.json
+++ b/packages/platform-ai/package.json
@@ -12,7 +12,8 @@
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "smoke:readiness": "tsx scripts/post-deploy-readiness.ts"
   },
   "dependencies": {
     "agents": "^0.17.0"
@@ -20,6 +21,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.16.20",
     "@cloudflare/workers-types": "^4.20260621.1",
+    "@types/node": "^26.0.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }

--- a/packages/platform-ai/scripts/post-deploy-readiness.ts
+++ b/packages/platform-ai/scripts/post-deploy-readiness.ts
@@ -1,0 +1,493 @@
+/* eslint-disable no-console */
+
+import { randomBytes } from 'node:crypto'
+import net from 'node:net'
+import { spawnSync } from 'node:child_process'
+import tls from 'node:tls'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { checkVoiceMappingReadiness, VOICE_ENV_BINDINGS } from '../src/voice-id-mapping.ts'
+
+type CheckStatus = 'pass' | 'fail' | 'skip'
+
+interface CheckResult {
+  status: CheckStatus
+  name: string
+  detail: string
+}
+
+const CHECKS: CheckResult[] = []
+const DEFAULT_BASE_URL = 'https://claw.amio.fans'
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const REPO_ROOT = resolve(PACKAGE_ROOT, '../..')
+const WRANGLER_CONFIG = resolve(PACKAGE_ROOT, 'wrangler.toml')
+
+function record(status: CheckStatus, name: string, detail: string): void {
+  CHECKS.push({ status, name, detail })
+  const label = status.toUpperCase().padEnd(4)
+  console.log(`[${label}] ${name} - ${detail}`)
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (value === undefined || value.trim() === '') {
+    throw new Error(`${name} is required for this opt-in check`)
+  }
+  return value
+}
+
+function baseUrl(): URL {
+  return new URL(process.env.PLATFORM_AI_BASE_URL ?? DEFAULT_BASE_URL)
+}
+
+function wsUrl(sessionName: string): URL {
+  const base = baseUrl()
+  const url = new URL(`/ai-ws/${sessionName}`, base.origin)
+  url.protocol = base.protocol === 'http:' ? 'ws:' : 'wss:'
+  return url
+}
+
+function runWrangler(args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(
+    'pnpm',
+    ['--dir', REPO_ROOT, 'exec', 'wrangler', `--config=${WRANGLER_CONFIG}`, ...args],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    }
+  )
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+async function checkWorkerVoiceSecretNames(): Promise<void> {
+  if (process.env.RUN_WORKER_SECRET_NAME_CHECK !== '1') {
+    record(
+      'skip',
+      'deployed voice secret names',
+      'set RUN_WORKER_SECRET_NAME_CHECK=1 to run wrangler secret list and verify VOLC_TTS_VOICE_COMPANION_* names'
+    )
+    return
+  }
+  const result = runWrangler(['secret', 'list'])
+  const combined = `${result.stdout}\n${result.stderr}`
+  if (result.status !== 0) {
+    record('fail', 'deployed voice secret names', combined.trim() || 'wrangler secret list failed')
+    return
+  }
+  const required = Array.from(new Set(Object.values(VOICE_ENV_BINDINGS)))
+  const missing = required.filter((name) => !combined.includes(name))
+  if (missing.length === 0) {
+    record('pass', 'deployed voice secret names', `found ${required.join(', ')}`)
+    return
+  }
+  record('fail', 'deployed voice secret names', `missing ${missing.join(', ')}`)
+}
+
+async function withTimeout<T>(label: string, ms: number, work: Promise<T>): Promise<T> {
+  let timer: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+      }),
+    ])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
+interface HandshakeResult {
+  status: number
+  statusLine: string
+  socket?: net.Socket
+  leftover: Buffer
+}
+
+function openTcp(url: URL): net.Socket {
+  const isTls = url.protocol === 'wss:'
+  const port = Number(url.port || (isTls ? 443 : 80))
+  if (isTls) {
+    return tls.connect({ host: url.hostname, port, servername: url.hostname })
+  }
+  return net.connect({ host: url.hostname, port })
+}
+
+async function websocketHandshake(url: URL, cookie?: string): Promise<HandshakeResult> {
+  const socket = openTcp(url)
+  const key = randomBytes(16).toString('base64')
+  const path = `${url.pathname}${url.search}`
+  const headers = [
+    `GET ${path} HTTP/1.1`,
+    `Host: ${url.host}`,
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    `Sec-WebSocket-Key: ${key}`,
+    'Sec-WebSocket-Version: 13',
+    ...(cookie === undefined ? [] : [`Cookie: ${cookie}`]),
+    '\r\n',
+  ].join('\r\n')
+
+  return withTimeout(
+    `websocket handshake ${url.href}`,
+    8000,
+    new Promise((resolvePromise, reject) => {
+      let buffer = Buffer.alloc(0)
+      const cleanup = (): void => {
+        socket.off('data', onData)
+        socket.off('error', onError)
+      }
+      const onError = (error: Error): void => {
+        cleanup()
+        reject(error)
+      }
+      const onData = (chunk: Buffer): void => {
+        buffer = Buffer.concat([buffer, chunk])
+        const headerEnd = buffer.indexOf('\r\n\r\n')
+        if (headerEnd === -1) return
+        cleanup()
+        const header = buffer.subarray(0, headerEnd).toString('utf8')
+        const [statusLine] = header.split('\r\n')
+        const status = Number(statusLine.split(' ')[1])
+        const leftover = buffer.subarray(headerEnd + 4)
+        if (status !== 101) socket.end()
+        resolvePromise({
+          status,
+          statusLine,
+          socket: status === 101 ? socket : undefined,
+          leftover,
+        })
+      }
+      socket.on('error', onError)
+      socket.on('data', onData)
+      socket.write(headers)
+    })
+  )
+}
+
+function websocketTextFrame(text: string): Buffer {
+  const payload = Buffer.from(text, 'utf8')
+  const mask = randomBytes(4)
+  const header =
+    payload.length < 126
+      ? Buffer.from([0x81, 0x80 | payload.length])
+      : Buffer.from([0x81, 0x80 | 126, (payload.length >> 8) & 0xff, payload.length & 0xff])
+  const masked = Buffer.alloc(payload.length)
+  for (let i = 0; i < payload.length; i += 1) {
+    masked[i] = payload[i] ^ mask[i % 4]
+  }
+  return Buffer.concat([header, mask, masked])
+}
+
+class ReadinessSocket {
+  private buffer: Buffer
+
+  constructor(
+    private readonly socket: net.Socket,
+    leftover: Buffer
+  ) {
+    this.buffer = leftover
+  }
+
+  sendJson(value: unknown): void {
+    this.socket.write(websocketTextFrame(JSON.stringify(value)))
+  }
+
+  close(): void {
+    this.socket.end()
+  }
+
+  async readText(timeoutMs = 8000): Promise<string> {
+    return withTimeout(
+      'websocket frame read',
+      timeoutMs,
+      new Promise((resolvePromise, reject) => {
+        const tryRead = (): boolean => {
+          if (this.buffer.length < 2) return false
+          const first = this.buffer[0]
+          const second = this.buffer[1]
+          const opcode = first & 0x0f
+          let offset = 2
+          let length = second & 0x7f
+          if (length === 126) {
+            if (this.buffer.length < 4) return false
+            length = this.buffer.readUInt16BE(2)
+            offset = 4
+          } else if (length === 127) {
+            reject(new Error('readiness socket does not support >64KB frames'))
+            return true
+          }
+          const masked = (second & 0x80) !== 0
+          const maskLength = masked ? 4 : 0
+          if (this.buffer.length < offset + maskLength + length) return false
+          const mask = masked ? this.buffer.subarray(offset, offset + 4) : undefined
+          offset += maskLength
+          const payload = Buffer.from(this.buffer.subarray(offset, offset + length))
+          this.buffer = this.buffer.subarray(offset + length)
+          if (mask !== undefined) {
+            for (let i = 0; i < payload.length; i += 1) {
+              payload[i] = payload[i] ^ mask[i % 4]
+            }
+          }
+          if (opcode === 0x8) {
+            reject(new Error('websocket closed before text response'))
+            return true
+          }
+          if (opcode !== 0x1) return tryRead()
+          resolvePromise(payload.toString('utf8'))
+          return true
+        }
+
+        const cleanup = (): void => {
+          this.socket.off('data', onData)
+          this.socket.off('error', onError)
+          this.socket.off('close', onClose)
+        }
+        const onData = (chunk: Buffer): void => {
+          this.buffer = Buffer.concat([this.buffer, chunk])
+          if (tryRead()) cleanup()
+        }
+        const onError = (error: Error): void => {
+          cleanup()
+          reject(error)
+        }
+        const onClose = (): void => {
+          cleanup()
+          reject(new Error('socket closed before text response'))
+        }
+        if (tryRead()) return
+        this.socket.on('data', onData)
+        this.socket.on('error', onError)
+        this.socket.on('close', onClose)
+      })
+    )
+  }
+}
+
+async function checkVoiceMapping(): Promise<void> {
+  const readiness = checkVoiceMappingReadiness(process.env)
+  if (readiness.ok) {
+    record(
+      'pass',
+      'voice mapping env',
+      `configured ${readiness.configured.map(({ voiceId }) => voiceId).join(', ')}`
+    )
+    return
+  }
+  record(
+    'fail',
+    'voice mapping env',
+    `missing ${readiness.missing.map(({ voiceId, envVar }) => `${voiceId}:${envVar}`).join(', ')}`
+  )
+}
+
+async function checkUnauthedWsReject(): Promise<void> {
+  const target = wsUrl(`readiness-unauth-${Date.now()}`)
+  const handshake = await websocketHandshake(target)
+  if (handshake.status === 401) {
+    record('pass', 'unauthenticated /ai-ws/* reject', `${target.href} returned 401`)
+    return
+  }
+  record(
+    'fail',
+    'unauthenticated /ai-ws/* reject',
+    `${target.href} returned ${handshake.statusLine}`
+  )
+}
+
+async function checkCompanionApiReadOnly(cookie: string | undefined): Promise<void> {
+  if (cookie === undefined) {
+    record(
+      'skip',
+      'Pages companion D1 binding visibility',
+      'set PLATFORM_AI_AUTH_COOKIE to run read-only GET /api/companion/profile'
+    )
+    return
+  }
+  const target = new URL('/api/companion/profile', baseUrl().origin)
+  const response = await fetch(target, { headers: { Cookie: cookie } })
+  if (response.status === 200 || response.status === 404) {
+    record(
+      'pass',
+      'Pages companion D1 binding visibility',
+      `${target.href} returned ${response.status}`
+    )
+    return
+  }
+  record(
+    'fail',
+    'Pages companion D1 binding visibility',
+    `${target.href} returned ${response.status}; expected 200 or 404 with a valid auth cookie`
+  )
+}
+
+async function checkSessionCreateShape(cookie: string | undefined): Promise<void> {
+  if (process.env.RUN_SESSION_CREATE_CHECK !== '1') {
+    record(
+      'skip',
+      'login-gated Platform AI session create',
+      'set RUN_SESSION_CREATE_CHECK=1 and PLATFORM_AI_AUTH_COOKIE to opt in; this creates and ends a demo-mock session'
+    )
+    return
+  }
+  if (cookie === undefined) throw new Error('PLATFORM_AI_AUTH_COOKIE is required')
+  const target = wsUrl(`readiness-auth-${Date.now()}`)
+  const handshake = await websocketHandshake(target, cookie)
+  if (handshake.status !== 101 || handshake.socket === undefined) {
+    record(
+      'fail',
+      'login-gated Platform AI session create',
+      `${target.href} returned ${handshake.statusLine}; expected 101 Switching Protocols`
+    )
+    return
+  }
+  const ws = new ReadinessSocket(handshake.socket, handshake.leftover)
+  ws.sendJson({
+    type: 'create',
+    gameId: 'demo-mock',
+    manualData: {
+      version: 'readiness-smoke',
+      sections: { intro: 'Post-deploy readiness smoke. No real providers.' },
+    },
+    gameState: { relevantSections: ['intro'] },
+    opening: false,
+    gameRunId: `readiness-${Date.now()}`,
+  })
+  const created = JSON.parse(await ws.readText()) as { type?: string; sessionId?: string }
+  if (created.type !== 'created' || typeof created.sessionId !== 'string') {
+    ws.close()
+    record(
+      'fail',
+      'login-gated Platform AI session create',
+      `unexpected frame ${JSON.stringify(created)}`
+    )
+    return
+  }
+  ws.sendJson({ type: 'end' })
+  const summary = JSON.parse(await ws.readText()) as { type?: string; summary?: unknown }
+  ws.close()
+  if (summary.type !== 'summary') {
+    record(
+      'fail',
+      'login-gated Platform AI session create',
+      `expected summary frame, got ${JSON.stringify(summary)}`
+    )
+    return
+  }
+  record(
+    'pass',
+    'login-gated Platform AI session create',
+    `created demo-mock session ${created.sessionId} and received summary`
+  )
+}
+
+async function checkD1Schema(): Promise<void> {
+  if (process.env.RUN_D1_SCHEMA_CHECK !== '1') {
+    record(
+      'skip',
+      'Companion D1 schema read',
+      'set RUN_D1_SCHEMA_CHECK=1 to run wrangler d1 execute --remote read-only schema query'
+    )
+    return
+  }
+  const database = process.env.COMPANION_D1_DATABASE_NAME ?? 'amiclaw-companion'
+  const sql =
+    "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('companion','episode','profile_claim','profile_claim_evidence','asset_entry','capture_event') ORDER BY name;"
+  const result = runWrangler(['d1', 'execute', database, '--remote', '--command', sql])
+  const combined = `${result.stdout}\n${result.stderr}`
+  const requiredTables = [
+    'asset_entry',
+    'capture_event',
+    'companion',
+    'episode',
+    'profile_claim',
+    'profile_claim_evidence',
+  ]
+  const missingTables = requiredTables.filter((name) => !combined.includes(name))
+  if (result.status === 0 && missingTables.length === 0) {
+    record('pass', 'Companion D1 schema read', `${database} exposes companion-memory tables`)
+    return
+  }
+  record(
+    'fail',
+    'Companion D1 schema read',
+    missingTables.length > 0
+      ? `missing ${missingTables.join(', ')} in ${database}`
+      : combined.trim() || 'wrangler d1 execute failed'
+  )
+}
+
+async function checkUsageWrite(): Promise<void> {
+  if (process.env.RUN_USAGE_WRITE_CHECK !== '1') {
+    record(
+      'skip',
+      'USAGE KV write visibility',
+      'set RUN_USAGE_WRITE_CHECK=1 and USAGE_KV_NAMESPACE_ID to opt into a write/get/delete smoke'
+    )
+    return
+  }
+  const namespaceId = requireEnv('USAGE_KV_NAMESPACE_ID')
+  const key = `readiness-smoke:${Date.now()}`
+  const value = JSON.stringify({ source: 'platform-ai-readiness', at: new Date().toISOString() })
+  const put = runWrangler([
+    'kv',
+    'key',
+    'put',
+    key,
+    value,
+    '--namespace-id',
+    namespaceId,
+    '--remote',
+  ])
+  if (put.status !== 0) {
+    record('fail', 'USAGE KV write visibility', put.stderr.trim() || put.stdout.trim())
+    return
+  }
+  const get = runWrangler(['kv', 'key', 'get', key, '--namespace-id', namespaceId, '--remote'])
+  const del = runWrangler(['kv', 'key', 'delete', key, '--namespace-id', namespaceId, '--remote'])
+  if (get.status === 0 && get.stdout.includes('platform-ai-readiness') && del.status === 0) {
+    record('pass', 'USAGE KV write visibility', `wrote, read, and deleted ${key}`)
+    return
+  }
+  record(
+    'fail',
+    'USAGE KV write visibility',
+    `get/delete failed after put; get=${get.status} delete=${del.status}`
+  )
+}
+
+async function main(): Promise<void> {
+  const cookie = process.env.PLATFORM_AI_AUTH_COOKIE
+
+  await checkVoiceMapping()
+  await checkWorkerVoiceSecretNames()
+  await checkUnauthedWsReject()
+  await checkCompanionApiReadOnly(cookie)
+  await checkSessionCreateShape(cookie)
+  await checkD1Schema()
+  await checkUsageWrite()
+
+  console.log('\nLog lookup:')
+  console.log('- Confirm packages/platform-ai/wrangler.toml keeps [observability].enabled = true.')
+  console.log(
+    '- Live tail: pnpm exec wrangler --config=packages/platform-ai/wrangler.toml tail platform-ai'
+  )
+  console.log('- Query Builder: filter Worker = platform-ai and log text contains turn-trace.')
+  console.log(
+    '- Companion capture: search for companion-capture or companion-consolidator messages.'
+  )
+
+  const failed = CHECKS.filter((check) => check.status === 'fail')
+  if (failed.length > 0) {
+    process.exitCode = 1
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/packages/platform-ai/src/companion-injection.test.ts
+++ b/packages/platform-ai/src/companion-injection.test.ts
@@ -202,23 +202,24 @@ describe('assembleSession — companion voice wiring', () => {
       volcengineVoiceType: 'zh_female_warm_real_token',
     })
     assembleSession('demo', 'user-a', MANUAL, undefined, VOLC_ENV, { companionContext: CONTEXT })
-    expect(voiceMapping.resolveVendorVoice).toHaveBeenCalledWith('companion-warm')
+    expect(voiceMapping.resolveVendorVoice).toHaveBeenCalledWith('companion-warm', VOLC_ENV)
     expect(speech).toHaveBeenCalledWith(
       expect.objectContaining({ ttsSpeaker: 'zh_female_warm_real_token' })
     )
   })
 
-  it('degrades to the provider default voice on a placeholder/missing mapping — never throws', () => {
+  it('degrades to the provider default voice on a missing deploy mapping — never throws', () => {
     const speech = vi.spyOn(volcengine, 'createVolcengineSpeechProvider')
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    // The committed mapping is all PLACEHOLDER_* tokens, so the real resolver
-    // degrades here — assembly must still succeed, with no speaker override.
+    // No VOLC_TTS_VOICE_COMPANION_* env vars are configured in this test env, so
+    // the real resolver degrades here — assembly must still succeed, with no
+    // speaker override.
     const assembled = assembleSession('demo', 'user-a', MANUAL, undefined, VOLC_ENV, {
       companionContext: CONTEXT,
     })
     expect(assembled.state.companionContext).toEqual(CONTEXT)
     expect(speech).toHaveBeenCalledWith(expect.objectContaining({ ttsSpeaker: undefined }))
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('unfilled placeholder'))
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing a real deploy env'))
   })
 
   it('does not consult the voice mapping without a companion context (zero behavior change)', () => {

--- a/packages/platform-ai/src/index.ts
+++ b/packages/platform-ai/src/index.ts
@@ -56,6 +56,20 @@ export { assembleLlmContext } from './manual-injection'
 export type { ProviderEnv, SessionProviders } from './providers/factory'
 export { createProviders } from './providers/factory'
 
+// Companion voice mapping readiness — runtime fails open, launch checks fail loud.
+export type {
+  VendorVoiceParams,
+  VoiceMappingEnv,
+  VoiceMappingIssue,
+  VoiceMappingReadiness,
+} from './voice-id-mapping'
+export {
+  VOICE_ENV_BINDINGS,
+  checkVoiceMappingReadiness,
+  assertVoiceMappingReady,
+  resolveVendorVoice,
+} from './voice-id-mapping'
+
 // Deterministic mock providers — no-credential demo / e2e harness backend.
 export type {
   MockLlmProvider,

--- a/packages/platform-ai/src/providers/factory.ts
+++ b/packages/platform-ai/src/providers/factory.ts
@@ -15,6 +15,7 @@
 
 import type { LlmProvider, SttProvider, TtsProvider } from './types'
 import type { ResolvedConfig } from '../provider-config'
+import type { VoiceMappingEnv } from '../voice-id-mapping'
 import { createDeepSeekLlmProvider } from './deepseek'
 import { createVolcengineSpeechProvider } from './volcengine'
 import { createMockLlmProvider, createMockSpeechProvider } from './mock'
@@ -36,7 +37,7 @@ const PROVIDER_MOCK = 'mock'
  * factory can throw a precise "missing credential" error for the specific
  * vendor a config actually selects, rather than failing on an unrelated one.
  */
-export interface ProviderEnv {
+export interface ProviderEnv extends VoiceMappingEnv {
   /** DeepSeek API key, server-side only. */
   DEEPSEEK_API_KEY?: string
   /** Optional DeepSeek base URL override. */

--- a/packages/platform-ai/src/session-assembly.ts
+++ b/packages/platform-ai/src/session-assembly.ts
@@ -89,7 +89,7 @@ export function assembleSession(
   const vendorVoice =
     extras.companionContext === undefined
       ? undefined
-      : resolveVendorVoice(extras.companionContext.companion.voice_id)
+      : resolveVendorVoice(extras.companionContext.companion.voice_id, env)
   const providers = createProviders(
     config,
     env,

--- a/packages/platform-ai/src/voice-id-mapping.test.ts
+++ b/packages/platform-ai/src/voice-id-mapping.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  assertVoiceMappingReady,
+  checkVoiceMappingReadiness,
   PLATFORM_VOICE_IDS,
   resolveVendorVoice,
-  VOICE_MAPPING,
-  type VendorVoiceParams,
+  VOICE_ENV_BINDINGS,
+  type VoiceMappingEnv,
 } from './voice-id-mapping'
 
-const FILLED: Record<string, VendorVoiceParams> = {
-  'companion-warm': { volcengineVoiceType: 'zh_female_warm_real_token' },
+const COMPLETE_ENV: VoiceMappingEnv = {
+  VOLC_TTS_VOICE_COMPANION_WARM: 'zh_female_warm_real_token',
+  VOLC_TTS_VOICE_COMPANION_BRIGHT: 'zh_female_bright_real_token',
+  VOLC_TTS_VOICE_COMPANION_CALM: 'zh_female_calm_real_token',
 }
 
 afterEach(() => {
@@ -15,15 +19,15 @@ afterEach(() => {
 })
 
 describe('voice-id-mapping', () => {
-  it('covers EVERY platform voice id (continuity: profile never blocked by a vendor gap)', () => {
+  it('assigns a deploy env var to EVERY platform voice id', () => {
     for (const voiceId of PLATFORM_VOICE_IDS) {
-      expect(VOICE_MAPPING[voiceId].volcengineVoiceType.length).toBeGreaterThan(0)
+      expect(VOICE_ENV_BINDINGS[voiceId]).toMatch(/^VOLC_TTS_VOICE_COMPANION_/)
     }
   })
 
-  it('resolves a filled mapping to its vendor voice params', () => {
+  it('resolves a configured env mapping to its vendor voice params', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    expect(resolveVendorVoice('companion-warm', FILLED)).toEqual({
+    expect(resolveVendorVoice('companion-warm', COMPLETE_ENV)).toEqual({
       volcengineVoiceType: 'zh_female_warm_real_token',
     })
     expect(warn).not.toHaveBeenCalled()
@@ -31,14 +35,75 @@ describe('voice-id-mapping', () => {
 
   it('degrades an unmapped voice id to undefined with a warning — never throws', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    expect(resolveVendorVoice('vendor-raw-token')).toBeUndefined()
+    expect(resolveVendorVoice('vendor-raw-token', COMPLETE_ENV)).toBeUndefined()
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('no vendor mapping'))
   })
 
-  it('degrades an unfilled PLACEHOLDER_* token to undefined with a warning — never throws', () => {
+  it('degrades a missing deploy env token to undefined with a warning — never throws', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    // The committed mapping is all placeholders until deploy back-fill.
-    expect(resolveVendorVoice('companion-warm')).toBeUndefined()
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('unfilled placeholder'))
+    expect(resolveVendorVoice('companion-warm', {})).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing a real deploy env'))
+  })
+
+  it('rejects placeholder-like deploy env tokens and never sends them to the vendor', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const env: VoiceMappingEnv = {
+      VOLC_TTS_VOICE_COMPANION_WARM: 'PLACEHOLDER_VOLC_VOICE_TYPE_WARM',
+      VOLC_TTS_VOICE_COMPANION_BRIGHT: '<real token>',
+      VOLC_TTS_VOICE_COMPANION_CALM: 'TODO',
+    }
+
+    expect(checkVoiceMappingReadiness(env)).toEqual({
+      ok: false,
+      configured: [],
+      missing: [
+        { voiceId: 'companion-warm', envVar: 'VOLC_TTS_VOICE_COMPANION_WARM' },
+        { voiceId: 'companion-bright', envVar: 'VOLC_TTS_VOICE_COMPANION_BRIGHT' },
+        { voiceId: 'companion-calm', envVar: 'VOLC_TTS_VOICE_COMPANION_CALM' },
+      ],
+    })
+    expect(resolveVendorVoice('companion-warm', env)).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing a real deploy env'))
+  })
+
+  it('reports launch readiness when every voice env var is configured', () => {
+    expect(checkVoiceMappingReadiness(COMPLETE_ENV)).toEqual({
+      ok: true,
+      configured: [
+        {
+          voiceId: 'companion-warm',
+          envVar: 'VOLC_TTS_VOICE_COMPANION_WARM',
+          volcengineVoiceType: 'zh_female_warm_real_token',
+        },
+        {
+          voiceId: 'companion-bright',
+          envVar: 'VOLC_TTS_VOICE_COMPANION_BRIGHT',
+          volcengineVoiceType: 'zh_female_bright_real_token',
+        },
+        {
+          voiceId: 'companion-calm',
+          envVar: 'VOLC_TTS_VOICE_COMPANION_CALM',
+          volcengineVoiceType: 'zh_female_calm_real_token',
+        },
+      ],
+      missing: [],
+    })
+    expect(() => assertVoiceMappingReady(COMPLETE_ENV)).not.toThrow()
+  })
+
+  it('fails launch readiness loudly when any deploy voice env var is missing', () => {
+    const incomplete: VoiceMappingEnv = {
+      VOLC_TTS_VOICE_COMPANION_WARM: 'zh_female_warm_real_token',
+      VOLC_TTS_VOICE_COMPANION_BRIGHT: '  ',
+    }
+    const readiness = checkVoiceMappingReadiness(incomplete)
+    expect(readiness.ok).toBe(false)
+    expect(readiness.missing).toEqual([
+      { voiceId: 'companion-bright', envVar: 'VOLC_TTS_VOICE_COMPANION_BRIGHT' },
+      { voiceId: 'companion-calm', envVar: 'VOLC_TTS_VOICE_COMPANION_CALM' },
+    ])
+    expect(() => assertVoiceMappingReady(incomplete)).toThrow(
+      /companion-bright -> VOLC_TTS_VOICE_COMPANION_BRIGHT/
+    )
   })
 })

--- a/packages/platform-ai/src/voice-id-mapping.ts
+++ b/packages/platform-ai/src/voice-id-mapping.ts
@@ -4,9 +4,10 @@
  *
  * Lives on the provider-config plane: the companion profile stores ONLY the
  * platform-neutral id (`companion-warm` / ...); the concrete vendor token is
- * resolved server-side here at session assembly (`session-assembly.ts` threads
- * it into the TTS provider as the speaker override). Switching the TTS vendor
- * or model = editing this mapping — the companion profile is never touched.
+ * resolved server-side from deploy configuration at session assembly
+ * (`session-assembly.ts` threads it into the TTS provider as the speaker
+ * override). Switching the TTS vendor or model = editing deploy configuration
+ * and this resolver plane — the companion profile is never touched.
  *
  * Resolution is TOTAL, mirroring the companion-context resolver's degrade
  * semantics: an unknown id or an unfilled deploy-time placeholder resolves to
@@ -14,13 +15,10 @@
  * default voice. A voice-mapping gap must never fail session creation — the
  * companion's voice is identity, but a degraded voice beats no session.
  *
- * The Volcengine tokens are deploy-time placeholders, mirroring the
- * `PLACEHOLDER_*` convention in `wrangler.toml`: the mapping MECHANISM and its
- * completeness test are the deliverable here; back-filling the concrete
- * voice_type tokens against the real endpoint is a DEPLOY-BLOCKING checklist
- * item (see `functions/api/companion/PROVISIONING.md` §5). No guessed token
- * goes on the wire: an unfilled placeholder degrades to the default voice at
- * runtime (warned, never thrown).
+ * Volcengine `voice_type` tokens are deploy configuration, not source code.
+ * The resolver reads `VOLC_TTS_VOICE_COMPANION_*` env vars; no guessed token is
+ * committed or sent on the wire. Runtime resolution stays fail-open for player
+ * experience, while `assertVoiceMappingReady` is fail-loud for launch checks.
  */
 
 import { PLATFORM_VOICE_IDS, type PlatformVoiceId } from '../../companion-memory/src/types'
@@ -31,46 +29,116 @@ export interface VendorVoiceParams {
   volcengineVoiceType: string
 }
 
-/** Deploy-time placeholder marker — an unfilled token, never sent on the wire. */
-const PLACEHOLDER_PREFIX = 'PLACEHOLDER_'
+/** Deploy-time environment variables carrying real Volcengine voice tokens. */
+export interface VoiceMappingEnv {
+  VOLC_TTS_VOICE_COMPANION_WARM?: string
+  VOLC_TTS_VOICE_COMPANION_BRIGHT?: string
+  VOLC_TTS_VOICE_COMPANION_CALM?: string
+}
 
 /**
- * The vendor mapping table. Exported so the completeness test can assert every
- * platform voice id has an entry (a vendor switch must never leave a companion
- * voice unmapped).
+ * Env var names keyed by the platform-neutral voice catalog. Exported so tests
+ * and runbooks can assert every platform voice id has a deploy variable.
  */
-export const VOICE_MAPPING: Record<PlatformVoiceId, VendorVoiceParams> = {
-  'companion-warm': { volcengineVoiceType: 'PLACEHOLDER_VOLC_VOICE_TYPE_WARM' },
-  'companion-bright': { volcengineVoiceType: 'PLACEHOLDER_VOLC_VOICE_TYPE_BRIGHT' },
-  'companion-calm': { volcengineVoiceType: 'PLACEHOLDER_VOLC_VOICE_TYPE_CALM' },
+export const VOICE_ENV_BINDINGS: Record<PlatformVoiceId, keyof VoiceMappingEnv> = {
+  'companion-warm': 'VOLC_TTS_VOICE_COMPANION_WARM',
+  'companion-bright': 'VOLC_TTS_VOICE_COMPANION_BRIGHT',
+  'companion-calm': 'VOLC_TTS_VOICE_COMPANION_CALM',
 }
 
 /** All platform voice ids (re-exported for mapping-completeness checks). */
 export { PLATFORM_VOICE_IDS }
 
+export interface VoiceMappingIssue {
+  voiceId: PlatformVoiceId
+  envVar: keyof VoiceMappingEnv
+}
+
+export interface VoiceMappingReadiness {
+  ok: boolean
+  configured: Array<VoiceMappingIssue & { volcengineVoiceType: string }>
+  missing: VoiceMappingIssue[]
+}
+
+function readConfiguredToken(env: VoiceMappingEnv, envVar: keyof VoiceMappingEnv): string | null {
+  const token = env[envVar]?.trim()
+  if (token === undefined || token === '') return null
+  if (isPlaceholderToken(token)) return null
+  return token
+}
+
+function isPlaceholderToken(token: string): boolean {
+  const normalized = token.toLowerCase()
+  return (
+    normalized.startsWith('placeholder_') ||
+    normalized.includes('placeholder') ||
+    normalized.includes('todo') ||
+    normalized.includes('replace_me') ||
+    normalized.includes('real token') ||
+    normalized.includes('<') ||
+    normalized.includes('>')
+  )
+}
+
+/**
+ * Read the configured Volcengine mapping from deployment env. Pure and
+ * side-effect free; use this in launch readiness checks where a missing token
+ * must fail loudly before exposing mode2.
+ */
+export function checkVoiceMappingReadiness(env: VoiceMappingEnv): VoiceMappingReadiness {
+  const configured: VoiceMappingReadiness['configured'] = []
+  const missing: VoiceMappingIssue[] = []
+
+  for (const voiceId of PLATFORM_VOICE_IDS) {
+    const envVar = VOICE_ENV_BINDINGS[voiceId]
+    const token = readConfiguredToken(env, envVar)
+    if (token === null) {
+      missing.push({ voiceId, envVar })
+    } else {
+      configured.push({ voiceId, envVar, volcengineVoiceType: token })
+    }
+  }
+
+  return { ok: missing.length === 0, configured, missing }
+}
+
+/**
+ * Launch-readiness gate: all platform voice ids must have real deploy-configured
+ * Volcengine voice tokens. Throws with exact missing variable names.
+ */
+export function assertVoiceMappingReady(env: VoiceMappingEnv): void {
+  const readiness = checkVoiceMappingReadiness(env)
+  if (readiness.ok) return
+  const missing = readiness.missing
+    .map(({ voiceId, envVar }) => `${voiceId} -> ${envVar}`)
+    .join(', ')
+  throw new Error(`voice-id-mapping: missing deploy voice mapping env vars: ${missing}`)
+}
+
 /**
  * Resolve the vendor voice parameters for a platform voice id at session
  * assembly. Total — never throws: an unknown id or an unfilled `PLACEHOLDER_*`
  * token degrades to `undefined` (caller keeps the provider's default voice)
- * with a `console.warn`, so session creation never fails on a voice-mapping
- * gap. `mapping` is injectable for tests only.
+ * with a `console.warn`, so session creation never fails on a voice-mapping gap.
  */
 export function resolveVendorVoice(
   voiceId: string,
-  mapping: Record<string, VendorVoiceParams> = VOICE_MAPPING
+  env: VoiceMappingEnv
 ): VendorVoiceParams | undefined {
-  const params = mapping[voiceId]
-  if (params === undefined) {
+  if (!(PLATFORM_VOICE_IDS as readonly string[]).includes(voiceId)) {
     console.warn(
       `voice-id-mapping: no vendor mapping for voice_id "${voiceId}" (known: ${PLATFORM_VOICE_IDS.join(', ')}); using the provider default voice`
     )
     return undefined
   }
-  if (params.volcengineVoiceType.startsWith(PLACEHOLDER_PREFIX)) {
+  const platformVoiceId = voiceId as PlatformVoiceId
+  const envVar = VOICE_ENV_BINDINGS[platformVoiceId]
+  const token = readConfiguredToken(env, envVar)
+  if (token === null) {
     console.warn(
-      `voice-id-mapping: voice_id "${voiceId}" maps to unfilled placeholder "${params.volcengineVoiceType}"; using the provider default voice (back-fill per functions/api/companion/PROVISIONING.md §5)`
+      `voice-id-mapping: voice_id "${voiceId}" is missing a real deploy env ${envVar}; using the provider default voice (run packages/platform-ai post-deploy readiness before launch)`
     )
     return undefined
   }
-  return params
+  return { volcengineVoiceType: token }
 }

--- a/packages/platform-ai/wrangler.toml
+++ b/packages/platform-ai/wrangler.toml
@@ -122,6 +122,9 @@ DEV_AUTH_BYPASS = "false"
 #   VOLC_API_KEY       — Volcengine (火山) console API key, sent as the single
 #                        X-Api-Key header (new-console-auth). Grants the Doubao
 #                        2.0 speech stack (seedasr ASR 2.0 + Doubao TTS 2.0).
+#   VOLC_TTS_VOICE_COMPANION_WARM   — Volcengine voice_type for companion-warm.
+#   VOLC_TTS_VOICE_COMPANION_BRIGHT — Volcengine voice_type for companion-bright.
+#   VOLC_TTS_VOICE_COMPANION_CALM   — Volcengine voice_type for companion-calm.
 # These are referenced by the provider adapters; declared here only as
 # documentation so the deploy operator knows what to provision.
 #

--- a/packages/platform/src/pages/PrivacyPage.test.tsx
+++ b/packages/platform/src/pages/PrivacyPage.test.tsx
@@ -3,8 +3,8 @@
  *
  * Asserts the production privacy policy renders and that the faithfulness-
  * critical facts are present: the retention windows (48h leaderboard / 30d
- * telemetry), the contact address, the "we do not collect email / phone /
- * real name" disclaimer, and the public-leaderboard disclosure. These are the
+ * telemetry / 30d sessions / 90d audit), the contact address, the mode① versus
+ * mode② data split, and the public-leaderboard disclosure. These are the
  * legal-compliance load-bearing claims, so the test guards them against an
  * accidental edit that would make the page misstate the real data practice.
  */
@@ -32,6 +32,8 @@ describe('PrivacyPage', () => {
     renderPage()
     expect(screen.getByText(/保留 48\s*小时后自动过期/)).toBeInTheDocument()
     expect(screen.getByText(/保留 30 天后自动过期/)).toBeInTheDocument()
+    expect(screen.getByText(/会话记录与会话[\s\S]*Cookie 默认保留 30 天/)).toBeInTheDocument()
+    expect(screen.getByText(/认证审计记录保留 90 天/)).toBeInTheDocument()
   })
 
   it('discloses the public leaderboard and what it shows', () => {
@@ -42,17 +44,27 @@ describe('PrivacyPage', () => {
     expect(screen.getByText(/在每日排行榜上公开展示/)).toBeInTheDocument()
   })
 
-  it('carries the faithful "we do not collect email / phone / real name" disclaimer', () => {
+  it('discloses the mode-specific email and account session collection', () => {
     renderPage()
-    expect(
-      screen.getByText(/我们不收集邮箱、手机号、真实姓名、精确地理位置或任何支付信息/)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/平台 AI[\s\S]*伙伴需要登录邮箱来建立账号会话/)).toBeInTheDocument()
+    expect(screen.getAllByText(/amiclaw_session/).length).toBeGreaterThan(0)
+    expect(screen.getByText(/自带 AI 游玩不要求邮箱、手机号或真实姓名/)).toBeInTheDocument()
   })
 
-  it('names Cloudflare as the hosting and storage processor', () => {
+  it('names Cloudflare and platform AI providers as processors', () => {
     renderPage()
     expect(screen.getByText(/Cloudflare Pages/)).toBeInTheDocument()
     expect(screen.getByText(/Cloudflare KV/)).toBeInTheDocument()
+    expect(screen.getByText(/Cloudflare D1/)).toBeInTheDocument()
+    expect(screen.getByText(/Volcengine/)).toBeInTheDocument()
+    expect(screen.getByText(/DeepSeek/)).toBeInTheDocument()
+  })
+
+  it('discloses Companion Memory and user controls', () => {
+    renderPage()
+    expect(screen.getAllByText(/Companion Memory/).length).toBeGreaterThan(0)
+    expect(screen.getByText(/删除对应回忆、删除或更正个人画像项/)).toBeInTheDocument()
+    expect(screen.getAllByText(/关闭个人画像层/).length).toBeGreaterThan(0)
   })
 
   it('provides the deletion / contact email and an effective date', () => {
@@ -60,6 +72,6 @@ describe('PrivacyPage', () => {
     const mailtoLinks = screen.getAllByRole('link', { name: 'hi@amio.love' })
     expect(mailtoLinks.length).toBeGreaterThan(0)
     expect(mailtoLinks[0]).toHaveAttribute('href', 'mailto:hi@amio.love')
-    expect(screen.getByText(/生效日期：2026-06-07/)).toBeInTheDocument()
+    expect(screen.getByText(/生效日期：2026-07-04/)).toBeInTheDocument()
   })
 })

--- a/packages/platform/src/pages/PrivacyPage.tsx
+++ b/packages/platform/src/pages/PrivacyPage.tsx
@@ -2,14 +2,13 @@ import { EyebrowTag, GlassCard } from '@amiclaw/ui'
 import styles from './PrivacyPage.module.css'
 
 const CONTACT_EMAIL = 'hi@amio.love'
-const EFFECTIVE_DATE = '2026-06-07'
+const EFFECTIVE_DATE = '2026-07-04'
 
 /* Privacy policy page — a production-grade Chinese privacy policy for
    AMIO Arcade (claw.amio.fans). The collected-data inventory is kept
-   faithful to the real submission and telemetry contracts (validation.ts /
-   post-event.ts / leaderboard-types.ts / event-types.ts) and the real KV
-   retention windows (leaderboard 48h, telemetry 30d). Platform chrome —
-   every accent is brand yellow; no BombSquad cyan on this surface. */
+   faithful to the anonymous leaderboard/event contracts, auth-session KV,
+   platform-AI Worker usage records, and Companion D1 memory plane. Platform
+   chrome — every accent is brand yellow; no BombSquad cyan on this surface. */
 export default function PrivacyPage() {
   return (
     <div className={styles.page}>
@@ -32,16 +31,20 @@ export default function PrivacyPage() {
               }
             </p>
             <p>
-              本服务不设账号体系，无须注册，也无须提供邮箱、手机号或真实姓名即可游玩。
-              下文逐项说明我们实际收集的信息。
+              本服务包含两种使用形态：不登录的自带 AI 游玩，以及登录后的平台 AI 伙伴游玩。
+              前者只使用本地设备标识与排行榜信息；后者会处理登录邮箱、会话、平台 AI
+              语音会话、使用量记录和 Companion Memory。下文逐项说明我们实际收集的信息。
             </p>
           </section>
 
           <section className={styles.section}>
             <h3 className={styles.heading}>二、我们收集哪些信息</h3>
-            <p>我们只收集运行游戏与维护排行榜所必需的信息，逐项列举如下，并说明每项的收集原因。</p>
+            <p>
+              我们按功能列出收集范围。未使用登录或平台 AI 伙伴时，对应的登录、语音会话和 Companion
+              Memory 数据不会产生。
+            </p>
 
-            <h4 className={styles.subheading}>1. 你主动提交的信息</h4>
+            <h4 className={styles.subheading}>1. 自带 AI 游玩中你主动提交的信息</h4>
             <ul className={styles.list}>
               <li>
                 <strong>昵称</strong>（最长 20
@@ -61,7 +64,50 @@ export default function PrivacyPage() {
               </li>
             </ul>
 
-            <h4 className={styles.subheading}>2. 游戏运行中自动产生的信息</h4>
+            <h4 className={styles.subheading}>2. 登录与账号会话信息</h4>
+            <ul className={styles.list}>
+              <li>
+                <strong>邮箱</strong>
+                ：你通过邮件登录或 Google 登录时，我们会处理已验证邮箱，并从邮箱派生稳定的
+                user_id。前端资料页会用邮箱本地部分显示一个基础名称。
+              </li>
+              <li>
+                <strong>会话 Cookie</strong>
+                ：登录后，服务器会设置名为 amiclaw_session 的 HttpOnly Cookie，保存不透明会话
+                ID，用于识别已登录用户。会话记录保存在 AUTH KV 中，可通过登出撤销。
+              </li>
+              <li>
+                <strong>登录安全记录</strong>
+                ：包括魔法链接 token 哈希、Google OAuth
+                state、登录/登出审计记录，以及邮件发送和验证接口的限流计数。
+              </li>
+            </ul>
+
+            <h4 className={styles.subheading}>3. 平台 AI 伙伴与 Companion Memory 信息</h4>
+            <ul className={styles.list}>
+              <li>
+                <strong>伙伴设置</strong>
+                ：包括伙伴名称、称呼方式、平台内 voice_id，以及是否启用个人画像层的开关。
+              </li>
+              <li>
+                <strong>语音会话数据</strong>
+                ：平台 AI Worker 会处理游戏 ID、当前模块手册、必要的游戏状态、你的语音转写、AI
+                回复、会话摘要、亮点和会话结束事件。语音音频会传输给语音供应商完成实时处理；平台记忆层保存的是摘要和结构化记录。
+              </li>
+              <li>
+                <strong>使用量记录</strong>
+                ：包括每个已结束平台 AI 会话的语言模型 token、语音识别与语音合成时长、识别来源和会话
+                ID，用于成本、滥用排查和运行可见性。
+              </li>
+              <li>
+                <strong>Companion Memory</strong>
+                ：包括可见回忆（episode）、个人画像判断（profile
+                claim）、画像证据、资产流水和待处理/已处理的 capture event。
+                这些数据只归属于你的登录 user_id。
+              </li>
+            </ul>
+
+            <h4 className={styles.subheading}>4. 游戏运行中自动产生的信息</h4>
             <ul className={styles.list}>
               <li>
                 <strong>设备标识符</strong>
@@ -79,7 +125,8 @@ export default function PrivacyPage() {
             </ul>
 
             <p className={styles.note}>
-              我们不收集邮箱、手机号、真实姓名、精确地理位置或任何支付信息。本服务目前不涉及付费，也不接入支付渠道。
+              自带 AI 游玩不要求邮箱、手机号或真实姓名。平台 AI
+              伙伴需要登录邮箱来建立账号会话。我们目前不收集精确地理位置或支付信息，本服务当前不接入支付渠道。
             </p>
           </section>
 
@@ -90,6 +137,14 @@ export default function PrivacyPage() {
               <li>进行成绩的服务端校验与基础反作弊，识别异常或刷榜的提交。</li>
               <li>以聚合方式统计游玩与完成情况，评估游戏体验并据此改进。</li>
               <li>根据问卷反馈了解协作中的问题，改进游戏设计。</li>
+              <li>建立与维护登录会话，让已登录用户使用平台 AI 伙伴与账号相关功能。</li>
+              <li>
+                组装平台 AI 语音会话，向 AI 伙伴提供当前游戏所需的手册、状态和 Companion Memory。
+              </li>
+              <li>
+                记录平台 AI 使用量、运行错误和低层诊断信号，以便控制成本、排查故障和发现滥用。
+              </li>
+              <li>维护、展示、更正或删除你的 Companion Memory 与个人画像。</li>
             </ul>
             <p>我们不会将上述信息用于与本服务无关的目的，也不会用于自动化决策对你产生重大影响。</p>
           </section>
@@ -104,13 +159,21 @@ export default function PrivacyPage() {
             </p>
             <p>
               <strong>托管与存储服务商</strong>：本服务托管于 Cloudflare。页面由 Cloudflare Pages
-              提供，服务端逻辑运行于 Cloudflare Workers，成绩与事件数据存储于 Cloudflare KV。
-              这意味着上述数据会经由 Cloudflare 的基础设施传输与存储，受其作为处理方的安全措施约束。
+              提供，服务端逻辑运行于 Cloudflare Workers，成绩、事件、认证和使用量数据存储于
+              Cloudflare KV，Companion Memory 存储于 Cloudflare D1，长连接会话运行于 Cloudflare
+              Durable Objects。这意味着上述数据会经由 Cloudflare
+              的基础设施传输与存储，受其作为处理方的安全措施约束。
             </p>
             <p>
               <strong>你自带的 AI 工具</strong>：你与之语音协作的 AI
               由你自行选择并独立使用，属于不受我们控制的第三方服务。你与该 AI
               的对话不经过本服务，也不由我们收集；该 AI 如何处理你的数据，由其各自的隐私政策约束。
+            </p>
+            <p>
+              <strong>平台 AI 供应商</strong>：当你使用平台 AI
+              伙伴时，语音识别、语音合成和语言模型回复会在实现会话所需范围内交由已配置的供应商处理。
+              当前代码路径包括 Volcengine 语音服务和 DeepSeek
+              兼容语言模型服务；供应商可能根据其条款处理必要的请求数据。
             </p>
             <p>
               除上述托管与存储服务商外，我们不向任何第三方出售、出租你的个人信息，也不会在法律要求之外对外共享。
@@ -120,10 +183,11 @@ export default function PrivacyPage() {
           <section className={styles.section}>
             <h3 className={styles.heading}>五、Cookie 与本地存储</h3>
             <p>
-              本服务不使用用于广告追踪的
-              Cookie。我们使用浏览器的本地存储（localStorage）保存上述设备标识符，以及你填过的昵称与
-              AI
-              工具信息，便于你下次游玩时无须重填；并使用会话存储（sessionStorage）在你提交成绩后临时保留你的排行榜成绩，用于即时展示。清除浏览器的本地存储即可移除这些数据。
+              本服务不使用用于广告追踪的 Cookie。登录后，我们使用名为 amiclaw_session 的 HttpOnly
+              Cookie 保存会话 ID；Google 登录流程还会短暂使用 oauth_state Cookie 防止登录 CSRF。
+              我们使用浏览器的本地存储（localStorage）保存上述设备标识符，以及你填过的昵称与 AI
+              工具信息，便于你下次游玩时无须重填；并使用会话存储（sessionStorage）在你提交成绩后临时保留你的排行榜成绩，用于即时展示。清除浏览器的本地存储即可移除本地数据；登出会清除登录会话
+              Cookie。
             </p>
           </section>
 
@@ -139,6 +203,21 @@ export default function PrivacyPage() {
                 <strong>匿名行为事件与问卷回答</strong>：自写入起保留 30 天后自动过期。
               </li>
               <li>
+                <strong>登录与认证数据</strong>
+                ：魔法链接 token 哈希保留 15 分钟，Google OAuth state 保留 10 分钟，会话记录与会话
+                Cookie 默认保留 30 天或在你登出时撤销，认证审计记录保留 90
+                天，限流计数按对应窗口自动过期。
+              </li>
+              <li>
+                <strong>平台 AI 使用量记录</strong>
+                ：用于成本、滥用排查和运行可见性，当前没有自动
+                TTL；我们会在目的完成、法律要求或你的有效删除请求范围内处理。
+              </li>
+              <li>
+                <strong>Companion Memory</strong>
+                ：保留至你删除对应回忆、删除或更正个人画像项、关闭个人画像层，或我们不再需要继续提供相关功能。
+              </li>
+              <li>
                 <strong>本地存储中的设备标识符与昵称等</strong>：保存在你的设备上，由你随时清除。
               </li>
             </ul>
@@ -150,13 +229,17 @@ export default function PrivacyPage() {
               在适用法律允许的范围内，你对自己的个人信息享有访问、更正、删除以及撤回同意的权利。
             </p>
             <p>
-              由于本服务不设账号，我们通过你提交时的昵称与提交日期来定位你的成绩记录。
+              对匿名排行榜记录，我们通过你提交时的昵称与提交日期来定位；对登录账号、平台 AI 会话和
+              Companion Memory，我们通过你的登录邮箱或 user_id 定位。Companion Memory
+              支持查看、删除回忆、删除或更正个人画像项，并可关闭个人画像层。
+            </p>
+            <p>
               如需行使上述权利，请发送邮件至{' '}
               <a className={styles.link} href={`mailto:${CONTACT_EMAIL}`}>
                 {CONTACT_EMAIL}
               </a>
-              ，并在邮件中附上你的昵称与成绩提交日期，以便我们核实并处理。
-              请注意，排行榜成绩与行为事件均会在前述保留期限到期后自动删除。
+              ，并在邮件中附上你的昵称与成绩提交日期，或你的登录邮箱，以便我们核实并处理。
+              请注意，排行榜成绩与行为事件会在前述保留期限到期后自动删除。
             </p>
           </section>
 

--- a/packages/platform/src/pages/TermsPage.test.tsx
+++ b/packages/platform/src/pages/TermsPage.test.tsx
@@ -3,8 +3,8 @@
  *
  * Asserts the production user agreement renders and that its mandatory
  * sections are present: the applicable-law / dispute clause, the disclaimer,
- * and the public-display-of-user-content clause. Also guards the contact
- * address and effective date.
+ * platform-AI account terms, companion memory controls, and the public-display
+ * clause. Also guards the contact address and effective date.
  */
 import { describe, expect, it } from 'vitest'
 import { render, screen } from '@testing-library/react'
@@ -36,6 +36,7 @@ describe('TermsPage', () => {
     renderPage()
     expect(screen.getByRole('heading', { name: /免责声明/ })).toBeInTheDocument()
     expect(screen.getByText(/按「现状」与「现有可用」基础提供/)).toBeInTheDocument()
+    expect(screen.getByText(/第三方语音和语言模型供应商/)).toBeInTheDocument()
   })
 
   it('discloses that submitted content is publicly displayed', () => {
@@ -43,11 +44,19 @@ describe('TermsPage', () => {
     expect(screen.getByText(/将在每日排行榜上公开展示/)).toBeInTheDocument()
   })
 
+  it('covers login-gated platform AI and companion memory controls', () => {
+    renderPage()
+    expect(screen.getByText(/登录后使用平台提供的 AI 伙伴/)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /身份、账号与昵称/ })).toBeInTheDocument()
+    expect(screen.getAllByText(/Companion Memory/).length).toBeGreaterThan(0)
+    expect(screen.getByText(/删除回忆、删除或更正个人画像项/)).toBeInTheDocument()
+  })
+
   it('provides the contact email and an effective date', () => {
     renderPage()
     const mailtoLinks = screen.getAllByRole('link', { name: 'hi@amio.love' })
     expect(mailtoLinks.length).toBeGreaterThan(0)
     expect(mailtoLinks[0]).toHaveAttribute('href', 'mailto:hi@amio.love')
-    expect(screen.getByText(/生效日期：2026-06-07/)).toBeInTheDocument()
+    expect(screen.getByText(/生效日期：2026-07-04/)).toBeInTheDocument()
   })
 })

--- a/packages/platform/src/pages/TermsPage.tsx
+++ b/packages/platform/src/pages/TermsPage.tsx
@@ -2,12 +2,12 @@ import { EyebrowTag, GlassCard } from '@amiclaw/ui'
 import styles from './TermsPage.module.css'
 
 const CONTACT_EMAIL = 'hi@amio.love'
-const EFFECTIVE_DATE = '2026-06-07'
+const EFFECTIVE_DATE = '2026-07-04'
 
 /* Terms-of-service page — a production-grade Chinese user agreement for
-   AMIO Arcade (claw.amio.fans). Mirrors the real service shape: no
-   accounts (device-id identity), the player-supplied AI tool is an
-   uncontrolled third party, nicknames + AI tool are publicly displayed.
+   AMIO Arcade (claw.amio.fans). Mirrors the real service shape: anonymous
+   bring-your-own-AI play, account-gated platform-AI play, companion memory
+   controls, public leaderboard content, and third-party AI providers.
    Platform chrome — every accent is brand yellow; no BombSquad cyan here. */
 export default function TermsPage() {
   return (
@@ -38,18 +38,28 @@ export default function TermsPage() {
               搭档仅通过语音沟通，共同完成拆弹挑战。
             </p>
             <p>
-              你所使用的语音 AI 工具由你自行选择、自行获取并独立使用，属于不受我们控制的第三方服务。
-              本服务不集成、不提供、不代理任何 AI
-              接口，也不对该第三方工具的可用性、准确性或其表现负责。
+              本服务包含两种游玩方式：你可以不登录并自带 AI 工具游玩；也可以登录后使用平台提供的 AI
+              伙伴。自带 AI 工具由你自行选择、自行获取并独立使用，属于不受我们控制的第三方服务。
+              平台 AI
+              伙伴由本服务通过已配置的语音和语言模型供应商实现，可能因供应商、网络、额度或运行故障而不可用。
+            </p>
+            <p>
+              AI
+              伙伴提供游戏协作与陪伴体验，可能理解错误、转写错误、回复不完整或给出不适合当前局面的建议。
+              游戏结果以页面显示、服务端校验和排行榜提交为准。
             </p>
           </section>
 
           <section className={styles.section}>
-            <h3 className={styles.heading}>三、身份与昵称</h3>
+            <h3 className={styles.heading}>三、身份、账号与昵称</h3>
             <p>
-              本服务不设账号体系，无须注册。我们通过你浏览器本地生成的设备标识符区分设备。
-              你在提交成绩时填写的昵称仅用于排行榜标识，并非账号，亦不构成对你真实身份的认证。
-              你应自行妥善管理使用本服务的设备。
+              自带 AI
+              游玩无须登录，我们通过你浏览器本地生成的设备标识符区分设备。你在提交成绩时填写的昵称仅用于排行榜标识，不构成对你真实身份的认证。
+            </p>
+            <p>
+              平台 AI 伙伴和 Companion Memory 需要登录。你可通过邮件登录或 Google
+              登录建立账号会话，并应自行妥善管理邮箱、Google
+              账号、设备和会话。如果发现账号或会话被未经授权使用，请及时联系我们。
             </p>
           </section>
 
@@ -60,6 +70,7 @@ export default function TermsPage() {
               <li>以伪造成绩、篡改用时、自动化脚本或任何作弊手段刷榜，或干扰排行榜的公平性。</li>
               <li>使用违法、侮辱、淫秽、仇恨、冒充他人或侵犯他人权利的昵称及内容。</li>
               <li>干扰、破坏本服务的正常运行，或试图未经授权访问本服务的系统与数据。</li>
+              <li>试图绕过登录、会话、额度、平台 AI 供应商或使用量记录的限制。</li>
               <li>以任何方式将本服务用于违反适用法律法规的目的。</li>
             </ul>
             <p>
@@ -72,6 +83,12 @@ export default function TermsPage() {
             <p>
               你提交的昵称，以及你所填写的 AI
               工具与模型信息，将在每日排行榜上公开展示。提交即表示你授权我们为运营本服务之目的展示、存储与处理这些内容。
+            </p>
+            <p>
+              当你使用平台 AI
+              伙伴时，你的伙伴设置、游戏会话摘要、可见回忆、个人画像判断、画像更正、删除操作和使用量记录会用于提供账号内的
+              Companion Memory
+              与运行可见性。你可以删除回忆、删除或更正个人画像项，并可关闭个人画像层。
             </p>
             <p>
               你应对自己提交的内容负责，并保证其不侵犯任何第三方的合法权利。请勿在昵称等内容中填写你不愿公开的个人信息。
@@ -93,8 +110,12 @@ export default function TermsPage() {
               AI 工具的兼容性作出任何明示或默示的保证。
             </p>
             <p>
-              你所使用的第三方 AI
-              工具不受我们控制，其表现、内容与可用性由该工具的提供方负责，与本服务无关。
+              你自带的第三方 AI 工具不受我们控制，其表现、内容与可用性由该工具的提供方负责。平台 AI
+              伙伴依赖第三方语音和语言模型供应商；供应商故障、额度限制、模型行为变化或网络问题可能影响语音识别、语音合成和回复质量。
+            </p>
+            <p>
+              请勿将本服务或 AI
+              伙伴用于安全关键、医疗、法律、财务或其他需要专业判断的场景。本服务中的游戏建议和陪伴内容只用于娱乐体验。
             </p>
           </section>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20260621.1
         version: 4.20260621.1
+      '@types/node':
+        specifier: ^26.0.1
+        version: 26.0.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1207,89 +1210,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1413,36 +1432,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -2694,24 +2719,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
## Summary

- Update privacy and terms pages for the real mode1/mode2 data boundary: auth sessions, Platform AI voice sessions, usage metering, Companion D1 memory, and provider processing.
- Make auth cookie parsing total for malformed percent encoding and move companion voice mapping to deploy-configured `VOLC_TTS_VOICE_COMPANION_*` values with placeholder rejection.
- Add a low-side-effect Platform AI post-deploy readiness script and runbook for auth, Companion D1 schema, usage KV, logs, and deployed voice secret names.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [x] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Manual/local verification:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter api run test:run`
- `pnpm --filter @amiclaw/platform-ai run test:run`
- `pnpm --filter @amiclaw/platform run test:run`
- `pnpm --filter @amiclaw/platform-ai exec tsc --ignoreConfig --noEmit --target ES2022 --module ES2022 --moduleResolution bundler --lib ES2022 --types node,@cloudflare/workers-types --allowImportingTsExtensions --skipLibCheck scripts/post-deploy-readiness.ts`
- Verified Wrangler command forms for `secret list`, `d1 execute`, and `kv key` with `--config=packages/platform-ai/wrangler.toml`.

Notes:

- No production secrets, DNS, Cloudflare dashboard settings, or live deployments were changed.
- The readiness script defaults to low-side-effect checks; session creation and USAGE KV write checks require explicit opt-in flags.
- Platform AI tests emit third-party sourcemap warnings from dependencies, but all tests pass.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

## AI attribution

Prepared by Codex in the manager thread. Claude Code was not used for this PR.