### PR TITLE
feat: add arcade local profile claim flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Your page now shows real local and account Arcade records** - New. Anonymous
+players now get a browser-local Arcade profile that records BombSquad results
+and real Oracle signs, so `/me` shows this device's actual play history instead
+of a promise card. Signed-in players can explicitly save unclaimed local records
+to their account, and new signed-in results are written to the account profile
+idempotently. Public leaderboard rows are unchanged and are never backfilled by
+profile claims.
+
 **BombSquad mode② voice sessions are easier to diagnose** - Change. The
 platform-AI worker now attaches the same opaque session id to the structured
 trace lines for a voice run's ASR, LLM, TTS, and turn-settle boundaries. When a

--- a/e2e/steps/auth.steps.ts
+++ b/e2e/steps/auth.steps.ts
@@ -54,21 +54,25 @@ Then('a magic-link request was sent for my email', async ({ world }) => {
   expect(world.magicLinkRequests.at(-1)).toMatchObject({ email: TEST_EMAIL })
 })
 
-// --- signed-out /me guide ----------------------------------------------------
+// --- signed-out /me local profile -------------------------------------------
 
 Then('I see the account login guide and no fake profile', async ({ page }) => {
   // Scope to the routed page content (<main>): the TopNav shell also renders a
   // 登录 / 注册 auth entry (substring-matched by name '登录'), so page-wide
   // role/text queries would be ambiguous.
   const main = page.getByRole('main')
-  // Exact match targets the guide-card title (the page header carries the same
-  // text plus a trailing 。, so a substring match would hit both).
-  await expect(main.getByText('登录后查看你的星轨', { exact: true })).toBeVisible()
-  await expect(main.getByText('战绩与单局完成率')).toBeVisible()
+  await expect(main.getByText('本设备的星轨。')).toBeVisible()
+  await expect(main.getByText('保存到账号', { exact: true })).toBeVisible()
+  await expect(
+    main.getByText('登录后可以把这台设备上的 BombSquad 和卦签记录保存到账号。')
+  ).toBeVisible()
+  await expect(main.getByText('今日')).toBeVisible()
+  await expect(main.getByText('未开始')).toBeVisible()
   await expect(main.getByRole('link', { name: '登录' })).toBeVisible()
   // No retired mock-profile content for anyone now.
   await expect(main.getByText('林星海')).toHaveCount(0)
   await expect(main.getByText('最近 5 局')).toHaveCount(0)
+  await expect(main.getByText('登录后查看你的星轨')).toHaveCount(0)
 })
 
 When('I click the login guide CTA', async ({ page }) => {
@@ -97,10 +101,15 @@ Then('I see my real identity from the session', async ({ page }) => {
 Then('I see the honest empty stats state with a play CTA', async ({ page }) => {
   // No fabricated numbers, no「即将推出」placeholder — an honest empty state.
   const main = page.getByRole('main')
-  await expect(main.getByText('还没有成绩，去玩一局。')).toBeVisible()
+  await expect(main.getByText('账号记录')).toBeVisible()
+  await expect(main.getByText('未开始')).toBeVisible()
+  await expect(main.getByText('还没有记录').first()).toBeVisible()
+  await expect(main.getByText('无记录').first()).toBeVisible()
   await expect(main.getByRole('link', { name: '开始玩' })).toBeVisible()
 })
 
 Then('the account login guide is not shown', async ({ page }) => {
-  await expect(page.getByRole('main').getByText('登录后查看你的星轨')).toHaveCount(0)
+  const main = page.getByRole('main')
+  await expect(main.getByText('登录后查看你的星轨')).toHaveCount(0)
+  await expect(main.getByText('本设备的星轨。')).toHaveCount(0)
 })

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -462,6 +462,54 @@ export const test = base.extend<{ world: World }>({
         })
       })
 
+      // Arcade profile — the static-build harness has no D1 or auth cookie
+      // runtime. Signed-in scenarios get an honest empty account profile; signed-
+      // out scenarios get the same 401 shape as production.
+      await page.route('**/api/arcade/profile**', async (route) => {
+        if (!world.authIdentity) {
+          await route.fulfill({
+            status: 401,
+            contentType: 'application/json',
+            body: JSON.stringify({ error: 'unauthorized' }),
+          })
+          return
+        }
+
+        const request = route.request()
+        const emptyProfile = {
+          profile_id: world.authIdentity.user_id,
+          last_activity_at: null,
+          today_played: false,
+          counts: { bombsquad_runs: 0, oracle_signs: 0 },
+          bombsquad: { recent: null, best_daily: null, best_practice: null },
+          oracle: { recent: null },
+        }
+
+        if (request.method() === 'POST' && request.url().includes('/claim')) {
+          const body = request.postDataJSON() as {
+            events?: Array<{ run?: { source_key?: string }; sign?: { source_key?: string } }>
+          }
+          const sourceKeys =
+            body.events
+              ?.map((event) => event.run?.source_key ?? event.sign?.source_key)
+              .filter((key): key is string => typeof key === 'string') ?? []
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            headers: { 'Cache-Control': 'no-store' },
+            body: JSON.stringify({ profile: emptyProfile, source_keys: sourceKeys, inserted: 0 }),
+          })
+          return
+        }
+
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          headers: { 'Cache-Control': 'no-store' },
+          body: JSON.stringify({ profile: emptyProfile }),
+        })
+      })
+
       // Companion identity read (GET /api/companion). 404 until setup, then the
       // created identity. The static build has no Workers runtime, so the
       // companion control plane is route-mocked exactly like the auth session.

--- a/functions/api/arcade/profile/claim.ts
+++ b/functions/api/arcade/profile/claim.ts
@@ -1,0 +1,25 @@
+import { handlePostArcadeProfileClaim } from '../../../../packages/api/src/handlers/arcade-profile'
+import type { ArcadeProfileApiEnv } from '../../../../packages/api/src/handlers/arcade-profile'
+import { applyCorsHeaders, buildCorsHeaders } from '../../../../packages/api/src/cors'
+
+interface Context {
+  request: Request
+  env: ArcadeProfileApiEnv
+}
+
+const CORS_METHODS = 'POST, OPTIONS'
+
+export async function onRequest(context: Context): Promise<Response> {
+  const { request, env } = context
+  const corsHeaders = buildCorsHeaders(request, CORS_METHODS)
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  if (request.method === 'POST') {
+    return applyCorsHeaders(await handlePostArcadeProfileClaim(request, env), corsHeaders)
+  }
+
+  return applyCorsHeaders(new Response('Method Not Allowed', { status: 405 }), corsHeaders)
+}

--- a/functions/api/arcade/profile/events.ts
+++ b/functions/api/arcade/profile/events.ts
@@ -1,0 +1,25 @@
+import { handlePostArcadeProfileEvent } from '../../../../packages/api/src/handlers/arcade-profile'
+import type { ArcadeProfileApiEnv } from '../../../../packages/api/src/handlers/arcade-profile'
+import { applyCorsHeaders, buildCorsHeaders } from '../../../../packages/api/src/cors'
+
+interface Context {
+  request: Request
+  env: ArcadeProfileApiEnv
+}
+
+const CORS_METHODS = 'POST, OPTIONS'
+
+export async function onRequest(context: Context): Promise<Response> {
+  const { request, env } = context
+  const corsHeaders = buildCorsHeaders(request, CORS_METHODS)
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  if (request.method === 'POST') {
+    return applyCorsHeaders(await handlePostArcadeProfileEvent(request, env), corsHeaders)
+  }
+
+  return applyCorsHeaders(new Response('Method Not Allowed', { status: 405 }), corsHeaders)
+}

--- a/functions/api/arcade/profile/index.ts
+++ b/functions/api/arcade/profile/index.ts
@@ -1,0 +1,25 @@
+import { handleGetArcadeProfile } from '../../../../packages/api/src/handlers/arcade-profile'
+import type { ArcadeProfileApiEnv } from '../../../../packages/api/src/handlers/arcade-profile'
+import { applyCorsHeaders, buildCorsHeaders } from '../../../../packages/api/src/cors'
+
+interface Context {
+  request: Request
+  env: ArcadeProfileApiEnv
+}
+
+const CORS_METHODS = 'GET, OPTIONS'
+
+export async function onRequest(context: Context): Promise<Response> {
+  const { request, env } = context
+  const corsHeaders = buildCorsHeaders(request, CORS_METHODS)
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  if (request.method === 'GET') {
+    return applyCorsHeaders(await handleGetArcadeProfile(request, env), corsHeaders)
+  }
+
+  return applyCorsHeaders(new Response('Method Not Allowed', { status: 405 }), corsHeaders)
+}

--- a/functions/api/companion/PROVISIONING.md
+++ b/functions/api/companion/PROVISIONING.md
@@ -1,7 +1,9 @@
 # Companion Memory — out-of-band provisioning
 
-The companion-memory backend needs one **D1 database** (the repo's first)
-bound in TWO places — the Cloudflare **Pages** project (the
+The account data backend currently uses one **D1 database** (the repo's first).
+It was introduced for companion-memory and is now also used by the
+arcade-profile component for small account-owned game profile records. The same
+physical database is bound in TWO places — the Cloudflare **Pages** project (the
 `/api/companion/*` control plane) and the **platform-ai Worker** (resolver
 read at session assembly + the consolidator's writes). Same database, two
 binding points, both with the variable name `COMPANION_DB`.
@@ -9,7 +11,8 @@ binding points, both with the variable name `COMPANION_DB`.
 The code ships inert without the bindings: the control plane returns errors
 only when called, the voice pipeline runs memory-less, and the tests run with
 zero configuration (they use an in-process SQLite stand-in). The steps below
-are required only for production / preview to actually persist memories.
+are required only for production / preview to actually persist memories and
+account Arcade profile records.
 
 ## 1. Create the database and apply migrations
 
@@ -17,9 +20,11 @@ are required only for production / preview to actually persist memories.
 wrangler d1 create amiclaw-companion
 ```
 
-Copy the `database_id` from the output, then apply the schema (the migrations
-SSOT lives in `packages/companion-memory/migrations/`; the platform-ai
-`wrangler.toml` points its `migrations_dir` there):
+Copy the `database_id` from the output, then apply the schema. The physical
+migrations SSOT currently lives in `packages/companion-memory/migrations/`
+because that package created the database first; migration `0002` adds
+arcade-profile tables owned by `packages/arcade-profile`, not by Companion
+Memory. The platform-ai `wrangler.toml` points its `migrations_dir` there:
 
 ```sh
 cd packages/platform-ai

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,9 @@
 {
   "name": "api",
   "private": true,
+  "dependencies": {
+    "@amiclaw/arcade-profile": "workspace:*"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "vitest",

--- a/packages/api/src/handlers/arcade-profile.test.ts
+++ b/packages/api/src/handlers/arcade-profile.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { createTestDb } from '../../../arcade-profile/src/test-support/sqlite-db'
+import { FakeKV } from '../auth/fake-kv'
+import {
+  handleGetArcadeProfile,
+  handlePostArcadeProfileClaim,
+  type ArcadeProfileApiEnv,
+} from './arcade-profile'
+
+const SESSION_COOKIE = 'amiclaw_session=sess-1'
+
+const CLAIM_BODY = {
+  profile_id: 'local-profile',
+  events: [
+    {
+      kind: 'bombsquad_run',
+      run: {
+        source_key: 'bombsquad:run-1',
+        run_id: 'run-1',
+        mode: 'daily',
+        outcome: 'defused',
+        duration_ms: 45_000,
+        attempt_number: 1,
+        module_count: 4,
+        completed_modules: 4,
+        strike_count: 0,
+        finished_at: '2026-07-06T08:00:00.000Z',
+      },
+    },
+  ],
+}
+
+async function env(): Promise<ArcadeProfileApiEnv> {
+  const auth = new FakeKV()
+  await auth.put(
+    'session:sess-1',
+    JSON.stringify({
+      user_id: 'user-a',
+      email: 'a@example.com',
+      created_at: '2026-07-06T07:00:00.000Z',
+    })
+  )
+  return {
+    AUTH: auth.asKV(),
+    COMPANION_DB: createTestDb(),
+  }
+}
+
+function request(body?: unknown, cookie = SESSION_COOKIE): Request {
+  return new Request('https://claw.amio.fans/api/arcade/profile/claim', {
+    method: body === undefined ? 'GET' : 'POST',
+    headers: {
+      ...(cookie ? { Cookie: cookie } : {}),
+      ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+}
+
+describe('arcade profile handlers', () => {
+  it('requires a session for account profile reads', async () => {
+    const response = await handleGetArcadeProfile(request(undefined, ''), await env())
+
+    expect(response.status).toBe(401)
+  })
+
+  it('claims bounded local events into the signed-in account idempotently', async () => {
+    const testEnv = await env()
+
+    const first = await handlePostArcadeProfileClaim(request(CLAIM_BODY), testEnv)
+    const replay = await handlePostArcadeProfileClaim(request(CLAIM_BODY), testEnv)
+    const profile = await handleGetArcadeProfile(request(), testEnv)
+
+    expect(first.status).toBe(200)
+    expect(await first.json()).toMatchObject({ inserted: 1, source_keys: ['bombsquad:run-1'] })
+    expect(await replay.json()).toMatchObject({ inserted: 0, source_keys: ['bombsquad:run-1'] })
+    expect(await profile.json()).toMatchObject({
+      profile: {
+        counts: { bombsquad_runs: 1, oracle_signs: 0 },
+        bombsquad: { best_daily: { run_id: 'run-1' } },
+      },
+    })
+  })
+})

--- a/packages/api/src/handlers/arcade-profile.ts
+++ b/packages/api/src/handlers/arcade-profile.ts
@@ -1,0 +1,76 @@
+import type {
+  ArcadeProfileClaimResponse,
+  ArcadeProfileResponse,
+} from '@amiclaw/arcade-profile/types'
+import type { ArcadeProfileDb } from '@amiclaw/arcade-profile/store'
+import { readArcadeAccountProfile, upsertArcadeProfileEvents } from '@amiclaw/arcade-profile/store'
+import {
+  parseArcadeProfileClaimBody,
+  parseArcadeProfileEvent,
+} from '@amiclaw/arcade-profile/validation'
+import { requireSession } from '../auth/require-session'
+import { jsonResponse } from '../auth/respond'
+import { parseJsonBody } from './companion-shared'
+
+export interface ArcadeProfileApiEnv {
+  AUTH: KVNamespace
+  /** Account data plane D1. The current Pages binding name is COMPANION_DB. */
+  COMPANION_DB: ArcadeProfileDb
+}
+
+export async function handleGetArcadeProfile(
+  request: Request,
+  env: ArcadeProfileApiEnv
+): Promise<Response> {
+  const auth = await requireSession(env.AUTH, request)
+  if (!auth.ok) return auth.response
+
+  const profile = await readArcadeAccountProfile(env.COMPANION_DB, auth.session.user_id)
+  const body: ArcadeProfileResponse = { profile }
+  return jsonResponse(body, 200, { 'Cache-Control': 'no-store' })
+}
+
+export async function handlePostArcadeProfileEvent(
+  request: Request,
+  env: ArcadeProfileApiEnv
+): Promise<Response> {
+  const auth = await requireSession(env.AUTH, request)
+  if (!auth.ok) return auth.response
+
+  const body = await parseJsonBody(request)
+  const event = parseArcadeProfileEvent(body)
+  if (!event) return jsonResponse({ error: 'invalid arcade profile event' }, 422)
+
+  await upsertArcadeProfileEvents(env.COMPANION_DB, auth.session.user_id, [event], {
+    profileId: event.profile_id,
+  })
+  const profile = await readArcadeAccountProfile(env.COMPANION_DB, auth.session.user_id)
+  const response: ArcadeProfileResponse = { profile }
+  return jsonResponse(response, 200, { 'Cache-Control': 'no-store' })
+}
+
+export async function handlePostArcadeProfileClaim(
+  request: Request,
+  env: ArcadeProfileApiEnv
+): Promise<Response> {
+  const auth = await requireSession(env.AUTH, request)
+  if (!auth.ok) return auth.response
+
+  const body = await parseJsonBody(request)
+  const claim = parseArcadeProfileClaimBody(body)
+  if (!claim) return jsonResponse({ error: 'invalid arcade profile claim' }, 422)
+
+  const result = await upsertArcadeProfileEvents(
+    env.COMPANION_DB,
+    auth.session.user_id,
+    claim.events,
+    { profileId: claim.profile_id }
+  )
+  const profile = await readArcadeAccountProfile(env.COMPANION_DB, auth.session.user_id)
+  const response: ArcadeProfileClaimResponse = {
+    profile,
+    source_keys: result.sourceKeys,
+    inserted: result.inserted,
+  }
+  return jsonResponse(response, 200, { 'Cache-Control': 'no-store' })
+}

--- a/packages/arcade-profile/package.json
+++ b/packages/arcade-profile/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@amiclaw/arcade-profile",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./api-client": "./src/api-client.ts",
+    "./local": "./src/local.ts",
+    "./store": "./src/store.ts",
+    "./types": "./src/types.ts",
+    "./validation": "./src/validation.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260621.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/arcade-profile/src/api-client.ts
+++ b/packages/arcade-profile/src/api-client.ts
@@ -1,0 +1,77 @@
+import type {
+  ArcadeProfileClaimBody,
+  ArcadeProfileClaimResponse,
+  ArcadeProfileEvent,
+  ArcadeProfileResponse,
+} from './types'
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' }
+const DEFAULT_API_BASE = 'https://claw.amio.fans'
+
+function apiBase(): string {
+  const meta = import.meta as ImportMeta & { env?: { VITE_API_BASE?: string } }
+  return meta.env?.VITE_API_BASE ?? DEFAULT_API_BASE
+}
+
+export type ArcadeProfileReadResult =
+  | { kind: 'ok'; profile: ArcadeProfileResponse['profile'] }
+  | { kind: 'anon' }
+  | { kind: 'error' }
+
+export type ArcadeProfileMutationResult =
+  | { kind: 'ok'; profile: ArcadeProfileResponse['profile']; sourceKeys?: string[] }
+  | { kind: 'anon' }
+  | { kind: 'invalid' }
+  | { kind: 'error' }
+
+export async function fetchArcadeProfile(): Promise<ArcadeProfileReadResult> {
+  try {
+    const res = await fetch(`${apiBase()}/api/arcade/profile`, { credentials: 'include' })
+    if (res.status === 401) return { kind: 'anon' }
+    if (!res.ok) return { kind: 'error' }
+    const data = (await res.json()) as ArcadeProfileResponse
+    return { kind: 'ok', profile: data.profile }
+  } catch {
+    return { kind: 'error' }
+  }
+}
+
+export async function submitArcadeProfileEvent(
+  event: ArcadeProfileEvent
+): Promise<ArcadeProfileMutationResult> {
+  try {
+    const res = await fetch(`${apiBase()}/api/arcade/profile/events`, {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      credentials: 'include',
+      body: JSON.stringify(event),
+    })
+    if (res.status === 401) return { kind: 'anon' }
+    if (res.status === 422 || res.status === 400) return { kind: 'invalid' }
+    if (!res.ok) return { kind: 'error' }
+    const data = (await res.json()) as ArcadeProfileResponse
+    return { kind: 'ok', profile: data.profile }
+  } catch {
+    return { kind: 'error' }
+  }
+}
+
+export async function claimArcadeProfile(
+  body: ArcadeProfileClaimBody
+): Promise<ArcadeProfileMutationResult> {
+  try {
+    const res = await fetch(`${apiBase()}/api/arcade/profile/claim`, {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      credentials: 'include',
+      body: JSON.stringify(body),
+    })
+    if (res.status === 401) return { kind: 'anon' }
+    if (res.status === 422 || res.status === 400) return { kind: 'invalid' }
+    if (!res.ok) return { kind: 'error' }
+    const data = (await res.json()) as ArcadeProfileClaimResponse
+    return { kind: 'ok', profile: data.profile, sourceKeys: data.source_keys }
+  } catch {
+    return { kind: 'error' }
+  }
+}

--- a/packages/arcade-profile/src/db.ts
+++ b/packages/arcade-profile/src/db.ts
@@ -1,0 +1,17 @@
+export interface ArcadeProfileDbRunResult {
+  meta: {
+    changes: number
+  }
+}
+
+export interface ArcadeProfileDbStatement {
+  bind(...values: unknown[]): ArcadeProfileDbStatement
+  run(): Promise<ArcadeProfileDbRunResult>
+  first<T>(): Promise<T | null>
+  all<T>(): Promise<{ results: T[] }>
+}
+
+export interface ArcadeProfileDb {
+  prepare(sql: string): ArcadeProfileDbStatement
+  batch(statements: ArcadeProfileDbStatement[]): Promise<ArcadeProfileDbRunResult[]>
+}

--- a/packages/arcade-profile/src/index.ts
+++ b/packages/arcade-profile/src/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './source-key'
+export * from './summary'

--- a/packages/arcade-profile/src/local.test.ts
+++ b/packages/arcade-profile/src/local.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  ARCADE_LOCAL_PROFILE_KEY,
+  getClaimableArcadeProfileEvents,
+  markArcadeProfileEventsClaimed,
+  readArcadeLocalProfile,
+  recordBombSquadLocalRun,
+  recordOracleLocalSign,
+  summarizeArcadeLocalProfile,
+} from './local'
+
+function storage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => map.set(key, value),
+    removeItem: (key) => map.delete(key),
+    clear: () => map.clear(),
+    key: (index) => Array.from(map.keys())[index] ?? null,
+    get length() {
+      return map.size
+    },
+  }
+}
+
+describe('local arcade profile', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('records BombSquad and Oracle entries into one stable local profile', () => {
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('11111111-1111-4111-8111-111111111111')
+    const store = storage()
+
+    const run = recordBombSquadLocalRun(
+      {
+        runId: 'run-1',
+        mode: 'daily',
+        outcome: 'defused',
+        durationMs: 123_456,
+        attemptNumber: 2,
+        moduleCount: 4,
+        completedModules: 4,
+        strikeCount: 1,
+        finishedAt: '2026-07-06T08:00:00.000Z',
+      },
+      store
+    )
+    const sign = recordOracleLocalSign(
+      {
+        sessionId: 'oracle-1',
+        signDate: '2026-07-06',
+        ben: '乾',
+        bian: '坤',
+        yaoValues: [7, 8, 7, 8, 7, 8],
+        createdAt: '2026-07-06T09:00:00.000Z',
+      },
+      store
+    )
+
+    expect(run?.profile_id).toBe('11111111-1111-4111-8111-111111111111')
+    expect(sign?.profile_id).toBe('11111111-1111-4111-8111-111111111111')
+    const profile = readArcadeLocalProfile(store)
+    expect(profile?.profile_id).toBe('11111111-1111-4111-8111-111111111111')
+    expect(profile?.bombsquad_runs).toHaveLength(1)
+    expect(profile?.oracle_signs).toHaveLength(1)
+    expect(store.getItem(ARCADE_LOCAL_PROFILE_KEY)).toContain(
+      '11111111-1111-4111-8111-111111111111'
+    )
+
+    const summary = summarizeArcadeLocalProfile(profile, '2026-07-06')
+    expect(summary.today_played).toBe(true)
+    expect(summary.bombsquad.best_daily?.run_id).toBe('run-1')
+    expect(summary.oracle.recent?.ben).toBe('乾')
+  })
+
+  it('dedupes claimable entries by source key after marking them claimed', () => {
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('22222222-2222-4222-8222-222222222222')
+    const store = storage()
+    const event = recordBombSquadLocalRun(
+      {
+        runId: 'run-2',
+        mode: 'practice',
+        outcome: 'practice-cleared',
+        durationMs: 10_000,
+        attemptNumber: 1,
+        moduleCount: 2,
+        completedModules: 2,
+        strikeCount: 0,
+        finishedAt: '2026-07-06T08:00:00.000Z',
+      },
+      store
+    )
+    expect(getClaimableArcadeProfileEvents(readArcadeLocalProfile(store))).toHaveLength(1)
+
+    expect(event?.kind).toBe('bombsquad_run')
+    markArcadeProfileEventsClaimed(['bombsquad:run-2'], store)
+
+    expect(getClaimableArcadeProfileEvents(readArcadeLocalProfile(store))).toHaveLength(0)
+  })
+
+  it('drops malformed local entries while keeping the profile readable', () => {
+    const store = storage()
+    store.setItem(
+      ARCADE_LOCAL_PROFILE_KEY,
+      JSON.stringify({
+        version: 1,
+        profile_id: 'local-profile',
+        created_at: '2026-07-06T08:00:00.000Z',
+        updated_at: '2026-07-06T08:00:00.000Z',
+        last_seen_at: '2026-07-06T08:00:00.000Z',
+        bombsquad_runs: [
+          {
+            source_key: 'bombsquad:valid-run',
+            run_id: 'valid-run',
+            mode: 'daily',
+            outcome: 'defused',
+            duration_ms: 90_000,
+            attempt_number: 1,
+            module_count: 4,
+            completed_modules: 4,
+            strike_count: 0,
+            finished_at: '2026-07-06T08:00:00.000Z',
+          },
+          {
+            source_key: 'bombsquad:wrong-source',
+            run_id: 'different-run',
+            mode: 'daily',
+            outcome: 'defused',
+            duration_ms: 90_000,
+            attempt_number: 1,
+            module_count: 4,
+            completed_modules: 4,
+            strike_count: 0,
+            finished_at: '2026-07-06T08:00:00.000Z',
+          },
+        ],
+        oracle_signs: [{ source_key: 'oracle:broken' }],
+        claimed_source_keys: ['bombsquad:valid-run', 42],
+      })
+    )
+
+    const profile = readArcadeLocalProfile(store)
+
+    expect(profile?.bombsquad_runs).toHaveLength(1)
+    expect(profile?.bombsquad_runs[0]?.run_id).toBe('valid-run')
+    expect(profile?.oracle_signs).toHaveLength(0)
+    expect(profile?.claimed_source_keys).toEqual(['bombsquad:valid-run'])
+    expect(summarizeArcadeLocalProfile(profile, '2026-07-06').today_played).toBe(true)
+  })
+})

--- a/packages/arcade-profile/src/local.ts
+++ b/packages/arcade-profile/src/local.ts
@@ -1,0 +1,262 @@
+import { getTodayString } from '../../../shared/date'
+import { summarizeArcadeProfile } from './summary'
+import { bombsquadRunSourceKey, oracleSignSourceKey } from './source-key'
+import { parseArcadeProfileEvent } from './validation'
+import type {
+  ArcadeLocalProfile,
+  ArcadeProfileEvent,
+  ArcadeProfileSummary,
+  BombSquadProfileOutcome,
+  BombSquadProfileRun,
+  BombSquadProfileMode,
+  OracleProfileSign,
+} from './types'
+
+export const ARCADE_LOCAL_PROFILE_KEY = 'arcade-local-profile-v1'
+
+const MAX_LOCAL_RUNS = 100
+const MAX_LOCAL_SIGNS = 100
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function randomProfileId(): string {
+  const cryptoApi = globalThis.crypto
+  if (cryptoApi && typeof cryptoApi.randomUUID === 'function') {
+    return cryptoApi.randomUUID()
+  }
+  return `local-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`
+}
+
+function browserStorage(): Storage | null {
+  if (typeof localStorage === 'undefined') return null
+  return localStorage
+}
+
+function emptyProfile(timestamp = nowIso()): ArcadeLocalProfile {
+  return {
+    version: 1,
+    profile_id: randomProfileId(),
+    created_at: timestamp,
+    updated_at: timestamp,
+    last_seen_at: timestamp,
+    bombsquad_runs: [],
+    oracle_signs: [],
+    claimed_source_keys: [],
+  }
+}
+
+function isLocalProfile(value: unknown): value is ArcadeLocalProfile {
+  if (typeof value !== 'object' || value === null) return false
+  const profile = value as ArcadeLocalProfile
+  return (
+    profile.version === 1 &&
+    typeof profile.profile_id === 'string' &&
+    typeof profile.created_at === 'string' &&
+    typeof profile.updated_at === 'string' &&
+    typeof profile.last_seen_at === 'string' &&
+    Array.isArray(profile.bombsquad_runs) &&
+    Array.isArray(profile.oracle_signs) &&
+    Array.isArray(profile.claimed_source_keys)
+  )
+}
+
+function sanitizeLocalProfile(value: unknown): ArcadeLocalProfile | null {
+  if (!isLocalProfile(value)) return null
+  return {
+    ...value,
+    bombsquad_runs: value.bombsquad_runs
+      .map((run) => {
+        const event = parseArcadeProfileEvent({ kind: 'bombsquad_run', run })
+        return event?.kind === 'bombsquad_run' ? event.run : null
+      })
+      .filter((run): run is BombSquadProfileRun => run !== null)
+      .slice(0, MAX_LOCAL_RUNS),
+    oracle_signs: value.oracle_signs
+      .map((sign) => {
+        const event = parseArcadeProfileEvent({ kind: 'oracle_sign', sign })
+        return event?.kind === 'oracle_sign' ? event.sign : null
+      })
+      .filter((sign): sign is OracleProfileSign => sign !== null)
+      .slice(0, MAX_LOCAL_SIGNS),
+    claimed_source_keys: value.claimed_source_keys.filter(
+      (sourceKey): sourceKey is string => typeof sourceKey === 'string' && sourceKey.length > 0
+    ),
+  }
+}
+
+function saveProfile(profile: ArcadeLocalProfile, storage = browserStorage()): void {
+  if (!storage) return
+  try {
+    storage.setItem(ARCADE_LOCAL_PROFILE_KEY, JSON.stringify(profile))
+  } catch {
+    // Local persistence is best-effort; gameplay must never depend on it.
+  }
+}
+
+export function readArcadeLocalProfile(storage = browserStorage()): ArcadeLocalProfile | null {
+  if (!storage) return null
+  try {
+    const raw = storage.getItem(ARCADE_LOCAL_PROFILE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as unknown
+    return sanitizeLocalProfile(parsed)
+  } catch {
+    return null
+  }
+}
+
+export function ensureArcadeLocalProfile(storage = browserStorage()): ArcadeLocalProfile {
+  const timestamp = nowIso()
+  const existing = readArcadeLocalProfile(storage)
+  const profile = existing ?? emptyProfile(timestamp)
+  profile.last_seen_at = timestamp
+  profile.updated_at = timestamp
+  saveProfile(profile, storage)
+  return profile
+}
+
+function upsertBySourceKey<T extends { source_key: string }>(
+  entries: T[],
+  next: T,
+  limit: number,
+  getDate: (entry: T) => string
+): T[] {
+  return [next, ...entries.filter((entry) => entry.source_key !== next.source_key)]
+    .sort((a, b) => getDate(b).localeCompare(getDate(a)))
+    .slice(0, limit)
+}
+
+export interface RecordBombSquadLocalRunInput {
+  runId: string
+  mode: BombSquadProfileMode
+  outcome: BombSquadProfileOutcome
+  durationMs: number
+  attemptNumber: number
+  moduleCount: number
+  completedModules: number
+  strikeCount: number
+  finishedAt?: string
+}
+
+export function recordBombSquadLocalRun(
+  input: RecordBombSquadLocalRunInput,
+  storage = browserStorage()
+): ArcadeProfileEvent | null {
+  if (input.durationMs < 0 || input.runId.length === 0) return null
+  const profile = ensureArcadeLocalProfile(storage)
+  const timestamp = nowIso()
+  const run: BombSquadProfileRun = {
+    source_key: bombsquadRunSourceKey(input.runId),
+    run_id: input.runId,
+    mode: input.mode,
+    outcome: input.outcome,
+    duration_ms: Math.round(input.durationMs),
+    attempt_number: input.attemptNumber,
+    module_count: input.moduleCount,
+    completed_modules: input.completedModules,
+    strike_count: input.strikeCount,
+    finished_at: input.finishedAt ?? timestamp,
+  }
+  profile.bombsquad_runs = upsertBySourceKey(
+    profile.bombsquad_runs,
+    run,
+    MAX_LOCAL_RUNS,
+    (entry) => entry.finished_at
+  )
+  profile.updated_at = timestamp
+  profile.last_seen_at = timestamp
+  saveProfile(profile, storage)
+  return { kind: 'bombsquad_run', profile_id: profile.profile_id, run }
+}
+
+export interface RecordOracleLocalSignInput {
+  sessionId: string
+  signDate: string
+  ben: string
+  bian: string
+  yaoValues: [number, number, number, number, number, number]
+  createdAt?: string
+}
+
+export function recordOracleLocalSign(
+  input: RecordOracleLocalSignInput,
+  storage = browserStorage()
+): ArcadeProfileEvent | null {
+  if (input.sessionId.length === 0 || input.signDate.length === 0) return null
+  const profile = ensureArcadeLocalProfile(storage)
+  const timestamp = nowIso()
+  const sign: OracleProfileSign = {
+    source_key: oracleSignSourceKey(input.signDate, input.sessionId),
+    session_id: input.sessionId,
+    sign_date: input.signDate,
+    ben: input.ben,
+    bian: input.bian,
+    yao_values: input.yaoValues,
+    created_at: input.createdAt ?? timestamp,
+  }
+  profile.oracle_signs = upsertBySourceKey(
+    profile.oracle_signs,
+    sign,
+    MAX_LOCAL_SIGNS,
+    (entry) => entry.created_at
+  )
+  profile.updated_at = timestamp
+  profile.last_seen_at = timestamp
+  saveProfile(profile, storage)
+  return { kind: 'oracle_sign', profile_id: profile.profile_id, sign }
+}
+
+export function summarizeArcadeLocalProfile(
+  profile: ArcadeLocalProfile | null,
+  today = getTodayString()
+): ArcadeProfileSummary {
+  return summarizeArcadeProfile({
+    profileId: profile?.profile_id,
+    bombsquadRuns: profile?.bombsquad_runs ?? [],
+    oracleSigns: profile?.oracle_signs ?? [],
+    today,
+  })
+}
+
+export function getClaimableArcadeProfileEvents(
+  profile: ArcadeLocalProfile | null
+): ArcadeProfileEvent[] {
+  if (!profile) return []
+  const claimed = new Set(profile.claimed_source_keys)
+  return [
+    ...profile.bombsquad_runs
+      .filter((run) => !claimed.has(run.source_key))
+      .map(
+        (run): ArcadeProfileEvent => ({
+          kind: 'bombsquad_run',
+          profile_id: profile.profile_id,
+          run,
+        })
+      ),
+    ...profile.oracle_signs
+      .filter((sign) => !claimed.has(sign.source_key))
+      .map(
+        (sign): ArcadeProfileEvent => ({
+          kind: 'oracle_sign',
+          profile_id: profile.profile_id,
+          sign,
+        })
+      ),
+  ]
+}
+
+export function markArcadeProfileEventsClaimed(
+  sourceKeys: string[],
+  storage = browserStorage()
+): ArcadeLocalProfile | null {
+  const profile = readArcadeLocalProfile(storage)
+  if (!profile) return null
+  const claimed = new Set(profile.claimed_source_keys)
+  for (const key of sourceKeys) claimed.add(key)
+  profile.claimed_source_keys = [...claimed].sort()
+  profile.updated_at = nowIso()
+  saveProfile(profile, storage)
+  return profile
+}

--- a/packages/arcade-profile/src/source-key.ts
+++ b/packages/arcade-profile/src/source-key.ts
@@ -1,0 +1,7 @@
+export function bombsquadRunSourceKey(runId: string): string {
+  return `bombsquad:${runId}`
+}
+
+export function oracleSignSourceKey(signDate: string, sessionId: string): string {
+  return `oracle:${signDate}:${sessionId}`
+}

--- a/packages/arcade-profile/src/store.test.ts
+++ b/packages/arcade-profile/src/store.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { readArcadeAccountProfile, upsertArcadeProfileEvents } from './store'
+import { createTestDb } from './test-support/sqlite-db'
+import type { ArcadeProfileEvent } from './types'
+
+const RUN_EVENT: ArcadeProfileEvent = {
+  kind: 'bombsquad_run',
+  profile_id: 'profile-1',
+  run: {
+    source_key: 'bombsquad:run-1',
+    run_id: 'run-1',
+    mode: 'daily',
+    outcome: 'defused',
+    duration_ms: 55_000,
+    attempt_number: 1,
+    module_count: 4,
+    completed_modules: 4,
+    strike_count: 0,
+    finished_at: '2026-07-06T08:00:00.000Z',
+  },
+}
+
+const SIGN_EVENT: ArcadeProfileEvent = {
+  kind: 'oracle_sign',
+  profile_id: 'profile-1',
+  sign: {
+    source_key: 'oracle:2026-07-06:oracle-1',
+    session_id: 'oracle-1',
+    sign_date: '2026-07-06',
+    ben: '乾',
+    bian: '坤',
+    yao_values: [7, 8, 7, 8, 7, 8],
+    created_at: '2026-07-06T09:00:00.000Z',
+  },
+}
+
+describe('arcade profile store', () => {
+  it('upserts source-keyed events idempotently and reads an account summary', async () => {
+    const db = createTestDb()
+    const deps = { now: () => '2026-07-06T10:00:00.000Z', today: () => '2026-07-06' }
+
+    const first = await upsertArcadeProfileEvents(db, 'user-1', [RUN_EVENT, SIGN_EVENT], { deps })
+    const replay = await upsertArcadeProfileEvents(db, 'user-1', [RUN_EVENT], { deps })
+    const profile = await readArcadeAccountProfile(db, 'user-1', deps)
+
+    expect(first.inserted).toBe(2)
+    expect(replay.inserted).toBe(0)
+    expect(profile.today_played).toBe(true)
+    expect(profile.counts).toEqual({ bombsquad_runs: 1, oracle_signs: 1 })
+    expect(profile.bombsquad.best_daily?.duration_ms).toBe(55_000)
+    expect(profile.oracle.recent?.ben).toBe('乾')
+  })
+})

--- a/packages/arcade-profile/src/store.ts
+++ b/packages/arcade-profile/src/store.ts
@@ -1,0 +1,178 @@
+import { getTodayString } from '../../../shared/date'
+import type { ArcadeProfileDb } from './db'
+import { summarizeArcadeProfile } from './summary'
+import type {
+  ArcadeProfileEvent,
+  ArcadeProfileSummary,
+  BombSquadProfileRun,
+  OracleProfileSign,
+} from './types'
+
+export type { ArcadeProfileDb } from './db'
+
+interface BombSquadRunRow {
+  source_key: string
+  profile_id: string | null
+  run_id: string
+  mode: BombSquadProfileRun['mode']
+  outcome: BombSquadProfileRun['outcome']
+  duration_ms: number
+  attempt_number: number
+  module_count: number
+  completed_modules: number
+  strike_count: number
+  finished_at: string
+}
+
+interface OracleSignRow {
+  source_key: string
+  profile_id: string | null
+  session_id: string
+  sign_date: string
+  ben: string
+  bian: string
+  yao_values: string
+  created_at: string
+}
+
+export interface StoreDeps {
+  now?: () => string
+  today?: () => string
+}
+
+function eventSourceKey(event: ArcadeProfileEvent): string {
+  return event.kind === 'bombsquad_run' ? event.run.source_key : event.sign.source_key
+}
+
+function eventProfileId(event: ArcadeProfileEvent, fallback?: string): string | null {
+  return event.profile_id ?? fallback ?? null
+}
+
+export async function upsertArcadeProfileEvents(
+  db: ArcadeProfileDb,
+  userId: string,
+  events: ArcadeProfileEvent[],
+  options: { profileId?: string; deps?: StoreDeps } = {}
+): Promise<{ inserted: number; sourceKeys: string[] }> {
+  const now = options.deps?.now ?? (() => new Date().toISOString())
+  let inserted = 0
+  const sourceKeys: string[] = []
+
+  for (const event of events) {
+    sourceKeys.push(eventSourceKey(event))
+    if (event.kind === 'bombsquad_run') {
+      const run = event.run
+      const result = await db
+        .prepare(
+          `INSERT INTO arcade_profile_bombsquad_run (
+             user_id, source_key, profile_id, run_id, mode, outcome, duration_ms,
+             attempt_number, module_count, completed_modules, strike_count,
+             finished_at, created_at
+           )
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT (user_id, source_key) DO NOTHING`
+        )
+        .bind(
+          userId,
+          run.source_key,
+          eventProfileId(event, options.profileId),
+          run.run_id,
+          run.mode,
+          run.outcome,
+          run.duration_ms,
+          run.attempt_number,
+          run.module_count,
+          run.completed_modules,
+          run.strike_count,
+          run.finished_at,
+          now()
+        )
+        .run()
+      inserted += result.meta.changes
+    } else {
+      const sign = event.sign
+      const result = await db
+        .prepare(
+          `INSERT INTO arcade_profile_oracle_sign (
+             user_id, source_key, profile_id, session_id, sign_date, ben, bian,
+             yao_values, created_at, inserted_at
+           )
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT (user_id, source_key) DO NOTHING`
+        )
+        .bind(
+          userId,
+          sign.source_key,
+          eventProfileId(event, options.profileId),
+          sign.session_id,
+          sign.sign_date,
+          sign.ben,
+          sign.bian,
+          JSON.stringify(sign.yao_values),
+          sign.created_at,
+          now()
+        )
+        .run()
+      inserted += result.meta.changes
+    }
+  }
+
+  return { inserted, sourceKeys }
+}
+
+export async function readArcadeAccountProfile(
+  db: ArcadeProfileDb,
+  userId: string,
+  deps: StoreDeps = {}
+): Promise<ArcadeProfileSummary> {
+  const { results: runRows } = await db
+    .prepare(
+      `SELECT source_key, profile_id, run_id, mode, outcome, duration_ms,
+              attempt_number, module_count, completed_modules, strike_count, finished_at
+       FROM arcade_profile_bombsquad_run
+       WHERE user_id = ?
+       ORDER BY finished_at DESC, source_key DESC
+       LIMIT 100`
+    )
+    .bind(userId)
+    .all<BombSquadRunRow>()
+
+  const { results: signRows } = await db
+    .prepare(
+      `SELECT source_key, profile_id, session_id, sign_date, ben, bian, yao_values, created_at
+       FROM arcade_profile_oracle_sign
+       WHERE user_id = ?
+       ORDER BY created_at DESC, source_key DESC
+       LIMIT 100`
+    )
+    .bind(userId)
+    .all<OracleSignRow>()
+
+  const bombsquadRuns: BombSquadProfileRun[] = runRows.map((row) => ({
+    source_key: row.source_key,
+    run_id: row.run_id,
+    mode: row.mode,
+    outcome: row.outcome,
+    duration_ms: row.duration_ms,
+    attempt_number: row.attempt_number,
+    module_count: row.module_count,
+    completed_modules: row.completed_modules,
+    strike_count: row.strike_count,
+    finished_at: row.finished_at,
+  }))
+  const oracleSigns: OracleProfileSign[] = signRows.map((row) => ({
+    source_key: row.source_key,
+    session_id: row.session_id,
+    sign_date: row.sign_date,
+    ben: row.ben,
+    bian: row.bian,
+    yao_values: JSON.parse(row.yao_values) as OracleProfileSign['yao_values'],
+    created_at: row.created_at,
+  }))
+
+  return summarizeArcadeProfile({
+    bombsquadRuns,
+    oracleSigns,
+    today: deps.today?.() ?? getTodayString(),
+  })
+}

--- a/packages/arcade-profile/src/summary.ts
+++ b/packages/arcade-profile/src/summary.ts
@@ -1,0 +1,58 @@
+import type { ArcadeProfileSummary, BombSquadProfileRun, OracleProfileSign } from './types'
+
+function newerFirst<T extends { source_key: string }>(
+  items: T[],
+  getDate: (item: T) => string
+): T[] {
+  return [...items].sort((a, b) => {
+    const byDate = getDate(b).localeCompare(getDate(a))
+    return byDate !== 0 ? byDate : b.source_key.localeCompare(a.source_key)
+  })
+}
+
+function bestRun(runs: BombSquadProfileRun[]): BombSquadProfileRun | null {
+  const winners = runs.filter((run) => run.duration_ms >= 0)
+  if (winners.length === 0) return null
+  return [...winners].sort((a, b) => a.duration_ms - b.duration_ms)[0] ?? null
+}
+
+export function summarizeArcadeProfile(input: {
+  profileId?: string
+  bombsquadRuns: BombSquadProfileRun[]
+  oracleSigns: OracleProfileSign[]
+  today: string
+}): ArcadeProfileSummary {
+  const bombsquadRuns = newerFirst(input.bombsquadRuns, (run) => run.finished_at)
+  const oracleSigns = newerFirst(input.oracleSigns, (sign) => sign.created_at)
+  const recentRun = bombsquadRuns[0] ?? null
+  const recentSign = oracleSigns[0] ?? null
+  const lastActivityAt =
+    [recentRun?.finished_at, recentSign?.created_at]
+      .filter((value): value is string => value !== undefined)
+      .sort()
+      .at(-1) ?? null
+
+  return {
+    ...(input.profileId ? { profile_id: input.profileId } : {}),
+    last_activity_at: lastActivityAt,
+    today_played:
+      bombsquadRuns.some((run) => run.finished_at.slice(0, 10) === input.today) ||
+      oracleSigns.some((sign) => sign.sign_date === input.today),
+    counts: {
+      bombsquad_runs: bombsquadRuns.length,
+      oracle_signs: oracleSigns.length,
+    },
+    bombsquad: {
+      recent: recentRun,
+      best_daily: bestRun(
+        bombsquadRuns.filter((run) => run.mode === 'daily' && run.outcome === 'defused')
+      ),
+      best_practice: bestRun(
+        bombsquadRuns.filter((run) => run.mode === 'practice' && run.outcome === 'practice-cleared')
+      ),
+    },
+    oracle: {
+      recent: recentSign,
+    },
+  }
+}

--- a/packages/arcade-profile/src/test-support/node-sqlite.d.ts
+++ b/packages/arcade-profile/src/test-support/node-sqlite.d.ts
@@ -1,0 +1,34 @@
+interface ImportMeta {
+  url: string
+}
+
+declare module 'node:fs' {
+  export function readFileSync(path: string, encoding: 'utf8'): string
+}
+
+declare module 'node:path' {
+  export function dirname(path: string): string
+  export function join(...parts: string[]): string
+}
+
+declare module 'node:url' {
+  export function fileURLToPath(url: string): string
+}
+
+declare module 'node:sqlite' {
+  export interface StatementResultingChanges {
+    changes: number | bigint
+  }
+
+  export class StatementSync {
+    run(...params: unknown[]): StatementResultingChanges
+    get(...params: unknown[]): unknown
+    all(...params: unknown[]): unknown[]
+  }
+
+  export class DatabaseSync {
+    constructor(path: string)
+    exec(sql: string): void
+    prepare(sql: string): StatementSync
+  }
+}

--- a/packages/arcade-profile/src/test-support/sqlite-db.ts
+++ b/packages/arcade-profile/src/test-support/sqlite-db.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { DatabaseSync } from 'node:sqlite'
+import type { ArcadeProfileDb, ArcadeProfileDbRunResult, ArcadeProfileDbStatement } from '../db'
+
+const MIGRATION = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  'companion-memory',
+  'migrations',
+  '0002_arcade_profile.sql'
+)
+
+class SqliteStatement implements ArcadeProfileDbStatement {
+  private params: unknown[] = []
+
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string
+  ) {}
+
+  bind(...values: unknown[]): ArcadeProfileDbStatement {
+    this.params = values
+    return this
+  }
+
+  runSync(): ArcadeProfileDbRunResult {
+    const result = this.db.prepare(this.sql).run(...this.params)
+    return { meta: { changes: Number(result.changes) } }
+  }
+
+  async run(): Promise<ArcadeProfileDbRunResult> {
+    return this.runSync()
+  }
+
+  async first<T>(): Promise<T | null> {
+    const row = this.db.prepare(this.sql).get(...this.params)
+    return row === undefined ? null : (row as T)
+  }
+
+  async all<T>(): Promise<{ results: T[] }> {
+    return { results: this.db.prepare(this.sql).all(...this.params) as T[] }
+  }
+}
+
+class SqliteArcadeProfileDb implements ArcadeProfileDb {
+  constructor(private readonly raw: DatabaseSync) {}
+
+  prepare(sql: string): ArcadeProfileDbStatement {
+    return new SqliteStatement(this.raw, sql)
+  }
+
+  async batch(statements: ArcadeProfileDbStatement[]): Promise<ArcadeProfileDbRunResult[]> {
+    this.raw.exec('BEGIN')
+    try {
+      const results = (statements as SqliteStatement[]).map((statement) => statement.runSync())
+      this.raw.exec('COMMIT')
+      return results
+    } catch (error) {
+      this.raw.exec('ROLLBACK')
+      throw error
+    }
+  }
+}
+
+export function createTestDb(): ArcadeProfileDb {
+  const db = new DatabaseSync(':memory:')
+  db.exec(readFileSync(MIGRATION, 'utf8'))
+  return new SqliteArcadeProfileDb(db)
+}

--- a/packages/arcade-profile/src/types.ts
+++ b/packages/arcade-profile/src/types.ts
@@ -1,0 +1,85 @@
+export type ArcadeProfileEventKind = 'bombsquad_run' | 'oracle_sign'
+
+export type BombSquadProfileMode = 'daily' | 'practice'
+
+export type BombSquadProfileOutcome =
+  | 'defused'
+  | 'exploded'
+  | 'practice-cleared'
+  | 'practice-timeout'
+  | 'daily-timeout'
+
+export interface BombSquadProfileRun {
+  source_key: string
+  run_id: string
+  mode: BombSquadProfileMode
+  outcome: BombSquadProfileOutcome
+  duration_ms: number
+  attempt_number: number
+  module_count: number
+  completed_modules: number
+  strike_count: number
+  finished_at: string
+}
+
+export interface OracleProfileSign {
+  source_key: string
+  session_id: string
+  sign_date: string
+  ben: string
+  bian: string
+  yao_values: [number, number, number, number, number, number]
+  created_at: string
+}
+
+export type ArcadeProfileEvent =
+  | { kind: 'bombsquad_run'; profile_id?: string; run: BombSquadProfileRun }
+  | { kind: 'oracle_sign'; profile_id?: string; sign: OracleProfileSign }
+
+export interface ArcadeLocalProfile {
+  version: 1
+  profile_id: string
+  created_at: string
+  updated_at: string
+  last_seen_at: string
+  bombsquad_runs: BombSquadProfileRun[]
+  oracle_signs: OracleProfileSign[]
+  claimed_source_keys: string[]
+}
+
+export interface BombSquadProfileSummary {
+  recent: BombSquadProfileRun | null
+  best_daily: BombSquadProfileRun | null
+  best_practice: BombSquadProfileRun | null
+}
+
+export interface OracleProfileSummary {
+  recent: OracleProfileSign | null
+}
+
+export interface ArcadeProfileSummary {
+  profile_id?: string
+  last_activity_at: string | null
+  today_played: boolean
+  counts: {
+    bombsquad_runs: number
+    oracle_signs: number
+  }
+  bombsquad: BombSquadProfileSummary
+  oracle: OracleProfileSummary
+}
+
+export interface ArcadeProfileResponse {
+  profile: ArcadeProfileSummary
+}
+
+export interface ArcadeProfileClaimBody {
+  profile_id: string
+  events: ArcadeProfileEvent[]
+}
+
+export interface ArcadeProfileClaimResponse {
+  profile: ArcadeProfileSummary
+  source_keys: string[]
+  inserted: number
+}

--- a/packages/arcade-profile/src/validation.test.ts
+++ b/packages/arcade-profile/src/validation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { parseArcadeProfileClaimBody, parseArcadeProfileEvent } from './validation'
+
+const RUN_EVENT = {
+  kind: 'bombsquad_run',
+  profile_id: 'profile-1',
+  run: {
+    source_key: 'bombsquad:run-1',
+    run_id: 'run-1',
+    mode: 'daily',
+    outcome: 'defused',
+    duration_ms: 1234,
+    attempt_number: 1,
+    module_count: 4,
+    completed_modules: 4,
+    strike_count: 0,
+    finished_at: '2026-07-06T08:00:00.000Z',
+  },
+}
+
+describe('arcade profile validation', () => {
+  it('accepts a bounded source-keyed event', () => {
+    expect(parseArcadeProfileEvent(RUN_EVENT)).toMatchObject({
+      kind: 'bombsquad_run',
+      run: { run_id: 'run-1' },
+    })
+  })
+
+  it('rejects owner ids and source-key mismatches', () => {
+    expect(parseArcadeProfileEvent({ ...RUN_EVENT, user_id: 'attacker' })).toBeNull()
+    expect(
+      parseArcadeProfileEvent({
+        ...RUN_EVENT,
+        run: { ...RUN_EVENT.run, source_key: 'bombsquad:other-run' },
+      })
+    ).toBeNull()
+  })
+
+  it('applies the claim profile id without accepting an owner id', () => {
+    const claim = parseArcadeProfileClaimBody({
+      profile_id: 'profile-claim',
+      events: [{ ...RUN_EVENT, profile_id: undefined }],
+    })
+    expect(claim?.events[0].profile_id).toBe('profile-claim')
+    expect(parseArcadeProfileClaimBody({ profile_id: 'p', user_id: 'u', events: [] })).toBeNull()
+  })
+})

--- a/packages/arcade-profile/src/validation.ts
+++ b/packages/arcade-profile/src/validation.ts
@@ -1,0 +1,169 @@
+import { bombsquadRunSourceKey, oracleSignSourceKey } from './source-key'
+import type {
+  ArcadeProfileClaimBody,
+  ArcadeProfileEvent,
+  BombSquadProfileMode,
+  BombSquadProfileOutcome,
+  BombSquadProfileRun,
+  OracleProfileSign,
+} from './types'
+
+const MODES = new Set<BombSquadProfileMode>(['daily', 'practice'])
+const OUTCOMES = new Set<BombSquadProfileOutcome>([
+  'defused',
+  'exploded',
+  'practice-cleared',
+  'practice-timeout',
+  'daily-timeout',
+])
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasUserId(value: Record<string, unknown>): boolean {
+  return Object.prototype.hasOwnProperty.call(value, 'user_id')
+}
+
+function text(value: unknown, max: number): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (trimmed.length === 0 || trimmed.length > max) return null
+  return trimmed
+}
+
+function integer(value: unknown, min: number, max: number): number | null {
+  if (typeof value !== 'number' || !Number.isInteger(value)) return null
+  if (value < min || value > max) return null
+  return value
+}
+
+function isoDateTime(value: unknown): string | null {
+  const candidate = text(value, 40)
+  if (candidate === null) return null
+  const time = Date.parse(candidate)
+  return Number.isNaN(time) ? null : candidate
+}
+
+function isoDate(value: unknown): string | null {
+  const candidate = text(value, 10)
+  if (candidate === null) return null
+  return /^\d{4}-\d{2}-\d{2}$/.test(candidate) ? candidate : null
+}
+
+function parseBombSquadRun(value: unknown): BombSquadProfileRun | null {
+  if (!isObject(value) || hasUserId(value)) return null
+  const runId = text(value.run_id, 120)
+  const sourceKey = text(value.source_key, 180)
+  const mode = text(value.mode, 20) as BombSquadProfileMode | null
+  const outcome = text(value.outcome, 40) as BombSquadProfileOutcome | null
+  const durationMs = integer(value.duration_ms, 0, 3_600_000)
+  const attemptNumber = integer(value.attempt_number, 1, 10_000)
+  const moduleCount = integer(value.module_count, 0, 20)
+  const completedModules = integer(value.completed_modules, 0, 20)
+  const strikeCount = integer(value.strike_count, 0, 100)
+  const finishedAt = isoDateTime(value.finished_at)
+  if (
+    runId === null ||
+    sourceKey === null ||
+    mode === null ||
+    outcome === null ||
+    durationMs === null ||
+    attemptNumber === null ||
+    moduleCount === null ||
+    completedModules === null ||
+    strikeCount === null ||
+    finishedAt === null
+  ) {
+    return null
+  }
+  if (!MODES.has(mode) || !OUTCOMES.has(outcome)) return null
+  if (completedModules > moduleCount) return null
+  if (sourceKey !== bombsquadRunSourceKey(runId)) return null
+  return {
+    source_key: sourceKey,
+    run_id: runId,
+    mode,
+    outcome,
+    duration_ms: durationMs,
+    attempt_number: attemptNumber,
+    module_count: moduleCount,
+    completed_modules: completedModules,
+    strike_count: strikeCount,
+    finished_at: finishedAt,
+  }
+}
+
+function parseYaoValues(value: unknown): OracleProfileSign['yao_values'] | null {
+  if (!Array.isArray(value) || value.length !== 6) return null
+  const values = value.map((item) => integer(item, 6, 9))
+  if (values.some((item) => item === null)) return null
+  return values as OracleProfileSign['yao_values']
+}
+
+function parseOracleSign(value: unknown): OracleProfileSign | null {
+  if (!isObject(value) || hasUserId(value)) return null
+  const sessionId = text(value.session_id, 120)
+  const sourceKey = text(value.source_key, 180)
+  const signDate = isoDate(value.sign_date)
+  const ben = text(value.ben, 20)
+  const bian = text(value.bian, 20)
+  const yaoValues = parseYaoValues(value.yao_values)
+  const createdAt = isoDateTime(value.created_at)
+  if (
+    sessionId === null ||
+    sourceKey === null ||
+    signDate === null ||
+    ben === null ||
+    bian === null ||
+    yaoValues === null ||
+    createdAt === null
+  ) {
+    return null
+  }
+  if (sourceKey !== oracleSignSourceKey(signDate, sessionId)) return null
+  return {
+    source_key: sourceKey,
+    session_id: sessionId,
+    sign_date: signDate,
+    ben,
+    bian,
+    yao_values: yaoValues,
+    created_at: createdAt,
+  }
+}
+
+export function parseArcadeProfileEvent(value: unknown): ArcadeProfileEvent | null {
+  if (!isObject(value) || hasUserId(value)) return null
+  const profileId = value.profile_id === undefined ? undefined : text(value.profile_id, 120)
+  if (value.profile_id !== undefined && profileId === null) return null
+  if (value.kind === 'bombsquad_run') {
+    const run = parseBombSquadRun(value.run)
+    return run
+      ? { kind: 'bombsquad_run', ...(profileId ? { profile_id: profileId } : {}), run }
+      : null
+  }
+  if (value.kind === 'oracle_sign') {
+    const sign = parseOracleSign(value.sign)
+    return sign
+      ? { kind: 'oracle_sign', ...(profileId ? { profile_id: profileId } : {}), sign }
+      : null
+  }
+  return null
+}
+
+export function parseArcadeProfileClaimBody(value: unknown): ArcadeProfileClaimBody | null {
+  if (!isObject(value) || hasUserId(value)) return null
+  const profileId = text(value.profile_id, 120)
+  if (profileId === null) return null
+  if (!Array.isArray(value.events) || value.events.length > 100) return null
+  const events = value.events.map(parseArcadeProfileEvent)
+  if (events.some((event) => event === null)) return null
+  return {
+    profile_id: profileId,
+    events: (events as ArcadeProfileEvent[]).map((event) => ({
+      ...event,
+      profile_id: event.profile_id ?? profileId,
+    })),
+  }
+}

--- a/packages/arcade-profile/tsconfig.json
+++ b/packages/arcade-profile/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"]
+}

--- a/packages/arcade-profile/vitest.config.ts
+++ b/packages/arcade-profile/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+})

--- a/packages/companion-memory/migrations/0002_arcade_profile.sql
+++ b/packages/companion-memory/migrations/0002_arcade_profile.sql
@@ -1,0 +1,49 @@
+-- Migration 0002 — Arcade profile account data.
+--
+-- This D1 database was first introduced for Companion Memory, but the
+-- physical database is now also the account data plane for small account-owned
+-- Arcade records. These tables are owned by the arcade-profile domain package,
+-- not by the Companion Memory model. They intentionally carry no foreign keys
+-- to `companion`: a player can have an account profile before creating an AI
+-- companion.
+
+CREATE TABLE arcade_profile_bombsquad_run (
+  user_id TEXT NOT NULL,
+  source_key TEXT NOT NULL,
+  profile_id TEXT,
+  run_id TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK (mode IN ('daily', 'practice')),
+  outcome TEXT NOT NULL CHECK (
+    outcome IN ('defused', 'exploded', 'practice-cleared', 'practice-timeout', 'daily-timeout')
+  ),
+  duration_ms INTEGER NOT NULL CHECK (duration_ms >= 0 AND duration_ms <= 3600000),
+  attempt_number INTEGER NOT NULL CHECK (attempt_number >= 1),
+  module_count INTEGER NOT NULL CHECK (module_count >= 0),
+  completed_modules INTEGER NOT NULL CHECK (
+    completed_modules >= 0 AND completed_modules <= module_count
+  ),
+  strike_count INTEGER NOT NULL CHECK (strike_count >= 0),
+  finished_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (user_id, source_key)
+);
+
+CREATE INDEX idx_arcade_bombsquad_user_finished
+  ON arcade_profile_bombsquad_run (user_id, finished_at DESC, source_key DESC);
+
+CREATE TABLE arcade_profile_oracle_sign (
+  user_id TEXT NOT NULL,
+  source_key TEXT NOT NULL,
+  profile_id TEXT,
+  session_id TEXT NOT NULL,
+  sign_date TEXT NOT NULL,
+  ben TEXT NOT NULL,
+  bian TEXT NOT NULL,
+  yao_values TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  inserted_at TEXT NOT NULL,
+  PRIMARY KEY (user_id, source_key)
+);
+
+CREATE INDEX idx_arcade_oracle_user_created
+  ON arcade_profile_oracle_sign (user_id, created_at DESC, source_key DESC);

--- a/packages/game-bombsquad/package.json
+++ b/packages/game-bombsquad/package.json
@@ -10,6 +10,7 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@amiclaw/arcade-profile": "workspace:*",
     "@amiclaw/ui": "workspace:*",
     "js-yaml": "^4.2.0",
     "react": "^19.2.7",

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -2,6 +2,8 @@ import { useState, useCallback, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import PostGameModal, { type PostGameModalResult } from '@/components/PostGameModal'
 import { Scenery } from '@amiclaw/ui'
+import { recordBombSquadLocalRun } from '@amiclaw/arcade-profile/local'
+import { submitArcadeProfileEvent } from '@amiclaw/arcade-profile/api-client'
 import Button from '@/components/bombsquad/Button'
 import Glyph, { type GlyphKey } from '@/components/bombsquad/Glyph'
 import { useGame, MAX_STRIKES, type GameOutcome } from '@/store/game-context'
@@ -110,6 +112,36 @@ export default function ResultPage() {
     state.totalStartTime !== null && state.totalEndTime !== null
       ? state.totalEndTime - state.totalStartTime
       : null
+
+  useEffect(() => {
+    if (noRunData) return
+    if (totalMs === null || state.gameRunId === null || state.outcome === null) return
+    const event = recordBombSquadLocalRun({
+      runId: state.gameRunId,
+      mode: state.mode,
+      outcome: state.outcome,
+      durationMs: totalMs,
+      attemptNumber: state.attemptNumber,
+      moduleCount: state.moduleSequence.length,
+      completedModules: state.moduleStats.length,
+      strikeCount: state.strikeCount,
+      finishedAt: new Date(state.totalEndTime ?? Date.now()).toISOString(),
+    })
+    if (event) {
+      void submitArcadeProfileEvent(event)
+    }
+  }, [
+    noRunData,
+    totalMs,
+    state.gameRunId,
+    state.outcome,
+    state.mode,
+    state.attemptNumber,
+    state.moduleSequence.length,
+    state.moduleStats.length,
+    state.strikeCount,
+    state.totalEndTime,
+  ])
 
   // Daily mode submits a score — but only on a successful defuse. An
   // exploded run never submits and never asks for a nickname. Practice mode

--- a/packages/game-bombsquad/src/test-setup.ts
+++ b/packages/game-bombsquad/src/test-setup.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+vi.mock('@amiclaw/arcade-profile/api-client', () => ({
+  submitArcadeProfileEvent: vi.fn(() => Promise.resolve({ kind: 'anon' })),
+}))

--- a/packages/game-yijing/package.json
+++ b/packages/game-yijing/package.json
@@ -10,12 +10,15 @@
     "test:run": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@amiclaw/arcade-profile": "workspace:*",
     "@amiclaw/ui": "workspace:*",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.18.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/packages/game-yijing/src/pages/PageSign.profile.test.tsx
+++ b/packages/game-yijing/src/pages/PageSign.profile.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ArcadeProfileEvent } from '@amiclaw/arcade-profile/types'
+
+const mocks = vi.hoisted(() => ({
+  session: {
+    sessionId: 'oracle-session',
+    yaoValues: null as number[] | null,
+  },
+  recordOracleLocalSign: vi.fn(),
+  submitArcadeProfileEvent: vi.fn(() => Promise.resolve({ kind: 'anon' })),
+}))
+
+vi.mock('../session', () => ({
+  useSession: () => mocks.session,
+}))
+
+vi.mock('@amiclaw/arcade-profile/local', () => ({
+  recordOracleLocalSign: mocks.recordOracleLocalSign,
+}))
+
+vi.mock('@amiclaw/arcade-profile/api-client', () => ({
+  submitArcadeProfileEvent: mocks.submitArcadeProfileEvent,
+}))
+
+import { PageSign } from './PageSign'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PageSign />
+    </MemoryRouter>
+  )
+}
+
+describe('PageSign arcade profile write', () => {
+  afterEach(() => {
+    cleanup()
+    mocks.session.sessionId = 'oracle-session'
+    mocks.session.yaoValues = null
+    mocks.recordOracleLocalSign.mockReset()
+    mocks.submitArcadeProfileEvent.mockReset()
+    mocks.submitArcadeProfileEvent.mockResolvedValue({ kind: 'anon' })
+  })
+
+  it('does not save the demo fallback sign', async () => {
+    renderPage()
+    await Promise.resolve()
+
+    expect(mocks.recordOracleLocalSign).not.toHaveBeenCalled()
+    expect(mocks.submitArcadeProfileEvent).not.toHaveBeenCalled()
+  })
+
+  it('saves a real cast sign locally and submits it for logged-in accounts', async () => {
+    const event: ArcadeProfileEvent = {
+      kind: 'oracle_sign',
+      profile_id: 'local-profile',
+      sign: {
+        source_key: 'oracle:2026-07-06:oracle-session',
+        session_id: 'oracle-session',
+        sign_date: '2026-07-06',
+        ben: '同人',
+        bian: '无妄',
+        yao_values: [7, 8, 9, 7, 7, 7],
+        created_at: '2026-07-06T08:00:00.000Z',
+      },
+    }
+    mocks.session.yaoValues = [7, 8, 9, 7, 7, 7]
+    mocks.recordOracleLocalSign.mockReturnValue(event)
+
+    renderPage()
+
+    await waitFor(() => expect(mocks.recordOracleLocalSign).toHaveBeenCalledTimes(1))
+    expect(mocks.recordOracleLocalSign).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'oracle-session',
+        yaoValues: [7, 8, 9, 7, 7, 7],
+      })
+    )
+    expect(mocks.submitArcadeProfileEvent).toHaveBeenCalledWith(event)
+  })
+})

--- a/packages/game-yijing/src/pages/PageSign.tsx
+++ b/packages/game-yijing/src/pages/PageSign.tsx
@@ -1,5 +1,9 @@
+import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button, Scenery } from '@amiclaw/ui'
+import { recordOracleLocalSign } from '@amiclaw/arcade-profile/local'
+import { submitArcadeProfileEvent } from '@amiclaw/arcade-profile/api-client'
+import { getTodayString } from '@shared/date'
 import { Hexagram } from '../glyphs'
 import { changedValues, ganzhi, hexagramFromBinary, type YaoSextet } from '../glyphs/utils'
 import { useSession } from '../session'
@@ -24,12 +28,26 @@ function todayCN(): string {
 
 export function PageSign() {
   const navigate = useNavigate()
-  const { yaoValues } = useSession()
+  const { sessionId, yaoValues } = useSession()
 
   const values: YaoSextet = yaoValues ?? DEMO_YAO
   const changed = changedValues(values) as unknown as YaoSextet
   const [, benCn] = hexagramFromBinary(values)
   const [, bianCn] = hexagramFromBinary(changed)
+
+  useEffect(() => {
+    if (yaoValues === null) return
+    const event = recordOracleLocalSign({
+      sessionId,
+      signDate: getTodayString(),
+      ben: benCn,
+      bian: bianCn,
+      yaoValues: [...yaoValues] as [number, number, number, number, number, number],
+    })
+    if (event) {
+      void submitArcadeProfileEvent(event)
+    }
+  }, [bianCn, benCn, sessionId, yaoValues])
 
   return (
     <main className={styles.page}>

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -10,6 +10,7 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@amiclaw/arcade-profile": "workspace:*",
     "@amiclaw/ui": "workspace:*",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/packages/platform/src/pages/AccountPage.module.css
+++ b/packages/platform/src/pages/AccountPage.module.css
@@ -125,6 +125,78 @@
   transform: translateY(-2px);
 }
 
+.skeleton {
+  min-height: 190px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.statsCard {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 22px;
+  padding: 28px;
+}
+
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  width: 100%;
+}
+
+.statBlock {
+  min-width: 0;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.statLabel {
+  font: 600 11px var(--font-body);
+  color: rgba(255, 255, 255, 0.45);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.statValue {
+  margin-top: 10px;
+  font: 400 22px var(--font-display);
+  color: var(--text-1);
+  overflow-wrap: anywhere;
+}
+
+.statDetail {
+  margin-top: 8px;
+  font: 500 13px var(--font-body);
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.58);
+}
+
+.claimCard {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 28px;
+}
+
+.claimText {
+  flex: 1;
+  margin: 0;
+  font: 400 15px var(--font-body);
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.claimStatus {
+  font: 600 13px var(--font-body);
+  color: var(--amio-yellow);
+  white-space: nowrap;
+}
+
 /* ----------  signed-out — login-guide empty state  ----------
    Shown to anonymous visitors instead of a fake profile. A single
    centered card: heading + a plain-text unlock preview + a primary CTA
@@ -159,6 +231,12 @@
 /* CTA — mirrors the primary Button affordance (yellow pill, dark text,
    glow-lift on hover). CSS-only animation; rendered as a react-router
    Link so it navigates to the homepage / onboarding surface. */
+.signedOutGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 28px;
+}
+
 .guideCta {
   display: inline-flex;
   align-items: center;
@@ -178,11 +256,28 @@
   transform: translateY(-2px);
 }
 
+.guideText {
+  margin: 16px 0 0;
+  font: 400 15px var(--font-body);
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.64);
+}
+
 /* ----------  responsive: mobile  ----------
    atlas.html ≤768px — .acct-grid collapses to one column (profile card
    stacks above the recent-runs / badges detail column). */
 @media (max-width: 768px) {
   .grid {
     grid-template-columns: 1fr;
+  }
+
+  .signedOutGrid,
+  .statGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .claimCard {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }

--- a/packages/platform/src/pages/AccountPage.test.tsx
+++ b/packages/platform/src/pages/AccountPage.test.tsx
@@ -14,9 +14,10 @@
  * is the real session fetch: each test stubs global.fetch.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import type { SessionResponse } from '@shared/auth-types'
+import { ARCADE_LOCAL_PROFILE_KEY } from '@amiclaw/arcade-profile/local'
 import AccountPage from './AccountPage'
 
 /** Resolve any fetch input to its URL string. */
@@ -33,13 +34,31 @@ function urlOf(input: RequestInfo | URL): string {
  */
 function stubApi(opts: {
   session: SessionResponse
+  arcadeProfile?: unknown
   companion?: { status: number; body?: unknown }
 }) {
   const companion = opts.companion ?? { status: 404, body: { error: 'no companion set up' } }
+  const arcadeProfile = opts.arcadeProfile ?? { profile: EMPTY_ARCADE_PROFILE }
   vi.stubGlobal(
     'fetch',
     vi.fn((input: RequestInfo | URL) => {
-      if (urlOf(input).includes('/api/companion')) {
+      const url = urlOf(input)
+      if (url.includes('/api/arcade/profile/claim')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              profile: ACCOUNT_ARCADE_PROFILE,
+              source_keys: ['bombsquad:local-run'],
+              inserted: 1,
+            }),
+            { status: 200 }
+          )
+        )
+      }
+      if (url.includes('/api/arcade/profile')) {
+        return Promise.resolve(new Response(JSON.stringify(arcadeProfile), { status: 200 }))
+      }
+      if (url.includes('/api/companion')) {
         return Promise.resolve(
           new Response(companion.body === undefined ? null : JSON.stringify(companion.body), {
             status: companion.status,
@@ -57,6 +76,108 @@ const AUTHED: SessionResponse = {
   identity: { user_id: 'u_1', email: 'nova@amio.fans' },
 }
 
+const EMPTY_ARCADE_PROFILE = {
+  last_activity_at: null,
+  today_played: false,
+  counts: { bombsquad_runs: 0, oracle_signs: 0 },
+  bombsquad: { recent: null, best_daily: null, best_practice: null },
+  oracle: { recent: null },
+}
+
+const ACCOUNT_ARCADE_PROFILE = {
+  last_activity_at: '2026-07-06T08:00:00.000Z',
+  today_played: true,
+  counts: { bombsquad_runs: 1, oracle_signs: 1 },
+  bombsquad: {
+    recent: {
+      source_key: 'bombsquad:account-run',
+      run_id: 'account-run',
+      mode: 'daily',
+      outcome: 'defused',
+      duration_ms: 65_000,
+      attempt_number: 1,
+      module_count: 4,
+      completed_modules: 4,
+      strike_count: 0,
+      finished_at: '2026-07-06T08:00:00.000Z',
+    },
+    best_daily: {
+      source_key: 'bombsquad:account-run',
+      run_id: 'account-run',
+      mode: 'daily',
+      outcome: 'defused',
+      duration_ms: 65_000,
+      attempt_number: 1,
+      module_count: 4,
+      completed_modules: 4,
+      strike_count: 0,
+      finished_at: '2026-07-06T08:00:00.000Z',
+    },
+    best_practice: null,
+  },
+  oracle: {
+    recent: {
+      source_key: 'oracle:2026-07-06:oracle-1',
+      session_id: 'oracle-1',
+      sign_date: '2026-07-06',
+      ben: '乾',
+      bian: '坤',
+      yao_values: [7, 8, 7, 8, 7, 8],
+      created_at: '2026-07-06T09:00:00.000Z',
+    },
+  },
+}
+
+function installFakeLocalStorage() {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  })
+  return store
+}
+
+function seedLocalProfile(store: Map<string, string>) {
+  store.set(
+    ARCADE_LOCAL_PROFILE_KEY,
+    JSON.stringify({
+      version: 1,
+      profile_id: 'local-profile',
+      created_at: '2026-07-06T07:00:00.000Z',
+      updated_at: '2026-07-06T08:00:00.000Z',
+      last_seen_at: '2026-07-06T08:00:00.000Z',
+      claimed_source_keys: [],
+      bombsquad_runs: [
+        {
+          source_key: 'bombsquad:local-run',
+          run_id: 'local-run',
+          mode: 'practice',
+          outcome: 'practice-cleared',
+          duration_ms: 42_000,
+          attempt_number: 1,
+          module_count: 2,
+          completed_modules: 2,
+          strike_count: 0,
+          finished_at: '2026-07-06T08:00:00.000Z',
+        },
+      ],
+      oracle_signs: [],
+    })
+  )
+}
+
 function renderAccount(entry = '/me') {
   return render(
     <MemoryRouter initialEntries={[entry]}>
@@ -69,24 +190,23 @@ function renderAccount(entry = '/me') {
 }
 
 describe('AccountPage /me', () => {
+  let localStore: Map<string, string>
+
   beforeEach(() => {
-    // Section eyebrow is shown in every state; identity drives the body.
+    localStore = installFakeLocalStorage()
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
-  it('renders the login guide and no fake profile for a signed-out visitor', async () => {
+  it('renders real local profile data and no fake profile for a signed-out visitor', async () => {
+    seedLocalProfile(localStore)
     stubApi({ session: ANON })
     renderAccount('/me')
 
-    // Login-guide markers: the heading and the plain-text unlock preview.
-    expect(await screen.findByText('登录后查看你的星轨')).toBeInTheDocument()
-    expect(screen.getByText('战绩与单局完成率')).toBeInTheDocument()
-    expect(screen.getByText('连胜与最快记录')).toBeInTheDocument()
-    expect(screen.getByText('勋章墙')).toBeInTheDocument()
-    // A functional CTA linking to /login.
+    expect(await screen.findByText('本设备的星轨。')).toBeInTheDocument()
+    expect(screen.getByText('练习 · 00:42 · 最快 00:42')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: '登录' })).toBeInTheDocument()
 
     // None of the retired mock-profile content may render for anyone now.
@@ -107,7 +227,7 @@ describe('AccountPage /me', () => {
   })
 
   it('renders the real-identity profile with an honest empty stats state', async () => {
-    stubApi({ session: AUTHED })
+    stubApi({ session: AUTHED, arcadeProfile: { profile: ACCOUNT_ARCADE_PROFILE } })
     renderAccount('/me')
 
     // Identity is derived from the session email local-part (nova@... → nova).
@@ -115,15 +235,31 @@ describe('AccountPage /me', () => {
     // so assert at least one match resolves once the session read returns.
     expect((await screen.findAllByText('nova', { exact: true })).length).toBeGreaterThan(0)
     expect(screen.getByText('nova@amio.fans')).toBeInTheDocument()
-    // Honest empty stats state — no fake numbers, no「即将推出」placeholder.
-    expect(screen.getByText('还没有成绩，去玩一局。')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: '开始玩' })).toBeInTheDocument()
+    // Account stats are read from /api/arcade/profile, not invented locally.
+    expect(await screen.findByText('账号记录')).toBeInTheDocument()
+    expect(screen.getByText('每日挑战 · 01:05 · 最快 01:05')).toBeInTheDocument()
+    expect(screen.getByText('乾 → 坤')).toBeInTheDocument()
     // The retired mock stats / runs / badges must be absent.
     expect(screen.queryByText('林星海')).not.toBeInTheDocument()
     expect(screen.queryByText('42')).not.toBeInTheDocument()
     expect(screen.queryByText('最近 5 局')).not.toBeInTheDocument()
     // The login-guide empty state must NOT be present.
-    expect(screen.queryByText('登录后查看你的星轨')).not.toBeInTheDocument()
+    expect(screen.queryByText('本设备的星轨。')).not.toBeInTheDocument()
+  })
+
+  it('claims local profile entries into the signed-in account and marks them locally claimed', async () => {
+    seedLocalProfile(localStore)
+    stubApi({ session: AUTHED, arcadeProfile: { profile: EMPTY_ARCADE_PROFILE } })
+    renderAccount('/me')
+
+    fireEvent.click(await screen.findByRole('button', { name: '保存到账号' }))
+
+    expect(await screen.findByText('已保存')).toBeInTheDocument()
+    await waitFor(() => {
+      const raw = localStore.get(ARCADE_LOCAL_PROFILE_KEY)
+      expect(raw).toContain('bombsquad:local-run')
+      expect(JSON.parse(raw ?? '{}').claimed_source_keys).toContain('bombsquad:local-run')
+    })
   })
 
   it('shows the companion setup CTA when the user has no companion yet', async () => {
@@ -172,6 +308,11 @@ describe('AccountPage /me', () => {
       }
       if (url.includes('/api/auth/logout')) {
         return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      }
+      if (url.includes('/api/arcade/profile')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ profile: EMPTY_ARCADE_PROFILE }), { status: 200 })
+        )
       }
       return Promise.resolve(new Response(JSON.stringify(AUTHED), { status: 200 }))
     })

--- a/packages/platform/src/pages/AccountPage.tsx
+++ b/packages/platform/src/pages/AccountPage.tsx
@@ -1,5 +1,16 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Button, ConicAvatar, EyebrowTag, GlassCard } from '@amiclaw/ui'
+import type { ArcadeLocalProfile, ArcadeProfileSummary } from '@amiclaw/arcade-profile/types'
+import {
+  ensureArcadeLocalProfile,
+  getClaimableArcadeProfileEvents,
+  markArcadeProfileEventsClaimed,
+  summarizeArcadeLocalProfile,
+} from '@amiclaw/arcade-profile/local'
+import { claimArcadeProfile, fetchArcadeProfile } from '@amiclaw/arcade-profile/api-client'
+import { formatMs } from '@shared/format-time'
+import { toChineseDateString } from '@shared/date'
 import { useAuth, type DisplayUser } from '@/hooks/useAuth'
 import CompanionCard from '@/components/companion/CompanionCard'
 import { companionSeedEnabled } from '@/lib/companion-seed'
@@ -14,6 +25,14 @@ import styles from './AccountPage.module.css'
    Platform chrome — every accent is brand yellow; no BombSquad cyan here. */
 export default function AccountPage() {
   const { status, user, logout } = useAuth()
+  const [localProfile, setLocalProfile] = useState<ArcadeLocalProfile | null>(() =>
+    ensureArcadeLocalProfile()
+  )
+  const localSummary = useMemo(() => summarizeArcadeLocalProfile(localProfile), [localProfile])
+  const claimableEvents = useMemo(
+    () => getClaimableArcadeProfileEvents(localProfile),
+    [localProfile]
+  )
   // The dev seed lets a Cloudflare preview feel the companion surfaces without a
   // live session; treat it as enough to show the companion entry here too.
   const seeded = companionSeedEnabled()
@@ -22,14 +41,54 @@ export default function AccountPage() {
     <div className={styles.page}>
       <EyebrowTag variant="section">我的 · ACCOUNT</EyebrowTag>
       {status === 'loading' && !seeded ? null : status === 'authed' && user ? (
-        <SignedInProfile user={user} onLogout={logout} />
+        <SignedInProfile
+          key={user.email}
+          user={user}
+          onLogout={logout}
+          localProfile={localProfile}
+          localSummary={localSummary}
+          claimableEvents={claimableEvents}
+          onLocalProfileChange={setLocalProfile}
+        />
       ) : seeded ? (
         <SeededCompanionPreview />
       ) : (
-        <SignedOutGuide />
+        <SignedOutGuide localSummary={localSummary} />
       )}
     </div>
   )
+}
+
+type AccountProfileState =
+  | { status: 'idle'; profile: null }
+  | { status: 'loading'; profile: null }
+  | { status: 'ok'; profile: ArcadeProfileSummary }
+  | { status: 'error'; profile: null }
+
+function useAccountArcadeProfile(): {
+  state: AccountProfileState
+  reload: () => void
+} {
+  const [state, setState] = useState<AccountProfileState>({ status: 'loading', profile: null })
+  const [nonce, setNonce] = useState(0)
+  const reload = useCallback(() => setNonce((n) => n + 1), [])
+
+  useEffect(() => {
+    let active = true
+    fetchArcadeProfile().then((result) => {
+      if (!active) return
+      if (result.kind === 'ok') {
+        setState({ status: 'ok', profile: result.profile })
+      } else {
+        setState({ status: 'error', profile: null })
+      }
+    })
+    return () => {
+      active = false
+    }
+  }, [nonce])
+
+  return { state, reload }
 }
 
 /* Dev-seed preview (anonymous + ?companionSeed=1): no real identity, but the
@@ -55,13 +114,29 @@ function SeededCompanionPreview() {
    fake-data problem PR #133 fixed for the signed-out state. So the detail
    column is an honest empty state — "还没有成绩，去玩一局" with a play CTA —
    not mock numbers and not a「即将推出」placeholder. */
-function SignedInProfile({ user, onLogout }: { user: DisplayUser; onLogout: () => void }) {
+function SignedInProfile({
+  user,
+  onLogout,
+  localProfile,
+  localSummary,
+  claimableEvents,
+  onLocalProfileChange,
+}: {
+  user: DisplayUser
+  onLogout: () => void
+  localProfile: ArcadeLocalProfile | null
+  localSummary: ArcadeProfileSummary
+  claimableEvents: ReturnType<typeof getClaimableArcadeProfileEvents>
+  onLocalProfileChange: (profile: ArcadeLocalProfile | null) => void
+}) {
+  const { state: accountProfile, reload: reloadAccountProfile } = useAccountArcadeProfile()
+
   return (
     <>
       <h2 className={styles.title}>
         <span className={styles.accent}>{user.displayName}</span> 的星轨。
       </h2>
-      <p className={styles.lead}>你的战绩、连胜、个人最快记录。所有数据只属于你。</p>
+      <p className={styles.lead}>这里显示这个账号已经保存的真实记录。</p>
 
       <div className={styles.grid}>
         <GlassCard radius="2xl" className={styles.profile}>
@@ -77,14 +152,25 @@ function SignedInProfile({ user, onLogout }: { user: DisplayUser; onLogout: () =
 
         <div className={styles.detail}>
           <section className={styles.section}>
-            <h3 className={styles.sectionTitle}>战绩</h3>
-            <GlassCard radius="2xl" className={styles.emptyCard}>
-              <p className={styles.emptyText}>还没有成绩，去玩一局。</p>
-              <a className={styles.emptyCta} href="/bombsquad/">
-                开始玩
-              </a>
-            </GlassCard>
+            <h3 className={styles.sectionTitle}>账号记录</h3>
+            {accountProfile.status === 'loading' || accountProfile.status === 'idle' ? (
+              <div className={styles.skeleton} aria-hidden="true" />
+            ) : accountProfile.status === 'ok' ? (
+              <ArcadeStatsCard profile={accountProfile.profile} emptyCtaHref="/bombsquad/" />
+            ) : (
+              <GlassCard radius="2xl" className={styles.emptyCard}>
+                <p className={styles.emptyText}>账号记录暂时读不出来，稍后再试。</p>
+              </GlassCard>
+            )}
           </section>
+
+          <ClaimLocalProfileCard
+            localProfile={localProfile}
+            localSummary={localSummary}
+            claimableEvents={claimableEvents}
+            onLocalProfileChange={onLocalProfileChange}
+            onClaimed={reloadAccountProfile}
+          />
 
           <CompanionCard />
         </div>
@@ -93,32 +179,172 @@ function SignedInProfile({ user, onLogout }: { user: DisplayUser; onLogout: () =
   )
 }
 
-/* What signing in unlocks — plain text only. No fake numbers, names, or a
-   blurred/skeleton fake-data placeholder; the anonymous visitor must never
-   see another user's stats here. */
-const UNLOCK_PREVIEW = ['战绩与单局完成率', '连胜与最快记录', '勋章墙']
-
-/* The anonymous empty state — a single login-guide card. Routes to the
-   magic-link /login page via react-router. */
-function SignedOutGuide() {
+/* The anonymous state reads the current device's local profile. It still routes
+   to login, but the page is no longer a promise card: it shows actual local
+   records or an honest empty state. */
+function SignedOutGuide({ localSummary }: { localSummary: ArcadeProfileSummary }) {
   return (
     <>
-      <h2 className={styles.title}>登录后查看你的星轨。</h2>
-      <p className={styles.lead}>登录后，这里会显示属于你的战绩、连胜和勋章。</p>
+      <h2 className={styles.title}>本设备的星轨。</h2>
+      <p className={styles.lead}>不登录也会先保存在这台设备上；登录后可以保存到账号。</p>
 
-      <GlassCard radius="2xl" className={styles.guideCard}>
-        <h3 className={styles.guideTitle}>登录后查看你的星轨</h3>
-        <ul className={styles.unlockList}>
-          {UNLOCK_PREVIEW.map((item) => (
-            <li key={item} className={styles.unlockItem}>
-              {item}
-            </li>
-          ))}
-        </ul>
-        <Link to="/login" className={styles.guideCta}>
-          登录
-        </Link>
-      </GlassCard>
+      <div className={styles.signedOutGrid}>
+        <ArcadeStatsCard profile={localSummary} emptyCtaHref="/bombsquad/" />
+        <GlassCard radius="2xl" className={styles.guideCard}>
+          <h3 className={styles.guideTitle}>保存到账号</h3>
+          <p className={styles.guideText}>
+            登录后可以把这台设备上的 BombSquad 和卦签记录保存到账号。
+          </p>
+          <Link to="/login" className={styles.guideCta}>
+            登录
+          </Link>
+        </GlassCard>
+      </div>
     </>
   )
+}
+
+function ClaimLocalProfileCard({
+  localProfile,
+  localSummary,
+  claimableEvents,
+  onLocalProfileChange,
+  onClaimed,
+}: {
+  localProfile: ArcadeLocalProfile | null
+  localSummary: ArcadeProfileSummary
+  claimableEvents: ReturnType<typeof getClaimableArcadeProfileEvents>
+  onLocalProfileChange: (profile: ArcadeLocalProfile | null) => void
+  onClaimed: () => void
+}) {
+  const [status, setStatus] = useState<'idle' | 'claiming' | 'claimed' | 'error'>('idle')
+  if (!localProfile || (claimableEvents.length === 0 && status !== 'claimed')) return null
+
+  const handleClaim = async () => {
+    setStatus('claiming')
+    const result = await claimArcadeProfile({
+      profile_id: localProfile.profile_id,
+      events: claimableEvents,
+    })
+    if (result.kind !== 'ok') {
+      setStatus('error')
+      return
+    }
+    onLocalProfileChange(markArcadeProfileEventsClaimed(result.sourceKeys ?? []))
+    onClaimed()
+    setStatus('claimed')
+  }
+
+  return (
+    <section className={styles.section}>
+      <h3 className={styles.sectionTitle}>本设备记录</h3>
+      <GlassCard radius="2xl" className={styles.claimCard}>
+        <p className={styles.claimText}>
+          {status === 'claimed'
+            ? '本设备记录已保存到账号。'
+            : `这台设备还有 ${claimableEvents.length} 条未保存到账号的记录。${
+                localSummary.last_activity_at
+                  ? ` 最近一次是 ${toChineseDateString(localSummary.last_activity_at.slice(0, 10))}。`
+                  : ''
+              }`}
+        </p>
+        {status !== 'claimed' && (
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleClaim}
+            disabled={status === 'claiming'}
+          >
+            {status === 'claiming' ? '保存中' : '保存到账号'}
+          </Button>
+        )}
+        {status === 'claimed' && <span className={styles.claimStatus}>已保存</span>}
+        {status === 'error' && <span className={styles.claimStatus}>保存失败</span>}
+      </GlassCard>
+    </section>
+  )
+}
+
+function ArcadeStatsCard({
+  profile,
+  emptyCtaHref,
+}: {
+  profile: ArcadeProfileSummary
+  emptyCtaHref: string
+}) {
+  const hasAnyRecord = profile.counts.bombsquad_runs > 0 || profile.counts.oracle_signs > 0
+  return (
+    <GlassCard radius="2xl" className={styles.statsCard}>
+      <div className={styles.statGrid}>
+        <StatBlock
+          label="今日"
+          value={profile.today_played ? '已开始' : '未开始'}
+          detail={
+            profile.last_activity_at
+              ? `最近 ${toChineseDateString(profile.last_activity_at.slice(0, 10))}`
+              : '还没有记录'
+          }
+        />
+        <StatBlock
+          label="BombSquad"
+          value={
+            profile.bombsquad.recent ? outcomeLabel(profile.bombsquad.recent.outcome) : '无记录'
+          }
+          detail={bombsquadDetail(profile)}
+        />
+        <StatBlock
+          label="卦签"
+          value={
+            profile.oracle.recent
+              ? `${profile.oracle.recent.ben} → ${profile.oracle.recent.bian}`
+              : '无记录'
+          }
+          detail={
+            profile.oracle.recent
+              ? toChineseDateString(profile.oracle.recent.sign_date)
+              : '完成一次卦签后会出现在这里'
+          }
+        />
+      </div>
+      {!hasAnyRecord && (
+        <a className={styles.emptyCta} href={emptyCtaHref}>
+          开始玩
+        </a>
+      )}
+    </GlassCard>
+  )
+}
+
+function StatBlock({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className={styles.statBlock}>
+      <div className={styles.statLabel}>{label}</div>
+      <div className={styles.statValue}>{value}</div>
+      <div className={styles.statDetail}>{detail}</div>
+    </div>
+  )
+}
+
+function outcomeLabel(outcome: string): string {
+  switch (outcome) {
+    case 'defused':
+    case 'practice-cleared':
+      return '完成'
+    case 'exploded':
+      return '三振出局'
+    case 'practice-timeout':
+    case 'daily-timeout':
+      return '到达上限'
+    default:
+      return outcome
+  }
+}
+
+function bombsquadDetail(profile: ArcadeProfileSummary): string {
+  const recent = profile.bombsquad.recent
+  if (!recent) return '完成一局后会出现在这里'
+  const mode = recent.mode === 'daily' ? '每日挑战' : '练习'
+  const best = profile.bombsquad.best_daily ?? profile.bombsquad.best_practice
+  const bestText = best ? ` · 最快 ${formatMs(best.duration_ms)}` : ''
+  return `${mode} · ${formatMs(recent.duration_ms)}${bestText}`
 }

--- a/packages/platform/src/pages/PrivacyPage.test.tsx
+++ b/packages/platform/src/pages/PrivacyPage.test.tsx
@@ -72,6 +72,6 @@ describe('PrivacyPage', () => {
     const mailtoLinks = screen.getAllByRole('link', { name: 'hi@amio.love' })
     expect(mailtoLinks.length).toBeGreaterThan(0)
     expect(mailtoLinks[0]).toHaveAttribute('href', 'mailto:hi@amio.love')
-    expect(screen.getByText(/生效日期：2026-07-04/)).toBeInTheDocument()
+    expect(screen.getByText(/生效日期：2026-07-06/)).toBeInTheDocument()
   })
 })

--- a/packages/platform/src/pages/PrivacyPage.tsx
+++ b/packages/platform/src/pages/PrivacyPage.tsx
@@ -2,13 +2,14 @@ import { EyebrowTag, GlassCard } from '@amiclaw/ui'
 import styles from './PrivacyPage.module.css'
 
 const CONTACT_EMAIL = 'hi@amio.love'
-const EFFECTIVE_DATE = '2026-07-04'
+const EFFECTIVE_DATE = '2026-07-06'
 
 /* Privacy policy page — a production-grade Chinese privacy policy for
    AMIO Arcade (claw.amio.fans). The collected-data inventory is kept
-   faithful to the anonymous leaderboard/event contracts, auth-session KV,
-   platform-AI Worker usage records, and Companion D1 memory plane. Platform
-   chrome — every accent is brand yellow; no BombSquad cyan on this surface. */
+   faithful to the anonymous leaderboard/event contracts, local Arcade profile,
+   auth-session KV, platform-AI Worker usage records, account Arcade profile,
+   and Companion D1 memory plane. Platform chrome — every accent is brand
+   yellow; no BombSquad cyan on this surface. */
 export default function PrivacyPage() {
   return (
     <div className={styles.page}>
@@ -81,6 +82,12 @@ export default function PrivacyPage() {
                 ：包括魔法链接 token 哈希、Google OAuth
                 state、登录/登出审计记录，以及邮件发送和验证接口的限流计数。
               </li>
+              <li>
+                <strong>账号内 Arcade 档案</strong>
+                ：当你登录后保存本设备记录，或登录状态下产生新的 BombSquad
+                结果和卦签时，我们会按你的 user_id
+                保存来源键、游戏类型、完成时间、用时、结果、尝试次数、模块完成数、卦签日期、本卦、变卦和六爻值。这些记录只用于你的账号内展示，不会回填公开排行榜。
+              </li>
             </ul>
 
             <h4 className={styles.subheading}>3. 平台 AI 伙伴与 Companion Memory 信息</h4>
@@ -122,6 +129,12 @@ export default function PrivacyPage() {
                 <strong>匿名行为事件</strong>
                 ：游戏开始、模块通关、通关、放弃、手册加载失败、再玩意向、三振出局、到达时间上限、问卷提交等事件的计数，附带发生时间与上述设备标识符。这些用于了解整体游玩与完成情况，均为聚合统计，不针对个人画像。
               </li>
+              <li>
+                <strong>本地 Arcade 档案</strong>
+                ：我们会在你的浏览器本地存储一个随机本地档案 ID，并保存本设备上的 BombSquad
+                最近结果、最好成绩、Oracle
+                最近卦签、最近访问时间和已保存到账号的来源键。清除浏览器本地存储会删除这些本地记录。
+              </li>
             </ul>
 
             <p className={styles.note}>
@@ -138,6 +151,9 @@ export default function PrivacyPage() {
               <li>以聚合方式统计游玩与完成情况，评估游戏体验并据此改进。</li>
               <li>根据问卷反馈了解协作中的问题，改进游戏设计。</li>
               <li>建立与维护登录会话，让已登录用户使用平台 AI 伙伴与账号相关功能。</li>
+              <li>
+                在我的页展示本设备或账号内的真实 Arcade 记录，并在你确认时把本设备记录保存到账号。
+              </li>
               <li>
                 组装平台 AI 语音会话，向 AI 伙伴提供当前游戏所需的手册、状态和 Companion Memory。
               </li>
@@ -160,8 +176,8 @@ export default function PrivacyPage() {
             <p>
               <strong>托管与存储服务商</strong>：本服务托管于 Cloudflare。页面由 Cloudflare Pages
               提供，服务端逻辑运行于 Cloudflare Workers，成绩、事件、认证和使用量数据存储于
-              Cloudflare KV，Companion Memory 存储于 Cloudflare D1，长连接会话运行于 Cloudflare
-              Durable Objects。这意味着上述数据会经由 Cloudflare
+              Cloudflare KV，账号内 Arcade 档案与 Companion Memory 存储于 Cloudflare
+              D1，长连接会话运行于 Cloudflare Durable Objects。这意味着上述数据会经由 Cloudflare
               的基础设施传输与存储，受其作为处理方的安全措施约束。
             </p>
             <p>
@@ -186,8 +202,9 @@ export default function PrivacyPage() {
               本服务不使用用于广告追踪的 Cookie。登录后，我们使用名为 amiclaw_session 的 HttpOnly
               Cookie 保存会话 ID；Google 登录流程还会短暂使用 oauth_state Cookie 防止登录 CSRF。
               我们使用浏览器的本地存储（localStorage）保存上述设备标识符，以及你填过的昵称与 AI
-              工具信息，便于你下次游玩时无须重填；并使用会话存储（sessionStorage）在你提交成绩后临时保留你的排行榜成绩，用于即时展示。清除浏览器的本地存储即可移除本地数据；登出会清除登录会话
-              Cookie。
+              工具信息、匿名 Arcade
+              档案和已保存来源键，便于你下次游玩时无须重填，并让我的页能显示本设备真实记录；我们使用会话存储（sessionStorage）在你提交成绩后临时保留你的排行榜成绩，用于即时展示。清除浏览器的本地存储即可移除本地数据；登出会清除登录会话
+              Cookie，但不会自动删除已经保存到账号的 Arcade 档案记录。
             </p>
           </section>
 
@@ -218,7 +235,12 @@ export default function PrivacyPage() {
                 ：保留至你删除对应回忆、删除或更正个人画像项、关闭个人画像层，或我们不再需要继续提供相关功能。
               </li>
               <li>
-                <strong>本地存储中的设备标识符与昵称等</strong>：保存在你的设备上，由你随时清除。
+                <strong>账号内 Arcade 档案</strong>
+                ：保留至你提出有效删除请求，或我们不再需要继续提供相关功能。
+              </li>
+              <li>
+                <strong>本地存储中的设备标识符、昵称与本地 Arcade 档案等</strong>
+                ：保存在你的设备上，由你随时清除。
               </li>
             </ul>
           </section>
@@ -229,9 +251,9 @@ export default function PrivacyPage() {
               在适用法律允许的范围内，你对自己的个人信息享有访问、更正、删除以及撤回同意的权利。
             </p>
             <p>
-              对匿名排行榜记录，我们通过你提交时的昵称与提交日期来定位；对登录账号、平台 AI 会话和
-              Companion Memory，我们通过你的登录邮箱或 user_id 定位。Companion Memory
-              支持查看、删除回忆、删除或更正个人画像项，并可关闭个人画像层。
+              对匿名排行榜记录，我们通过你提交时的昵称与提交日期来定位；对登录账号、账号内 Arcade
+              档案、平台 AI 会话和 Companion Memory，我们通过你的登录邮箱或 user_id 定位。Companion
+              Memory 支持查看、删除回忆、删除或更正个人画像项，并可关闭个人画像层。
             </p>
             <p>
               如需行使上述权利，请发送邮件至{' '}

--- a/packages/platform/src/pages/TermsPage.test.tsx
+++ b/packages/platform/src/pages/TermsPage.test.tsx
@@ -57,6 +57,6 @@ describe('TermsPage', () => {
     const mailtoLinks = screen.getAllByRole('link', { name: 'hi@amio.love' })
     expect(mailtoLinks.length).toBeGreaterThan(0)
     expect(mailtoLinks[0]).toHaveAttribute('href', 'mailto:hi@amio.love')
-    expect(screen.getByText(/生效日期：2026-07-04/)).toBeInTheDocument()
+    expect(screen.getByText(/生效日期：2026-07-06/)).toBeInTheDocument()
   })
 })

--- a/packages/platform/src/pages/TermsPage.tsx
+++ b/packages/platform/src/pages/TermsPage.tsx
@@ -2,12 +2,13 @@ import { EyebrowTag, GlassCard } from '@amiclaw/ui'
 import styles from './TermsPage.module.css'
 
 const CONTACT_EMAIL = 'hi@amio.love'
-const EFFECTIVE_DATE = '2026-07-04'
+const EFFECTIVE_DATE = '2026-07-06'
 
 /* Terms-of-service page — a production-grade Chinese user agreement for
    AMIO Arcade (claw.amio.fans). Mirrors the real service shape: anonymous
-   bring-your-own-AI play, account-gated platform-AI play, companion memory
-   controls, public leaderboard content, and third-party AI providers.
+   bring-your-own-AI play, local Arcade profiles, account claims,
+   account-gated platform-AI play, companion memory controls, public
+   leaderboard content, and third-party AI providers.
    Platform chrome — every accent is brand yellow; no BombSquad cyan here. */
 export default function TermsPage() {
   return (
@@ -57,8 +58,13 @@ export default function TermsPage() {
               游玩无须登录，我们通过你浏览器本地生成的设备标识符区分设备。你在提交成绩时填写的昵称仅用于排行榜标识，不构成对你真实身份的认证。
             </p>
             <p>
-              平台 AI 伙伴和 Companion Memory 需要登录。你可通过邮件登录或 Google
-              登录建立账号会话，并应自行妥善管理邮箱、Google
+              不登录时，本服务可以在你的浏览器本地保存 Arcade 档案，用来在我的页显示本设备上的
+              BombSquad
+              和卦签记录。登录后，你可以选择把本设备记录保存到账号；该保存动作只影响账号内档案，不会自动修改或补交公开排行榜成绩。
+            </p>
+            <p>
+              平台 AI 伙伴、账号内 Arcade 档案和 Companion Memory 需要登录。你可通过邮件登录或
+              Google 登录建立账号会话，并应自行妥善管理邮箱、Google
               账号、设备和会话。如果发现账号或会话被未经授权使用，请及时联系我们。
             </p>
           </section>
@@ -83,6 +89,11 @@ export default function TermsPage() {
             <p>
               你提交的昵称，以及你所填写的 AI
               工具与模型信息，将在每日排行榜上公开展示。提交即表示你授权我们为运营本服务之目的展示、存储与处理这些内容。
+            </p>
+            <p>
+              你保存到账号内的 Arcade
+              档案记录用于个人页展示和账号内同步，不作为公开排行榜内容展示。公开排行榜仍只展示你主动提交上榜的昵称、成绩和
+              AI 工具信息。
             </p>
             <p>
               当你使用平台 AI

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,22 @@ importers:
         version: 4.103.0(@cloudflare/workers-types@4.20260621.1)
 
   packages/api:
+    dependencies:
+      '@amiclaw/arcade-profile':
+        specifier: workspace:*
+        version: link:../arcade-profile
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260621.1
+        version: 4.20260621.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/arcade-profile:
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20260621.1
@@ -96,6 +112,9 @@ importers:
 
   packages/game-bombsquad:
     dependencies:
+      '@amiclaw/arcade-profile':
+        specifier: workspace:*
+        version: link:../arcade-profile
       '@amiclaw/ui':
         specifier: workspace:*
         version: link:../ui
@@ -120,10 +139,10 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@9.3.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@testing-library/user-event':
         specifier: ^14.5.0
-        version: 14.6.1(@testing-library/dom@9.3.4)
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/js-yaml':
         specifier: ^4.0.0
         version: 4.0.9
@@ -154,6 +173,9 @@ importers:
 
   packages/game-yijing:
     dependencies:
+      '@amiclaw/arcade-profile':
+        specifier: workspace:*
+        version: link:../arcade-profile
       '@amiclaw/ui':
         specifier: workspace:*
         version: link:../ui
@@ -167,6 +189,12 @@ importers:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/node':
         specifier: ^26.0.1
         version: 26.0.1
@@ -213,6 +241,9 @@ importers:
 
   packages/platform:
     dependencies:
+      '@amiclaw/arcade-profile':
+        specifier: workspace:*
+        version: link:../arcade-profile
       '@amiclaw/ui':
         specifier: workspace:*
         version: link:../ui
@@ -231,10 +262,10 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@9.3.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@testing-library/user-event':
         specifier: ^14.5.0
-        version: 14.6.1(@testing-library/dom@9.3.4)
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^26.0.1
         version: 26.0.1
@@ -289,7 +320,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@9.3.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -1538,9 +1569,9 @@ packages:
     resolution: {integrity: sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==}
     engines: {node: '>=14'}
 
-  '@testing-library/dom@9.3.4':
-    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
-    engines: {node: '>=14'}
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
 
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
@@ -1790,10 +1821,6 @@ packages:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
@@ -1805,15 +1832,11 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  aria-query@5.1.3:
-    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
-    engines: {node: '>= 0.4'}
-
-  array-buffer-byte-length@1.0.2:
-    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
 
   array-ify@1.0.0:
@@ -1822,10 +1845,6 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
-
-  available-typed-arrays@1.0.7:
-    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
-    engines: {node: '>= 0.4'}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1870,10 +1889,6 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  call-bind@1.0.9:
-    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
-    engines: {node: '>= 0.4'}
-
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
@@ -1888,10 +1903,6 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
-
-  chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
 
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
@@ -1923,13 +1934,6 @@ packages:
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
-
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -2047,20 +2051,8 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
-  deep-equal@2.2.3:
-    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
-    engines: {node: '>= 0.4'}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
-
-  define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2136,9 +2128,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-get-iterator@1.1.3:
-    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -2311,10 +2300,6 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  for-each@0.3.5:
-    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
-    engines: {node: '>= 0.4'}
-
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -2335,9 +2320,6 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  functions-have-names@1.2.3:
-    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2393,23 +2375,8 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  has-bigints@1.1.0:
-    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
-    engines: {node: '>= 0.4'}
-
-  has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
-
-  has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
-
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.4:
@@ -2470,10 +2437,6 @@ packages:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  internal-slot@1.1.0:
-    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
-    engines: {node: '>= 0.4'}
-
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
@@ -2488,32 +2451,8 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
-  is-arguments@1.2.0:
-    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
-    engines: {node: '>= 0.4'}
-
-  is-array-buffer@3.0.5:
-    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
-    engines: {node: '>= 0.4'}
-
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  is-bigint@1.1.0:
-    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
-    engines: {node: '>= 0.4'}
-
-  is-boolean-object@1.2.2:
-    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
-    engines: {node: '>= 0.4'}
-
-  is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
-    engines: {node: '>= 0.4'}
-
-  is-date-object@1.1.0:
-    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
-    engines: {node: '>= 0.4'}
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
@@ -2537,14 +2476,6 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
-  is-map@2.0.3:
-    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
-    engines: {node: '>= 0.4'}
-
-  is-number-object@1.1.1:
-    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
-    engines: {node: '>= 0.4'}
-
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -2566,37 +2497,6 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
-
-  is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
-
-  is-set@2.0.3:
-    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
-    engines: {node: '>= 0.4'}
-
-  is-shared-array-buffer@1.0.4:
-    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
-    engines: {node: '>= 0.4'}
-
-  is-string@1.1.1:
-    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
-    engines: {node: '>= 0.4'}
-
-  is-symbol@1.1.1:
-    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
-    engines: {node: '>= 0.4'}
-
-  is-weakmap@2.0.2:
-    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
-    engines: {node: '>= 0.4'}
-
-  is-weakset@2.0.4:
-    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
-    engines: {node: '>= 0.4'}
-
-  isarray@2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2997,18 +2897,6 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  object-is@1.1.6:
-    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
-    engines: {node: '>= 0.4'}
-
-  object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
-
-  object.assign@4.1.7:
-    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
-    engines: {node: '>= 0.4'}
-
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -3112,10 +3000,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  possible-typed-array-names@1.1.0:
-    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
-    engines: {node: '>= 0.4'}
-
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3203,10 +3087,6 @@ packages:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
 
-  regexp.prototype.flags@1.5.4:
-    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
-    engines: {node: '>= 0.4'}
-
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -3242,10 +3122,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  safe-regex-test@1.1.0:
-    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
-    engines: {node: '>= 0.4'}
-
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -3280,14 +3156,6 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
-
-  set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
-
-  set-function-name@2.0.2:
-    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
-    engines: {node: '>= 0.4'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3364,10 +3232,6 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  stop-iteration-iterator@1.1.0:
-    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
-    engines: {node: '>= 0.4'}
-
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -3403,10 +3267,6 @@ packages:
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
-
-  supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -3620,18 +3480,6 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  which-boxed-primitive@1.1.1:
-    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
-    engines: {node: '>= 0.4'}
-
-  which-collection@1.0.2:
-    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
-    engines: {node: '>= 0.4'}
-
-  which-typed-array@1.1.22:
-    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
-    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4758,15 +4606,15 @@ snapshots:
 
   '@teppeis/multimaps@3.0.0': {}
 
-  '@testing-library/dom@9.3.4':
+  '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
-      aria-query: 5.1.3
-      chalk: 4.1.2
+      aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
+      picocolors: 1.1.1
       pretty-format: 27.5.1
 
   '@testing-library/jest-dom@6.9.1':
@@ -4778,19 +4626,19 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@9.3.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@testing-library/dom': 9.3.4
+      '@testing-library/dom': 10.4.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@testing-library/user-event@14.6.1(@testing-library/dom@9.3.4)':
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
-      '@testing-library/dom': 9.3.4
+      '@testing-library/dom': 10.4.1
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -5041,34 +4889,21 @@ snapshots:
 
   ansi-regex@6.2.2: {}
 
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
 
-  aria-query@5.1.3:
+  aria-query@5.3.0:
     dependencies:
-      deep-equal: 2.2.3
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
-
-  array-buffer-byte-length@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      is-array-buffer: 3.0.5
 
   array-ify@1.0.0: {}
 
   assertion-error@2.0.1: {}
-
-  available-typed-arrays@1.0.7:
-    dependencies:
-      possible-typed-array-names: 1.1.0
 
   balanced-match@4.0.4: {}
 
@@ -5119,13 +4954,6 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  call-bind@1.0.9:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      get-intrinsic: 1.3.0
-      set-function-length: 1.2.2
-
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5136,11 +4964,6 @@ snapshots:
   caniuse-lite@1.0.30001788: {}
 
   chai@6.2.2: {}
-
-  chalk@4.1.2:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
 
   character-entities-legacy@3.0.0: {}
 
@@ -5172,12 +4995,6 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
-
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
 
   commander@13.1.0: {}
 
@@ -5274,40 +5091,7 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  deep-equal@2.2.3:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.9
-      es-get-iterator: 1.1.3
-      get-intrinsic: 1.3.0
-      is-arguments: 1.2.0
-      is-array-buffer: 3.0.5
-      is-date-object: 1.1.0
-      is-regex: 1.2.1
-      is-shared-array-buffer: 1.0.4
-      isarray: 2.0.5
-      object-is: 1.1.6
-      object-keys: 1.1.1
-      object.assign: 4.1.7
-      regexp.prototype.flags: 1.5.4
-      side-channel: 1.1.1
-      which-boxed-primitive: 1.1.1
-      which-collection: 1.0.2
-      which-typed-array: 1.1.22
-
   deep-is@0.1.4: {}
-
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
-  define-properties@1.2.1:
-    dependencies:
-      define-data-property: 1.1.4
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
 
   depd@2.0.0: {}
 
@@ -5360,18 +5144,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-get-iterator@1.1.3:
-    dependencies:
-      call-bind: 1.0.9
-      get-intrinsic: 1.3.0
-      has-symbols: 1.1.0
-      is-arguments: 1.2.0
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-string: 1.1.1
-      isarray: 2.0.5
-      stop-iteration-iterator: 1.1.0
 
   es-module-lexer@2.1.0: {}
 
@@ -5637,10 +5409,6 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  for-each@0.3.5:
-    dependencies:
-      is-callable: 1.2.7
-
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -5652,8 +5420,6 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
-
-  functions-have-names@1.2.3: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -5714,19 +5480,7 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  has-bigints@1.1.0: {}
-
-  has-flag@4.0.0: {}
-
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.1
-
   has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
 
   hasown@2.0.4:
     dependencies:
@@ -5777,12 +5531,6 @@ snapshots:
 
   ini@6.0.0: {}
 
-  internal-slot@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      hasown: 2.0.4
-      side-channel: 1.1.1
-
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -5794,34 +5542,7 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
-  is-arguments@1.2.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-array-buffer@3.0.5:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-
   is-arrayish@0.2.1: {}
-
-  is-bigint@1.1.0:
-    dependencies:
-      has-bigints: 1.1.0
-
-  is-boolean-object@1.2.2:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-callable@1.2.7: {}
-
-  is-date-object@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
 
   is-decimal@2.0.1: {}
 
@@ -5839,13 +5560,6 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
-  is-map@2.0.3: {}
-
-  is-number-object@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
   is-number@7.0.0: {}
 
   is-obj@2.0.0: {}
@@ -5857,39 +5571,6 @@ snapshots:
   is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
-
-  is-regex@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
-
-  is-set@2.0.3: {}
-
-  is-shared-array-buffer@1.0.4:
-    dependencies:
-      call-bound: 1.0.4
-
-  is-string@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-symbol@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-symbols: 1.1.0
-      safe-regex-test: 1.1.0
-
-  is-weakmap@2.0.2: {}
-
-  is-weakset@2.0.4:
-    dependencies:
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-
-  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -6371,22 +6052,6 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  object-is@1.1.6:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-
-  object-keys@1.1.1: {}
-
-  object.assign@4.1.7:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
-      has-symbols: 1.1.0
-      object-keys: 1.1.1
-
   obug@2.1.3: {}
 
   on-finished@2.4.1:
@@ -6497,8 +6162,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  possible-typed-array-names@1.1.0: {}
-
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
@@ -6576,15 +6239,6 @@ snapshots:
 
   regexp-tree@0.1.27: {}
 
-  regexp.prototype.flags@1.5.4:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-errors: 1.3.0
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      set-function-name: 2.0.2
-
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
@@ -6635,12 +6289,6 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-regex-test@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-regex: 1.2.1
-
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -6681,22 +6329,6 @@ snapshots:
       - supports-color
 
   set-cookie-parser@2.7.2: {}
-
-  set-function-length@1.2.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.3.0
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-
-  set-function-name@2.0.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      functions-have-names: 1.2.3
-      has-property-descriptors: 1.0.2
 
   setprototypeof@1.2.0: {}
 
@@ -6798,11 +6430,6 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  stop-iteration-iterator@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      internal-slot: 1.1.0
-
   string-argv@0.3.2: {}
 
   string-width@4.2.3:
@@ -6840,10 +6467,6 @@ snapshots:
       min-indent: 1.0.1
 
   supports-color@10.2.2: {}
-
-  supports-color@7.2.0:
-    dependencies:
-      has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -7000,31 +6623,6 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  which-boxed-primitive@1.1.1:
-    dependencies:
-      is-bigint: 1.1.0
-      is-boolean-object: 1.2.2
-      is-number-object: 1.1.1
-      is-string: 1.1.1
-      is-symbol: 1.1.1
-
-  which-collection@1.0.2:
-    dependencies:
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-weakmap: 2.0.2
-      is-weakset: 2.0.4
-
-  which-typed-array@1.1.22:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      for-each: 0.3.5
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds the `@amiclaw/arcade-profile` domain package, D1 tables, API handlers, and Pages Function routes for account-owned Arcade profile data.
- Wires BombSquad and Oracle completions into local profile storage and best-effort account writes, with explicit `/me` claim for local anonymous records.
- Updates `/me`, privacy/terms copy, changelog, provisioning notes, and E2E auth expectations to reflect the new profile data plane.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter @amiclaw/arcade-profile test:run`
- [x] `pnpm --filter api test:run`
- [x] `pnpm --filter @amiclaw/platform test:run`
- [x] `pnpm --filter @amiclaw/game-bombsquad test:run`
- [x] `pnpm --filter @amiclaw/game-yijing test:run`
- [x] `pnpm build`
- [x] `pnpm test:e2e`
- [x] `pnpm test:run` via pre-commit hook
- [x] Targeted Prettier check for all task-owned files

## Deployment notes

- Apply `packages/companion-memory/migrations/0002_arcade_profile.sql` before production deploy.
- Full local `pnpm format:check` still reports pre-existing untracked `packages/platform-ai/demo/closing-recap-probe.mjs`, which is outside this PR and was not touched.

## Attribution

- Prepared by Codex.
