### PR TITLE
feat(platform-ai): correlate voice turn traces by session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**BombSquad mode② voice sessions are easier to diagnose** - Change. The
+platform-AI worker now attaches the same opaque session id to the structured
+trace lines for a voice run's ASR, LLM, TTS, and turn-settle boundaries. When a
+live run stalls or fails, maintainers can query one session directly in
+Cloudflare Workers Logs instead of stitching the run together from time windows.
+
 **BombSquad mode② memory: one run now carries one join key** - Change. A daily
 run now gets a stable `gameRunId` when the run starts, and that same id is passed
 to the platform-AI voice session, reused as the leaderboard `run_id`, and written

--- a/packages/platform-ai/src/session-assembly.test.ts
+++ b/packages/platform-ai/src/session-assembly.test.ts
@@ -64,6 +64,7 @@ describe('assembleSession — all-or-nothing session construction', () => {
     expect(assembled.providers.llm).toBeDefined()
     expect(assembled.providers.tts).toBeDefined()
     expect(assembled.state.config.gameId).toBe('demo-mock')
+    expect(assembled.state.traceSessionId).toBe(assembled.sessionId)
     expect(assembled.state.manualData).toBe(MANUAL)
     // Omitted game state defaults to the empty injection selection.
     expect(assembled.state.gameState).toEqual({ relevantSections: [] })

--- a/packages/platform-ai/src/session-assembly.ts
+++ b/packages/platform-ai/src/session-assembly.ts
@@ -79,6 +79,7 @@ export function assembleSession(
   extras: AssembleSessionExtras = {}
 ): AssembledSession {
   const config = resolveConfig(gameId)
+  const sessionId = crypto.randomUUID()
   // Companion voice wiring (L2 §Mechanism Variant 2): the companion's
   // platform-neutral `voice_id` resolves to vendor voice params HERE, at
   // assembly. Resolution is total — an unknown id or an unfilled placeholder
@@ -96,6 +97,7 @@ export function assembleSession(
     vendorVoice === undefined ? undefined : { ttsSpeaker: vendorVoice.volcengineVoiceType }
   )
   const state: SessionState = {
+    traceSessionId: sessionId,
     config,
     manualData,
     gameState: gameState ?? { relevantSections: [] },
@@ -108,5 +110,5 @@ export function assembleSession(
     ...(extras.companionContext !== undefined ? { companionContext: extras.companionContext } : {}),
     ...(extras.gameRunId !== undefined ? { gameRunId: extras.gameRunId } : {}),
   }
-  return { sessionId: crypto.randomUUID(), userId, providers, state }
+  return { sessionId, userId, providers, state }
 }

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -805,7 +805,10 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
         // transcript, not a rejection), so it never reaches here.
         if (this.turnEpoch === myEpoch) {
           const reason = err instanceof Error ? err.message : 'live ASR failed'
-          traceTurnError('asr', 'live-error', { messageChars: reason.length })
+          traceTurnError('asr', 'live-error', {
+            sessionId: this.sessionId,
+            messageChars: reason.length,
+          })
           try {
             ws.close(1008, safeCloseReason(reason))
           } catch {
@@ -833,7 +836,7 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
     myEpoch: number
   ): Promise<UtteranceResult> {
     if (!this.providers) throw new Error('session-do: speech-start before createSession')
-    const gen = runUtteranceStt(this.providers, bridge)[Symbol.asyncIterator]()
+    const gen = runUtteranceStt(this.providers, bridge, this.sessionId)[Symbol.asyncIterator]()
     try {
       for (;;) {
         const next = await gen.next()
@@ -1118,7 +1121,10 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
       // the socket now).
       if (this.turnEpoch === myEpoch) {
         const reason = err instanceof Error ? err.message : 'opening greeting failed'
-        traceTurnError('turn', 'opening-error', { messageChars: reason.length })
+        traceTurnError('turn', 'opening-error', {
+          sessionId: this.sessionId,
+          messageChars: reason.length,
+        })
         try {
           ws.close(1008, safeCloseReason(reason))
         } catch {
@@ -1149,7 +1155,10 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
       // the socket now). Mirrors the opening-greeting error path exactly.
       if (this.turnEpoch === myEpoch) {
         const reason = err instanceof Error ? err.message : 'closing recap failed'
-        traceTurnError('turn', 'closing-error', { messageChars: reason.length })
+        traceTurnError('turn', 'closing-error', {
+          sessionId: this.sessionId,
+          messageChars: reason.length,
+        })
         try {
           ws.close(1008, safeCloseReason(reason))
         } catch {

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -186,6 +186,67 @@ describe('runTurn', () => {
     expect(chunks.at(-1)?.done).toBe(true)
   })
 
+  it('attaches the session id to production turn-trace lines', async () => {
+    const logs: string[] = []
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((message?: unknown) => {
+      if (typeof message === 'string') logs.push(message)
+    })
+    try {
+      const state = freshState()
+      state.traceSessionId = 'session-trace-1'
+      const turn = runTurn(
+        providers(
+          mockStt([{ text: 'I see a red wire.', isFinal: true }]),
+          mockLlm(['Cut the blue wire.']),
+          mockTts([])
+        ),
+        state,
+        fromArray<AudioChunk>([new Uint8Array([1])])
+      )
+      await collect(turn)
+
+      const traces = logs
+        .map(
+          (line) =>
+            JSON.parse(line) as { t?: string; hop?: string; stage?: string; sessionId?: string }
+        )
+        .filter((entry) => entry.t === 'turn-trace')
+
+      expect(traces).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            hop: 'turn',
+            stage: 'pipeline-start',
+            sessionId: 'session-trace-1',
+          }),
+          expect.objectContaining({
+            hop: 'asr',
+            stage: 'final-transcript',
+            sessionId: 'session-trace-1',
+          }),
+          expect.objectContaining({
+            hop: 'llm',
+            stage: 'first-delta',
+            sessionId: 'session-trace-1',
+          }),
+          expect.objectContaining({
+            hop: 'tts',
+            stage: 'first-frame',
+            sessionId: 'session-trace-1',
+          }),
+          expect.objectContaining({
+            hop: 'turn',
+            stage: 'settle',
+            sessionId: 'session-trace-1',
+          }),
+        ])
+      )
+      expect(traces.every((entry) => entry.sessionId === 'session-trace-1')).toBe(true)
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
   it('emits the player transcript as a leading chunk, before the AI reply chunks', async () => {
     const turn = runTurn(
       providers(

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -72,6 +72,12 @@ function audioSecondsFromBytes(byteLength: number): number {
  * into the next turn.
  */
 export interface SessionState {
+  /**
+   * Opaque session id attached to structured trace lines so one production voice
+   * session can be queried end to end in Workers Logs. This is diagnostic only;
+   * it never crosses the provider boundary and does not affect protocol state.
+   */
+  traceSessionId?: string
   /** Resolved provider/prompt config for this session's game. */
   config: ResolvedConfig
   /** This run's manual payload (deterministic injection source). */
@@ -352,7 +358,8 @@ async function* streamLlmTts(
   providers: Pick<TurnProviders, 'llm' | 'tts'>,
   model: string,
   messages: ChatMessage[],
-  turnStart: number
+  turnStart: number,
+  traceSessionId?: string
 ): AsyncGenerator<AiResponseChunk, LlmTtsResult> {
   // LLM + TTS run concurrently: the LLM loop segments text into sentences and
   // feeds a queue the TTS provider drains. We interleave text chunks (as the
@@ -431,7 +438,10 @@ async function* streamLlmTts(
             llmDeltaCount += 1
             if (!firstDeltaTraced) {
               firstDeltaTraced = true
-              traceTurn('llm', 'first-delta', { elapsedMs: Date.now() - turnStart })
+              traceTurn('llm', 'first-delta', {
+                sessionId: traceSessionId,
+                elapsedMs: Date.now() - turnStart,
+              })
             }
             yield { kind: 'text', text: delta, done: false }
           }
@@ -446,6 +456,7 @@ async function* streamLlmTts(
           // LLM stream finished and all text has crossed into TTS — the boundary
           // is fully drained. A park AFTER this with no audio isolates TTS.
           traceTurn('llm', 'stream-end', {
+            sessionId: traceSessionId,
             deltaCount: llmDeltaCount,
             sentenceCount,
             assistantChars: assistantText.length,
@@ -460,7 +471,10 @@ async function* streamLlmTts(
             llmDeltaCount += 1
             if (!firstDeltaTraced) {
               firstDeltaTraced = true
-              traceTurn('llm', 'first-delta', { elapsedMs: Date.now() - turnStart })
+              traceTurn('llm', 'first-delta', {
+                sessionId: traceSessionId,
+                elapsedMs: Date.now() - turnStart,
+              })
             }
             yield { kind: 'text', text: delta, done: false }
             const { sentences, remainder } = splitSentences(pending)
@@ -481,6 +495,7 @@ async function* streamLlmTts(
             if (!firstFrameTraced) {
               firstFrameTraced = true
               traceTurn('tts', 'first-frame', {
+                sessionId: traceSessionId,
                 frameBytes: result.value.audio.byteLength,
                 elapsedMs: Date.now() - turnStart,
               })
@@ -531,13 +546,15 @@ async function* streamLlmTts(
  */
 export async function* runUtteranceStt(
   providers: Pick<TurnProviders, 'stt'>,
-  audio: AsyncIterable<AudioChunk>
+  audio: AsyncIterable<AudioChunk>,
+  traceSessionId?: string
 ): AsyncGenerator<AiResponseChunk, UtteranceResult> {
   const sttStart = Date.now()
   const { transcript, audioBytes } = yield* collectFinalTranscript(providers.stt, audio)
   // ASR hop boundary: the complete cumulative transcript is in hand (length only —
   // never the text). An empty transcript here explains a downstream LLM no-op.
   traceTurn('asr', 'final-transcript', {
+    sessionId: traceSessionId,
     transcriptChars: transcript.length,
     elapsedMs: Date.now() - sttStart,
   })
@@ -575,6 +592,7 @@ export async function* runReply(
   // `runUtteranceStt` (fail loud), never reaching here with a transcript.
   if (playerText.trim().length === 0) {
     traceTurn('turn', 'skip-no-speech', {
+      sessionId: state.traceSessionId,
       turnCount: state.turnCount,
       elapsedMs: Date.now() - turnStart,
     })
@@ -596,7 +614,13 @@ export async function* runReply(
   const messages: ChatMessage[] = [...assembleSystem(state), ...state.history, userMessage]
 
   // LLM + TTS run concurrently via the shared half.
-  const result = yield* streamLlmTts(providers, state.config.llm.model, messages, turnStart)
+  const result = yield* streamLlmTts(
+    providers,
+    state.config.llm.model,
+    messages,
+    turnStart,
+    state.traceSessionId
+  )
 
   // Settle turn state: record history, count, and usage; emit the terminal chunk
   // so the consumer can close out the turn.
@@ -612,6 +636,7 @@ export async function* runReply(
   // ttsFrameCount:0 says nothing flowed past LLM; a high llmDeltaCount with
   // ttsFrameCount:0 isolates TTS at the LLM->TTS boundary.
   traceTurn('turn', 'settle', {
+    sessionId: state.traceSessionId,
     turnCount: state.turnCount,
     llmDeltaCount: result.llmDeltaCount,
     llmOutputTokens: outputTokens,
@@ -647,9 +672,10 @@ export async function* runTurn(
   audio: AsyncIterable<AudioChunk>
 ): AsyncIterable<AiResponseChunk> {
   traceTurn('turn', 'pipeline-start', {
+    sessionId: state.traceSessionId,
     turnCount: state.turnCount,
   })
-  const utterance = yield* runUtteranceStt(providers, audio)
+  const utterance = yield* runUtteranceStt(providers, audio, state.traceSessionId)
   yield* runReply(providers, state, utterance)
 }
 
@@ -689,7 +715,13 @@ export async function* runClosingTurn(
   const userMessage: ChatMessage = { role: 'user', content: CLOSING_DIRECTIVE }
   const messages: ChatMessage[] = [...assembleSystem(state), ...state.history, userMessage]
 
-  const result = yield* streamLlmTts(providers, state.config.llm.model, messages, turnStart)
+  const result = yield* streamLlmTts(
+    providers,
+    state.config.llm.model,
+    messages,
+    turnStart,
+    state.traceSessionId
+  )
 
   // Settle: the closing directive is synthetic and must never leak into history
   // (the recap it elicits is the only thing remembered). turnCount tracks
@@ -698,6 +730,7 @@ export async function* runClosingTurn(
   const { outputTokens } = applyLlmTtsUsage(providers, state, result)
 
   traceTurn('turn', 'closing-settle', {
+    sessionId: state.traceSessionId,
     turnCount: state.turnCount,
     llmDeltaCount: result.llmDeltaCount,
     llmOutputTokens: outputTokens,
@@ -732,7 +765,13 @@ export async function* runOpeningTurn(
   const userMessage: ChatMessage = { role: 'user', content: OPENING_DIRECTIVE }
   const messages: ChatMessage[] = [...assembleSystem(state), ...state.history, userMessage]
 
-  const result = yield* streamLlmTts(providers, state.config.llm.model, messages, turnStart)
+  const result = yield* streamLlmTts(
+    providers,
+    state.config.llm.model,
+    messages,
+    turnStart,
+    state.traceSessionId
+  )
 
   // Settle. The opening directive is synthetic and must never leak into history
   // (the greeting it elicits is the only thing remembered). turnCount tracks
@@ -742,6 +781,7 @@ export async function* runOpeningTurn(
   const { outputTokens } = applyLlmTtsUsage(providers, state, result)
 
   traceTurn('turn', 'opening-settle', {
+    sessionId: state.traceSessionId,
     turnCount: state.turnCount,
     llmDeltaCount: result.llmDeltaCount,
     llmOutputTokens: outputTokens,


### PR DESCRIPTION
## Summary

- Attach the platform voice session id to structured platform-AI turn traces across ASR, LLM, TTS, opening/closing, error, and settle boundaries.
- Store the trace id in in-memory session state without changing the client protocol or provider payloads.
- Add tests and changelog coverage for the observability improvement.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [ ] Tested manually and documented below

Additional verification:

- `pnpm --filter @amiclaw/platform-ai test:run -- src/turn-pipeline.test.ts src/session-assembly.test.ts`
- `pnpm --filter @amiclaw/platform-ai typecheck`
- `pnpm exec eslint packages/platform-ai/src/turn-pipeline.ts packages/platform-ai/src/session-assembly.ts packages/platform-ai/src/session-do.ts packages/platform-ai/src/turn-pipeline.test.ts packages/platform-ai/src/session-assembly.test.ts`
- `pnpm exec markdownlint-cli2 CHANGELOG.md`
- `pnpm --filter @amiclaw/platform-ai test:run`
- Commit hook: `pnpm -r run test:run`

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

## Attribution

- Assisted by Codex in Codex Desktop.
