### PR TITLE
feat(arcade): add daily streak loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Daily Arcade loop and streaks** - New. The homepage now shows a real daily
+checklist for BombSquad and Oracle, result pages show profile-save and share
+feedback, and the leaderboard now includes a public streak board for claimed
+account profiles. Streaks are derived from Arcade profile events: BombSquad
+daily defuses and real Oracle signs count, while practice, failures, and
+timeouts do not.
+
 **Your page now shows real local and account Arcade records** - New. Anonymous
 players now get a browser-local Arcade profile that records BombSquad results
 and real Oracle signs, so `/me` shows this device's actual play history instead

--- a/e2e/steps/auth.steps.ts
+++ b/e2e/steps/auth.steps.ts
@@ -67,7 +67,7 @@ Then('I see the account login guide and no fake profile', async ({ page }) => {
     main.getByText('登录后可以把这台设备上的 BombSquad 和卦签记录保存到账号。')
   ).toBeVisible()
   await expect(main.getByText('今日')).toBeVisible()
-  await expect(main.getByText('未开始')).toBeVisible()
+  await expect(main.getByText('未打卡')).toBeVisible()
   await expect(main.getByRole('link', { name: '登录' })).toBeVisible()
   // No retired mock-profile content for anyone now.
   await expect(main.getByText('林星海')).toHaveCount(0)
@@ -102,7 +102,7 @@ Then('I see the honest empty stats state with a play CTA', async ({ page }) => {
   // No fabricated numbers, no「即将推出」placeholder — an honest empty state.
   const main = page.getByRole('main')
   await expect(main.getByText('账号记录')).toBeVisible()
-  await expect(main.getByText('未开始')).toBeVisible()
+  await expect(main.getByText('未打卡')).toBeVisible()
   await expect(main.getByText('还没有记录').first()).toBeVisible()
   await expect(main.getByText('无记录').first()).toBeVisible()
   await expect(main.getByRole('link', { name: '开始玩' })).toBeVisible()

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -99,6 +99,31 @@ const MANUAL_YAML = readFileSync(resolve(FIXTURES_DIR, 'daily-manual.yaml'), 'ut
 const LEADERBOARD_DEFAULT = readJson<{ get: LeaderboardGetResponse; post: SubmitResponse }>(
   'leaderboard-default.json'
 )
+const ARCADE_PROFILE_TODAY = new Date(ANSWERS.seed).toISOString().slice(0, 10)
+
+function emptyArcadeProfile(profileId?: string) {
+  return {
+    ...(profileId ? { profile_id: profileId } : {}),
+    last_activity_at: null,
+    today_played: false,
+    counts: { bombsquad_runs: 0, oracle_signs: 0 },
+    bombsquad: { recent: null, best_daily: null, best_practice: null },
+    oracle: { recent: null },
+    daily_loop: {
+      date: ARCADE_PROFILE_TODAY,
+      checklist: {
+        bombsquad_daily: { completed: false, completed_at: null },
+        oracle_sign: { completed: false, completed_at: null },
+      },
+      streak: {
+        today_completed: false,
+        current_days: 0,
+        longest_days: 0,
+        last_active_date: null,
+      },
+    },
+  }
+}
 
 // --- Voice-session stub ------------------------------------------------------
 //
@@ -476,14 +501,7 @@ export const test = base.extend<{ world: World }>({
         }
 
         const request = route.request()
-        const emptyProfile = {
-          profile_id: world.authIdentity.user_id,
-          last_activity_at: null,
-          today_played: false,
-          counts: { bombsquad_runs: 0, oracle_signs: 0 },
-          bombsquad: { recent: null, best_daily: null, best_practice: null },
-          oracle: { recent: null },
-        }
+        const emptyProfile = emptyArcadeProfile(world.authIdentity.user_id)
 
         if (request.method() === 'POST' && request.url().includes('/claim')) {
           const body = request.postDataJSON() as {
@@ -497,7 +515,12 @@ export const test = base.extend<{ world: World }>({
             status: 200,
             contentType: 'application/json',
             headers: { 'Cache-Control': 'no-store' },
-            body: JSON.stringify({ profile: emptyProfile, source_keys: sourceKeys, inserted: 0 }),
+            body: JSON.stringify({
+              profile: emptyProfile,
+              source_keys: sourceKeys,
+              inserted: 0,
+              public_profile: { claimed: true, public_label: 'Player E2E' },
+            }),
           })
           return
         }
@@ -506,7 +529,10 @@ export const test = base.extend<{ world: World }>({
           status: 200,
           contentType: 'application/json',
           headers: { 'Cache-Control': 'no-store' },
-          body: JSON.stringify({ profile: emptyProfile }),
+          body: JSON.stringify({
+            profile: emptyProfile,
+            public_profile: { claimed: false, public_label: null },
+          }),
         })
       })
 

--- a/functions/api/arcade/streaks.ts
+++ b/functions/api/arcade/streaks.ts
@@ -1,0 +1,25 @@
+import { handleGetArcadeStreakLeaderboard } from '../../../packages/api/src/handlers/arcade-profile'
+import type { ArcadeProfileApiEnv } from '../../../packages/api/src/handlers/arcade-profile'
+import { applyCorsHeaders, buildCorsHeaders } from '../../../packages/api/src/cors'
+
+interface Context {
+  request: Request
+  env: ArcadeProfileApiEnv
+}
+
+const CORS_METHODS = 'GET, OPTIONS'
+
+export async function onRequest(context: Context): Promise<Response> {
+  const { request, env } = context
+  const corsHeaders = buildCorsHeaders(request, CORS_METHODS)
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  if (request.method === 'GET') {
+    return applyCorsHeaders(await handleGetArcadeStreakLeaderboard(request, env), corsHeaders)
+  }
+
+  return applyCorsHeaders(new Response('Method Not Allowed', { status: 405 }), corsHeaders)
+}

--- a/packages/api/src/handlers/arcade-profile.test.ts
+++ b/packages/api/src/handlers/arcade-profile.test.ts
@@ -33,7 +33,7 @@ const CLAIM_BODY = {
   ],
 }
 
-async function env(): Promise<ArcadeProfileApiEnv> {
+async function env(db = createTestDb()): Promise<ArcadeProfileApiEnv> {
   const auth = new FakeKV()
   await auth.put(
     'session:sess-1',
@@ -45,7 +45,7 @@ async function env(): Promise<ArcadeProfileApiEnv> {
   )
   return {
     AUTH: auth.asKV(),
-    COMPANION_DB: createTestDb(),
+    COMPANION_DB: db,
   }
 }
 
@@ -112,6 +112,21 @@ describe('arcade profile handlers', () => {
 
     expect(response.status).toBe(200)
     expect(await board.json()).toEqual({ date: '2026-07-06', entries: [] })
+  })
+
+  it('keeps account profile reads working before public-profile migration exists', async () => {
+    const testEnv = await env(createTestDb({ migrations: ['0002_arcade_profile.sql'] }))
+
+    await handlePostArcadeProfileEvent(request(CLAIM_BODY.events[0]), testEnv)
+    const response = await handleGetArcadeProfile(request(), testEnv)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      profile: {
+        counts: { bombsquad_runs: 1, oracle_signs: 0 },
+      },
+      public_profile: { claimed: false, public_label: null },
+    })
   })
 
   it('lets an explicit empty claim enable public streak eligibility for existing account events', async () => {

--- a/packages/api/src/handlers/arcade-profile.test.ts
+++ b/packages/api/src/handlers/arcade-profile.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
+import type { ArcadeStreakLeaderboardResponse } from '@amiclaw/arcade-profile/types'
 import { createTestDb } from '../../../arcade-profile/src/test-support/sqlite-db'
 import { FakeKV } from '../auth/fake-kv'
 import {
+  handleGetArcadeStreakLeaderboard,
   handleGetArcadeProfile,
   handlePostArcadeProfileClaim,
+  handlePostArcadeProfileEvent,
   type ArcadeProfileApiEnv,
 } from './arcade-profile'
 
@@ -57,6 +60,13 @@ function request(body?: unknown, cookie = SESSION_COOKIE): Request {
   })
 }
 
+function getRequest(url: string, cookie = SESSION_COOKIE): Request {
+  return new Request(url, {
+    method: 'GET',
+    headers: cookie ? { Cookie: cookie } : {},
+  })
+}
+
 describe('arcade profile handlers', () => {
   it('requires a session for account profile reads', async () => {
     const response = await handleGetArcadeProfile(request(undefined, ''), await env())
@@ -72,13 +82,84 @@ describe('arcade profile handlers', () => {
     const profile = await handleGetArcadeProfile(request(), testEnv)
 
     expect(first.status).toBe(200)
-    expect(await first.json()).toMatchObject({ inserted: 1, source_keys: ['bombsquad:run-1'] })
+    expect(await first.json()).toMatchObject({
+      inserted: 1,
+      source_keys: ['bombsquad:run-1'],
+      public_profile: {
+        claimed: true,
+        public_label: expect.stringMatching(/^Player [0-9A-F]{4}$/),
+      },
+    })
     expect(await replay.json()).toMatchObject({ inserted: 0, source_keys: ['bombsquad:run-1'] })
     expect(await profile.json()).toMatchObject({
       profile: {
         counts: { bombsquad_runs: 1, oracle_signs: 0 },
         bombsquad: { best_daily: { run_id: 'run-1' } },
+        daily_loop: { streak: { current_days: 1 } },
       },
+      public_profile: { claimed: true },
     })
+  })
+
+  it('does not let event writes create public streak-board eligibility', async () => {
+    const testEnv = await env()
+
+    const response = await handlePostArcadeProfileEvent(request(CLAIM_BODY.events[0]), testEnv)
+    const board = await handleGetArcadeStreakLeaderboard(
+      getRequest('https://claw.amio.fans/api/arcade/streaks?date=2026-07-06'),
+      testEnv
+    )
+
+    expect(response.status).toBe(200)
+    expect(await board.json()).toEqual({ date: '2026-07-06', entries: [] })
+  })
+
+  it('lets an explicit empty claim enable public streak eligibility for existing account events', async () => {
+    const testEnv = await env()
+
+    await handlePostArcadeProfileEvent(request(CLAIM_BODY.events[0]), testEnv)
+    const claim = await handlePostArcadeProfileClaim(
+      request({ profile_id: 'local-profile', events: [] }),
+      testEnv
+    )
+    const board = await handleGetArcadeStreakLeaderboard(
+      getRequest('https://claw.amio.fans/api/arcade/streaks?date=2026-07-06'),
+      testEnv
+    )
+    const body = (await board.json()) as ArcadeStreakLeaderboardResponse
+
+    expect(claim.status).toBe(200)
+    expect(await claim.clone().json()).toMatchObject({
+      inserted: 0,
+      source_keys: [],
+      public_profile: { claimed: true },
+    })
+    expect(body.entries).toHaveLength(1)
+    expect(body.entries[0].current_streak_days).toBe(1)
+  })
+
+  it('returns public streak entries without private identity fields', async () => {
+    const testEnv = await env()
+
+    await handlePostArcadeProfileClaim(
+      request({ ...CLAIM_BODY, public_label: 'a@example.com' }),
+      testEnv
+    )
+    const response = await handleGetArcadeStreakLeaderboard(
+      getRequest('https://claw.amio.fans/api/arcade/streaks?date=2026-07-06&limit=10'),
+      testEnv
+    )
+    const body = (await response.json()) as ArcadeStreakLeaderboardResponse
+    const serialized = JSON.stringify(body)
+
+    expect(response.status).toBe(200)
+    expect(body.entries).toHaveLength(1)
+    expect(body.entries[0].public_label).toMatch(/^Player [0-9A-F]{4}$/)
+    expect(serialized).not.toContain('user-a')
+    expect(serialized).not.toContain('a@example.com')
+    expect(serialized).not.toContain('example.com')
+    expect(serialized).not.toContain('local-profile')
+    expect(serialized).not.toContain('profile_id')
+    expect(serialized).not.toContain('user_id')
   })
 })

--- a/packages/api/src/handlers/arcade-profile.ts
+++ b/packages/api/src/handlers/arcade-profile.ts
@@ -1,10 +1,18 @@
 import type {
   ArcadeProfileClaimResponse,
   ArcadeProfileResponse,
+  ArcadeStreakLeaderboardResponse,
 } from '@amiclaw/arcade-profile/types'
 import type { ArcadeProfileDb } from '@amiclaw/arcade-profile/store'
-import { readArcadeAccountProfile, upsertArcadeProfileEvents } from '@amiclaw/arcade-profile/store'
 import {
+  readArcadeAccountProfile,
+  readArcadePublicProfile,
+  readArcadeStreakLeaderboard,
+  upsertArcadeProfileEvents,
+  upsertArcadePublicProfile,
+} from '@amiclaw/arcade-profile/store'
+import {
+  sanitizeArcadePublicLabel,
   parseArcadeProfileClaimBody,
   parseArcadeProfileEvent,
 } from '@amiclaw/arcade-profile/validation'
@@ -25,8 +33,11 @@ export async function handleGetArcadeProfile(
   const auth = await requireSession(env.AUTH, request)
   if (!auth.ok) return auth.response
 
-  const profile = await readArcadeAccountProfile(env.COMPANION_DB, auth.session.user_id)
-  const body: ArcadeProfileResponse = { profile }
+  const [profile, publicProfile] = await Promise.all([
+    readArcadeAccountProfile(env.COMPANION_DB, auth.session.user_id),
+    readArcadePublicProfile(env.COMPANION_DB, auth.session.user_id),
+  ])
+  const body: ArcadeProfileResponse = { profile, public_profile: publicProfile }
   return jsonResponse(body, 200, { 'Cache-Control': 'no-store' })
 }
 
@@ -44,8 +55,11 @@ export async function handlePostArcadeProfileEvent(
   await upsertArcadeProfileEvents(env.COMPANION_DB, auth.session.user_id, [event], {
     profileId: event.profile_id,
   })
-  const profile = await readArcadeAccountProfile(env.COMPANION_DB, auth.session.user_id)
-  const response: ArcadeProfileResponse = { profile }
+  const [profile, publicProfile] = await Promise.all([
+    readArcadeAccountProfile(env.COMPANION_DB, auth.session.user_id),
+    readArcadePublicProfile(env.COMPANION_DB, auth.session.user_id),
+  ])
+  const response: ArcadeProfileResponse = { profile, public_profile: publicProfile }
   return jsonResponse(response, 200, { 'Cache-Control': 'no-store' })
 }
 
@@ -66,11 +80,51 @@ export async function handlePostArcadeProfileClaim(
     claim.events,
     { profileId: claim.profile_id }
   )
+  const existingPublicProfile = await readArcadePublicProfile(
+    env.COMPANION_DB,
+    auth.session.user_id
+  )
+  const publicLabel =
+    claim.public_label === undefined &&
+    existingPublicProfile.claimed &&
+    existingPublicProfile.public_label
+      ? existingPublicProfile.public_label
+      : sanitizeArcadePublicLabel(claim.public_label, auth.session.user_id)
+  const publicProfile = await upsertArcadePublicProfile(env.COMPANION_DB, auth.session.user_id, {
+    profileId: claim.profile_id,
+    publicLabel,
+  })
   const profile = await readArcadeAccountProfile(env.COMPANION_DB, auth.session.user_id)
   const response: ArcadeProfileClaimResponse = {
     profile,
     source_keys: result.sourceKeys,
     inserted: result.inserted,
+    public_profile: {
+      claimed: true,
+      public_label: publicProfile.public_label as string,
+    },
   }
   return jsonResponse(response, 200, { 'Cache-Control': 'no-store' })
+}
+
+export async function handleGetArcadeStreakLeaderboard(
+  request: Request,
+  env: ArcadeProfileApiEnv
+): Promise<Response> {
+  const url = new URL(request.url)
+  const date = url.searchParams.get('date') ?? undefined
+  const rawLimit = url.searchParams.get('limit')
+  const limit = rawLimit === null ? undefined : Number(rawLimit)
+  if (date !== undefined && !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return jsonResponse({ error: 'invalid date' }, 422)
+  }
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 100)) {
+    return jsonResponse({ error: 'invalid limit' }, 422)
+  }
+
+  const body: ArcadeStreakLeaderboardResponse = await readArcadeStreakLeaderboard(
+    env.COMPANION_DB,
+    { date, limit }
+  )
+  return jsonResponse(body, 200, { 'Cache-Control': 'no-store' })
 }

--- a/packages/arcade-profile/src/api-client.ts
+++ b/packages/arcade-profile/src/api-client.ts
@@ -3,6 +3,7 @@ import type {
   ArcadeProfileClaimResponse,
   ArcadeProfileEvent,
   ArcadeProfileResponse,
+  ArcadeStreakLeaderboardResponse,
 } from './types'
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' }
@@ -13,15 +14,32 @@ function apiBase(): string {
   return meta.env?.VITE_API_BASE ?? DEFAULT_API_BASE
 }
 
+function publicProfileOf(data: ArcadeProfileResponse): ArcadeProfileResponse['public_profile'] {
+  return data.public_profile ?? { claimed: false, public_label: null }
+}
+
 export type ArcadeProfileReadResult =
-  | { kind: 'ok'; profile: ArcadeProfileResponse['profile'] }
+  | {
+      kind: 'ok'
+      profile: ArcadeProfileResponse['profile']
+      publicProfile: ArcadeProfileResponse['public_profile']
+    }
   | { kind: 'anon' }
   | { kind: 'error' }
 
 export type ArcadeProfileMutationResult =
-  | { kind: 'ok'; profile: ArcadeProfileResponse['profile']; sourceKeys?: string[] }
+  | {
+      kind: 'ok'
+      profile: ArcadeProfileResponse['profile']
+      publicProfile: ArcadeProfileResponse['public_profile']
+      sourceKeys?: string[]
+    }
   | { kind: 'anon' }
   | { kind: 'invalid' }
+  | { kind: 'error' }
+
+export type ArcadeStreakLeaderboardReadResult =
+  | { kind: 'ok'; board: ArcadeStreakLeaderboardResponse }
   | { kind: 'error' }
 
 export async function fetchArcadeProfile(): Promise<ArcadeProfileReadResult> {
@@ -30,7 +48,7 @@ export async function fetchArcadeProfile(): Promise<ArcadeProfileReadResult> {
     if (res.status === 401) return { kind: 'anon' }
     if (!res.ok) return { kind: 'error' }
     const data = (await res.json()) as ArcadeProfileResponse
-    return { kind: 'ok', profile: data.profile }
+    return { kind: 'ok', profile: data.profile, publicProfile: publicProfileOf(data) }
   } catch {
     return { kind: 'error' }
   }
@@ -50,7 +68,7 @@ export async function submitArcadeProfileEvent(
     if (res.status === 422 || res.status === 400) return { kind: 'invalid' }
     if (!res.ok) return { kind: 'error' }
     const data = (await res.json()) as ArcadeProfileResponse
-    return { kind: 'ok', profile: data.profile }
+    return { kind: 'ok', profile: data.profile, publicProfile: publicProfileOf(data) }
   } catch {
     return { kind: 'error' }
   }
@@ -70,7 +88,29 @@ export async function claimArcadeProfile(
     if (res.status === 422 || res.status === 400) return { kind: 'invalid' }
     if (!res.ok) return { kind: 'error' }
     const data = (await res.json()) as ArcadeProfileClaimResponse
-    return { kind: 'ok', profile: data.profile, sourceKeys: data.source_keys }
+    return {
+      kind: 'ok',
+      profile: data.profile,
+      publicProfile: publicProfileOf(data),
+      sourceKeys: data.source_keys,
+    }
+  } catch {
+    return { kind: 'error' }
+  }
+}
+
+export async function fetchArcadeStreakLeaderboard(
+  options: { date?: string; limit?: number } = {}
+): Promise<ArcadeStreakLeaderboardReadResult> {
+  const params = new URLSearchParams()
+  if (options.date) params.set('date', options.date)
+  if (options.limit !== undefined) params.set('limit', String(options.limit))
+  const query = params.toString()
+  try {
+    const res = await fetch(`${apiBase()}/api/arcade/streaks${query ? `?${query}` : ''}`)
+    if (!res.ok) return { kind: 'error' }
+    const data = (await res.json()) as ArcadeStreakLeaderboardResponse
+    return { kind: 'ok', board: data }
   } catch {
     return { kind: 'error' }
   }

--- a/packages/arcade-profile/src/store.test.ts
+++ b/packages/arcade-profile/src/store.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { readArcadeAccountProfile, upsertArcadeProfileEvents } from './store'
+import {
+  readArcadeAccountProfile,
+  readArcadeStreakLeaderboard,
+  upsertArcadeProfileEvents,
+  upsertArcadePublicProfile,
+} from './store'
 import { createTestDb } from './test-support/sqlite-db'
 import type { ArcadeProfileEvent } from './types'
 
@@ -46,8 +51,106 @@ describe('arcade profile store', () => {
     expect(first.inserted).toBe(2)
     expect(replay.inserted).toBe(0)
     expect(profile.today_played).toBe(true)
+    expect(profile.daily_loop.streak.current_days).toBe(1)
     expect(profile.counts).toEqual({ bombsquad_runs: 1, oracle_signs: 1 })
     expect(profile.bombsquad.best_daily?.duration_ms).toBe(55_000)
     expect(profile.oracle.recent?.ben).toBe('乾')
+  })
+
+  it('uses full account history for streaks beyond the recent 100-row summary', async () => {
+    const db = createTestDb()
+    const deps = { now: () => '2026-07-06T10:00:00.000Z', today: () => '2026-07-06' }
+    const events: ArcadeProfileEvent[] = Array.from({ length: 102 }, (_, index) => {
+      const date = new Date(Date.UTC(2026, 2, 27 + index)).toISOString().slice(0, 10)
+      const runId = `run-${date}`
+      return {
+        kind: 'bombsquad_run',
+        profile_id: 'profile-long',
+        run: {
+          source_key: `bombsquad:${runId}`,
+          run_id: runId,
+          mode: 'daily',
+          outcome: 'defused',
+          duration_ms: 60_000 + index,
+          attempt_number: 1,
+          module_count: 4,
+          completed_modules: 4,
+          strike_count: 0,
+          finished_at: `${date}T08:00:00.000Z`,
+        },
+      }
+    })
+
+    await upsertArcadeProfileEvents(db, 'user-long', events, { deps })
+    const profile = await readArcadeAccountProfile(db, 'user-long', deps)
+
+    expect(profile.counts.bombsquad_runs).toBe(102)
+    expect(profile.daily_loop.streak.current_days).toBe(102)
+    expect(profile.daily_loop.streak.longest_days).toBe(102)
+  })
+
+  it('derives the public streak board only from claimed public profiles', async () => {
+    const db = createTestDb()
+    const deps = { now: () => '2026-07-06T10:00:00.000Z', today: () => '2026-07-06' }
+
+    await upsertArcadeProfileEvents(db, 'user-claimed', [RUN_EVENT, SIGN_EVENT], { deps })
+    await upsertArcadeProfileEvents(
+      db,
+      'user-private',
+      [
+        {
+          ...RUN_EVENT,
+          run: {
+            ...RUN_EVENT.run,
+            source_key: 'bombsquad:private-run',
+            run_id: 'private-run',
+            finished_at: '2026-07-06T07:00:00.000Z',
+          },
+        },
+      ],
+      { deps }
+    )
+    await upsertArcadePublicProfile(db, 'user-claimed', {
+      profileId: 'profile-1',
+      publicLabel: 'Atlas Player',
+      deps,
+    })
+    await upsertArcadeProfileEvents(
+      db,
+      'user-stale',
+      [
+        {
+          ...RUN_EVENT,
+          run: {
+            ...RUN_EVENT.run,
+            source_key: 'bombsquad:stale-run',
+            run_id: 'stale-run',
+            finished_at: '2026-07-03T07:00:00.000Z',
+          },
+        },
+      ],
+      { deps }
+    )
+    await upsertArcadePublicProfile(db, 'user-stale', {
+      profileId: 'profile-stale',
+      publicLabel: 'Stale Player',
+      deps,
+    })
+
+    const board = await readArcadeStreakLeaderboard(db, { date: '2026-07-06' })
+
+    expect(board.entries).toEqual([
+      {
+        rank: 1,
+        public_label: 'Atlas Player',
+        current_streak_days: 1,
+        longest_streak_days: 1,
+        last_active_date: '2026-07-06',
+        today: { bombsquad_defused: true, oracle_signed: true },
+      },
+    ])
+    expect(JSON.stringify(board)).not.toContain('user-claimed')
+    expect(JSON.stringify(board)).not.toContain('profile-1')
+    expect(JSON.stringify(board)).not.toContain('Stale Player')
   })
 })

--- a/packages/arcade-profile/src/store.test.ts
+++ b/packages/arcade-profile/src/store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   readArcadeAccountProfile,
+  readArcadePublicProfile,
   readArcadeStreakLeaderboard,
   upsertArcadeProfileEvents,
   upsertArcadePublicProfile,
@@ -87,6 +88,47 @@ describe('arcade profile store', () => {
     expect(profile.counts.bombsquad_runs).toBe(102)
     expect(profile.daily_loop.streak.current_days).toBe(102)
     expect(profile.daily_loop.streak.longest_days).toBe(102)
+  })
+
+  it('ignores Oracle signs whose persisted sign date does not match creation date', async () => {
+    const db = createTestDb()
+    const deps = { now: () => '2026-07-06T10:00:00.000Z', today: () => '2026-07-06' }
+    const staleSign: ArcadeProfileEvent = {
+      ...SIGN_EVENT,
+      sign: {
+        ...SIGN_EVENT.sign,
+        source_key: 'oracle:2026-07-06:stale-session',
+        session_id: 'stale-session',
+        sign_date: '2026-07-06',
+        created_at: '2026-07-05T09:00:00.000Z',
+      },
+    }
+
+    await upsertArcadeProfileEvents(db, 'user-stale-oracle', [staleSign], { deps })
+    await upsertArcadePublicProfile(db, 'user-stale-oracle', {
+      profileId: 'profile-stale-oracle',
+      publicLabel: 'Stale Oracle',
+      deps,
+    })
+    const profile = await readArcadeAccountProfile(db, 'user-stale-oracle', deps)
+    const board = await readArcadeStreakLeaderboard(db, { date: '2026-07-06' })
+
+    expect(profile.today_played).toBe(false)
+    expect(profile.daily_loop.checklist.oracle_sign.completed).toBe(false)
+    expect(profile.daily_loop.streak.current_days).toBe(0)
+    expect(board.entries).toHaveLength(0)
+  })
+
+  it('keeps public profile reads compatible before migration 0003 exists', async () => {
+    const db = createTestDb({ migrations: ['0002_arcade_profile.sql'] })
+    const deps = { now: () => '2026-07-06T10:00:00.000Z', today: () => '2026-07-06' }
+
+    await upsertArcadeProfileEvents(db, 'user-before-0003', [RUN_EVENT], { deps })
+    const profile = await readArcadeAccountProfile(db, 'user-before-0003', deps)
+    const publicProfile = await readArcadePublicProfile(db, 'user-before-0003')
+
+    expect(profile.counts.bombsquad_runs).toBe(1)
+    expect(publicProfile).toEqual({ claimed: false, public_label: null })
   })
 
   it('derives the public streak board only from claimed public profiles', async () => {

--- a/packages/arcade-profile/src/store.ts
+++ b/packages/arcade-profile/src/store.ts
@@ -72,6 +72,10 @@ function eventProfileId(event: ArcadeProfileEvent, fallback?: string): string | 
   return event.profile_id ?? fallback ?? null
 }
 
+function isMissingPublicProfileTableError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('arcade_public_profile')
+}
+
 async function readAccountQualifiedDates(
   db: ArcadeProfileDb,
   userId: string
@@ -93,7 +97,7 @@ async function readAccountQualifiedDates(
     .prepare(
       `SELECT sign_date AS activity_date, MAX(created_at) AS completed_at
        FROM arcade_profile_oracle_sign
-       WHERE user_id = ?
+       WHERE user_id = ? AND substr(created_at, 1, 10) = sign_date
        GROUP BY sign_date`
     )
     .bind(userId)
@@ -216,10 +220,16 @@ export async function readArcadePublicProfile(
   db: ArcadeProfileDb,
   userId: string
 ): Promise<ArcadePublicProfileStatus> {
-  const row = await db
-    .prepare(`SELECT public_label FROM arcade_public_profile WHERE user_id = ? LIMIT 1`)
-    .bind(userId)
-    .first<PublicProfileRow>()
+  let row: PublicProfileRow | null
+  try {
+    row = await db
+      .prepare(`SELECT public_label FROM arcade_public_profile WHERE user_id = ? LIMIT 1`)
+      .bind(userId)
+      .first<PublicProfileRow>()
+  } catch (error) {
+    if (!isMissingPublicProfileTableError(error)) throw error
+    return { claimed: false, public_label: null }
+  }
   if (!row) return { claimed: false, public_label: null }
   return { claimed: true, public_label: row.public_label }
 }
@@ -325,7 +335,7 @@ export async function readArcadeStreakLeaderboard(
               MAX(o.created_at) AS completed_at, 'oracle' AS activity_kind
        FROM arcade_public_profile p
        JOIN arcade_profile_oracle_sign o ON o.user_id = p.user_id
-       WHERE o.sign_date <= ?
+       WHERE o.sign_date <= ? AND substr(o.created_at, 1, 10) = o.sign_date
        GROUP BY p.user_id, p.public_label, activity_date`
     )
     .bind(date, date)

--- a/packages/arcade-profile/src/store.ts
+++ b/packages/arcade-profile/src/store.ts
@@ -1,9 +1,12 @@
 import { getTodayString } from '../../../shared/date'
 import type { ArcadeProfileDb } from './db'
-import { summarizeArcadeProfile } from './summary'
+import { computeArcadeStreak, summarizeArcadeProfile, type QualifiedActivityDate } from './summary'
 import type {
   ArcadeProfileEvent,
   ArcadeProfileSummary,
+  ArcadePublicProfileStatus,
+  ArcadeStreakLeaderboardEntry,
+  ArcadeStreakLeaderboardResponse,
   BombSquadProfileRun,
   OracleProfileSign,
 } from './types'
@@ -35,6 +38,27 @@ interface OracleSignRow {
   created_at: string
 }
 
+interface CountRow {
+  count: number
+}
+
+interface QualifiedDateRow {
+  activity_date: string
+  completed_at: string
+}
+
+interface PublicProfileRow {
+  public_label: string
+}
+
+interface PublicQualifiedActivityRow {
+  user_id: string
+  public_label: string
+  activity_date: string
+  completed_at: string
+  activity_kind: 'bombsquad' | 'oracle'
+}
+
 export interface StoreDeps {
   now?: () => string
   today?: () => string
@@ -46,6 +70,45 @@ function eventSourceKey(event: ArcadeProfileEvent): string {
 
 function eventProfileId(event: ArcadeProfileEvent, fallback?: string): string | null {
   return event.profile_id ?? fallback ?? null
+}
+
+async function readAccountQualifiedDates(
+  db: ArcadeProfileDb,
+  userId: string
+): Promise<{
+  bombsquad: QualifiedActivityDate[]
+  oracle: QualifiedActivityDate[]
+}> {
+  const { results: bombsquadRows } = await db
+    .prepare(
+      `SELECT substr(finished_at, 1, 10) AS activity_date, MAX(finished_at) AS completed_at
+       FROM arcade_profile_bombsquad_run
+       WHERE user_id = ? AND mode = 'daily' AND outcome = 'defused'
+       GROUP BY activity_date`
+    )
+    .bind(userId)
+    .all<QualifiedDateRow>()
+
+  const { results: oracleRows } = await db
+    .prepare(
+      `SELECT sign_date AS activity_date, MAX(created_at) AS completed_at
+       FROM arcade_profile_oracle_sign
+       WHERE user_id = ?
+       GROUP BY sign_date`
+    )
+    .bind(userId)
+    .all<QualifiedDateRow>()
+
+  return {
+    bombsquad: bombsquadRows.map((row) => ({
+      date: row.activity_date,
+      completed_at: row.completed_at,
+    })),
+    oracle: oracleRows.map((row) => ({
+      date: row.activity_date,
+      completed_at: row.completed_at,
+    })),
+  }
 }
 
 export async function upsertArcadeProfileEvents(
@@ -120,6 +183,47 @@ export async function upsertArcadeProfileEvents(
   return { inserted, sourceKeys }
 }
 
+export async function upsertArcadePublicProfile(
+  db: ArcadeProfileDb,
+  userId: string,
+  input: {
+    profileId: string
+    publicLabel: string
+    deps?: StoreDeps
+  }
+): Promise<ArcadePublicProfileStatus> {
+  const now = input.deps?.now ?? (() => new Date().toISOString())
+  const timestamp = now()
+  await db
+    .prepare(
+      `INSERT INTO arcade_public_profile (
+         user_id, profile_id, public_label, claimed_at, label_updated_at, updated_at
+       )
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT (user_id) DO UPDATE SET
+         profile_id = excluded.profile_id,
+         public_label = excluded.public_label,
+         label_updated_at = excluded.label_updated_at,
+         updated_at = excluded.updated_at`
+    )
+    .bind(userId, input.profileId, input.publicLabel, timestamp, timestamp, timestamp)
+    .run()
+
+  return { claimed: true, public_label: input.publicLabel }
+}
+
+export async function readArcadePublicProfile(
+  db: ArcadeProfileDb,
+  userId: string
+): Promise<ArcadePublicProfileStatus> {
+  const row = await db
+    .prepare(`SELECT public_label FROM arcade_public_profile WHERE user_id = ? LIMIT 1`)
+    .bind(userId)
+    .first<PublicProfileRow>()
+  if (!row) return { claimed: false, public_label: null }
+  return { claimed: true, public_label: row.public_label }
+}
+
 export async function readArcadeAccountProfile(
   db: ArcadeProfileDb,
   userId: string,
@@ -148,6 +252,18 @@ export async function readArcadeAccountProfile(
     .bind(userId)
     .all<OracleSignRow>()
 
+  const [bombsquadCount, oracleCount, qualifiedDates] = await Promise.all([
+    db
+      .prepare(`SELECT COUNT(*) AS count FROM arcade_profile_bombsquad_run WHERE user_id = ?`)
+      .bind(userId)
+      .first<CountRow>(),
+    db
+      .prepare(`SELECT COUNT(*) AS count FROM arcade_profile_oracle_sign WHERE user_id = ?`)
+      .bind(userId)
+      .first<CountRow>(),
+    readAccountQualifiedDates(db, userId),
+  ])
+
   const bombsquadRuns: BombSquadProfileRun[] = runRows.map((row) => ({
     source_key: row.source_key,
     run_id: row.run_id,
@@ -171,8 +287,103 @@ export async function readArcadeAccountProfile(
   }))
 
   return summarizeArcadeProfile({
+    profileId:
+      runRows.find((row) => row.profile_id !== null)?.profile_id ??
+      signRows.find((row) => row.profile_id !== null)?.profile_id ??
+      undefined,
     bombsquadRuns,
     oracleSigns,
     today: deps.today?.() ?? getTodayString(),
+    counts: {
+      bombsquad_runs: bombsquadCount?.count ?? bombsquadRuns.length,
+      oracle_signs: oracleCount?.count ?? oracleSigns.length,
+    },
+    qualifiedBombSquadDates: qualifiedDates.bombsquad,
+    qualifiedOracleDates: qualifiedDates.oracle,
   })
+}
+
+export async function readArcadeStreakLeaderboard(
+  db: ArcadeProfileDb,
+  options: {
+    date?: string
+    limit?: number
+  } = {}
+): Promise<ArcadeStreakLeaderboardResponse> {
+  const date = options.date ?? getTodayString()
+  const limit = Math.min(Math.max(options.limit ?? 50, 1), 100)
+  const { results } = await db
+    .prepare(
+      `SELECT p.user_id, p.public_label, substr(b.finished_at, 1, 10) AS activity_date,
+              MAX(b.finished_at) AS completed_at, 'bombsquad' AS activity_kind
+       FROM arcade_public_profile p
+       JOIN arcade_profile_bombsquad_run b ON b.user_id = p.user_id
+       WHERE b.mode = 'daily' AND b.outcome = 'defused' AND substr(b.finished_at, 1, 10) <= ?
+       GROUP BY p.user_id, p.public_label, activity_date
+       UNION ALL
+       SELECT p.user_id, p.public_label, o.sign_date AS activity_date,
+              MAX(o.created_at) AS completed_at, 'oracle' AS activity_kind
+       FROM arcade_public_profile p
+       JOIN arcade_profile_oracle_sign o ON o.user_id = p.user_id
+       WHERE o.sign_date <= ?
+       GROUP BY p.user_id, p.public_label, activity_date`
+    )
+    .bind(date, date)
+    .all<PublicQualifiedActivityRow>()
+
+  const grouped = new Map<
+    string,
+    {
+      publicLabel: string
+      bombsquad: QualifiedActivityDate[]
+      oracle: QualifiedActivityDate[]
+    }
+  >()
+
+  for (const row of results) {
+    const entry = grouped.get(row.user_id) ?? {
+      publicLabel: row.public_label,
+      bombsquad: [],
+      oracle: [],
+    }
+    const activity = { date: row.activity_date, completed_at: row.completed_at }
+    if (row.activity_kind === 'bombsquad') {
+      entry.bombsquad.push(activity)
+    } else {
+      entry.oracle.push(activity)
+    }
+    grouped.set(row.user_id, entry)
+  }
+
+  const entries: Omit<ArcadeStreakLeaderboardEntry, 'rank'>[] = []
+  for (const entry of grouped.values()) {
+    const streak = computeArcadeStreak([...entry.bombsquad, ...entry.oracle], date)
+    if (!streak.last_active_date || streak.current_days === 0) continue
+    entries.push({
+      public_label: entry.publicLabel,
+      current_streak_days: streak.current_days,
+      longest_streak_days: streak.longest_days,
+      last_active_date: streak.last_active_date,
+      today: {
+        bombsquad_defused: entry.bombsquad.some((item) => item.date === date),
+        oracle_signed: entry.oracle.some((item) => item.date === date),
+      },
+    })
+  }
+
+  return {
+    date,
+    entries: entries
+      .sort((a, b) => {
+        const byCurrent = b.current_streak_days - a.current_streak_days
+        if (byCurrent !== 0) return byCurrent
+        const byLongest = b.longest_streak_days - a.longest_streak_days
+        if (byLongest !== 0) return byLongest
+        const byRecent = b.last_active_date.localeCompare(a.last_active_date)
+        if (byRecent !== 0) return byRecent
+        return a.public_label.localeCompare(b.public_label)
+      })
+      .slice(0, limit)
+      .map((entry, index) => ({ rank: index + 1, ...entry })),
+  }
 }

--- a/packages/arcade-profile/src/summary.test.ts
+++ b/packages/arcade-profile/src/summary.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeDailyLoop } from './summary'
+import type { BombSquadProfileRun, OracleProfileSign } from './types'
+
+function run(
+  runId: string,
+  date: string,
+  outcome: BombSquadProfileRun['outcome'] = 'defused',
+  mode: BombSquadProfileRun['mode'] = 'daily'
+): BombSquadProfileRun {
+  return {
+    source_key: `bombsquad:${runId}`,
+    run_id: runId,
+    mode,
+    outcome,
+    duration_ms: 60_000,
+    attempt_number: 1,
+    module_count: mode === 'daily' ? 4 : 2,
+    completed_modules:
+      outcome === 'defused' || outcome === 'practice-cleared' ? (mode === 'daily' ? 4 : 2) : 1,
+    strike_count: outcome === 'exploded' ? 3 : 0,
+    finished_at: `${date}T08:00:00.000Z`,
+  }
+}
+
+function sign(sessionId: string, date: string): OracleProfileSign {
+  return {
+    source_key: `oracle:${date}:${sessionId}`,
+    session_id: sessionId,
+    sign_date: date,
+    ben: '乾',
+    bian: '坤',
+    yao_values: [7, 8, 7, 8, 7, 8],
+    created_at: `${date}T09:00:00.000Z`,
+  }
+}
+
+describe('daily loop summary', () => {
+  it('counts only qualified daily activities and dedupes same-day completions', () => {
+    const summary = summarizeDailyLoop({
+      today: '2026-07-06',
+      bombsquadRuns: [
+        run('daily-1', '2026-07-06'),
+        run('daily-2', '2026-07-06'),
+        run('practice-1', '2026-07-05', 'practice-cleared', 'practice'),
+        run('failed-1', '2026-07-05', 'exploded'),
+      ],
+      oracleSigns: [sign('oracle-1', '2026-07-05')],
+    })
+
+    expect(summary.checklist.bombsquad_daily.completed).toBe(true)
+    expect(summary.checklist.oracle_sign.completed).toBe(false)
+    expect(summary.streak.today_completed).toBe(true)
+    expect(summary.streak.current_days).toBe(2)
+    expect(summary.streak.longest_days).toBe(2)
+  })
+
+  it('carries yesterday streak through today and resets after a gap', () => {
+    const active = summarizeDailyLoop({
+      today: '2026-07-06',
+      bombsquadRuns: [run('daily-1', '2026-07-04'), run('daily-2', '2026-07-05')],
+      oracleSigns: [],
+    })
+    const broken = summarizeDailyLoop({
+      today: '2026-07-06',
+      bombsquadRuns: [run('daily-1', '2026-07-03'), run('daily-2', '2026-07-04')],
+      oracleSigns: [],
+    })
+
+    expect(active.streak.current_days).toBe(2)
+    expect(active.streak.today_completed).toBe(false)
+    expect(broken.streak.current_days).toBe(0)
+    expect(broken.streak.longest_days).toBe(2)
+  })
+})

--- a/packages/arcade-profile/src/summary.test.ts
+++ b/packages/arcade-profile/src/summary.test.ts
@@ -35,6 +35,14 @@ function sign(sessionId: string, date: string): OracleProfileSign {
   }
 }
 
+function staleSign(sessionId: string, signDate: string, createdDate: string): OracleProfileSign {
+  return {
+    ...sign(sessionId, signDate),
+    source_key: `oracle:${signDate}:${sessionId}`,
+    created_at: `${createdDate}T09:00:00.000Z`,
+  }
+}
+
 describe('daily loop summary', () => {
   it('counts only qualified daily activities and dedupes same-day completions', () => {
     const summary = summarizeDailyLoop({
@@ -71,5 +79,17 @@ describe('daily loop summary', () => {
     expect(active.streak.today_completed).toBe(false)
     expect(broken.streak.current_days).toBe(0)
     expect(broken.streak.longest_days).toBe(2)
+  })
+
+  it('does not count reopened Oracle signs as fresh streak activity', () => {
+    const summary = summarizeDailyLoop({
+      today: '2026-07-06',
+      bombsquadRuns: [],
+      oracleSigns: [staleSign('oracle-1', '2026-07-06', '2026-07-05')],
+    })
+
+    expect(summary.checklist.oracle_sign.completed).toBe(false)
+    expect(summary.streak.today_completed).toBe(false)
+    expect(summary.streak.current_days).toBe(0)
   })
 })

--- a/packages/arcade-profile/src/summary.ts
+++ b/packages/arcade-profile/src/summary.ts
@@ -1,4 +1,10 @@
-import type { ArcadeProfileSummary, BombSquadProfileRun, OracleProfileSign } from './types'
+import type {
+  ArcadeDailyLoopSummary,
+  ArcadeProfileSummary,
+  ArcadeStreakSummary,
+  BombSquadProfileRun,
+  OracleProfileSign,
+} from './types'
 
 function newerFirst<T extends { source_key: string }>(
   items: T[],
@@ -16,14 +22,140 @@ function bestRun(runs: BombSquadProfileRun[]): BombSquadProfileRun | null {
   return [...winners].sort((a, b) => a.duration_ms - b.duration_ms)[0] ?? null
 }
 
+export interface QualifiedActivityDate {
+  date: string
+  completed_at: string | null
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+function isIsoDate(value: string): boolean {
+  return ISO_DATE_RE.test(value)
+}
+
+function shiftDate(date: string, deltaDays: number): string | null {
+  if (!isIsoDate(date)) return null
+  const [year, month, day] = date.split('-').map(Number)
+  const time = Date.UTC(year, month - 1, day) + deltaDays * 86_400_000
+  return new Date(time).toISOString().slice(0, 10)
+}
+
+function normalizeQualifiedDates(dates: QualifiedActivityDate[], today: string): string[] {
+  return [
+    ...new Set(dates.map((item) => item.date).filter((date) => isIsoDate(date) && date <= today)),
+  ].sort()
+}
+
+function latestCompletedAt(items: QualifiedActivityDate[], today: string): string | null {
+  return (
+    items
+      .filter((item) => item.date === today && item.completed_at !== null)
+      .map((item) => item.completed_at as string)
+      .sort()
+      .at(-1) ?? null
+  )
+}
+
+export function qualifiedBombSquadRunDate(run: BombSquadProfileRun): QualifiedActivityDate | null {
+  if (run.mode !== 'daily' || run.outcome !== 'defused') return null
+  const date = run.finished_at.slice(0, 10)
+  return isIsoDate(date) ? { date, completed_at: run.finished_at } : null
+}
+
+export function qualifiedOracleSignDate(sign: OracleProfileSign): QualifiedActivityDate | null {
+  return isIsoDate(sign.sign_date) ? { date: sign.sign_date, completed_at: sign.created_at } : null
+}
+
+export function computeArcadeStreak(
+  dates: QualifiedActivityDate[],
+  today: string
+): ArcadeStreakSummary {
+  const sortedDates = normalizeQualifiedDates(dates, today)
+  const dateSet = new Set(sortedDates)
+  let longestDays = 0
+  let runLength = 0
+  let previous: string | null = null
+
+  for (const date of sortedDates) {
+    runLength = previous && shiftDate(previous, 1) === date ? runLength + 1 : 1
+    longestDays = Math.max(longestDays, runLength)
+    previous = date
+  }
+
+  const todayCompleted = dateSet.has(today)
+  const anchor = todayCompleted ? today : (shiftDate(today, -1) ?? today)
+  let currentDays = 0
+  let cursor: string | null = anchor
+  while (cursor !== null && dateSet.has(cursor)) {
+    currentDays += 1
+    cursor = shiftDate(cursor, -1)
+  }
+
+  return {
+    today_completed: todayCompleted,
+    current_days: currentDays,
+    longest_days: longestDays,
+    last_active_date: sortedDates.at(-1) ?? null,
+  }
+}
+
+export function summarizeDailyLoop(input: {
+  bombsquadRuns: BombSquadProfileRun[]
+  oracleSigns: OracleProfileSign[]
+  today: string
+  qualifiedBombSquadDates?: QualifiedActivityDate[]
+  qualifiedOracleDates?: QualifiedActivityDate[]
+}): ArcadeDailyLoopSummary {
+  const bombsquadDates =
+    input.qualifiedBombSquadDates ??
+    input.bombsquadRuns
+      .map(qualifiedBombSquadRunDate)
+      .filter((item): item is QualifiedActivityDate => item !== null)
+  const oracleDates =
+    input.qualifiedOracleDates ??
+    input.oracleSigns
+      .map(qualifiedOracleSignDate)
+      .filter((item): item is QualifiedActivityDate => item !== null)
+  const allDates = [...bombsquadDates, ...oracleDates]
+  const streak = computeArcadeStreak(allDates, input.today)
+
+  return {
+    date: input.today,
+    checklist: {
+      bombsquad_daily: {
+        completed: bombsquadDates.some((item) => item.date === input.today),
+        completed_at: latestCompletedAt(bombsquadDates, input.today),
+      },
+      oracle_sign: {
+        completed: oracleDates.some((item) => item.date === input.today),
+        completed_at: latestCompletedAt(oracleDates, input.today),
+      },
+    },
+    streak,
+  }
+}
+
 export function summarizeArcadeProfile(input: {
   profileId?: string
   bombsquadRuns: BombSquadProfileRun[]
   oracleSigns: OracleProfileSign[]
   today: string
+  counts?: {
+    bombsquad_runs: number
+    oracle_signs: number
+  }
+  qualifiedBombSquadDates?: QualifiedActivityDate[]
+  qualifiedOracleDates?: QualifiedActivityDate[]
 }): ArcadeProfileSummary {
   const bombsquadRuns = newerFirst(input.bombsquadRuns, (run) => run.finished_at)
   const oracleSigns = newerFirst(input.oracleSigns, (sign) => sign.created_at)
+  const dailyLoop = summarizeDailyLoop({
+    bombsquadRuns,
+    oracleSigns,
+    today: input.today,
+    qualifiedBombSquadDates: input.qualifiedBombSquadDates,
+    qualifiedOracleDates: input.qualifiedOracleDates,
+  })
   const recentRun = bombsquadRuns[0] ?? null
   const recentSign = oracleSigns[0] ?? null
   const lastActivityAt =
@@ -39,8 +171,8 @@ export function summarizeArcadeProfile(input: {
       bombsquadRuns.some((run) => run.finished_at.slice(0, 10) === input.today) ||
       oracleSigns.some((sign) => sign.sign_date === input.today),
     counts: {
-      bombsquad_runs: bombsquadRuns.length,
-      oracle_signs: oracleSigns.length,
+      bombsquad_runs: input.counts?.bombsquad_runs ?? bombsquadRuns.length,
+      oracle_signs: input.counts?.oracle_signs ?? oracleSigns.length,
     },
     bombsquad: {
       recent: recentRun,
@@ -54,5 +186,6 @@ export function summarizeArcadeProfile(input: {
     oracle: {
       recent: recentSign,
     },
+    daily_loop: dailyLoop,
   }
 }

--- a/packages/arcade-profile/src/summary.ts
+++ b/packages/arcade-profile/src/summary.ts
@@ -63,7 +63,8 @@ export function qualifiedBombSquadRunDate(run: BombSquadProfileRun): QualifiedAc
 }
 
 export function qualifiedOracleSignDate(sign: OracleProfileSign): QualifiedActivityDate | null {
-  return isIsoDate(sign.sign_date) ? { date: sign.sign_date, completed_at: sign.created_at } : null
+  if (!isIsoDate(sign.sign_date) || sign.created_at.slice(0, 10) !== sign.sign_date) return null
+  return { date: sign.sign_date, completed_at: sign.created_at }
 }
 
 export function computeArcadeStreak(
@@ -169,7 +170,7 @@ export function summarizeArcadeProfile(input: {
     last_activity_at: lastActivityAt,
     today_played:
       bombsquadRuns.some((run) => run.finished_at.slice(0, 10) === input.today) ||
-      oracleSigns.some((sign) => sign.sign_date === input.today),
+      oracleSigns.some((sign) => qualifiedOracleSignDate(sign)?.date === input.today),
     counts: {
       bombsquad_runs: input.counts?.bombsquad_runs ?? bombsquadRuns.length,
       oracle_signs: input.counts?.oracle_signs ?? oracleSigns.length,

--- a/packages/arcade-profile/src/test-support/sqlite-db.ts
+++ b/packages/arcade-profile/src/test-support/sqlite-db.ts
@@ -66,9 +66,9 @@ class SqliteArcadeProfileDb implements ArcadeProfileDb {
   }
 }
 
-export function createTestDb(): ArcadeProfileDb {
+export function createTestDb(options: { migrations?: string[] } = {}): ArcadeProfileDb {
   const db = new DatabaseSync(':memory:')
-  for (const file of ARCADE_MIGRATIONS) {
+  for (const file of options.migrations ?? ARCADE_MIGRATIONS) {
     db.exec(readFileSync(join(MIGRATIONS_DIR, file), 'utf8'))
   }
   return new SqliteArcadeProfileDb(db)

--- a/packages/arcade-profile/src/test-support/sqlite-db.ts
+++ b/packages/arcade-profile/src/test-support/sqlite-db.ts
@@ -4,15 +4,15 @@ import { fileURLToPath } from 'node:url'
 import { DatabaseSync } from 'node:sqlite'
 import type { ArcadeProfileDb, ArcadeProfileDbRunResult, ArcadeProfileDbStatement } from '../db'
 
-const MIGRATION = join(
+const MIGRATIONS_DIR = join(
   dirname(fileURLToPath(import.meta.url)),
   '..',
   '..',
   '..',
   'companion-memory',
-  'migrations',
-  '0002_arcade_profile.sql'
+  'migrations'
 )
+const ARCADE_MIGRATIONS = ['0002_arcade_profile.sql', '0003_arcade_public_profile.sql']
 
 class SqliteStatement implements ArcadeProfileDbStatement {
   private params: unknown[] = []
@@ -68,6 +68,8 @@ class SqliteArcadeProfileDb implements ArcadeProfileDb {
 
 export function createTestDb(): ArcadeProfileDb {
   const db = new DatabaseSync(':memory:')
-  db.exec(readFileSync(MIGRATION, 'utf8'))
+  for (const file of ARCADE_MIGRATIONS) {
+    db.exec(readFileSync(join(MIGRATIONS_DIR, file), 'utf8'))
+  }
   return new SqliteArcadeProfileDb(db)
 }

--- a/packages/arcade-profile/src/types.ts
+++ b/packages/arcade-profile/src/types.ts
@@ -57,6 +57,31 @@ export interface OracleProfileSummary {
   recent: OracleProfileSign | null
 }
 
+export type ArcadeDailyLoopActivityId = 'bombsquad_daily' | 'oracle_sign'
+
+export interface ArcadeDailyLoopActivityStatus {
+  completed: boolean
+  completed_at: string | null
+}
+
+export interface ArcadeDailyLoopChecklist {
+  bombsquad_daily: ArcadeDailyLoopActivityStatus
+  oracle_sign: ArcadeDailyLoopActivityStatus
+}
+
+export interface ArcadeStreakSummary {
+  today_completed: boolean
+  current_days: number
+  longest_days: number
+  last_active_date: string | null
+}
+
+export interface ArcadeDailyLoopSummary {
+  date: string
+  checklist: ArcadeDailyLoopChecklist
+  streak: ArcadeStreakSummary
+}
+
 export interface ArcadeProfileSummary {
   profile_id?: string
   last_activity_at: string | null
@@ -67,19 +92,48 @@ export interface ArcadeProfileSummary {
   }
   bombsquad: BombSquadProfileSummary
   oracle: OracleProfileSummary
+  daily_loop: ArcadeDailyLoopSummary
+}
+
+export interface ArcadePublicProfileStatus {
+  claimed: boolean
+  public_label: string | null
 }
 
 export interface ArcadeProfileResponse {
   profile: ArcadeProfileSummary
+  public_profile: ArcadePublicProfileStatus
 }
 
 export interface ArcadeProfileClaimBody {
   profile_id: string
   events: ArcadeProfileEvent[]
+  public_label?: string
 }
 
 export interface ArcadeProfileClaimResponse {
   profile: ArcadeProfileSummary
   source_keys: string[]
   inserted: number
+  public_profile: {
+    claimed: true
+    public_label: string
+  }
+}
+
+export interface ArcadeStreakLeaderboardEntry {
+  rank: number
+  public_label: string
+  current_streak_days: number
+  longest_streak_days: number
+  last_active_date: string
+  today: {
+    bombsquad_defused: boolean
+    oracle_signed: boolean
+  }
+}
+
+export interface ArcadeStreakLeaderboardResponse {
+  date: string
+  entries: ArcadeStreakLeaderboardEntry[]
 }

--- a/packages/arcade-profile/src/validation.test.ts
+++ b/packages/arcade-profile/src/validation.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { parseArcadeProfileClaimBody, parseArcadeProfileEvent } from './validation'
+import {
+  defaultArcadePublicLabel,
+  parseArcadeProfileClaimBody,
+  parseArcadeProfileEvent,
+  sanitizeArcadePublicLabel,
+} from './validation'
 
 const RUN_EVENT = {
   kind: 'bombsquad_run',
@@ -40,8 +45,19 @@ describe('arcade profile validation', () => {
     const claim = parseArcadeProfileClaimBody({
       profile_id: 'profile-claim',
       events: [{ ...RUN_EVENT, profile_id: undefined }],
+      public_label: 'Atlas Player',
     })
     expect(claim?.events[0].profile_id).toBe('profile-claim')
+    expect(claim?.public_label).toBe('Atlas Player')
     expect(parseArcadeProfileClaimBody({ profile_id: 'p', user_id: 'u', events: [] })).toBeNull()
+  })
+
+  it('sanitizes public labels and falls back without deriving from email text', () => {
+    const fallback = defaultArcadePublicLabel('user-a')
+
+    expect(sanitizeArcadePublicLabel('  Atlas   Player  ', 'user-a')).toBe('Atlas Player')
+    expect(sanitizeArcadePublicLabel('a@example.com', 'user-a')).toBe(fallback)
+    expect(sanitizeArcadePublicLabel('', 'user-a')).toBe(fallback)
+    expect(sanitizeArcadePublicLabel('x'.repeat(40), 'user-a')).toBe('x'.repeat(28))
   })
 })

--- a/packages/arcade-profile/src/validation.ts
+++ b/packages/arcade-profile/src/validation.ts
@@ -16,6 +16,7 @@ const OUTCOMES = new Set<BombSquadProfileOutcome>([
   'practice-timeout',
   'daily-timeout',
 ])
+const PUBLIC_LABEL_MAX_LENGTH = 28
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -30,6 +31,31 @@ function text(value: unknown, max: number): string | null {
   const trimmed = value.trim()
   if (trimmed.length === 0 || trimmed.length > max) return null
   return trimmed
+}
+
+export function defaultArcadePublicLabel(userId: string): string {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < userId.length; i += 1) {
+    hash ^= userId.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return `Player ${((hash >>> 0) & 0xffff).toString(16).toUpperCase().padStart(4, '0')}`
+}
+
+export function sanitizeArcadePublicLabel(value: unknown, userId: string): string {
+  if (typeof value !== 'string') return defaultArcadePublicLabel(userId)
+  const trimmed = value.trim().replace(/\s+/g, ' ')
+  if (trimmed.length === 0) return defaultArcadePublicLabel(userId)
+  if (trimmed.includes('@') || /^https?:\/\//i.test(trimmed)) {
+    return defaultArcadePublicLabel(userId)
+  }
+  const safe = Array.from(trimmed)
+    .filter((char) => /[\p{L}\p{N} _.'-]/u.test(char))
+    .join('')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .slice(0, PUBLIC_LABEL_MAX_LENGTH)
+  return safe.length > 0 ? safe : defaultArcadePublicLabel(userId)
 }
 
 function integer(value: unknown, min: number, max: number): number | null {
@@ -165,5 +191,6 @@ export function parseArcadeProfileClaimBody(value: unknown): ArcadeProfileClaimB
       ...event,
       profile_id: event.profile_id ?? profileId,
     })),
+    ...(typeof value.public_label === 'string' ? { public_label: value.public_label } : {}),
   }
 }

--- a/packages/companion-memory/migrations/0003_arcade_public_profile.sql
+++ b/packages/companion-memory/migrations/0003_arcade_public_profile.sql
@@ -1,0 +1,23 @@
+-- Migration 0003 — Arcade public streak profile metadata.
+--
+-- Public streak-board eligibility is explicit metadata. Streak counters remain
+-- derived from arcade-profile event tables; this migration only adds read
+-- indexes and the public label table.
+
+CREATE INDEX idx_arcade_bombsquad_user_daily_streak
+  ON arcade_profile_bombsquad_run (user_id, mode, outcome, finished_at DESC);
+
+CREATE INDEX idx_arcade_oracle_user_sign_date
+  ON arcade_profile_oracle_sign (user_id, sign_date DESC, created_at DESC);
+
+CREATE TABLE arcade_public_profile (
+  user_id TEXT PRIMARY KEY,
+  profile_id TEXT NOT NULL,
+  public_label TEXT NOT NULL CHECK (length(public_label) >= 1 AND length(public_label) <= 28),
+  claimed_at TEXT NOT NULL,
+  label_updated_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_arcade_public_profile_label
+  ON arcade_public_profile (public_label);

--- a/packages/game-bombsquad/src/pages/ResultPage.module.css
+++ b/packages/game-bombsquad/src/pages/ResultPage.module.css
@@ -230,6 +230,74 @@
   outline-offset: 2px;
 }
 
+/* ----------  profile / daily-loop feedback  ---------- */
+.loopCard {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 16px;
+  border: 1px solid rgba(255, 229, 62, 0.16);
+  border-radius: 18px;
+  background: rgba(255, 229, 62, 0.06);
+}
+
+.loopLabel {
+  font: 500 10px var(--amio-font-mono);
+  color: rgba(255, 229, 62, 0.7);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.loopTitle {
+  margin-top: 6px;
+  font: 400 19px var(--font-display);
+  color: #fff;
+}
+
+.loopText {
+  margin: 6px 0 0;
+  font: 400 13px/1.55 var(--font-body);
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.shareStatus {
+  margin: 8px 0 0;
+  font: 600 12px var(--font-body);
+  color: var(--y);
+}
+
+.loopActions {
+  display: flex;
+  flex: 0 0 132px;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.loopAction {
+  padding: 8px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.86);
+  font: 600 12px var(--font-body);
+  cursor: pointer;
+  transition:
+    border-color 0.2s,
+    background 0.2s,
+    color 0.2s;
+}
+
+.loopAction:hover {
+  border-color: rgba(255, 229, 62, 0.36);
+  background: rgba(255, 229, 62, 0.08);
+  color: #fff;
+}
+
+.loopAction:focus-visible {
+  outline: 2px solid var(--y);
+  outline-offset: 2px;
+}
+
 /* ----------  AI consolation quote (failure only)  ---------- */
 .quote {
   padding: 14px 16px;
@@ -435,6 +503,7 @@
       'time     breakdown'
       'subtitle breakdown'
       'rank     breakdown'
+      'loop     breakdown'
       'quote    breakdown'
       'cta      breakdown';
     gap: 8px 56px;
@@ -463,6 +532,11 @@
   .rankCard {
     grid-area: rank;
     margin-top: 18px;
+  }
+
+  .loopCard {
+    grid-area: loop;
+    margin-top: 14px;
   }
 
   .quote {
@@ -496,5 +570,15 @@
     grid-template-columns: 40px 1fr 80px 80px;
     padding: 14px 6px;
     font-size: 15px;
+  }
+}
+
+@media (max-width: 520px) {
+  .loopCard {
+    flex-direction: column;
+  }
+
+  .loopActions {
+    flex: none;
   }
 }

--- a/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
@@ -49,6 +49,9 @@ vi.mock('@/utils/survey', () => ({
 
 import ResultPage from './ResultPage'
 import { submitScore } from '@shared/leaderboard-api'
+import { submitArcadeProfileEvent } from '@amiclaw/arcade-profile/api-client'
+import type { ArcadeProfileSummary } from '@amiclaw/arcade-profile/types'
+import { ARCADE_LOCAL_PROFILE_KEY, readArcadeLocalProfile } from '@amiclaw/arcade-profile/local'
 import { GameProvider, type GameState } from '@/store/game-context'
 
 const PERSISTENCE_KEY = 'bombsquad:game-state:v4'
@@ -56,6 +59,7 @@ const NICKNAME_KEY = 'bombsquad-nickname'
 const AI_TOOL_KEY = 'bombsquad-leaderboard-ai-tool'
 
 const mockedSubmit = vi.mocked(submitScore)
+const mockedProfileSubmit = vi.mocked(submitArcadeProfileEvent)
 
 // jsdom's `localStorage` in this workspace is a method-less stub (see the
 // boot-time `--localstorage-file` warning and the precedent in
@@ -134,6 +138,8 @@ describe('ResultPage nickname gate', () => {
     sessionStorage.clear()
     mockedSubmit.mockReset()
     mockedSubmit.mockResolvedValue({ ok: true, data: { rank: 5, total_players: 100 } })
+    mockedProfileSubmit.mockReset()
+    mockedProfileSubmit.mockResolvedValue({ kind: 'anon' })
   })
 
   afterEach(() => {
@@ -215,6 +221,59 @@ describe('ResultPage nickname gate', () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
     expect(writeText.mock.calls[0][0]).toContain('BombSquad 每日挑战')
     expect(await screen.findByText('分享文案已复制。')).toBeInTheDocument()
+  })
+
+  it('does not show a local-save success when local profile persistence fails', async () => {
+    localStorage.setItem(NICKNAME_KEY, '小红')
+    localStorage.setItem(AI_TOOL_KEY, 'chatgpt')
+    const originalSetItem = localStorage.setItem.bind(localStorage)
+    localStorage.setItem = vi.fn((key: string, value: string) => {
+      if (key === ARCADE_LOCAL_PROFILE_KEY) throw new Error('quota exceeded')
+      originalSetItem(key, value)
+    })
+    sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedDailyState()))
+
+    renderResultPage()
+
+    expect(await screen.findByText('本局暂未写入档案')).toBeInTheDocument()
+    expect(readArcadeLocalProfile()).toBeNull()
+  })
+
+  it('marks auto-synced result profile events as claimed locally', async () => {
+    localStorage.setItem(NICKNAME_KEY, '小红')
+    localStorage.setItem(AI_TOOL_KEY, 'chatgpt')
+    const syncedProfile: ArcadeProfileSummary = {
+      profile_id: 'local-profile',
+      last_activity_at: '2023-11-14T22:15:50.000Z',
+      today_played: true,
+      counts: { bombsquad_runs: 1, oracle_signs: 0 },
+      bombsquad: { recent: null, best_daily: null, best_practice: null },
+      oracle: { recent: null },
+      daily_loop: {
+        date: '2023-11-14',
+        checklist: {
+          bombsquad_daily: { completed: true, completed_at: '2023-11-14T22:15:50.000Z' },
+          oracle_sign: { completed: false, completed_at: null },
+        },
+        streak: {
+          today_completed: true,
+          current_days: 1,
+          longest_days: 1,
+          last_active_date: '2023-11-14',
+        },
+      },
+    }
+    mockedProfileSubmit.mockResolvedValue({
+      kind: 'ok',
+      profile: syncedProfile,
+      publicProfile: { claimed: false, public_label: null },
+    })
+    sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedDailyState()))
+
+    renderResultPage()
+
+    expect(await screen.findByText('已保存到账号档案')).toBeInTheDocument()
+    expect(readArcadeLocalProfile()?.claimed_source_keys).toContain('bombsquad:run-daily-result')
   })
 
   it('practice mode: never shows the modal and never submits', async () => {

--- a/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
@@ -196,6 +196,27 @@ describe('ResultPage nickname gate', () => {
     })
   })
 
+  it('shows profile save, share, and leaderboard actions on a daily result', async () => {
+    const writeText = vi.fn((_: string) => Promise.resolve())
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+    localStorage.setItem(NICKNAME_KEY, '小红')
+    localStorage.setItem(AI_TOOL_KEY, 'chatgpt')
+    sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedDailyState()))
+
+    renderResultPage()
+
+    expect(await screen.findByText('已保存到本设备')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '分享今日成绩' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '查看排行榜' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '保存到我的档案' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '分享今日成绩' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    expect(writeText.mock.calls[0][0]).toContain('BombSquad 每日挑战')
+    expect(await screen.findByText('分享文案已复制。')).toBeInTheDocument()
+  })
+
   it('practice mode: never shows the modal and never submits', async () => {
     sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedPracticeState()))
 

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -2,7 +2,12 @@ import { useState, useCallback, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import PostGameModal, { type PostGameModalResult } from '@/components/PostGameModal'
 import { Scenery } from '@amiclaw/ui'
-import { recordBombSquadLocalRun } from '@amiclaw/arcade-profile/local'
+import {
+  readArcadeLocalProfile,
+  recordBombSquadLocalRun,
+  summarizeArcadeLocalProfile,
+} from '@amiclaw/arcade-profile/local'
+import type { ArcadeDailyLoopSummary } from '@amiclaw/arcade-profile/types'
 import { submitArcadeProfileEvent } from '@amiclaw/arcade-profile/api-client'
 import Button from '@/components/bombsquad/Button'
 import Glyph, { type GlyphKey } from '@/components/bombsquad/Glyph'
@@ -50,6 +55,8 @@ const RESULT_FEEDBACK_SURVEY_DELAY_MS = 1800
 /** The result screen has two visual variants (handoff README §6.6 / §6.7). */
 type ResultVariant = 'success' | 'failure'
 type PostGameModalPurpose = 'leaderboard' | 'survey'
+type ProfileSaveState = 'idle' | 'saved-local' | 'synced' | 'account-error' | 'unavailable'
+type ShareState = 'idle' | 'shared' | 'copied' | 'error'
 
 /**
  * Map a frozen game outcome to a result variant. `defused` and
@@ -87,6 +94,9 @@ export default function ResultPage() {
   const [submitFailKind, setSubmitFailKind] = useState<'network' | 'rejected' | null>(null)
   const [submitFailMessage, setSubmitFailMessage] = useState<string | null>(null)
   const [entryRecovery] = useState(() => readEntryRecoveryState())
+  const [profileSaveState, setProfileSaveState] = useState<ProfileSaveState>('idle')
+  const [dailyLoop, setDailyLoop] = useState<ArcadeDailyLoopSummary | null>(null)
+  const [shareState, setShareState] = useState<ShareState>('idle')
 
   // Fall back to `defused` for any legacy RESULT state persisted before the
   // game-modes rework added the `outcome` field.
@@ -128,7 +138,23 @@ export default function ResultPage() {
       finishedAt: new Date(state.totalEndTime ?? Date.now()).toISOString(),
     })
     if (event) {
-      void submitArcadeProfileEvent(event)
+      const localDailyLoop = summarizeArcadeLocalProfile(readArcadeLocalProfile()).daily_loop
+      queueMicrotask(() => {
+        setProfileSaveState('saved-local')
+        setDailyLoop(localDailyLoop)
+      })
+      submitArcadeProfileEvent(event).then((result) => {
+        if (result.kind === 'ok') {
+          setProfileSaveState('synced')
+          setDailyLoop(result.profile.daily_loop)
+        } else if (result.kind === 'anon') {
+          setProfileSaveState('saved-local')
+        } else {
+          setProfileSaveState('account-error')
+        }
+      })
+    } else {
+      queueMicrotask(() => setProfileSaveState('unavailable'))
     }
   }, [
     noRunData,
@@ -384,6 +410,38 @@ export default function ResultPage() {
     performSubmission(nickname, leaderboardMetadata)
   }, [performSubmission, nickname, leaderboardMetadata])
 
+  const buildShareText = useCallback(() => {
+    const time = totalMs !== null ? formatMs(totalMs) : '一局'
+    const mode = state.mode === 'daily' ? 'BombSquad 每日挑战' : 'BombSquad 练习'
+    const result = variant === 'success' ? '完成' : '差一点'
+    const streak =
+      state.mode === 'daily' && outcome === 'defused' && dailyLoop
+        ? ` · 连续 ${dailyLoop.streak.current_days} 天`
+        : ''
+    return `${mode} ${result}：${time}${streak}。来 AMIO 游乐场一起玩：${window.location.origin}/bombsquad/`
+  }, [dailyLoop, outcome, state.mode, totalMs, variant])
+
+  const handleShareResult = useCallback(async () => {
+    const text = buildShareText()
+    try {
+      const share = (navigator as Navigator & { share?: (data: ShareData) => Promise<void> }).share
+      if (share) {
+        await share({
+          title: 'AMIO Arcade BombSquad',
+          text,
+          url: `${window.location.origin}/bombsquad/`,
+        })
+        setShareState('shared')
+        return
+      }
+      if (!navigator.clipboard?.writeText) throw new Error('clipboard unavailable')
+      await navigator.clipboard.writeText(text)
+      setShareState('copied')
+    } catch {
+      setShareState('error')
+    }
+  }, [buildShareText])
+
   const handlePlayAgain = () => {
     // Emit BEFORE the RESET so we still capture the just-finished run's mode
     // and attempt number — after RESET those revert to INITIAL_STATE values
@@ -488,6 +546,7 @@ export default function ResultPage() {
     stuckKind !== undefined ? `${modeMeta} · 卡在${MODULE_LABEL[stuckKind] ?? stuckKind}` : modeMeta
 
   const showRankCard = variant === 'success' && state.mode === 'daily' && outcome === 'defused'
+  const showDailyLoopCard = totalMs !== null && state.gameRunId !== null
   const showBreakdown = state.moduleStats.length > 0
   const breakdownTitle = variant === 'success' ? '模块用时' : '本局回顾'
   const okMarker = variant === 'success' ? '— —' : '✓'
@@ -579,6 +638,46 @@ export default function ResultPage() {
             </div>
           )}
 
+          {showDailyLoopCard && (
+            <div className={styles.loopCard}>
+              <div>
+                <div className={styles.loopLabel}>我的档案</div>
+                <div className={styles.loopTitle}>{profileSaveText(profileSaveState)}</div>
+                <p className={styles.loopText}>
+                  {state.mode === 'daily' &&
+                  outcome === 'defused' &&
+                  dailyLoop?.streak.today_completed
+                    ? `今日已打卡 · 连续 ${dailyLoop.streak.current_days} 天 · 最长 ${dailyLoop.streak.longest_days} 天`
+                    : state.mode === 'daily' && outcome === 'defused'
+                      ? '本局已保存；连续打卡状态以今日活动为准。'
+                      : '本局已保存；练习、失败和超时不计入连续打卡。'}
+                </p>
+                {shareState !== 'idle' && (
+                  <p className={styles.shareStatus}>{shareStatusText(shareState)}</p>
+                )}
+              </div>
+              <div className={styles.loopActions}>
+                <button type="button" className={styles.loopAction} onClick={handleShareResult}>
+                  分享今日成绩
+                </button>
+                <button
+                  type="button"
+                  className={styles.loopAction}
+                  onClick={() => window.location.assign('/leaderboard')}
+                >
+                  查看排行榜
+                </button>
+                <button
+                  type="button"
+                  className={styles.loopAction}
+                  onClick={() => window.location.assign('/me')}
+                >
+                  保存到我的档案
+                </button>
+              </div>
+            </div>
+          )}
+
           {variant === 'failure' && (
             <div className={styles.quote}>
               <div className={styles.quoteLabel}>AI 说</div>
@@ -658,4 +757,32 @@ export default function ResultPage() {
       />
     </main>
   )
+}
+
+function profileSaveText(state: ProfileSaveState): string {
+  switch (state) {
+    case 'synced':
+      return '已保存到账号档案'
+    case 'saved-local':
+      return '已保存到本设备'
+    case 'account-error':
+      return '本设备已保存，账号同步失败'
+    case 'unavailable':
+      return '本局暂未写入档案'
+    default:
+      return '保存中…'
+  }
+}
+
+function shareStatusText(state: ShareState): string {
+  switch (state) {
+    case 'shared':
+      return '已打开系统分享。'
+    case 'copied':
+      return '分享文案已复制。'
+    case 'error':
+      return '分享失败，请稍后再试。'
+    default:
+      return ''
+  }
 }

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import PostGameModal, { type PostGameModalResult } from '@/components/PostGameModal'
 import { Scenery } from '@amiclaw/ui'
 import {
+  markArcadeProfileEventsClaimed,
   readArcadeLocalProfile,
   recordBombSquadLocalRun,
   summarizeArcadeLocalProfile,
@@ -138,19 +139,30 @@ export default function ResultPage() {
       finishedAt: new Date(state.totalEndTime ?? Date.now()).toISOString(),
     })
     if (event) {
-      const localDailyLoop = summarizeArcadeLocalProfile(readArcadeLocalProfile()).daily_loop
+      if (event.kind !== 'bombsquad_run') {
+        queueMicrotask(() => setProfileSaveState('unavailable'))
+        return
+      }
+      const sourceKey = event.run.source_key
+      const localProfile = readArcadeLocalProfile()
+      const localSaved =
+        localProfile?.bombsquad_runs.some((run) => run.source_key === sourceKey) ?? false
+      const localDailyLoop = localSaved
+        ? summarizeArcadeLocalProfile(localProfile).daily_loop
+        : null
       queueMicrotask(() => {
-        setProfileSaveState('saved-local')
-        setDailyLoop(localDailyLoop)
+        setProfileSaveState(localSaved ? 'saved-local' : 'unavailable')
+        if (localDailyLoop) setDailyLoop(localDailyLoop)
       })
       submitArcadeProfileEvent(event).then((result) => {
         if (result.kind === 'ok') {
+          markArcadeProfileEventsClaimed([sourceKey])
           setProfileSaveState('synced')
           setDailyLoop(result.profile.daily_loop)
         } else if (result.kind === 'anon') {
-          setProfileSaveState('saved-local')
+          setProfileSaveState(localSaved ? 'saved-local' : 'unavailable')
         } else {
-          setProfileSaveState('account-error')
+          setProfileSaveState(localSaved ? 'account-error' : 'unavailable')
         }
       })
     } else {

--- a/packages/game-yijing/src/pages/PageSign.module.css
+++ b/packages/game-yijing/src/pages/PageSign.module.css
@@ -261,6 +261,34 @@
   gap: 8px;
   padding-top: 4px;
 }
+
+.feedback {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 16px;
+  border: 1px solid rgba(255, 229, 62, 0.16);
+  border-radius: 18px;
+  background: rgba(255, 229, 62, 0.06);
+}
+
+.feedbackLabel {
+  font: 500 10px var(--amio-font-mono);
+  color: rgba(255, 229, 62, 0.7);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.feedbackValue {
+  color: #fff;
+  font: 400 20px var(--font-display);
+}
+
+.feedbackMeta {
+  color: rgba(255, 255, 255, 0.62);
+  font: 400 12px/1.45 var(--font-body);
+}
+
 .actions > button {
   width: 100%;
   padding: 14px 20px;

--- a/packages/game-yijing/src/pages/PageSign.profile.test.tsx
+++ b/packages/game-yijing/src/pages/PageSign.profile.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ArcadeProfileEvent } from '@amiclaw/arcade-profile/types'
@@ -42,6 +42,7 @@ describe('PageSign arcade profile write', () => {
     mocks.recordOracleLocalSign.mockReset()
     mocks.submitArcadeProfileEvent.mockReset()
     mocks.submitArcadeProfileEvent.mockResolvedValue({ kind: 'anon' })
+    vi.unstubAllGlobals()
   })
 
   it('does not save the demo fallback sign', async () => {
@@ -50,6 +51,7 @@ describe('PageSign arcade profile write', () => {
 
     expect(mocks.recordOracleLocalSign).not.toHaveBeenCalled()
     expect(mocks.submitArcadeProfileEvent).not.toHaveBeenCalled()
+    expect(screen.getByText('等待真实卦签')).toBeTruthy()
   })
 
   it('saves a real cast sign locally and submits it for logged-in accounts', async () => {
@@ -72,6 +74,7 @@ describe('PageSign arcade profile write', () => {
     renderPage()
 
     await waitFor(() => expect(mocks.recordOracleLocalSign).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText('已保存到本设备')).toBeTruthy()
     expect(mocks.recordOracleLocalSign).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'oracle-session',
@@ -79,5 +82,17 @@ describe('PageSign arcade profile write', () => {
       })
     )
     expect(mocks.submitArcadeProfileEvent).toHaveBeenCalledWith(event)
+  })
+
+  it('copies the share text with visible feedback', async () => {
+    const writeText = vi.fn((_: string) => Promise.resolve())
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: '复制卦签' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    expect(writeText.mock.calls[0][0]).toContain('AMIO 游乐场今日卦签')
+    expect(await screen.findByText('分享文案已复制。')).toBeTruthy()
   })
 })

--- a/packages/game-yijing/src/pages/PageSign.profile.test.tsx
+++ b/packages/game-yijing/src/pages/PageSign.profile.test.tsx
@@ -7,8 +7,11 @@ const mocks = vi.hoisted(() => ({
   session: {
     sessionId: 'oracle-session',
     yaoValues: null as number[] | null,
+    castCreatedAt: null as string | null,
   },
   recordOracleLocalSign: vi.fn(),
+  readArcadeLocalProfile: vi.fn(),
+  markArcadeProfileEventsClaimed: vi.fn(),
   submitArcadeProfileEvent: vi.fn(() => Promise.resolve({ kind: 'anon' })),
 }))
 
@@ -18,6 +21,8 @@ vi.mock('../session', () => ({
 
 vi.mock('@amiclaw/arcade-profile/local', () => ({
   recordOracleLocalSign: mocks.recordOracleLocalSign,
+  readArcadeLocalProfile: mocks.readArcadeLocalProfile,
+  markArcadeProfileEventsClaimed: mocks.markArcadeProfileEventsClaimed,
 }))
 
 vi.mock('@amiclaw/arcade-profile/api-client', () => ({
@@ -39,7 +44,10 @@ describe('PageSign arcade profile write', () => {
     cleanup()
     mocks.session.sessionId = 'oracle-session'
     mocks.session.yaoValues = null
+    mocks.session.castCreatedAt = null
     mocks.recordOracleLocalSign.mockReset()
+    mocks.readArcadeLocalProfile.mockReset()
+    mocks.markArcadeProfileEventsClaimed.mockReset()
     mocks.submitArcadeProfileEvent.mockReset()
     mocks.submitArcadeProfileEvent.mockResolvedValue({ kind: 'anon' })
     vi.unstubAllGlobals()
@@ -69,7 +77,11 @@ describe('PageSign arcade profile write', () => {
       },
     }
     mocks.session.yaoValues = [7, 8, 9, 7, 7, 7]
+    mocks.session.castCreatedAt = '2026-07-06T08:00:00.000Z'
     mocks.recordOracleLocalSign.mockReturnValue(event)
+    mocks.readArcadeLocalProfile.mockReturnValue({
+      oracle_signs: [event.sign],
+    })
 
     renderPage()
 
@@ -78,10 +90,23 @@ describe('PageSign arcade profile write', () => {
     expect(mocks.recordOracleLocalSign).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'oracle-session',
+        signDate: '2026-07-06',
+        createdAt: '2026-07-06T08:00:00.000Z',
         yaoValues: [7, 8, 9, 7, 7, 7],
       })
     )
     expect(mocks.submitArcadeProfileEvent).toHaveBeenCalledWith(event)
+  })
+
+  it('does not save a persisted sign when the cast creation date is unavailable', async () => {
+    mocks.session.yaoValues = [7, 8, 9, 7, 7, 7]
+    mocks.session.castCreatedAt = null
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByText('本次卦签暂未写入档案')).toBeTruthy())
+    expect(mocks.recordOracleLocalSign).not.toHaveBeenCalled()
+    expect(mocks.submitArcadeProfileEvent).not.toHaveBeenCalled()
   })
 
   it('copies the share text with visible feedback', async () => {

--- a/packages/game-yijing/src/pages/PageSign.tsx
+++ b/packages/game-yijing/src/pages/PageSign.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button, Scenery } from '@amiclaw/ui'
-import { recordOracleLocalSign } from '@amiclaw/arcade-profile/local'
+import {
+  markArcadeProfileEventsClaimed,
+  readArcadeLocalProfile,
+  recordOracleLocalSign,
+} from '@amiclaw/arcade-profile/local'
 import { submitArcadeProfileEvent } from '@amiclaw/arcade-profile/api-client'
-import { getTodayString } from '@shared/date'
 import { Hexagram } from '../glyphs'
 import { changedValues, ganzhi, hexagramFromBinary, type YaoSextet } from '../glyphs/utils'
 import { useSession } from '../session'
@@ -20,7 +23,7 @@ const DEMO_YAO: YaoSextet = [7, 8, 9, 7, 7, 7]
 const JUDGMENT = '同人于野，亨。利涉大川，利君子贞。'
 const INSIGHT =
   '在协同与方向之间，你正寻求一致。占据更高视角，便能看见同心而异轨者亦可同人——主动停一停，不是放弃，是让真正的同行人显形。'
-type SaveState = 'demo' | 'saving' | 'saved-local' | 'synced' | 'account-error'
+type SaveState = 'demo' | 'saving' | 'saved-local' | 'synced' | 'account-error' | 'unavailable'
 type ShareState = 'idle' | 'shared' | 'copied' | 'error'
 
 function todayCN(): string {
@@ -30,7 +33,7 @@ function todayCN(): string {
 
 export function PageSign() {
   const navigate = useNavigate()
-  const { sessionId, yaoValues } = useSession()
+  const { sessionId, yaoValues, castCreatedAt } = useSession()
   const [saveState, setSaveState] = useState<SaveState>(yaoValues === null ? 'demo' : 'saving')
   const [shareState, setShareState] = useState<ShareState>('idle')
 
@@ -44,24 +47,38 @@ export function PageSign() {
       queueMicrotask(() => setSaveState('demo'))
       return
     }
+    if (castCreatedAt === null) {
+      queueMicrotask(() => setSaveState('unavailable'))
+      return
+    }
     const event = recordOracleLocalSign({
       sessionId,
-      signDate: getTodayString(),
+      signDate: castCreatedAt.slice(0, 10),
       ben: benCn,
       bian: bianCn,
       yaoValues: [...yaoValues] as [number, number, number, number, number, number],
+      createdAt: castCreatedAt,
     })
-    if (!event) {
-      queueMicrotask(() => setSaveState('account-error'))
+    if (!event || event.kind !== 'oracle_sign') {
+      queueMicrotask(() => setSaveState('unavailable'))
       return
     }
-    queueMicrotask(() => setSaveState('saved-local'))
+    const sourceKey = event.sign.source_key
+    const localProfile = readArcadeLocalProfile()
+    const localSaved =
+      localProfile?.oracle_signs.some((sign) => sign.source_key === sourceKey) ?? false
+    queueMicrotask(() => setSaveState(localSaved ? 'saved-local' : 'unavailable'))
     submitArcadeProfileEvent(event).then((result) => {
-      setSaveState(
-        result.kind === 'ok' ? 'synced' : result.kind === 'anon' ? 'saved-local' : 'account-error'
-      )
+      if (result.kind === 'ok') {
+        markArcadeProfileEventsClaimed([sourceKey])
+        setSaveState('synced')
+      } else if (result.kind === 'anon') {
+        setSaveState(localSaved ? 'saved-local' : 'unavailable')
+      } else {
+        setSaveState(localSaved ? 'account-error' : 'unavailable')
+      }
     })
-  }, [bianCn, benCn, sessionId, yaoValues])
+  }, [bianCn, benCn, castCreatedAt, sessionId, yaoValues])
 
   const shareText = useCallback(
     () => `AMIO 游乐场今日卦签：${benCn} → ${bianCn}。${INSIGHT} ${window.location.origin}/oracle/`,
@@ -170,7 +187,11 @@ export function PageSign() {
             <span className={styles.feedbackLabel}>保存状态</span>
             <strong className={styles.feedbackValue}>{saveStatusText(saveState)}</strong>
             <span className={styles.feedbackMeta}>
-              {yaoValues === null ? 'Demo 卦签不会写入档案。' : '真实卦签已计入今日清单。'}
+              {saveState === 'unavailable'
+                ? '本次卦签没有写入档案；请重新问卦后再试。'
+                : yaoValues === null
+                  ? 'Demo 卦签不会写入档案。'
+                  : '真实卦签已计入今日清单。'}
             </span>
             {shareState !== 'idle' && (
               <span className={styles.feedbackMeta}>{shareStatusText(shareState)}</span>
@@ -232,6 +253,8 @@ function saveStatusText(state: SaveState): string {
       return '已保存到本设备'
     case 'account-error':
       return '本设备已保存，账号同步失败'
+    case 'unavailable':
+      return '本次卦签暂未写入档案'
     case 'saving':
       return '保存中…'
     default:

--- a/packages/game-yijing/src/pages/PageSign.tsx
+++ b/packages/game-yijing/src/pages/PageSign.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button, Scenery } from '@amiclaw/ui'
 import { recordOracleLocalSign } from '@amiclaw/arcade-profile/local'
@@ -20,6 +20,8 @@ const DEMO_YAO: YaoSextet = [7, 8, 9, 7, 7, 7]
 const JUDGMENT = '同人于野，亨。利涉大川，利君子贞。'
 const INSIGHT =
   '在协同与方向之间，你正寻求一致。占据更高视角，便能看见同心而异轨者亦可同人——主动停一停，不是放弃，是让真正的同行人显形。'
+type SaveState = 'demo' | 'saving' | 'saved-local' | 'synced' | 'account-error'
+type ShareState = 'idle' | 'shared' | 'copied' | 'error'
 
 function todayCN(): string {
   const d = new Date()
@@ -29,6 +31,8 @@ function todayCN(): string {
 export function PageSign() {
   const navigate = useNavigate()
   const { sessionId, yaoValues } = useSession()
+  const [saveState, setSaveState] = useState<SaveState>(yaoValues === null ? 'demo' : 'saving')
+  const [shareState, setShareState] = useState<ShareState>('idle')
 
   const values: YaoSextet = yaoValues ?? DEMO_YAO
   const changed = changedValues(values) as unknown as YaoSextet
@@ -36,7 +40,10 @@ export function PageSign() {
   const [, bianCn] = hexagramFromBinary(changed)
 
   useEffect(() => {
-    if (yaoValues === null) return
+    if (yaoValues === null) {
+      queueMicrotask(() => setSaveState('demo'))
+      return
+    }
     const event = recordOracleLocalSign({
       sessionId,
       signDate: getTodayString(),
@@ -44,10 +51,53 @@ export function PageSign() {
       bian: bianCn,
       yaoValues: [...yaoValues] as [number, number, number, number, number, number],
     })
-    if (event) {
-      void submitArcadeProfileEvent(event)
+    if (!event) {
+      queueMicrotask(() => setSaveState('account-error'))
+      return
     }
+    queueMicrotask(() => setSaveState('saved-local'))
+    submitArcadeProfileEvent(event).then((result) => {
+      setSaveState(
+        result.kind === 'ok' ? 'synced' : result.kind === 'anon' ? 'saved-local' : 'account-error'
+      )
+    })
   }, [bianCn, benCn, sessionId, yaoValues])
+
+  const shareText = useCallback(
+    () => `AMIO 游乐场今日卦签：${benCn} → ${bianCn}。${INSIGHT} ${window.location.origin}/oracle/`,
+    [benCn, bianCn]
+  )
+
+  const handleShare = useCallback(async () => {
+    const text = shareText()
+    try {
+      const share = (navigator as Navigator & { share?: (data: ShareData) => Promise<void> }).share
+      if (share) {
+        await share({
+          title: 'AMIO Arcade Oracle',
+          text,
+          url: `${window.location.origin}/oracle/`,
+        })
+        setShareState('shared')
+        return
+      }
+      if (!navigator.clipboard?.writeText) throw new Error('clipboard unavailable')
+      await navigator.clipboard.writeText(text)
+      setShareState('copied')
+    } catch {
+      setShareState('error')
+    }
+  }, [shareText])
+
+  const handleCopy = useCallback(async () => {
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error('clipboard unavailable')
+      await navigator.clipboard.writeText(shareText())
+      setShareState('copied')
+    } catch {
+      setShareState('error')
+    }
+  }, [shareText])
 
   return (
     <main className={styles.page}>
@@ -116,7 +166,17 @@ export function PageSign() {
         </div>
 
         <div className={styles.actions}>
-          <Button variant="primary">
+          <div className={styles.feedback}>
+            <span className={styles.feedbackLabel}>保存状态</span>
+            <strong className={styles.feedbackValue}>{saveStatusText(saveState)}</strong>
+            <span className={styles.feedbackMeta}>
+              {yaoValues === null ? 'Demo 卦签不会写入档案。' : '真实卦签已计入今日清单。'}
+            </span>
+            {shareState !== 'idle' && (
+              <span className={styles.feedbackMeta}>{shareStatusText(shareState)}</span>
+            )}
+          </div>
+          <Button variant="primary" onClick={handleShare}>
             <svg
               viewBox="0 0 24 24"
               width="16"
@@ -133,7 +193,7 @@ export function PageSign() {
             </svg>
             分享卦签
           </Button>
-          <Button variant="ghost">
+          <Button variant="ghost" onClick={handleCopy}>
             <svg
               viewBox="0 0 24 24"
               width="16"
@@ -149,6 +209,9 @@ export function PageSign() {
             </svg>
             复制卦签
           </Button>
+          <Button variant="ghost" onClick={() => window.location.assign('/me')}>
+            保存到我的档案
+          </Button>
           <Button variant="ghost" onClick={() => navigate('/casting')}>
             再问一次
           </Button>
@@ -159,4 +222,32 @@ export function PageSign() {
       </div>
     </main>
   )
+}
+
+function saveStatusText(state: SaveState): string {
+  switch (state) {
+    case 'synced':
+      return '已保存到账号档案'
+    case 'saved-local':
+      return '已保存到本设备'
+    case 'account-error':
+      return '本设备已保存，账号同步失败'
+    case 'saving':
+      return '保存中…'
+    default:
+      return '等待真实卦签'
+  }
+}
+
+function shareStatusText(state: ShareState): string {
+  switch (state) {
+    case 'shared':
+      return '已打开系统分享。'
+    case 'copied':
+      return '分享文案已复制。'
+    case 'error':
+      return '分享失败，请稍后再试。'
+    default:
+      return ''
+  }
 }

--- a/packages/game-yijing/src/session/SessionProvider.tsx
+++ b/packages/game-yijing/src/session/SessionProvider.tsx
@@ -15,6 +15,7 @@ const STORAGE_KEY = 'amiclaw-yijing-session-v1'
 interface StoredSession {
   picked: ProjArtId[]
   yaoValues: YaoSextet | null
+  castCreatedAt?: string | null
   phase: ColdReadingPhase
   voiceState: VoiceState
   sessionId: string
@@ -45,6 +46,9 @@ export function SessionProvider({ children }: SessionProviderProps) {
   const [yaoValues, setYaoValuesState] = useState<YaoSextet | null>(
     () => loadStored()?.yaoValues ?? null
   )
+  const [castCreatedAt, setCastCreatedAt] = useState<string | null>(
+    () => loadStored()?.castCreatedAt ?? null
+  )
   const [phase, setPhaseState] = useState<ColdReadingPhase>(() => loadStored()?.phase ?? 0)
   const [voiceState, setVoiceStateState] = useState<VoiceState>(
     () => loadStored()?.voiceState ?? 'idle'
@@ -61,6 +65,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
 
   const setYaoValues = useCallback((values: YaoSextet) => {
     setYaoValuesState(values)
+    setCastCreatedAt(new Date().toISOString())
   }, [])
 
   const setPhase = useCallback((next: ColdReadingPhase) => {
@@ -84,6 +89,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
     }
     setPicked([])
     setYaoValuesState(null)
+    setCastCreatedAt(null)
     setPhaseState(0)
     setVoiceStateState('idle')
     setSessionId(crypto.randomUUID())
@@ -93,17 +99,25 @@ export function SessionProvider({ children }: SessionProviderProps) {
   // the in-memory session is the source of truth; sessionStorage is a hint.
   useEffect(() => {
     try {
-      const snapshot: StoredSession = { picked, yaoValues, phase, voiceState, sessionId }
+      const snapshot: StoredSession = {
+        picked,
+        yaoValues,
+        castCreatedAt,
+        phase,
+        voiceState,
+        sessionId,
+      }
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot))
     } catch {
       // Swallow — full quota, disabled storage, serialization failure.
     }
-  }, [picked, yaoValues, phase, voiceState, sessionId])
+  }, [picked, yaoValues, castCreatedAt, phase, voiceState, sessionId])
 
   const value = useMemo<SessionContextValue>(
     () => ({
       picked,
       yaoValues,
+      castCreatedAt,
       phase,
       voiceState,
       sessionId,
@@ -117,6 +131,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
     [
       picked,
       yaoValues,
+      castCreatedAt,
       phase,
       voiceState,
       sessionId,

--- a/packages/game-yijing/src/session/types.ts
+++ b/packages/game-yijing/src/session/types.ts
@@ -21,6 +21,9 @@ export interface SessionState {
   /** Six yao values produced by the casting engine; null until cast completes. */
   yaoValues: YaoSextet | null
 
+  /** ISO timestamp for the cast that produced `yaoValues`; null until cast completes. */
+  castCreatedAt: string | null
+
   /** Cold-reading sub-phase on the reading screen. */
   phase: ColdReadingPhase
 

--- a/packages/platform/src/components/home/DailyChecklist.module.css
+++ b/packages/platform/src/components/home/DailyChecklist.module.css
@@ -1,0 +1,158 @@
+.section {
+  margin: 0 0 36px;
+  padding: 26px;
+  border: 1px solid var(--border-soft);
+  border-radius: 24px;
+  background: rgba(13, 13, 26, 0.58);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.kicker {
+  margin: 0 0 8px;
+  color: var(--text-4);
+  font: 700 11px var(--font-body);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.title {
+  margin: 0;
+  color: var(--text-1);
+  font: 400 30px/1.1 var(--font-display);
+}
+
+.streak {
+  min-width: 132px;
+  padding: 14px 16px;
+  border: 1px solid rgba(255, 229, 62, 0.16);
+  border-radius: 18px;
+  background: rgba(255, 229, 62, 0.06);
+  text-align: right;
+}
+
+.streakValue {
+  display: block;
+  color: var(--amio-yellow);
+  font: 400 36px/1 var(--font-display);
+}
+
+.streakLabel {
+  display: block;
+  margin-top: 4px;
+  color: rgba(255, 255, 255, 0.58);
+  font: 600 11px var(--font-body);
+  letter-spacing: 0.08em;
+}
+
+.items {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.item {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 0.2s,
+    background 0.2s,
+    transform 0.2s;
+}
+
+.item:hover {
+  border-color: rgba(255, 229, 62, 0.28);
+  background: rgba(255, 255, 255, 0.07);
+  transform: translateY(-1px);
+}
+
+.checkDone,
+.checkTodo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  font: 700 15px var(--font-body);
+}
+
+.checkDone {
+  background: rgba(75, 210, 102, 0.14);
+  color: var(--amio-positive);
+}
+
+.checkTodo {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.itemBody {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.itemTitle {
+  color: var(--text-1);
+  font: 600 15px var(--font-body);
+  overflow-wrap: anywhere;
+}
+
+.itemDetail {
+  color: rgba(255, 255, 255, 0.58);
+  font: 400 12px var(--font-body);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.itemAction {
+  color: var(--amio-yellow);
+  font: 700 12px var(--font-body);
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+
+.note {
+  margin: 16px 0 0;
+  color: rgba(255, 255, 255, 0.48);
+  font: 400 12px var(--font-body);
+}
+
+@media (max-width: 768px) {
+  .section {
+    padding: 22px;
+  }
+
+  .header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .streak {
+    width: 100%;
+    text-align: left;
+  }
+
+  .items {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/platform/src/components/home/DailyChecklist.tsx
+++ b/packages/platform/src/components/home/DailyChecklist.tsx
@@ -1,0 +1,77 @@
+import type { ArcadeProfileSummary } from '@amiclaw/arcade-profile/types'
+import { toChineseDateString } from '@shared/date'
+import styles from './DailyChecklist.module.css'
+
+interface DailyChecklistProps {
+  profile: ArcadeProfileSummary
+  scope: 'account' | 'device'
+  loading?: boolean
+}
+
+export default function DailyChecklist({ profile, scope, loading = false }: DailyChecklistProps) {
+  const loop = profile.daily_loop
+  const scopeText = scope === 'account' ? '本账号' : '本设备'
+  const items = [
+    {
+      id: 'bombsquad',
+      title: 'BombSquad 每日挑战',
+      detail: '成功拆除才计入连续打卡',
+      href: '/bombsquad/',
+      completed: loop.checklist.bombsquad_daily.completed,
+      completedAt: loop.checklist.bombsquad_daily.completed_at,
+    },
+    {
+      id: 'oracle',
+      title: 'Oracle 今日卦签',
+      detail: '完成真实卦签计入连续打卡',
+      href: '/oracle/#/home',
+      completed: loop.checklist.oracle_sign.completed,
+      completedAt: loop.checklist.oracle_sign.completed_at,
+    },
+  ]
+
+  return (
+    <section className={styles.section} aria-label="今日清单">
+      <div className={styles.header}>
+        <div>
+          <p className={styles.kicker}>{toChineseDateString(loop.date)} · 今日清单</p>
+          <h2 className={styles.title}>
+            {loop.streak.today_completed ? '今日已打卡' : '今天还没打卡'}
+          </h2>
+        </div>
+        <div className={styles.streak}>
+          <span className={styles.streakValue}>{loop.streak.current_days}</span>
+          <span className={styles.streakLabel}>连续天数 · {scopeText}</span>
+        </div>
+      </div>
+
+      <div className={styles.items}>
+        {items.map((item) => (
+          <a key={item.id} className={styles.item} href={item.href}>
+            <span
+              className={item.completed ? styles.checkDone : styles.checkTodo}
+              aria-hidden="true"
+            >
+              {item.completed ? '✓' : '○'}
+            </span>
+            <span className={styles.itemBody}>
+              <span className={styles.itemTitle}>{item.title}</span>
+              <span className={styles.itemDetail}>
+                {item.completed
+                  ? `已完成${item.completedAt ? ` · ${item.completedAt.slice(11, 16)} UTC` : ''}`
+                  : item.detail}
+              </span>
+            </span>
+            <span className={styles.itemAction}>{item.completed ? '再玩' : '开始'}</span>
+          </a>
+        ))}
+      </div>
+
+      <p className={styles.note}>
+        {loading
+          ? '正在读取账号记录；暂时显示这台设备上的状态。'
+          : `最长连续 ${loop.streak.longest_days} 天。匿名状态只代表这台设备。`}
+      </p>
+    </section>
+  )
+}

--- a/packages/platform/src/components/leaderboard/StreakLeaderboardList.module.css
+++ b/packages/platform/src/components/leaderboard/StreakLeaderboardList.module.css
@@ -1,0 +1,88 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.headRow,
+.row {
+  display: grid;
+  grid-template-columns: 56px 1fr 104px;
+  gap: 8px;
+  align-items: center;
+}
+
+.headRow {
+  padding: 0 14px 8px;
+  border-bottom: 1px solid var(--border-hairline);
+  color: rgba(255, 255, 255, 0.35);
+  font: 500 10px var(--font-body);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.headScore {
+  text-align: right;
+}
+
+.row {
+  padding: 12px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  font: 500 13px var(--font-body);
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+.rank {
+  color: var(--amio-yellow);
+  font-family: var(--amio-font-mono);
+}
+
+.nameCell {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.name {
+  color: var(--text-1);
+  overflow-wrap: anywhere;
+}
+
+.meta {
+  color: var(--text-3);
+  font: 400 11px var(--font-body);
+  line-height: 1.35;
+}
+
+.score {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  color: var(--text-1);
+  font-family: var(--amio-font-mono);
+  text-align: right;
+}
+
+.scoreSub {
+  color: var(--text-3);
+  font: 400 11px var(--font-body);
+}
+
+.status {
+  padding: 32px;
+  color: var(--text-3);
+  font: 400 14px var(--font-body);
+  text-align: center;
+}
+
+.errorBlock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 0;
+}

--- a/packages/platform/src/components/leaderboard/StreakLeaderboardList.tsx
+++ b/packages/platform/src/components/leaderboard/StreakLeaderboardList.tsx
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@amiclaw/ui'
+import { fetchArcadeStreakLeaderboard } from '@amiclaw/arcade-profile/api-client'
+import type { ArcadeStreakLeaderboardEntry } from '@amiclaw/arcade-profile/types'
+import { getTodayString, toChineseDateString } from '@shared/date'
+import styles from './StreakLeaderboardList.module.css'
+
+function todayText(entry: ArcadeStreakLeaderboardEntry): string {
+  const completed = [
+    entry.today.bombsquad_defused ? 'BombSquad' : null,
+    entry.today.oracle_signed ? 'Oracle' : null,
+  ].filter((item): item is string => item !== null)
+  return completed.length > 0 ? `今日 ${completed.join(' + ')}` : '今日未完成'
+}
+
+export default function StreakLeaderboardList() {
+  const today = getTodayString()
+  const [entries, setEntries] = useState<ArcadeStreakLeaderboardEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+
+  const load = useCallback(() => {
+    fetchArcadeStreakLeaderboard({ date: today, limit: 50 }).then((result) => {
+      setLoading(false)
+      if (result.kind === 'ok') {
+        setEntries(result.board.entries)
+      } else {
+        setError(true)
+      }
+    })
+  }, [today])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const handleRetry = useCallback(() => {
+    setLoading(true)
+    setError(false)
+    load()
+  }, [load])
+
+  if (loading) return <p className={styles.status}>加载中…</p>
+  if (error) {
+    return (
+      <div className={styles.errorBlock}>
+        <p className={styles.status}>连续榜暂不可用，稍后再试。</p>
+        <Button variant="ghost" size="sm" onClick={handleRetry}>
+          重试
+        </Button>
+      </div>
+    )
+  }
+  if (entries.length === 0) {
+    return <p className={styles.status}>还没有公开连续记录。登录后保存本设备记录即可上榜。</p>
+  }
+
+  return (
+    <div className={styles.list} role="table" aria-label="连续打卡榜">
+      <div className={styles.headRow} role="row">
+        <span role="columnheader">名次</span>
+        <span role="columnheader">玩家</span>
+        <span className={styles.headScore} role="columnheader">
+          连续
+        </span>
+      </div>
+      {entries.map((entry) => (
+        <div key={`${entry.rank}-${entry.public_label}`} className={styles.row} role="row">
+          <span className={styles.rank} role="cell">
+            #{String(entry.rank).padStart(3, '0')}
+          </span>
+          <span className={styles.nameCell} role="cell">
+            <span className={styles.name}>{entry.public_label}</span>
+            <span className={styles.meta}>
+              {todayText(entry)} · 最近 {toChineseDateString(entry.last_active_date)}
+            </span>
+          </span>
+          <span className={styles.score} role="cell">
+            {entry.current_streak_days} 天
+            <span className={styles.scoreSub}>最长 {entry.longest_streak_days} 天</span>
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/platform/src/pages/AccountPage.module.css
+++ b/packages/platform/src/pages/AccountPage.module.css
@@ -142,7 +142,7 @@
 
 .statGrid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 16px;
   width: 100%;
 }
@@ -195,6 +195,45 @@
   font: 600 13px var(--font-body);
   color: var(--amio-yellow);
   white-space: nowrap;
+}
+
+.publicCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 16px;
+  padding: 22px 26px;
+}
+
+.publicTitle {
+  margin: 0;
+  font: 400 20px var(--font-display);
+  color: var(--text-1);
+}
+
+.publicText {
+  margin: 8px 0 0;
+  font: 400 14px var(--font-body);
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.64);
+}
+
+.publicError {
+  margin: 8px 0 0;
+  color: var(--amio-danger);
+  font: 600 12px var(--font-body);
+}
+
+.publicLink {
+  flex: 0 0 auto;
+  color: var(--amio-yellow);
+  font: 600 13px var(--font-body);
+  text-decoration: none;
+}
+
+.publicLink:hover {
+  color: #fff;
 }
 
 /* ----------  signed-out — login-guide empty state  ----------
@@ -263,6 +302,12 @@
   color: rgba(255, 255, 255, 0.64);
 }
 
+@media (max-width: 1080px) {
+  .statGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 /* ----------  responsive: mobile  ----------
    atlas.html ≤768px — .acct-grid collapses to one column (profile card
    stacks above the recent-runs / badges detail column). */
@@ -276,7 +321,8 @@
     grid-template-columns: 1fr;
   }
 
-  .claimCard {
+  .claimCard,
+  .publicCard {
     align-items: flex-start;
     flex-direction: column;
   }

--- a/packages/platform/src/pages/AccountPage.test.tsx
+++ b/packages/platform/src/pages/AccountPage.test.tsx
@@ -38,36 +38,39 @@ function stubApi(opts: {
   companion?: { status: number; body?: unknown }
 }) {
   const companion = opts.companion ?? { status: 404, body: { error: 'no companion set up' } }
-  const arcadeProfile = opts.arcadeProfile ?? { profile: EMPTY_ARCADE_PROFILE }
-  vi.stubGlobal(
-    'fetch',
-    vi.fn((input: RequestInfo | URL) => {
-      const url = urlOf(input)
-      if (url.includes('/api/arcade/profile/claim')) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              profile: ACCOUNT_ARCADE_PROFILE,
-              source_keys: ['bombsquad:local-run'],
-              inserted: 1,
-            }),
-            { status: 200 }
-          )
+  const arcadeProfile = opts.arcadeProfile ?? {
+    profile: EMPTY_ARCADE_PROFILE,
+    public_profile: { claimed: false, public_label: null },
+  }
+  const fetchSpy = vi.fn((input: RequestInfo | URL) => {
+    const url = urlOf(input)
+    if (url.includes('/api/arcade/profile/claim')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            profile: ACCOUNT_ARCADE_PROFILE,
+            source_keys: ['bombsquad:local-run'],
+            inserted: 1,
+            public_profile: { claimed: true, public_label: 'Player 8F3A' },
+          }),
+          { status: 200 }
         )
-      }
-      if (url.includes('/api/arcade/profile')) {
-        return Promise.resolve(new Response(JSON.stringify(arcadeProfile), { status: 200 }))
-      }
-      if (url.includes('/api/companion')) {
-        return Promise.resolve(
-          new Response(companion.body === undefined ? null : JSON.stringify(companion.body), {
-            status: companion.status,
-          })
-        )
-      }
-      return Promise.resolve(new Response(JSON.stringify(opts.session), { status: 200 }))
-    })
-  )
+      )
+    }
+    if (url.includes('/api/arcade/profile')) {
+      return Promise.resolve(new Response(JSON.stringify(arcadeProfile), { status: 200 }))
+    }
+    if (url.includes('/api/companion')) {
+      return Promise.resolve(
+        new Response(companion.body === undefined ? null : JSON.stringify(companion.body), {
+          status: companion.status,
+        })
+      )
+    }
+    return Promise.resolve(new Response(JSON.stringify(opts.session), { status: 200 }))
+  })
+  vi.stubGlobal('fetch', fetchSpy)
+  return fetchSpy
 }
 
 const ANON: SessionResponse = { authenticated: false, identity: null }
@@ -82,9 +85,23 @@ const EMPTY_ARCADE_PROFILE = {
   counts: { bombsquad_runs: 0, oracle_signs: 0 },
   bombsquad: { recent: null, best_daily: null, best_practice: null },
   oracle: { recent: null },
+  daily_loop: {
+    date: '2026-07-06',
+    checklist: {
+      bombsquad_daily: { completed: false, completed_at: null },
+      oracle_sign: { completed: false, completed_at: null },
+    },
+    streak: {
+      today_completed: false,
+      current_days: 0,
+      longest_days: 0,
+      last_active_date: null,
+    },
+  },
 }
 
 const ACCOUNT_ARCADE_PROFILE = {
+  profile_id: 'local-profile',
   last_activity_at: '2026-07-06T08:00:00.000Z',
   today_played: true,
   counts: { bombsquad_runs: 1, oracle_signs: 1 },
@@ -124,6 +141,19 @@ const ACCOUNT_ARCADE_PROFILE = {
       bian: '坤',
       yao_values: [7, 8, 7, 8, 7, 8],
       created_at: '2026-07-06T09:00:00.000Z',
+    },
+  },
+  daily_loop: {
+    date: '2026-07-06',
+    checklist: {
+      bombsquad_daily: { completed: true, completed_at: '2026-07-06T08:00:00.000Z' },
+      oracle_sign: { completed: true, completed_at: '2026-07-06T09:00:00.000Z' },
+    },
+    streak: {
+      today_completed: true,
+      current_days: 1,
+      longest_days: 1,
+      last_active_date: '2026-07-06',
     },
   },
 }
@@ -227,7 +257,13 @@ describe('AccountPage /me', () => {
   })
 
   it('renders the real-identity profile with an honest empty stats state', async () => {
-    stubApi({ session: AUTHED, arcadeProfile: { profile: ACCOUNT_ARCADE_PROFILE } })
+    stubApi({
+      session: AUTHED,
+      arcadeProfile: {
+        profile: ACCOUNT_ARCADE_PROFILE,
+        public_profile: { claimed: true, public_label: 'Player 8F3A' },
+      },
+    })
     renderAccount('/me')
 
     // Identity is derived from the session email local-part (nova@... → nova).
@@ -237,8 +273,10 @@ describe('AccountPage /me', () => {
     expect(screen.getByText('nova@amio.fans')).toBeInTheDocument()
     // Account stats are read from /api/arcade/profile, not invented locally.
     expect(await screen.findByText('账号记录')).toBeInTheDocument()
+    expect(screen.getByText('1 天')).toBeInTheDocument()
     expect(screen.getByText('每日挑战 · 01:05 · 最快 01:05')).toBeInTheDocument()
     expect(screen.getByText('乾 → 坤')).toBeInTheDocument()
+    expect(screen.getByText('上榜名：Player 8F3A')).toBeInTheDocument()
     // The retired mock stats / runs / badges must be absent.
     expect(screen.queryByText('林星海')).not.toBeInTheDocument()
     expect(screen.queryByText('42')).not.toBeInTheDocument()
@@ -249,7 +287,13 @@ describe('AccountPage /me', () => {
 
   it('claims local profile entries into the signed-in account and marks them locally claimed', async () => {
     seedLocalProfile(localStore)
-    stubApi({ session: AUTHED, arcadeProfile: { profile: EMPTY_ARCADE_PROFILE } })
+    stubApi({
+      session: AUTHED,
+      arcadeProfile: {
+        profile: EMPTY_ARCADE_PROFILE,
+        public_profile: { claimed: false, public_label: null },
+      },
+    })
     renderAccount('/me')
 
     fireEvent.click(await screen.findByRole('button', { name: '保存到账号' }))
@@ -259,6 +303,31 @@ describe('AccountPage /me', () => {
       const raw = localStore.get(ARCADE_LOCAL_PROFILE_KEY)
       expect(raw).toContain('bombsquad:local-run')
       expect(JSON.parse(raw ?? '{}').claimed_source_keys).toContain('bombsquad:local-run')
+    })
+  })
+
+  it('enables the public streak profile for existing account records without new local events', async () => {
+    const fetchSpy = stubApi({
+      session: AUTHED,
+      arcadeProfile: {
+        profile: ACCOUNT_ARCADE_PROFILE,
+        public_profile: { claimed: false, public_label: null },
+      },
+    })
+    renderAccount('/me')
+
+    fireEvent.click(await screen.findByRole('button', { name: '启用公开上榜' }))
+
+    await waitFor(() => {
+      const claimCall = fetchSpy.mock.calls.find(([input]) =>
+        urlOf(input as RequestInfo | URL).includes('/api/arcade/profile/claim')
+      )
+      expect(claimCall).toBeDefined()
+      const [, init] = claimCall as unknown as [RequestInfo | URL, RequestInit]
+      expect(JSON.parse(String(init.body))).toEqual({
+        profile_id: 'local-profile',
+        events: [],
+      })
     })
   })
 
@@ -311,7 +380,13 @@ describe('AccountPage /me', () => {
       }
       if (url.includes('/api/arcade/profile')) {
         return Promise.resolve(
-          new Response(JSON.stringify({ profile: EMPTY_ARCADE_PROFILE }), { status: 200 })
+          new Response(
+            JSON.stringify({
+              profile: EMPTY_ARCADE_PROFILE,
+              public_profile: { claimed: false, public_label: null },
+            }),
+            { status: 200 }
+          )
         )
       }
       return Promise.resolve(new Response(JSON.stringify(AUTHED), { status: 200 }))

--- a/packages/platform/src/pages/AccountPage.test.tsx
+++ b/packages/platform/src/pages/AccountPage.test.tsx
@@ -273,7 +273,7 @@ describe('AccountPage /me', () => {
     expect(screen.getByText('nova@amio.fans')).toBeInTheDocument()
     // Account stats are read from /api/arcade/profile, not invented locally.
     expect(await screen.findByText('账号记录')).toBeInTheDocument()
-    expect(screen.getByText('1 天')).toBeInTheDocument()
+    expect(await screen.findByText('1 天')).toBeInTheDocument()
     expect(screen.getByText('每日挑战 · 01:05 · 最快 01:05')).toBeInTheDocument()
     expect(screen.getByText('乾 → 坤')).toBeInTheDocument()
     expect(screen.getByText('上榜名：Player 8F3A')).toBeInTheDocument()

--- a/packages/platform/src/pages/AccountPage.tsx
+++ b/packages/platform/src/pages/AccountPage.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Button, ConicAvatar, EyebrowTag, GlassCard } from '@amiclaw/ui'
-import type { ArcadeLocalProfile, ArcadeProfileSummary } from '@amiclaw/arcade-profile/types'
+import type {
+  ArcadeLocalProfile,
+  ArcadeProfileSummary,
+  ArcadePublicProfileStatus,
+} from '@amiclaw/arcade-profile/types'
 import {
   ensureArcadeLocalProfile,
   getClaimableArcadeProfileEvents,
@@ -62,7 +66,11 @@ export default function AccountPage() {
 type AccountProfileState =
   | { status: 'idle'; profile: null }
   | { status: 'loading'; profile: null }
-  | { status: 'ok'; profile: ArcadeProfileSummary }
+  | {
+      status: 'ok'
+      profile: ArcadeProfileSummary
+      publicProfile: ArcadePublicProfileStatus
+    }
   | { status: 'error'; profile: null }
 
 function useAccountArcadeProfile(): {
@@ -78,7 +86,11 @@ function useAccountArcadeProfile(): {
     fetchArcadeProfile().then((result) => {
       if (!active) return
       if (result.kind === 'ok') {
-        setState({ status: 'ok', profile: result.profile })
+        setState({
+          status: 'ok',
+          profile: result.profile,
+          publicProfile: result.publicProfile,
+        })
       } else {
         setState({ status: 'error', profile: null })
       }
@@ -156,7 +168,14 @@ function SignedInProfile({
             {accountProfile.status === 'loading' || accountProfile.status === 'idle' ? (
               <div className={styles.skeleton} aria-hidden="true" />
             ) : accountProfile.status === 'ok' ? (
-              <ArcadeStatsCard profile={accountProfile.profile} emptyCtaHref="/bombsquad/" />
+              <>
+                <ArcadeStatsCard profile={accountProfile.profile} emptyCtaHref="/bombsquad/" />
+                <PublicProfileCard
+                  profile={accountProfile.profile}
+                  publicProfile={accountProfile.publicProfile}
+                  onEnabled={reloadAccountProfile}
+                />
+              </>
             ) : (
               <GlassCard radius="2xl" className={styles.emptyCard}>
                 <p className={styles.emptyText}>账号记录暂时读不出来，稍后再试。</p>
@@ -278,12 +297,17 @@ function ArcadeStatsCard({
       <div className={styles.statGrid}>
         <StatBlock
           label="今日"
-          value={profile.today_played ? '已开始' : '未开始'}
+          value={profile.daily_loop.streak.today_completed ? '已打卡' : '未打卡'}
           detail={
             profile.last_activity_at
               ? `最近 ${toChineseDateString(profile.last_activity_at.slice(0, 10))}`
               : '还没有记录'
           }
+        />
+        <StatBlock
+          label="连续"
+          value={`${profile.daily_loop.streak.current_days} 天`}
+          detail={`最长 ${profile.daily_loop.streak.longest_days} 天`}
         />
         <StatBlock
           label="BombSquad"
@@ -310,6 +334,62 @@ function ArcadeStatsCard({
         <a className={styles.emptyCta} href={emptyCtaHref}>
           开始玩
         </a>
+      )}
+    </GlassCard>
+  )
+}
+
+function PublicProfileCard({
+  profile,
+  publicProfile,
+  onEnabled,
+}: {
+  profile: ArcadeProfileSummary
+  publicProfile: ArcadePublicProfileStatus
+  onEnabled: () => void
+}) {
+  const [status, setStatus] = useState<'idle' | 'saving' | 'error'>('idle')
+  const canEnable =
+    !publicProfile.claimed &&
+    profile.profile_id !== undefined &&
+    (profile.counts.bombsquad_runs > 0 || profile.counts.oracle_signs > 0)
+
+  const handleEnable = async () => {
+    if (!profile.profile_id) return
+    setStatus('saving')
+    const result = await claimArcadeProfile({
+      profile_id: profile.profile_id,
+      events: [],
+    })
+    if (result.kind !== 'ok') {
+      setStatus('error')
+      return
+    }
+    setStatus('idle')
+    onEnabled()
+  }
+
+  return (
+    <GlassCard radius="2xl" className={styles.publicCard}>
+      <div>
+        <h3 className={styles.publicTitle}>公开连续榜</h3>
+        <p className={styles.publicText}>
+          {publicProfile.claimed
+            ? `上榜名：${publicProfile.public_label}`
+            : canEnable
+              ? '账号已有记录；启用公开上榜名后，会进入连续打卡榜。'
+              : '保存本设备记录到账号后，会生成公开上榜名。'}
+        </p>
+        {status === 'error' && <p className={styles.publicError}>启用失败，请稍后再试。</p>}
+      </div>
+      {canEnable ? (
+        <Button variant="ghost" size="sm" onClick={handleEnable} disabled={status === 'saving'}>
+          {status === 'saving' ? '启用中' : '启用公开上榜'}
+        </Button>
+      ) : (
+        <Link to="/leaderboard" className={styles.publicLink}>
+          查看排行榜
+        </Link>
       )}
     </GlassCard>
   )

--- a/packages/platform/src/pages/GamesPage.test.tsx
+++ b/packages/platform/src/pages/GamesPage.test.tsx
@@ -24,6 +24,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { fetchLeaderboard } from '@shared/leaderboard-api'
 import type { SessionResponse } from '@shared/auth-types'
+import { ARCADE_LOCAL_PROFILE_KEY } from '@amiclaw/arcade-profile/local'
 import GamesPage from './GamesPage'
 
 // The daily countdown ticks on a setInterval; these tests never assert on live
@@ -55,12 +56,89 @@ const AUTHED: SessionResponse = {
   identity: { user_id: 'u_1', email: 'nova@amio.fans' },
 }
 
-/** Stub the useAuth session read (GET /api/auth/session). */
-function stubSession(body: SessionResponse) {
+const EMPTY_ARCADE_PROFILE = {
+  last_activity_at: null,
+  today_played: false,
+  counts: { bombsquad_runs: 0, oracle_signs: 0 },
+  bombsquad: { recent: null, best_daily: null, best_practice: null },
+  oracle: { recent: null },
+  daily_loop: {
+    date: '2026-07-06',
+    checklist: {
+      bombsquad_daily: { completed: false, completed_at: null },
+      oracle_sign: { completed: false, completed_at: null },
+    },
+    streak: {
+      today_completed: false,
+      current_days: 0,
+      longest_days: 0,
+      last_active_date: null,
+    },
+  },
+}
+
+const ACCOUNT_ARCADE_PROFILE = {
+  ...EMPTY_ARCADE_PROFILE,
+  last_activity_at: '2026-07-06T08:00:00.000Z',
+  today_played: true,
+  counts: { bombsquad_runs: 1, oracle_signs: 0 },
+  daily_loop: {
+    date: '2026-07-06',
+    checklist: {
+      bombsquad_daily: { completed: true, completed_at: '2026-07-06T08:00:00.000Z' },
+      oracle_sign: { completed: false, completed_at: null },
+    },
+    streak: {
+      today_completed: true,
+      current_days: 3,
+      longest_days: 4,
+      last_active_date: '2026-07-06',
+    },
+  },
+}
+
+/** Stub real API reads used by useAuth and the homepage profile checklist. */
+function stubApi(body: SessionResponse, arcadeProfile: unknown = EMPTY_ARCADE_PROFILE) {
   vi.stubGlobal(
     'fetch',
-    vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), { status: 200 })))
+    vi.fn((input: RequestInfo | URL) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/api/arcade/profile')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              profile: arcadeProfile,
+              public_profile: { claimed: false, public_label: null },
+            }),
+            { status: 200 }
+          )
+        )
+      }
+      return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))
+    })
   )
+}
+
+function installFakeLocalStorage() {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  })
+  return store
 }
 
 function renderHomepage(entry = '/') {
@@ -77,7 +155,7 @@ describe('GamesPage homepage', () => {
   beforeEach(() => {
     assignSpy.mockClear()
     // Default to anonymous; the signed-in test overrides before rendering.
-    stubSession(ANON)
+    stubApi(ANON)
     vi.stubGlobal('location', { ...window.location, assign: assignSpy })
     // Default every test to an empty daily board (beta reality). Individual
     // tests can override before rendering when they need populated rows.
@@ -106,6 +184,8 @@ describe('GamesPage homepage', () => {
     expect(screen.getByRole('button', { name: /开始玩/ })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /看看 BombSquad/ })).not.toBeInTheDocument()
     expect(screen.queryByText(/一起拆弹/)).not.toBeInTheDocument()
+    expect(screen.getByRole('region', { name: '今日清单' })).toBeInTheDocument()
+    expect(screen.getByText('今天还没打卡')).toBeInTheDocument()
   })
 
   it('routes to the BombSquad landing from the anonymous hero「开始玩」CTA', async () => {
@@ -117,13 +197,52 @@ describe('GamesPage homepage', () => {
   })
 
   it('renders the WelcomeStrip instead of the hero for a signed-in visitor', async () => {
-    stubSession(AUTHED)
+    stubApi(AUTHED, ACCOUNT_ARCADE_PROFILE)
     renderHomepage('/')
 
     // WelcomeStrip greets by the session-derived display name (nova@... → nova).
     expect(await screen.findByText('nova', { exact: true })).toBeInTheDocument()
+    expect(await screen.findByText('今日已打卡')).toBeInTheDocument()
+    expect(screen.getByText('连续天数 · 本账号')).toBeInTheDocument()
     // The anonymous hero eyebrow must NOT be present.
     expect(screen.queryByText('本周开服 · BOMBSQUAD 公测中')).not.toBeInTheDocument()
+  })
+
+  it('shows local daily checklist completion for an anonymous visitor', async () => {
+    const store = installFakeLocalStorage()
+    const today = new Date().toISOString().slice(0, 10)
+    store.set(
+      ARCADE_LOCAL_PROFILE_KEY,
+      JSON.stringify({
+        version: 1,
+        profile_id: 'local-profile',
+        created_at: `${today}T07:00:00.000Z`,
+        updated_at: `${today}T08:00:00.000Z`,
+        last_seen_at: `${today}T08:00:00.000Z`,
+        claimed_source_keys: [],
+        bombsquad_runs: [
+          {
+            source_key: 'bombsquad:local-run',
+            run_id: 'local-run',
+            mode: 'daily',
+            outcome: 'defused',
+            duration_ms: 42_000,
+            attempt_number: 1,
+            module_count: 4,
+            completed_modules: 4,
+            strike_count: 0,
+            finished_at: `${today}T08:00:00.000Z`,
+          },
+        ],
+        oracle_signs: [],
+      })
+    )
+
+    renderHomepage('/')
+
+    expect(await screen.findByText('今日已打卡')).toBeInTheDocument()
+    expect(screen.getByText('已完成 · 08:00 UTC')).toBeInTheDocument()
+    expect(screen.getByText('连续天数 · 本设备')).toBeInTheDocument()
   })
 
   it('shows honest empty / zero states when the real daily board is empty', async () => {

--- a/packages/platform/src/pages/GamesPage.tsx
+++ b/packages/platform/src/pages/GamesPage.tsx
@@ -1,9 +1,14 @@
+import { useEffect, useMemo, useState } from 'react'
 import AnonHero from '@/components/home/AnonHero'
 import WelcomeStrip from '@/components/home/WelcomeStrip'
+import DailyChecklist from '@/components/home/DailyChecklist'
 import FeaturedBombSquad from '@/components/home/FeaturedBombSquad'
 import WhatIsAmiclaw from '@/components/home/WhatIsAmiclaw'
 import UpcomingGames from '@/components/home/UpcomingGames'
 import FooterPitch from '@/components/home/FooterPitch'
+import type { ArcadeProfileSummary } from '@amiclaw/arcade-profile/types'
+import { fetchArcadeProfile } from '@amiclaw/arcade-profile/api-client'
+import { readArcadeLocalProfile, summarizeArcadeLocalProfile } from '@amiclaw/arcade-profile/local'
 import { useAuth } from '@/hooks/useAuth'
 import { useDailyBoard } from '@/hooks/useDailyBoard'
 
@@ -25,6 +30,12 @@ import { useDailyBoard } from '@/hooks/useDailyBoard'
 export default function GamesPage() {
   const { status, user } = useAuth()
   const board = useDailyBoard()
+  const [localProfile] = useState(() => readArcadeLocalProfile())
+  const localSummary = useMemo(() => summarizeArcadeLocalProfile(localProfile), [localProfile])
+  const [accountSummary, setAccountSummary] = useState<{
+    userId: string
+    profile: ArcadeProfileSummary
+  } | null>(null)
 
   /* The AnonHero primary CTA's target — the BombSquad landing page. Mode is
      chosen on the landing, not here. BombSquad now lives in its own SPA at
@@ -41,6 +52,28 @@ export default function GamesPage() {
      loading→authed transition swaps it in without a jarring signed-in flash.
      `authed` requires a resolved `user`. */
   const signedIn = status === 'authed' && user !== null
+  const signedInUserId = signedIn ? user.user_id : null
+
+  useEffect(() => {
+    if (signedInUserId === null) return
+    let active = true
+    fetchArcadeProfile().then((result) => {
+      if (!active) return
+      setAccountSummary(
+        result.kind === 'ok' ? { userId: signedInUserId, profile: result.profile } : null
+      )
+    })
+    return () => {
+      active = false
+    }
+  }, [signedInUserId])
+
+  const accountProfile =
+    signedInUserId !== null && accountSummary?.userId === signedInUserId
+      ? accountSummary.profile
+      : null
+  const checklistProfile = accountProfile ?? localSummary
+  const checklistScope = accountProfile ? 'account' : 'device'
 
   return (
     <>
@@ -50,6 +83,11 @@ export default function GamesPage() {
         <AnonHero onStart={enterBombSquad} board={board} />
       )}
 
+      <DailyChecklist
+        profile={checklistProfile}
+        scope={checklistScope}
+        loading={signedIn && accountProfile === null}
+      />
       <FeaturedBombSquad />
       {!signedIn && <WhatIsAmiclaw />}
       <UpcomingGames />

--- a/packages/platform/src/pages/LeaderboardPage.module.css
+++ b/packages/platform/src/pages/LeaderboardPage.module.css
@@ -25,6 +25,34 @@
   color: rgba(255, 255, 255, 0.6);
 }
 
+.boardGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.72fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.boardSection {
+  min-width: 0;
+}
+
+.sectionHead {
+  margin-bottom: 14px;
+}
+
+.sectionTitle {
+  margin: 0;
+  color: var(--text-1);
+  font: 400 24px var(--font-display);
+}
+
+.sectionLead {
+  margin: 6px 0 0;
+  color: rgba(255, 255, 255, 0.55);
+  font: 400 13px var(--font-body);
+  line-height: 1.5;
+}
+
 /* §6.9 long-leaderboard card container. */
 .card {
   padding: 14px;
@@ -33,4 +61,10 @@
   background: var(--glass-card);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
+}
+
+@media (max-width: 960px) {
+  .boardGrid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/packages/platform/src/pages/LeaderboardPage.test.tsx
+++ b/packages/platform/src/pages/LeaderboardPage.test.tsx
@@ -14,6 +14,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import LeaderboardPage from './LeaderboardPage'
 import { fetchLeaderboard } from '@shared/leaderboard-api'
+import { fetchArcadeStreakLeaderboard } from '@amiclaw/arcade-profile/api-client'
 import { saveOptimisticEntry, loadOptimisticEntry } from '@shared/leaderboard-optimistic'
 import { getTodayString } from '@shared/date'
 import type { LeaderboardEntry } from '@shared/leaderboard-types'
@@ -22,7 +23,12 @@ vi.mock('@shared/leaderboard-api', () => ({
   fetchLeaderboard: vi.fn(),
 }))
 
+vi.mock('@amiclaw/arcade-profile/api-client', () => ({
+  fetchArcadeStreakLeaderboard: vi.fn(),
+}))
+
 const mockedFetch = vi.mocked(fetchLeaderboard)
+const mockedStreakFetch = vi.mocked(fetchArcadeStreakLeaderboard)
 
 const otherEntries: LeaderboardEntry[] = [
   { rank: 1, nickname: 'Alpha', time_ms: 80000, attempt_number: 1 },
@@ -41,6 +47,11 @@ describe('LeaderboardPage optimistic flow', () => {
   beforeEach(() => {
     sessionStorage.clear()
     mockedFetch.mockReset()
+    mockedStreakFetch.mockReset()
+    mockedStreakFetch.mockResolvedValue({
+      kind: 'ok',
+      board: { date: getTodayString(), entries: [] },
+    })
   })
 
   afterEach(() => {
@@ -163,5 +174,34 @@ describe('LeaderboardPage optimistic flow', () => {
     expect(bodyRows[0]).toHaveTextContent('ChatGPT')
     expect(bodyRows[1]).toHaveTextContent('Legacy')
     expect(bodyRows[1]).not.toHaveTextContent('ChatGPT')
+  })
+
+  it('renders the public streak leaderboard without private identifiers', async () => {
+    const today = getTodayString()
+    mockedFetch.mockResolvedValueOnce({ date: today, entries: [] })
+    mockedStreakFetch.mockResolvedValueOnce({
+      kind: 'ok',
+      board: {
+        date: today,
+        entries: [
+          {
+            rank: 1,
+            public_label: 'Player 8F3A',
+            current_streak_days: 5,
+            longest_streak_days: 7,
+            last_active_date: today,
+            today: { bombsquad_defused: true, oracle_signed: false },
+          },
+        ],
+      },
+    })
+
+    renderPage()
+
+    expect(await screen.findByText('Player 8F3A')).toBeInTheDocument()
+    expect(screen.getByText(/今日 BombSquad/)).toBeInTheDocument()
+    expect(screen.getByText('最长 7 天')).toBeInTheDocument()
+    expect(screen.queryByText(/user_/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/@/)).not.toBeInTheDocument()
   })
 })

--- a/packages/platform/src/pages/LeaderboardPage.tsx
+++ b/packages/platform/src/pages/LeaderboardPage.tsx
@@ -1,23 +1,41 @@
 import { EyebrowTag } from '@amiclaw/ui'
 import DailyLeaderboardList from '@/components/leaderboard/DailyLeaderboardList'
+import StreakLeaderboardList from '@/components/leaderboard/StreakLeaderboardList'
 import { toChineseDateString } from '@shared/date'
 import styles from './LeaderboardPage.module.css'
 
-/* Leaderboard page — handoff §6.9. Only the 每日 board exists: it reads the
-   real daily API (DailyLeaderboardList). There is NO week / month / all-time
-   aggregation backend (the API stores per-day KV only), so those tabs are not
-   shown — surfacing them would promise aggregates the product does not track. */
+/* Leaderboard page — BombSquad's daily time board remains the KV-backed daily
+   leaderboard. The public streak board is a separate arcade-profile read
+   model backed by claimed public profiles, not by leaderboard rows. */
 export default function LeaderboardPage() {
   return (
     <div className={styles.page}>
       <EyebrowTag variant="section">排行榜 · LEADERBOARD</EyebrowTag>
       <h2 className={styles.title}>
-        BombSquad · <span className={styles.accent}>每日</span>
+        Arcade · <span className={styles.accent}>每日</span>
       </h2>
       <p className={styles.lead}>{toChineseDateString()} · 每日 UTC 0 点重置。</p>
 
-      <div className={styles.card}>
-        <DailyLeaderboardList />
+      <div className={styles.boardGrid}>
+        <section className={styles.boardSection}>
+          <div className={styles.sectionHead}>
+            <h3 className={styles.sectionTitle}>BombSquad 每日时间榜</h3>
+            <p className={styles.sectionLead}>只记录成功拆除的每日挑战成绩。</p>
+          </div>
+          <div className={styles.card}>
+            <DailyLeaderboardList />
+          </div>
+        </section>
+
+        <section className={styles.boardSection}>
+          <div className={styles.sectionHead}>
+            <h3 className={styles.sectionTitle}>连续打卡榜</h3>
+            <p className={styles.sectionLead}>登录并保存到账号后公开展示上榜名。</p>
+          </div>
+          <div className={styles.card}>
+            <StreakLeaderboardList />
+          </div>
+        </section>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- Add Arcade daily-loop summaries, current/longest streak derivation, and a public streak leaderboard backed by explicit account claim metadata.
- Wire homepage daily checklist, `/me` public streak controls, leaderboard streak panel, and BombSquad/Oracle result save-share feedback.
- Add D1 migration `0003_arcade_public_profile.sql` for public streak metadata and read indexes, leaving the existing applied `0002` migration stable.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Manual / command coverage:

- [x] `pnpm --filter @amiclaw/arcade-profile test:run`
- [x] `pnpm --filter api test:run`
- [x] `pnpm --filter @amiclaw/platform test:run`
- [x] `pnpm --filter @amiclaw/game-bombsquad test:run`
- [x] `pnpm --filter @amiclaw/game-yijing test:run`
- [x] `pnpm --filter @amiclaw/companion-memory test:run`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Commit hook `pnpm -r run test:run`
- [x] Playwright smoke on `http://localhost:5173/`: homepage daily checklist and leaderboard streak heading rendered. Local API calls logged connection-refused errors because no local Pages Functions backend was running.

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

## Notes

- Production needs the new D1 migration `0003_arcade_public_profile.sql` applied before `/api/arcade/streaks` can read public streak metadata.
- Public streak responses expose only rank, public label, streak numbers, last active date, and today's activity flags.
- `POST /api/arcade/profile/events` never creates public streak-board eligibility; explicit claim remains the public opt-in boundary.

## Attribution

- Implemented by Codex for TaskNote `arcade-daily-loop-results-sharing`.
