### PR TITLE
feat(creation): game-agnostic creation-schema package (validator + engine + 3 case games)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ submission. This lets a voice session summary and the finished run settle into
 one memory event. Anonymous leaderboard submissions still work the same way and
 do not write memory.
 
+**Creation-engine foundation (game-agnostic)** - Internal change. Adds a new
+`packages/creation` workspace package: the first implementation of the
+game-agnostic element+rule creation schema. It ships an executable validator
+(universal checks + per-form floor checks with a co-play-form floor registry), a
+declarative rule engine with a bounded-search solver, three worked case-game
+instantiations (Radio Cipher, Sound Garden, Botanical Garden) that each pass
+validation and play to a win through the engine, and a developer-only dev shell
+for driving a game locally. Not wired into any player-facing surface; no product
+behavior changes.
+
 **Sign out, and a login page that knows you're already in** - New. Signed-in
 players now have a 退出登录 action on their 我的 account page, and opening the
 login page while already signed in shows your email with two clear next steps —

--- a/packages/creation/README.md
+++ b/packages/creation/README.md
@@ -1,0 +1,31 @@
+# @amiclaw/creation
+
+Game-agnostic creation-schema meta-model: TypeScript types, YAML loader,
+validators (universal checks + hidden_info_coop and co_build floor checks),
+a minimal declarative rule engine, and the Radio Cipher + Sound Garden
+case-game fixtures. The design SSOT is
+`docs/architecture/arch-component-creation-schema.md`.
+
+## Dev shell (playable prototype)
+
+A dev-only Vite shell for playing a level locally — one human acts both
+roles over the engine's leak-guarded per-role views. Pipeline validation UI,
+not product UI; it has zero footprint on the production packages.
+
+```sh
+pnpm --filter @amiclaw/creation dev
+```
+
+Then open the printed local URL. Features: a game selector (Radio Cipher /
+Sound Garden), per-role tabs (authentic hidden info; symmetric shared
+timeline for co_build), vocabulary-driven action panel, running score for
+score_threshold levels, placement badges under the construction model, event
+log, win banner, restart, and a clearly-labeled "self-play spoiler" toggle
+that shows both role views side-by-side for solo testing.
+
+## Tests
+
+```sh
+pnpm --filter @amiclaw/creation test:run
+pnpm --filter @amiclaw/creation typecheck
+```

--- a/packages/creation/dev/App.test.tsx
+++ b/packages/creation/dev/App.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Minimal component tests per the sibling testing-library convention: the
+ * active role tab renders exactly that role's filtered view (no cannot_see
+ * leakage in the DOM), one action interaction advances session state, and
+ * the game selector switches into the co_build shell (score bar, shared
+ * timeline for both builder roles).
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../src/schema/load'
+import type { GameOption } from './App'
+import { App } from './App'
+import { DevShellStore } from './store'
+
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const radioGameType = loadGameType(
+  readFileSync(join(fixtures, 'radio-cipher', 'game-type.yaml'), 'utf8')
+)
+const radioLevel = loadLevel(
+  readFileSync(join(fixtures, 'radio-cipher', 'level.rc-demo-001.yaml'), 'utf8')
+)
+const gardenGameType = loadGameType(
+  readFileSync(join(fixtures, 'sound-garden', 'game-type.yaml'), 'utf8')
+)
+const gardenLevel = loadLevel(
+  readFileSync(join(fixtures, 'sound-garden', 'level.sg-demo-001.yaml'), 'utf8')
+)
+
+let radioStore: DevShellStore
+let gardenStore: DevShellStore
+
+function makeGames(): GameOption[] {
+  radioStore = new DevShellStore(radioGameType, radioLevel)
+  gardenStore = new DevShellStore(gardenGameType, gardenLevel)
+  return [
+    { id: 'radio-cipher', label: 'Radio Cipher (hidden_info_coop)', create: () => radioStore },
+    { id: 'sound-garden', label: 'Sound Garden (co_build)', create: () => gardenStore },
+  ]
+}
+
+describe('dev shell App', () => {
+  it('renders the listener tab without any cannot_see field in the DOM', () => {
+    const { container } = render(<App games={makeGames()} />)
+    // Listener view: segments visible, hidden fields and decoder-only
+    // elements absent.
+    expect(screen.getByLabelText('listener view')).toBeTruthy()
+    expect(container.textContent).toContain('seg-1')
+    expect(container.textContent).toContain('content_length')
+    expect(container.textContent).not.toContain('plaintext_category')
+    expect(container.textContent).not.toContain('key-1')
+    expect(container.textContent).not.toContain('shift_amount')
+  })
+
+  it('advances session state when an action is performed', () => {
+    render(<App games={makeGames()} />)
+    const actionSelect = screen.getByLabelText('Action') as HTMLSelectElement
+    fireEvent.change(actionSelect, { target: { value: 'execute_decryption' } })
+    fireEvent.click(screen.getByText('Perform'))
+    // seg-1 advanced encrypted → partial; the log records the rule firing.
+    expect(radioStore.stateOf('seg-1').decryption_progress).toBe('partial')
+    expect(screen.getByText(/rule-decrypt-1/)).toBeTruthy()
+    expect(screen.getAllByText(/partial/).length).toBeGreaterThan(0)
+  })
+
+  it('shows both role views only when the spoiler toggle is on', () => {
+    render(<App games={makeGames()} />)
+    expect(screen.queryByLabelText('decoder view')).toBeNull()
+    fireEvent.click(screen.getByLabelText(/Self-play spoiler/))
+    expect(screen.getByLabelText('listener view')).toBeTruthy()
+    expect(screen.getByLabelText('decoder view')).toBeTruthy()
+  })
+
+  it('switches to the sound-garden co_build shell with a score bar and shared timeline', () => {
+    const { container } = render(<App games={makeGames()} />)
+    fireEvent.change(screen.getByLabelText('Game'), { target: { value: 'sound-garden' } })
+    expect(container.textContent).toContain('声音花园')
+    expect(screen.getByText(/Score: 0 \/ target 10/)).toBeTruthy()
+    // Symmetric partition: the rhythm builder's tab shows BOTH piece kinds.
+    expect(screen.getByLabelText('rhythm_builder view')).toBeTruthy()
+    expect(container.textContent).toContain('r1')
+    expect(container.textContent).toContain('m1')
+    expect(container.textContent).toContain('unplaced')
+  })
+
+  it('placing pieces through the UI raises the score', () => {
+    render(<App games={makeGames()} />)
+    fireEvent.change(screen.getByLabelText('Game'), { target: { value: 'sound-garden' } })
+    // rhythm_builder places r1 (default action place_piece, default target r1).
+    fireEvent.click(screen.getByText('Perform'))
+    expect(gardenStore.placementOf('r1')).toBe('placed')
+    // Switch to the melody builder tab and place m1 → first pair scores 3.
+    fireEvent.click(screen.getByText(/旋律手/))
+    const targetSelect = screen.getByLabelText('Target element') as HTMLSelectElement
+    fireEvent.change(targetSelect, { target: { value: 'm1' } })
+    fireEvent.click(screen.getByText('Perform'))
+    expect(gardenStore.score()?.current).toBe(3)
+    expect(screen.getByText(/Score: 3 \/ target 10/)).toBeTruthy()
+  })
+
+  it('F6: the target dropdown only offers archetypes the acting role can target', () => {
+    makeGames()
+    // melody_builder.target_archetypes = [melody_piece]: only melody pieces,
+    // no rhythm pieces (which it would see under symmetric co_build visibility).
+    const melodyTargets = gardenStore.targetableElements('melody_builder').map((e) => e.element_id)
+    expect(melodyTargets).toEqual(['m1', 'm2', 'm3', 'm4'])
+    expect(melodyTargets).not.toContain('r1')
+    const rhythmTargets = gardenStore.targetableElements('rhythm_builder').map((e) => e.element_id)
+    expect(rhythmTargets).toEqual(['r1', 'r2', 'r3', 'r4'])
+    expect(rhythmTargets).not.toContain('m1')
+  })
+})

--- a/packages/creation/dev/App.tsx
+++ b/packages/creation/dev/App.tsx
@@ -1,0 +1,279 @@
+/**
+ * Dev-only shell UI: a game selector over the bundled fixtures, per-role
+ * tabs over GameSession's leak-guarded views, a vocabulary-driven action
+ * panel, running score (score_threshold levels), an event log, win banner
+ * and restart. No game logic lives here — everything renders from
+ * vocabulary data and the session API. The "self-play spoiler" toggle shows
+ * both role views side-by-side for solo testing (default OFF = authentic
+ * hidden info; for symmetric co_build partitions it is merely convenience).
+ */
+
+import { useState } from 'react'
+import type { DevShellStore, LogEntry } from './store'
+
+export interface GameOption {
+  id: string
+  label: string
+  create: () => DevShellStore
+}
+
+export function App({ games }: { games: GameOption[] }) {
+  const [, setVersion] = useState(0)
+  const bump = () => setVersion((v) => v + 1)
+  const [gameId, setGameId] = useState(games[0]?.id ?? '')
+  const [store, setStore] = useState<DevShellStore>(() => games[0].create())
+  const roles = store.roleIds()
+  const [activeRole, setActiveRole] = useState(roles[0] ?? '')
+  const [spoiler, setSpoiler] = useState(false)
+  const won = store.won()
+  const score = store.score()
+
+  const selectGame = (nextId: string) => {
+    const option = games.find((game) => game.id === nextId)
+    if (!option) return
+    const nextStore = option.create()
+    setGameId(nextId)
+    setStore(nextStore)
+    setActiveRole(nextStore.roleIds()[0] ?? '')
+  }
+
+  return (
+    <main className="shell">
+      <header className="shell-header">
+        <h1>creation dev shell</h1>
+        <p className="subtitle">{store.title()}</p>
+        <div className="controls">
+          <label className="game-select">
+            Game
+            <select value={gameId} onChange={(event) => selectGame(event.target.value)}>
+              {games.map((game) => (
+                <option key={game.id} value={game.id}>
+                  {game.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="spoiler-toggle">
+            <input
+              type="checkbox"
+              checked={spoiler}
+              onChange={(event) => setSpoiler(event.target.checked)}
+            />
+            Self-play spoiler: show BOTH role views (breaks hidden info on purpose)
+          </label>
+          <button
+            type="button"
+            onClick={() => {
+              store.reset()
+              bump()
+            }}
+          >
+            Restart
+          </button>
+        </div>
+      </header>
+
+      {score && (
+        <div className="score-bar" role="status">
+          Score: {score.current} / target {score.target}
+        </div>
+      )}
+
+      {won && (
+        <div className="win-banner" role="status">
+          Level solved — the win condition is reached. Restart to play again.
+        </div>
+      )}
+
+      {!spoiler && (
+        <nav className="tabs" aria-label="role tabs">
+          {roles.map((roleId) => (
+            <button
+              key={roleId}
+              type="button"
+              aria-pressed={roleId === activeRole}
+              className={roleId === activeRole ? 'tab active' : 'tab'}
+              onClick={() => setActiveRole(roleId)}
+            >
+              {store.roleLabel(roleId)}
+            </button>
+          ))}
+        </nav>
+      )}
+
+      <div className={spoiler ? 'panels split' : 'panels'}>
+        {(spoiler ? roles : [activeRole]).map((roleId) => (
+          <RolePanel key={roleId} store={store} roleId={roleId} onChanged={bump} />
+        ))}
+      </div>
+
+      <LogPane entries={store.log()} />
+    </main>
+  )
+}
+
+function RolePanel({
+  store,
+  roleId,
+  onChanged,
+}: {
+  store: DevShellStore
+  roleId: string
+  onChanged: () => void
+}) {
+  const view = store.view(roleId)
+  const rules = store.ruleSummaries(view.visible_rules)
+  return (
+    <section className="role-panel" aria-label={`${roleId} view`}>
+      <h2>{store.roleLabel(roleId)}</h2>
+
+      <h3>Visible elements</h3>
+      <ul className="elements">
+        {view.elements.map((element) => (
+          <li key={element.element_id} className="element">
+            <span className="element-id">
+              {store.audioPlaceholder(roleId, element.archetype) ? '[audio] ' : ''}
+              {element.element_id}
+            </span>
+            <span className="element-archetype">{element.archetype}</span>
+            {store.placementOf(element.element_id) !== undefined && (
+              <span
+                className={
+                  store.placementOf(element.element_id) === 'placed'
+                    ? 'placement placed'
+                    : 'placement'
+                }
+              >
+                {store.placementOf(element.element_id)}
+              </span>
+            )}
+            <dl>
+              {Object.entries(element.visible_params).map(([key, value]) => (
+                <div key={key}>
+                  <dt>{key}</dt>
+                  <dd>{String(value)}</dd>
+                </div>
+              ))}
+              {Object.entries(element.visible_states).map(([key, value]) => (
+                <div key={key} className="state">
+                  <dt>{key}</dt>
+                  <dd>{String(value)}</dd>
+                </div>
+              ))}
+            </dl>
+          </li>
+        ))}
+      </ul>
+
+      {rules.length > 0 && (
+        <>
+          <h3>Codebook (visible rules)</h3>
+          <ul className="codebook">
+            {rules.map((rule) => (
+              <li key={rule.id}>
+                <code>{rule.id}</code> · {rule.template}
+                <pre>{rule.bindings}</pre>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      <ActionPanel store={store} roleId={roleId} onChanged={onChanged} />
+    </section>
+  )
+}
+
+function ActionPanel({
+  store,
+  roleId,
+  onChanged,
+}: {
+  store: DevShellStore
+  roleId: string
+  onChanged: () => void
+}) {
+  const actions = store.actionsFor(roleId)
+  // F6: only offer targets the engine will accept — the role's visible
+  // elements filtered by its action_capability.target_archetypes.
+  const targets = store.targetableElements(roleId)
+  const [action, setAction] = useState(actions[0]?.name ?? '')
+  const [elementId, setElementId] = useState(targets[0]?.element_id ?? '')
+  const [actionType, setActionType] = useState('')
+
+  if (actions.length === 0) {
+    return <p className="no-actions">This role has no performable actions.</p>
+  }
+
+  const selected = actions.find((a) => a.name === action) ?? actions[0]
+
+  return (
+    <form
+      className="action-panel"
+      onSubmit={(event) => {
+        event.preventDefault()
+        store.perform(roleId, selected.name, {
+          element_id: elementId || undefined,
+          action_type: actionType || undefined,
+        })
+        onChanged()
+      }}
+    >
+      <h3>Perform action</h3>
+      <label>
+        Action
+        <select value={selected.name} onChange={(event) => setAction(event.target.value)}>
+          {actions.map((entry) => (
+            <option key={entry.name} value={entry.name}>
+              {entry.name} — {entry.description}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Target element
+        <select value={elementId} onChange={(event) => setElementId(event.target.value)}>
+          <option value="">(none)</option>
+          {targets.map((element) => (
+            <option key={element.element_id} value={element.element_id}>
+              {element.element_id}
+            </option>
+          ))}
+        </select>
+      </label>
+      {store.hasEventMapping() && (
+        <label>
+          action_type
+          <input
+            value={actionType}
+            placeholder="event mapping key"
+            onChange={(event) => setActionType(event.target.value)}
+          />
+        </label>
+      )}
+      <button type="submit">Perform</button>
+    </form>
+  )
+}
+
+function LogPane({ entries }: { entries: readonly LogEntry[] }) {
+  return (
+    <section className="log-pane" aria-label="event log">
+      <h3>Event log</h3>
+      {entries.length === 0 ? (
+        <p className="log-empty">No actions yet.</p>
+      ) : (
+        <ol className="log">
+          {entries.map((entry) => (
+            <li key={entry.seq} className={entry.ok ? 'log-ok' : 'log-error'}>
+              <span className="log-seq">#{entry.seq}</span>
+              <span className="log-role">{entry.role}</span>
+              <span className="log-summary">{entry.summary}</span>
+              <span className="log-detail">{entry.detail}</span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  )
+}

--- a/packages/creation/dev/app.css
+++ b/packages/creation/dev/app.css
@@ -1,0 +1,277 @@
+/* Dev shell styling — dark-only per product convention, CSS-only. */
+
+:root {
+  color-scheme: dark;
+  --bg: #0f1115;
+  --panel: #181b22;
+  --border: #2a2f3a;
+  --text: #e6e8ee;
+  --muted: #9aa3b2;
+  --accent: #7cc4ff;
+  --ok: #3fbf7f;
+  --error: #ff7b72;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}
+
+.shell {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.shell-header h1 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0.75rem;
+  color: var(--muted);
+}
+
+.controls {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.spoiler-toggle {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+button {
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.4rem 0.9rem;
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: var(--accent);
+}
+
+.win-banner {
+  background: rgba(63, 191, 127, 0.15);
+  border: 1px solid var(--ok);
+  color: var(--ok);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+}
+
+.score-bar {
+  background: rgba(124, 196, 255, 0.12);
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+}
+
+.game-select {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.game-select select {
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.3rem 0.5rem;
+}
+
+.placement {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+}
+
+.placement.placed {
+  color: var(--ok);
+  border-color: var(--ok);
+}
+
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tab.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.panels {
+  display: grid;
+  gap: 1rem;
+}
+
+.panels.split {
+  grid-template-columns: 1fr 1fr;
+}
+
+.role-panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+.role-panel h2 {
+  margin-top: 0;
+  font-size: 1.05rem;
+}
+
+.role-panel h3 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.elements,
+.codebook,
+.log {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.element {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+}
+
+.element-id {
+  font-weight: 600;
+  margin-right: 0.5rem;
+}
+
+.element-archetype {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.element dl {
+  margin: 0.4rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 1rem;
+}
+
+.element dl div {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.element dt {
+  color: var(--muted);
+}
+
+.element dt::after {
+  content: ':';
+}
+
+.element dd {
+  margin: 0;
+}
+
+.element .state dd {
+  color: var(--accent);
+}
+
+.codebook pre {
+  margin: 0.25rem 0 0;
+  padding: 0.4rem 0.6rem;
+  background: var(--bg);
+  border-radius: 6px;
+  overflow-x: auto;
+  font-size: 0.8rem;
+}
+
+.action-panel {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.action-panel label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.action-panel select,
+.action-panel input {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.4rem 0.5rem;
+}
+
+.log-pane {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+.log li {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.35rem;
+}
+
+.log-seq {
+  color: var(--muted);
+}
+
+.log-ok .log-detail {
+  color: var(--ok);
+}
+
+.log-error .log-detail {
+  color: var(--error);
+}
+
+.log-empty,
+.no-actions {
+  color: var(--muted);
+}

--- a/packages/creation/dev/index.html
+++ b/packages/creation/dev/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>creation dev shell</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/packages/creation/dev/main.tsx
+++ b/packages/creation/dev/main.tsx
@@ -1,0 +1,35 @@
+import { createRoot } from 'react-dom/client'
+import { loadGameType, loadLevel } from '../src/schema/load'
+import radioCipherGameTypeYaml from '../fixtures/radio-cipher/game-type.yaml?raw'
+import radioCipherLevelYaml from '../fixtures/radio-cipher/level.rc-demo-001.yaml?raw'
+import soundGardenGameTypeYaml from '../fixtures/sound-garden/game-type.yaml?raw'
+import soundGardenLevelYaml from '../fixtures/sound-garden/level.sg-demo-001.yaml?raw'
+import botanicalGameTypeYaml from '../fixtures/botanical-garden/game-type.yaml?raw'
+import botanicalLevelYaml from '../fixtures/botanical-garden/level.bg-demo-001.yaml?raw'
+import type { GameOption } from './App'
+import { App } from './App'
+import { DevShellStore } from './store'
+import './app.css'
+
+const games: GameOption[] = [
+  {
+    id: 'radio-cipher',
+    label: 'Radio Cipher (hidden_info_coop)',
+    create: () =>
+      new DevShellStore(loadGameType(radioCipherGameTypeYaml), loadLevel(radioCipherLevelYaml)),
+  },
+  {
+    id: 'sound-garden',
+    label: 'Sound Garden (co_build)',
+    create: () =>
+      new DevShellStore(loadGameType(soundGardenGameTypeYaml), loadLevel(soundGardenLevelYaml)),
+  },
+  {
+    id: 'botanical-garden',
+    label: 'Botanical Garden (hidden_info_coop)',
+    create: () =>
+      new DevShellStore(loadGameType(botanicalGameTypeYaml), loadLevel(botanicalLevelYaml)),
+  },
+]
+
+createRoot(document.getElementById('root') as HTMLElement).render(<App games={games} />)

--- a/packages/creation/dev/store.test.ts
+++ b/packages/creation/dev/store.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Node-level tests for the dev-shell wiring: role listing, log recording,
+ * a full scripted playthrough to the win, invalid actions, and restart.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../src/schema/load'
+import { DevShellStore } from './store'
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures', 'radio-cipher')
+const gameType = loadGameType(readFileSync(join(fixturesDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(fixturesDir, 'level.rc-demo-001.yaml'), 'utf8'))
+
+describe('DevShellStore', () => {
+  it('lists roles and role-scoped actions from vocabulary data', () => {
+    const store = new DevShellStore(gameType, level)
+    expect(store.roleIds()).toEqual(['listener', 'decoder'])
+    expect(store.actionsFor('listener').map((a) => a.name)).toEqual([
+      'describe_heard_content',
+      'execute_decryption',
+    ])
+    expect(store.actionsFor('decoder').map((a) => a.name)).toEqual(['give_instruction'])
+    expect(store.hasEventMapping()).toBe(false)
+  })
+
+  it('plays through to the win and records the log', () => {
+    const store = new DevShellStore(gameType, level)
+    store.perform('listener', 'execute_decryption', { element_id: 'seg-1' })
+    store.perform('listener', 'execute_decryption', { element_id: 'seg-1' })
+    expect(store.won()).toBe(false)
+    store.perform('listener', 'execute_decryption', { element_id: 'seg-2' })
+    expect(store.won()).toBe(true)
+    expect(store.stateOf('seg-1').decryption_progress).toBe('decrypted')
+    expect(store.stateOf('seg-2').decryption_progress).toBe('decrypted')
+    expect(store.log()).toHaveLength(3)
+    expect(store.log().every((entry) => entry.ok)).toBe(true)
+  })
+
+  it('logs invalid actions as failures without state drift', () => {
+    const store = new DevShellStore(gameType, level)
+    const before = JSON.stringify(store.stateOf('seg-1'))
+    store.perform('decoder', 'execute_decryption', { element_id: 'seg-1' })
+    expect(store.log()[0].ok).toBe(false)
+    expect(store.log()[0].detail).toContain('cannot perform')
+    expect(JSON.stringify(store.stateOf('seg-1'))).toBe(before)
+  })
+
+  it('restart resets session state and the log', () => {
+    const store = new DevShellStore(gameType, level)
+    store.perform('listener', 'execute_decryption', { element_id: 'seg-1' })
+    store.reset()
+    expect(store.log()).toHaveLength(0)
+    expect(store.stateOf('seg-1').decryption_progress).toBe('encrypted')
+    expect(store.won()).toBe(false)
+  })
+})

--- a/packages/creation/dev/store.ts
+++ b/packages/creation/dev/store.ts
@@ -1,0 +1,162 @@
+/**
+ * Framework-free wiring between the dev shell UI and a GameSession. All
+ * game knowledge flows from vocabulary data + the session API — the store
+ * adds only presentation conveniences (log, labels, restart). Kept free of
+ * React so the wiring is testable in plain Node.
+ */
+
+import type { ActionResult, RoleView } from '../src/engine/engine'
+import { GameSession } from '../src/engine/engine'
+import { PLACEMENT_STATE } from '../src/engine/rules'
+import type { ActionDefinition, GameType, Level, LevelRule } from '../src/schema/types'
+
+export interface LogEntry {
+  seq: number
+  role: string
+  summary: string
+  ok: boolean
+  detail: string
+}
+
+export interface RuleSummary {
+  id: string
+  template: string
+  bindings: string
+}
+
+export class DevShellStore {
+  private session: GameSession
+  private entries: LogEntry[] = []
+  private seq = 0
+
+  constructor(
+    private readonly gameType: GameType,
+    private readonly level: Level
+  ) {
+    this.session = new GameSession(gameType, level)
+  }
+
+  title(): string {
+    return `${this.gameType.display_name} · ${this.level.metadata.title} (${this.level.metadata.id})`
+  }
+
+  roleIds(): string[] {
+    return (this.gameType.information_partition_template?.roles ?? []).map((role) => role.id)
+  }
+
+  roleLabel(roleId: string): string {
+    const role = this.gameType.information_partition_template?.roles.find((r) => r.id === roleId)
+    return role ? `${role.display_name} (${role.id})` : roleId
+  }
+
+  view(roleId: string): RoleView {
+    return this.session.getRoleView(roleId)
+  }
+
+  /**
+   * Audio placeholder only when the CONTENT is auditory AND the viewing
+   * role perceives it aurally (input_modality) — a visual builder looking
+   * at a shared timeline needs no placeholder (R5 verify note applied).
+   */
+  audioPlaceholder(roleId: string, archetypeId: string): boolean {
+    const category = this.gameType.element_archetypes.find((a) => a.id === archetypeId)?.category
+    const modality = this.gameType.information_partition_template?.roles.find(
+      (r) => r.id === roleId
+    )?.input_modality
+    return category === 'auditory' && modality === 'auditory'
+  }
+
+  /** Current score vs target for score_threshold levels; undefined otherwise. */
+  score(): { current: number; target: number } | undefined {
+    const current = this.session.score()
+    const target = this.level.win_condition.params.target_score
+    if (current === undefined || typeof target !== 'number') return undefined
+    return { current, target }
+  }
+
+  /** Placement state under the co_build construction model; undefined without one. */
+  placementOf(elementId: string): string | undefined {
+    const value = this.session.getState().elements[elementId]?.[PLACEMENT_STATE]
+    return typeof value === 'string' ? value : undefined
+  }
+
+  /** Registry definitions for a role's performable actions (param metadata). */
+  actionsFor(roleId: string): ActionDefinition[] {
+    const names = this.view(roleId).can_perform
+    return this.gameType.action_registry.filter((action) => names.includes(action.name))
+  }
+
+  /**
+   * Elements this role may act on — its visible elements filtered by the
+   * role's action_capability.target_archetypes (empty = all). Mirrors the
+   * engine's performAction gate so the shell only offers targets the engine
+   * will accept (F6).
+   */
+  targetableElements(roleId: string): { element_id: string; archetype: string }[] {
+    const capability = this.gameType.information_partition_template?.action_capability.find(
+      (entry) => entry.role === roleId
+    )
+    const targets = capability?.target_archetypes ?? []
+    return this.view(roleId).elements.filter(
+      (element) => targets.length === 0 || targets.includes(element.archetype)
+    )
+  }
+
+  /** Codebook entries for the rule ids a role may see. */
+  ruleSummaries(ruleIds: string[]): RuleSummary[] {
+    return this.level.rules
+      .filter((rule): rule is LevelRule => ruleIds.includes(rule.id))
+      .map((rule) => ({
+        id: rule.id,
+        template: rule.template,
+        bindings: JSON.stringify(rule.bindings),
+      }))
+  }
+
+  hasEventMapping(): boolean {
+    return (this.gameType.action_event_mapping ?? []).length > 0
+  }
+
+  stateOf(elementId: string): Record<string, unknown> {
+    return this.session.getState().elements[elementId] ?? {}
+  }
+
+  won(): boolean {
+    return this.session.isWon()
+  }
+
+  log(): readonly LogEntry[] {
+    return this.entries
+  }
+
+  perform(
+    roleId: string,
+    actionName: string,
+    args: { element_id?: string; action_type?: string }
+  ): ActionResult {
+    const result = this.session.performAction(roleId, actionName, args)
+    this.seq += 1
+    const target = args.element_id ? ` → ${args.element_id}` : ''
+    this.entries = [
+      {
+        seq: this.seq,
+        role: roleId,
+        summary: `${actionName}${target}`,
+        ok: result.ok,
+        detail: result.ok
+          ? result.effects.length > 0
+            ? result.effects.join('; ')
+            : 'no effect'
+          : result.reason,
+      },
+      ...this.entries,
+    ]
+    return result
+  }
+
+  reset(): void {
+    this.session = new GameSession(this.gameType, this.level)
+    this.entries = []
+    this.seq = 0
+  }
+}

--- a/packages/creation/dev/vite-env.d.ts
+++ b/packages/creation/dev/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/creation/dev/vite.config.ts
+++ b/packages/creation/dev/vite.config.ts
@@ -1,0 +1,9 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+// Dev-only shell for playing creation-schema levels locally. Never built or
+// deployed — zero footprint on production packages and Pages routing.
+export default defineConfig({
+  root: __dirname,
+  plugins: [react()],
+})

--- a/packages/creation/fixtures/botanical-garden/game-type.yaml
+++ b/packages/creation/fixtures/botanical-garden/game-type.yaml
@@ -1,0 +1,317 @@
+# Botanical Garden GameType vocabulary (v1.0.0). Extracted from the
+# creation-schema design spec (docs/architecture/arch-component-creation-schema.md,
+# "实例化 B：植物园养护") and RESTRUCTURED per the R7 H1 decision: the care
+# loop runs entirely through already-formal mechanisms (state_transition
+# tables + condition_action direct-style predicates + action_event_mapping
+# `<template>_event` columns + optimization_target). The non-machine-consumed
+# action_event_mapping condition/side_effect columns are RETIRED (their
+# behaviour is now carried by the light_adjustment state_transition rule and
+# the health_response/growth_advancement tables). See the r7-produce report
+# for the full decision + every spec line moved. Chinese strings are
+# target-language instantiation DATA; comments are English per repo policy.
+GameType:
+  id: botanical-garden
+  version: '1.0.0'
+  display_name: 植物园养护
+  description: 视觉多实体并行管理——一方看植物园场景，另一方持养护手册
+
+  co_play_form: hidden_info_coop # gardener sees the scene, botanist knows the rules
+
+  element_archetypes:
+    - id: plant
+      category: visual
+      verbal_label:
+        canonical: '植株'
+        phonetic_pinyin: 'zhí zhū'
+        aliases: ['植物']
+        forbidden_terms: ['花', '草'] # too generic
+      description: 一株植物，有品种、生长阶段和健康状态
+      attributes:
+        - name: species
+          type: enum
+          required: true
+          values: [fern, succulent, orchid, moss, vine]
+          display_labels:
+            { fern: '蕨类', succulent: '多肉', orchid: '兰花', moss: '苔藓', vine: '藤蔓' }
+          verbal_template: '{species}植株'
+        - name: pot_position
+          type: range
+          required: true
+          min: 1
+          max: 9 # 3x3 grid
+          step: 1
+          verbal_template: '在{pot_position}号位置'
+        - name: soil_type
+          type: enum
+          required: false
+          values: [sandy, loamy, peaty]
+          default: loamy
+      states:
+        # RESTRUCTURE: health ordered worst→best so advance_state = heal, and
+        # so optimization_target's `at_least` ranks by declared order.
+        - name: health
+          type: enum
+          values: [critical, wilting, stable, thriving]
+          initial: stable
+          verbal_template: '健康状态{health}'
+        - name: growth_stage
+          type: enum
+          values: [seedling, juvenile, mature, flowering]
+          initial: seedling
+          verbal_template: '生长阶段{growth_stage}'
+        - name: effective_light
+          type: enum
+          values: [full_sun, partial_shade, full_shade]
+          initial: full_sun # per-instance override via Level.elements[].initial_states
+          verbal_template: '实际光照{effective_light}'
+      interaction_model: reactive
+
+    - id: environment_zone
+      category: visual
+      verbal_label:
+        canonical: '环境区'
+        phonetic_pinyin: 'huán jìng qū'
+        aliases: ['区域']
+        forbidden_terms: ['地方', '位置']
+      description: 覆盖若干花盆位置的环境因子区域
+      attributes:
+        - name: zone_id
+          type: enum
+          required: true
+          values: [north, center, south]
+          verbal_template: '{zone_id}区'
+        - name: light_level
+          type: enum
+          required: true
+          values: [full_sun, partial_shade, full_shade]
+          verbal_template: '光照{light_level}'
+        - name: temperature
+          type: enum
+          required: true
+          values: [cool, moderate, warm]
+          verbal_template: '温度{temperature}'
+        - name: covers_positions
+          type: set
+          required: true
+          values: ['1', '2', '3', '4', '5', '6', '7', '8', '9']
+      states: []
+      interaction_model: stateless
+
+  action_registry:
+    - name: apply_care
+      description: 对植株执行养护操作（浇水/施肥/遮光/换盆/催花）
+      params: [{ name: action_type, type: string }]
+      scope: both
+      # apply_care drives the botanist manual's condition rules + compatibility
+      # matrix; the state_transition tables (health/growth/light) are driven by
+      # action_event_mapping events, not triggers.
+      triggers: [needs_rule, compatibility_matrix]
+    - name: heal
+      description: 健康状态推进一档（引擎内部效果）
+      params: []
+      scope: rule_verb
+      state_effect: advance_state # advances health toward thriving (worst→best order)
+    - name: change_health
+      description: 健康状态变更（引擎内部效果，供兼容矩阵手册引用；本关卡不触发）
+      params: [{ name: delta, type: string }]
+      scope: rule_verb
+    - name: give_instruction
+      description: 植物学家给出养护指令
+      params: []
+      scope: player_action
+    - name: describe_state
+      description: 园丁描述植株当前状态
+      params: []
+      scope: player_action
+
+  # action_type → per-template rule event. ONLY the `<rule_template_id>_event`
+  # columns exist and are machine-consumed (the retired condition/side_effect
+  # columns are gone). A single apply_care action_type may drive several
+  # templates by carrying several `_event` columns.
+  action_event_mapping:
+    - action_type: water
+      health_response_event: correct_care
+    - action_type: overwater
+      health_response_event: wrong_care # over-application harms health (degradation demo)
+    - action_type: shade
+      light_adjustment_event: shade_applied
+    - action_type: fertilize
+      growth_advancement_event: fertilize_correct
+    - action_type: repot
+      growth_advancement_event: repot_correct
+    - action_type: bloom
+      growth_advancement_event: bloom_correct
+
+  rule_templates:
+    # Botanist manual: species care rules (direct-style predicates — a param
+    # name is an attribute or state name; the engine resolves it structurally).
+    - id: needs_rule
+      type: condition_action
+      condition_schema:
+        predicates:
+          - name: species_is
+            params: [{ name: species, type: string }]
+            description: 植株品种等于指定值
+          - name: light_is
+            params: [{ name: effective_light, type: string }]
+            description: 植株实际光照等于指定值
+          - name: growth_is
+            params: [{ name: growth_stage, type: string }]
+            description: 植株生长阶段等于指定值
+          - name: soil_is
+            params: [{ name: soil_type, type: string }]
+            description: 土壤类型等于指定值
+        combinators: [AND, OR, NOT]
+      action_schema:
+        verbs: [heal, change_health]
+      communication_weight: 2.0 # per plant: describe → ask species → look up → instruct → execute → confirm
+
+    - id: compatibility_matrix
+      type: interaction_matrix
+      matrix_schema:
+        entity_types: [fern, succulent, orchid, moss, vine]
+        entity_type_attributes: [species]
+        relation_types: [compatible, incompatible, synergy, neutral]
+        effect_schema:
+          - relation: compatible
+            effect: change_health # inert on this level (no state_effect): the botanist's compatibility manual
+            params: [{ name: delta, type: string }]
+          - relation: incompatible
+            effect: change_health
+            params: [{ name: delta, type: string }]
+          - relation: synergy
+            effect: change_health
+            params: [{ name: delta, type: string }]
+          - relation: neutral
+            effect: change_health
+            params: [{ name: delta, type: string }]
+      communication_weight: 0.5
+
+    - id: health_response
+      type: state_transition
+      transition_table_schema:
+        states: [critical, wilting, stable, thriving]
+        events: [correct_care, wrong_care, neglect]
+      communication_weight: 0.5
+
+    - id: growth_advancement
+      type: state_transition
+      transition_table_schema:
+        states: [seedling, juvenile, mature, flowering]
+        events: [fertilize_correct, repot_correct, bloom_correct]
+      communication_weight: 1.0 # growth advance needs a round: confirm condition → execute → observe
+
+    - id: light_adjustment
+      type: state_transition
+      transition_table_schema:
+        states: [full_sun, partial_shade, full_shade]
+        events: [shade_applied]
+      communication_weight: 0.5 # shade action adjusts effective_light one step
+
+  information_partition_template:
+    roles:
+      - id: gardener
+        display_name: 园丁
+        verbal_label: '园丁'
+        description: 看到植物园场景，能执行养护操作，但不知道养护规则
+        input_modality: visual
+        output_modality: voice
+      - id: botanist
+        display_name: 植物学家
+        verbal_label: '植物学家'
+        description: 持有养护手册，知道规则和兼容性矩阵，但看不到当前场景
+        input_modality: visual
+        output_modality: voice
+
+    visibility_rules:
+      - role: gardener
+        can_see:
+          - element_archetype: plant
+            attributes: [species, pot_position] # species is a shared reference-label source
+            states: [health, growth_stage, effective_light]
+          - element_archetype: environment_zone
+            attributes: [zone_id, light_level, temperature, covers_positions]
+            states: []
+        cannot_see:
+          - element_archetype: plant
+            attributes: [soil_type]
+            states: []
+      - role: botanist
+        can_see:
+          - element_archetype: plant
+            attributes: [species, soil_type]
+            states: []
+        cannot_see:
+          - element_archetype: plant
+            attributes: [pot_position]
+            states: [health, growth_stage, effective_light]
+          - element_archetype: environment_zone
+            attributes: [light_level, temperature]
+            states: []
+
+    shared_label_attributes: # only cross-role-communicated archetypes
+      - element_archetype: plant
+        attributes: [species] # species is visible to both → instance_label 「蕨类植株」…
+
+    rule_visibility:
+      - role: gardener
+        visible_rule_templates: []
+      - role: botanist
+        visible_rule_templates:
+          [needs_rule, compatibility_matrix, health_response, growth_advancement, light_adjustment]
+
+    action_capability:
+      - role: gardener
+        can_perform: [apply_care, describe_state]
+        target_archetypes: [plant]
+      - role: botanist
+        can_perform: [give_instruction]
+        target_archetypes: []
+
+    communication_channels:
+      - from: gardener
+        to: botanist
+        modality: voice
+        constraints:
+          turn_time_limit_seconds: 30
+      - from: botanist
+        to: gardener
+        modality: voice
+        constraints:
+          turn_time_limit_seconds: 30
+
+    partition_pattern: ability_complement
+
+  win_condition_type:
+    type: optimization_target
+    description: 所有植株健康达到 stable 或更高，且至少一株生长阶段达到 flowering
+
+  difficulty_budget:
+    element_count:
+      min: 4
+      max: 15
+    rule_count:
+      min: 3
+      max: 15
+    partition_complexity:
+      max: 8.0
+    weights:
+      element: 0.8
+      rule: 1.2
+      partition: 2.0
+    total_score:
+      min: 6.0
+      max: 35.0
+
+  communication_budget:
+    max_round_trips: 20
+    estimated_seconds_per_round: 10.0
+    time_limit_seconds: 480
+    safety_margin: 0.75
+
+  solver_strategy: csp # larger state space (3 plants × health × growth × light × care combos)
+  # CALIBRATED (R7, engine-backed bounded search): golden bg-demo-001 solves
+  # in ~99ms median / 119ms max; a stressed variant (require 2 flowering)
+  # ~677ms median / 732ms max. 3000ms ≈ 4× the hardest measured — an
+  # evidence-based bound (was a 10000ms guess). Closes design-debt #2.
+  solver_timeout_ms: 3000

--- a/packages/creation/fixtures/botanical-garden/level.bg-demo-001.yaml
+++ b/packages/creation/fixtures/botanical-garden/level.bg-demo-001.yaml
@@ -1,0 +1,197 @@
+# Botanical Garden worked Level (bg-demo-001). Restructured per the R7 H1
+# decision to run entirely on formal mechanisms. Per-instance starting states
+# come from elements[].initial_states (the small general schema field added
+# this round). Winning path (all via apply_care → action_event_mapping →
+# state_transition / condition_action):
+#   water plant-1 (fern wilting → stable)
+#   shade plant-3 (orchid: effective_light full_sun→partial_shade, which lets
+#         rule-orchid-care advance its health wilting→stable in the same care)
+#   fertilize / repot / bloom plant-3 (seedling→juvenile→mature→flowering)
+Level:
+  metadata:
+    id: bg-demo-001
+    game_type: botanical-garden
+    game_type_version: '1.0.0'
+    title: 小花圃急救
+    author: ai-author-002
+    created_at: '2026-07-02T22:00:00+08:00'
+
+  # partition_complexity:
+  # total_fields: plant(3 attr + 3 state = 6) + environment_zone(4 attr = 4) = 10
+  # gardener hidden: plant.soil_type(1) = 1; ratio = 1/10 = 0.1
+  # botanist hidden: plant.pot_position(1) + health/growth_stage/effective_light(3)
+  #                  + env.light_level/temperature(2) = 6; ratio = 6/10 = 0.6
+  # mean_hidden = (0.1+0.6)/2 = 0.35; roles_term = 2*0.35 = 0.7
+  # channels: 2 × 1 constraint each; mean = 1.0; channels_term = 2*1.0 = 2.0
+  # partition_complexity = 0.7 + 2.0 = 2.7
+  difficulty:
+    element_count: 6 # plant-1..3 + zone-north/center/south
+    rule_count: 6 # light + orchid-care + fern-needs + compatibility + health + growth
+    partition_complexity: 2.7
+    total_score: 17.4 # 6*0.8 + 6*1.2 + 2.7*2.0 = 4.8 + 7.2 + 5.4
+
+  # round_trips: light(0.5) + needs_rule×2(2.0+2.0) + compatibility(0.5)
+  #            + health_response(0.5) + growth_advancement(1.0) = 6.5 → ceil = 7
+  communication_estimate:
+    round_trips: 7
+    estimated_seconds: 70
+    time_limit_seconds: 480
+    feasibility: feasible # 70 <= 480*0.75 = 360
+
+  elements:
+    - id: plant-1
+      archetype: plant
+      params:
+        species: fern
+        pot_position: 1
+        soil_type: peaty
+      position: { slot: 1 }
+      initial_states: { health: wilting, effective_light: partial_shade } # north zone: partial_shade
+    - id: plant-2
+      archetype: plant
+      params:
+        species: succulent
+        pot_position: 5
+        soil_type: sandy
+      position: { slot: 5 }
+      initial_states: { health: stable, effective_light: full_sun } # center zone: full_sun
+    - id: plant-3
+      archetype: plant
+      params:
+        species: orchid
+        pot_position: 6
+        soil_type: loamy
+      position: { slot: 6 }
+      initial_states: { health: wilting, effective_light: full_sun } # center zone: full_sun
+    - id: zone-north
+      archetype: environment_zone
+      params:
+        zone_id: north
+        light_level: partial_shade
+        temperature: cool
+        covers_positions: ['1', '2', '3']
+    - id: zone-center
+      archetype: environment_zone
+      params:
+        zone_id: center
+        light_level: full_sun
+        temperature: warm
+        covers_positions: ['4', '5', '6']
+    - id: zone-south
+      archetype: environment_zone
+      params:
+        zone_id: south
+        light_level: full_shade
+        temperature: moderate
+        covers_positions: ['7', '8', '9']
+
+  rules:
+    # Order matters: rule-light precedes rule-orchid-care so a single
+    # apply_care(shade) on the orchid sets partial_shade THEN heals it.
+    - id: rule-light
+      template: light_adjustment
+      bindings:
+        transitions:
+          - [full_sun, shade_applied, partial_shade]
+          - [partial_shade, shade_applied, full_shade]
+      target_elements: [plant-1, plant-2, plant-3]
+    - id: rule-orchid-care
+      template: needs_rule
+      bindings:
+        predicates:
+          [
+            { name: species_is, species: orchid },
+            { name: light_is, effective_light: partial_shade },
+          ]
+        combinator: AND
+        action: { verb: heal }
+      target_elements: [plant-3]
+    - id: rule-fern-needs
+      template: needs_rule
+      # Danger rule (botanist manual): a fern under full_shade suffers. In this
+      # safe garden the fern sits under partial_shade, so it never fires.
+      bindings:
+        predicates:
+          [{ name: species_is, species: fern }, { name: light_is, effective_light: full_shade }]
+        combinator: AND
+        action: { verb: change_health, delta: down }
+      target_elements: [plant-1]
+    - id: rule-compatibility
+      template: compatibility_matrix
+      bindings:
+        matrix:
+          - [fern, succulent, incompatible]
+          - [fern, orchid, compatible]
+          - [succulent, orchid, neutral]
+          - [fern, moss, synergy]
+          - [succulent, vine, compatible]
+      target_elements: [plant-1, plant-2, plant-3]
+    - id: rule-health
+      template: health_response
+      bindings:
+        transitions:
+          - [wilting, correct_care, stable]
+          - [stable, correct_care, thriving]
+          - [critical, correct_care, wilting]
+          - [stable, wrong_care, wilting]
+          - [thriving, wrong_care, stable]
+          - [wilting, wrong_care, critical]
+          - [thriving, neglect, stable]
+          - [stable, neglect, wilting]
+      target_elements: [plant-1, plant-2]
+    - id: rule-growth
+      template: growth_advancement
+      bindings:
+        transitions:
+          - [seedling, fertilize_correct, juvenile]
+          - [juvenile, repot_correct, mature]
+          - [mature, bloom_correct, flowering]
+      target_elements: [plant-1, plant-2, plant-3]
+
+  information_partition:
+    role_assignments:
+      - role: gardener
+        element_views:
+          - {
+              element_id: plant-1,
+              visible_attributes: [species, pot_position],
+              visible_states: [health, growth_stage, effective_light],
+            }
+          - {
+              element_id: plant-2,
+              visible_attributes: [species, pot_position],
+              visible_states: [health, growth_stage, effective_light],
+            }
+          - {
+              element_id: plant-3,
+              visible_attributes: [species, pot_position],
+              visible_states: [health, growth_stage, effective_light],
+            }
+          - {
+              element_id: zone-north,
+              visible_attributes: [zone_id, light_level, temperature, covers_positions],
+              visible_states: [],
+            }
+          - {
+              element_id: zone-center,
+              visible_attributes: [zone_id, light_level, temperature, covers_positions],
+              visible_states: [],
+            }
+          - {
+              element_id: zone-south,
+              visible_attributes: [zone_id, light_level, temperature, covers_positions],
+              visible_states: [],
+            }
+      - role: botanist
+        element_views:
+          - { element_id: plant-1, visible_attributes: [species, soil_type], visible_states: [] }
+          - { element_id: plant-2, visible_attributes: [species, soil_type], visible_states: [] }
+          - { element_id: plant-3, visible_attributes: [species, soil_type], visible_states: [] }
+
+  win_condition:
+    type: optimization_target
+    params:
+      all_states_at_least:
+        - { state: health, value: stable } # every plant health >= stable (declared-order rank)
+      count_states_equal:
+        - { state: growth_stage, value: flowering, count: 1 } # >= 1 plant flowering

--- a/packages/creation/fixtures/radio-cipher/game-type.yaml
+++ b/packages/creation/fixtures/radio-cipher/game-type.yaml
@@ -1,0 +1,284 @@
+# Radio Cipher GameType vocabulary (v1.0.0), extracted verbatim from the
+# creation-schema design spec (docs/architecture/arch-component-creation-schema.md,
+# "实例化 A：密码电台" — Schema instantiation A). Data values are spec-faithful;
+# inline commentary is translated to English per the repo language policy.
+# Chinese strings (display names, verbal labels, descriptions) are DATA in the
+# target language, as the spec mandates for GameType instantiations.
+GameType:
+  id: radio-cipher
+  version: '1.0.0'
+  display_name: 密码电台
+  description: 听觉信息不对称解密协作——一方听到加密消息，另一方持有密码本
+
+  co_play_form: hidden_info_coop # each side holds half the information; voice merges them
+
+  element_archetypes:
+    - id: cipher_segment
+      category: auditory
+      verbal_label:
+        canonical: '密文段'
+        phonetic_pinyin: 'mì wén duàn'
+        aliases: ['加密片段']
+        forbidden_terms: ['密码', '暗号']
+      description: 一段经过加密处理的语音片段
+      attributes:
+        - name: content_length
+          type: enum
+          required: true
+          values: [short, medium, long] # 3/5/8 syllables
+          display_labels: { short: '短', medium: '中等', long: '长' }
+          verbal_template: '{content_length}密文段' # rendered with display_label: 「短密文段」「中等密文段」
+        - name: plaintext_category
+          type: enum
+          required: true
+          values: [animal, color, number_word, direction, weather]
+          verbal_template: '答案是一个{plaintext_category}类词汇'
+      states:
+        - name: decryption_progress
+          type: enum
+          values: [encrypted, partial, decrypted]
+          initial: encrypted
+          verbal_template: '这段目前{decryption_progress}'
+      interaction_model: stateful
+
+    - id: cipher_key
+      category: visual
+      verbal_label:
+        canonical: '密钥'
+        phonetic_pinyin: 'mì yào'
+        aliases: ['钥匙']
+        forbidden_terms: ['密码本']
+      description: 解密所需的密钥参数——每种加密方法的密钥材料均为有界整数
+      attributes:
+        - name: target_method
+          type: enum
+          required: true
+          values: [caesar_shift, reverse]
+          display_labels: { caesar_shift: '凯撒偏移', reverse: '反转' }
+          verbal_template: '{target_method}密钥'
+        - name: shift_amount
+          type: range
+          required: false
+          min: 1
+          max: 25
+          step: 1
+          verbal_template: '偏移量{shift_amount}'
+          # caesar_shift uses this field; reverse needs no key parameter (self-inverse operation)
+      states: []
+      interaction_model: stateless
+
+    - id: frequency_hint
+      category: visual
+      verbal_label:
+        canonical: '频率提示'
+        phonetic_pinyin: 'pín lǜ tí shì'
+        aliases: []
+        forbidden_terms: ['线索', '暗示']
+      description: 音节出现频率的统计提示
+      attributes:
+        - name: hint_type
+          type: enum
+          required: true
+          values: [most_frequent, least_frequent, repeated]
+          display_labels: { most_frequent: '最高频', least_frequent: '最低频', repeated: '重复' }
+          verbal_template: '{hint_type}音节提示'
+        - name: target_syllable
+          type: enum
+          required: true
+          values: [a, e, i, o, u, ai, ei, ao, ou, an, en, ang, eng]
+      states: []
+      interaction_model: stateless
+
+  action_registry:
+    - name: apply_key
+      description: 对密文段应用密钥执行解密
+      params: [{ name: cipher_segment_id, type: string }, { name: cipher_key_id, type: string }]
+      scope: rule_verb
+      state_effect: advance_state # each application advances one step: encrypted→partial→decrypted
+    - name: reverse_decode
+      description: 对密文段执行反转解密（无需密钥）
+      params: [{ name: cipher_segment_id, type: string }]
+      scope: rule_verb
+      state_effect: complete_state # self-inverse operation jumps to the terminal state: encrypted→decrypted
+    - name: identify_shift
+      description: 根据频率分析确定偏移量
+      params: [{ name: shift_value, type: int }]
+      scope: rule_verb
+    - name: confirm_decryption
+      description: 确认该段解密正确
+      params: []
+      scope: rule_verb
+    - name: retry_decryption
+      description: 重试解密（密钥可能错误）
+      params: []
+      scope: rule_verb
+    - name: describe_heard_content
+      description: 口头复述听到的加密内容
+      params: []
+      scope: player_action
+      # pure communication: repeating what is heard fires no rule
+    - name: execute_decryption
+      description: 按译码员指令执行解密操作
+      params: []
+      scope: player_action
+      triggers: [decrypt_step, reverse_decrypt, verification_check] # the listener's decrypt action drives the pipelines
+    - name: give_instruction
+      description: 根据密码本给出解密指令
+      params: []
+      scope: player_action
+
+  rule_templates:
+    - id: decrypt_step
+      type: temporal_sequence
+      sequence_schema:
+        max_steps: 5
+        step_schema:
+          action: apply_key # references action_registry
+          params:
+            - name: cipher_segment_id
+              type: string
+            - name: cipher_key_id
+              type: string
+        ordering: strict
+      communication_weight: 2.0 # each step needs: listen → repeat → look up → instruct → execute → confirm
+
+    - id: reverse_decrypt
+      type: temporal_sequence
+      sequence_schema:
+        max_steps: 1
+        step_schema:
+          action: reverse_decode # references action_registry
+          params:
+            - name: cipher_segment_id
+              type: string
+        ordering: strict
+      communication_weight: 1.5 # reverse decryption is simpler: listen → repeat → instruct "say it backwards" → execute → confirm
+
+    - id: verification_check
+      type: condition_action
+      condition_schema:
+        predicates:
+          - name: plaintext_is_valid_word
+            params:
+              - name: category
+                type: string
+            description: 解密结果是否为目标类别的合法词汇
+        combinators: [AND]
+      action_schema:
+        verbs: [confirm_decryption, retry_decryption] # references an action_registry subset
+      communication_weight: 1.0
+
+  information_partition_template:
+    roles:
+      - id: listener
+        display_name: 监听员
+        verbal_label: '监听员'
+        description: 听到加密语音消息，需要口头复述听到的内容
+        input_modality: auditory
+        output_modality: voice
+      - id: decoder
+        display_name: 译码员
+        verbal_label: '译码员'
+        description: 持有密码本和频率提示，指导监听员解密
+        input_modality: visual
+        output_modality: voice
+
+    visibility_rules:
+      - role: listener
+        can_see:
+          - element_archetype: cipher_segment
+            attributes: [content_length] # content_length is visible to both sides (shared label source)
+            states: [decryption_progress]
+        cannot_see:
+          - element_archetype: cipher_segment
+            attributes: [plaintext_category]
+            states: []
+          - element_archetype: cipher_key
+            attributes: ['*']
+            states: []
+          - element_archetype: frequency_hint
+            attributes: ['*']
+            states: []
+      - role: decoder
+        can_see:
+          - element_archetype: cipher_key
+            attributes: ['*']
+            states: []
+          - element_archetype: frequency_hint
+            attributes: ['*']
+            states: []
+          - element_archetype: cipher_segment
+            attributes: [plaintext_category, content_length]
+            states: [decryption_progress]
+        cannot_see:
+          - element_archetype: cipher_segment
+            attributes: []
+            states: []
+
+    # Cross-role shared label source — only archetypes needing cross-role
+    # communication are listed, and the attributes must be visible to all
+    # communicating roles.
+    shared_label_attributes:
+      - element_archetype: cipher_segment
+        attributes: [content_length] # visible to both → instance_label like 「短密文段」「中等密文段」
+      # cipher_key and frequency_hint are consumed by the decoder only — no
+      # cross-role communication need, so they are not listed here.
+
+    rule_visibility:
+      - role: listener
+        visible_rule_templates: []
+      - role: decoder
+        visible_rule_templates: [decrypt_step, reverse_decrypt, verification_check]
+
+    action_capability:
+      - role: listener
+        can_perform: [describe_heard_content, execute_decryption] # references action_registry
+        target_archetypes: [cipher_segment]
+      - role: decoder
+        can_perform: [give_instruction]
+        target_archetypes: []
+
+    communication_channels:
+      - from: listener
+        to: decoder
+        modality: voice
+        constraints:
+          turn_time_limit_seconds: 30
+      - from: decoder
+        to: listener
+        modality: voice
+        constraints:
+          forbidden_content: [plaintext_answer]
+          turn_time_limit_seconds: 30
+
+    partition_pattern: describe_execute
+
+  win_condition_type:
+    type: all_solved
+    description: 所有 cipher_segment 的 decryption_progress 到达 decrypted 状态
+
+  difficulty_budget:
+    element_count:
+      min: 3
+      max: 12
+    rule_count:
+      min: 1
+      max: 8
+    partition_complexity:
+      max: 6.0
+    weights:
+      element: 1.0
+      rule: 1.5
+      partition: 2.0
+    total_score:
+      min: 5.0
+      max: 30.0
+
+  communication_budget:
+    max_round_trips: 15
+    estimated_seconds_per_round: 12.0
+    time_limit_seconds: 300
+    safety_margin: 0.8
+
+  solver_strategy: exhaustive_path_search # small state space (2 segments × 2 methods × bounded key space)
+  solver_timeout_ms: 5000 # provisional bound — calibration lands with spec design-debt "solver_strategy / solver_timeout_ms 校准"

--- a/packages/creation/fixtures/radio-cipher/level.rc-demo-001.yaml
+++ b/packages/creation/fixtures/radio-cipher/level.rc-demo-001.yaml
@@ -1,0 +1,118 @@
+# Radio Cipher worked Level example (rc-demo-001), extracted verbatim from the
+# creation-schema design spec (docs/architecture/arch-component-creation-schema.md,
+# "工作关卡示例" — worked level example). Data values are spec-faithful; inline
+# commentary is translated to English per the repo language policy.
+Level:
+  metadata:
+    id: rc-demo-001
+    game_type: radio-cipher
+    game_type_version: '1.0.0'
+    title: 新手训练电台
+    author: ai-author-001
+    created_at: '2026-07-02T22:00:00+08:00'
+
+  # partition_complexity computation (from the spec):
+  # total_fields: cipher_segment(2attr+1state=3) + cipher_key(2attr=2) + frequency_hint(2attr=2) = 7
+  # listener hidden: cipher_segment.plaintext_category(1) + cipher_key.*(2) + frequency_hint.*(2) = 5; ratio=5/7=0.714
+  # decoder hidden: 0; ratio=0/7=0.0
+  # mean_hidden=(0.714+0.0)/2=0.357; roles_term=2*0.357=0.714
+  # channels: listener→decoder: time_limit(1)=1; decoder→listener: forbidden(1)+time_limit(1)=2; mean=1.5
+  # channels_term=2*1.5=3.0
+  # partition_complexity=0.714+3.0=3.71
+  difficulty:
+    element_count: 5 # seg-1, seg-2, key-1, hint-1, hint-2
+    rule_count: 3 # rule-decrypt-1, rule-reverse-2, rule-verify
+    partition_complexity: 3.71
+    total_score: 16.92 # 5*1.0 + 3*1.5 + 3.71*2.0 = 5.0+4.5+7.42
+
+  # round_trips: decrypt_step(2.0) + reverse_decrypt(1.5) + verification_check(1.0) = 4.5 → ceil = 5
+  communication_estimate:
+    round_trips: 5
+    estimated_seconds: 60
+    time_limit_seconds: 300
+    feasibility: feasible # 60 <= 300*0.8=240
+
+  elements:
+    - id: seg-1
+      archetype: cipher_segment
+      params:
+        content_length: short
+        plaintext_category: animal
+      position:
+        slot: 1
+    - id: seg-2
+      archetype: cipher_segment
+      params:
+        content_length: medium
+        plaintext_category: color
+      position:
+        slot: 2
+    - id: key-1
+      archetype: cipher_key
+      params:
+        target_method: caesar_shift
+        shift_amount: 3
+    - id: hint-1
+      archetype: frequency_hint
+      params:
+        hint_type: most_frequent
+        target_syllable: a
+    - id: hint-2
+      archetype: frequency_hint
+      params:
+        hint_type: repeated
+        target_syllable: ei
+
+  rules:
+    - id: rule-decrypt-1
+      template: decrypt_step
+      bindings:
+        cipher_segment_id: seg-1
+        cipher_key_id: key-1 # seg-1 uses caesar_shift; key-1 has shift_amount=3
+      target_elements: [seg-1, key-1]
+    - id: rule-reverse-2
+      template: reverse_decrypt
+      bindings:
+        cipher_segment_id: seg-2 # seg-2 uses reverse (self-inverse, no key needed)
+      target_elements: [seg-2]
+    - id: rule-verify
+      template: verification_check
+      bindings:
+        predicates: [{ name: plaintext_is_valid_word, category: animal }]
+        combinator: AND
+        action: { verb: confirm_decryption }
+      target_elements: [seg-1]
+
+  information_partition:
+    role_assignments:
+      - role: listener
+        element_views:
+          - element_id: seg-1
+            visible_attributes: [content_length]
+            visible_states: [decryption_progress]
+          - element_id: seg-2
+            visible_attributes: [content_length]
+            visible_states: [decryption_progress]
+      - role: decoder
+        element_views:
+          - element_id: key-1
+            visible_attributes: [target_method, shift_amount]
+            visible_states: []
+          - element_id: hint-1
+            visible_attributes: [hint_type, target_syllable]
+            visible_states: []
+          - element_id: hint-2
+            visible_attributes: [hint_type, target_syllable]
+            visible_states: []
+          - element_id: seg-1
+            visible_attributes: [plaintext_category, content_length]
+            visible_states: [decryption_progress]
+          - element_id: seg-2
+            visible_attributes: [plaintext_category, content_length]
+            visible_states: [decryption_progress]
+
+  win_condition:
+    type: all_solved
+    params:
+      target_state: decrypted
+      target_elements: [seg-1, seg-2]

--- a/packages/creation/fixtures/sound-garden/game-type.yaml
+++ b/packages/creation/fixtures/sound-garden/game-type.yaml
@@ -1,0 +1,210 @@
+# Sound Garden GameType vocabulary (v1.0.0), extracted verbatim from the
+# creation-schema design spec (docs/architecture/arch-component-creation-schema.md,
+# "实例化 C：声音花园（Sound Garden）— co_build 形态"). Data values are
+# spec-faithful; inline commentary is translated to English per the repo
+# language policy. Chinese strings are target-language instantiation DATA.
+GameType:
+  id: sound-garden
+  version: '1.0.0'
+  display_name: 声音花园
+  description: 共同建造——双方在共享时间线上放置节奏与旋律元素，追求和声目标
+
+  co_play_form: co_build # co-construction form
+
+  element_archetypes:
+    - id: rhythm_piece
+      category: auditory
+      verbal_label:
+        canonical: '节奏件'
+        phonetic_pinyin: 'jié zòu jiàn'
+        aliases: ['鼓点']
+        forbidden_terms: ['音符']
+      description: 放置在时间线上的节奏元素
+      attributes:
+        - name: rhythm_type
+          type: enum
+          required: true
+          values: [kick, snare, hihat, clap]
+          display_labels: { kick: '底鼓', snare: '军鼓', hihat: '踩镲', clap: '拍掌' }
+          verbal_template: '{rhythm_type}节奏件'
+        - name: timeline_slot
+          type: range
+          required: true
+          min: 1
+          max: 8
+          step: 1
+          verbal_template: '第{timeline_slot}拍'
+      states: []
+      interaction_model: stateless
+
+    - id: melody_piece
+      category: auditory
+      verbal_label:
+        canonical: '旋律件'
+        phonetic_pinyin: 'xuán lǜ jiàn'
+        aliases: ['音色']
+        forbidden_terms: ['节奏']
+      description: 放置在时间线上的旋律元素
+      attributes:
+        - name: melody_type
+          type: enum
+          required: true
+          values: [bell, chime, flute, harp]
+          display_labels: { bell: '铃铛', chime: '风铃', flute: '笛音', harp: '竖琴' }
+          verbal_template: '{melody_type}旋律件'
+        - name: timeline_slot
+          type: range
+          required: true
+          min: 1
+          max: 8
+          step: 1
+          verbal_template: '第{timeline_slot}拍'
+      states: []
+      interaction_model: stateless
+
+  action_registry:
+    - name: place_piece
+      description: 在时间线槽位放置一个元素
+      params: [{ name: slot, type: int }]
+      scope: both
+      construction_effect: place # declarative construction effect: place the target element
+      triggers: [harmony_rule] # placing a piece re-evaluates same-slot harmony
+    - name: remove_piece
+      description: 从时间线移除一个元素
+      params: [{ name: slot, type: int }]
+      scope: both
+      construction_effect: remove # declarative construction effect: remove the target element
+      triggers: [harmony_rule] # removing a piece re-evaluates same-slot harmony
+    - name: propose_plan
+      description: 口头提议放置计划
+      params: []
+      scope: player_action # pure coordination: proposing a plan fires no rule
+    - name: score_harmony
+      description: 计算当前花园的和声得分（引擎内部）
+      params: []
+      scope: rule_verb
+
+  rule_templates:
+    - id: harmony_rule
+      type: interaction_matrix # rhythm×melody pair lookup — only same-timeline_slot pairs score
+      matrix_schema:
+        entity_types: [kick, snare, hihat, clap, bell, chime, flute, harp]
+        entity_type_attributes: [rhythm_type, melody_type] # entity type from each piece's type attribute
+        pair_match_attributes: [timeline_slot] # only same-slot pairs are eligible (formal declaration)
+        relation_types: [synergy, compatible, neutral, incompatible]
+        relation_scores: { synergy: 3, compatible: 2, neutral: 1, incompatible: -1 }
+        # the SINGLE machine scoring source: score = sum of eligible pairs'
+        # matrix relations mapped through this table (score_threshold basis)
+        effect_schema:
+          - relation: synergy
+            effect: score_harmony # references action_registry
+            params: []
+          - relation: compatible
+            effect: score_harmony
+            params: []
+          - relation: neutral
+            effect: score_harmony
+            params: []
+          - relation: incompatible
+            effect: score_harmony
+            params: []
+      communication_weight: 0.5 # passive scoring, no active communication needed
+
+  information_partition_template:
+    roles:
+      - id: rhythm_builder
+        display_name: 节奏手
+        verbal_label: '节奏手'
+        description: 放置节奏元素，看到完整时间线
+        input_modality: visual
+        output_modality: voice
+      - id: melody_builder
+        display_name: 旋律手
+        verbal_label: '旋律手'
+        description: 放置旋律元素，看到完整时间线
+        input_modality: visual
+        output_modality: voice
+
+    visibility_rules: # co_build form: both sides share the full state
+      - role: rhythm_builder
+        can_see:
+          - element_archetype: rhythm_piece
+            attributes: ['*']
+            states: []
+          - element_archetype: melody_piece
+            attributes: ['*']
+            states: []
+        cannot_see: []
+      - role: melody_builder
+        can_see:
+          - element_archetype: rhythm_piece
+            attributes: ['*']
+            states: []
+          - element_archetype: melody_piece
+            attributes: ['*']
+            states: []
+        cannot_see: []
+
+    shared_label_attributes: # co_build: both see everything — disambiguate via type+slot
+      - element_archetype: rhythm_piece
+        attributes: [rhythm_type, timeline_slot]
+      - element_archetype: melody_piece
+        attributes: [melody_type, timeline_slot]
+
+    rule_visibility: # co_build: both sides know the harmony rule
+      - role: rhythm_builder
+        visible_rule_templates: [harmony_rule]
+      - role: melody_builder
+        visible_rule_templates: [harmony_rule]
+
+    action_capability:
+      - role: rhythm_builder
+        can_perform: [place_piece, remove_piece, propose_plan]
+        target_archetypes: [rhythm_piece] # may only place rhythm pieces
+      - role: melody_builder
+        can_perform: [place_piece, remove_piece, propose_plan]
+        target_archetypes: [melody_piece] # may only place melody pieces
+
+    communication_channels:
+      - from: rhythm_builder
+        to: melody_builder
+        modality: voice
+        constraints:
+          turn_time_limit_seconds: 30
+      - from: melody_builder
+        to: rhythm_builder
+        modality: voice
+        constraints:
+          turn_time_limit_seconds: 30
+
+    partition_pattern: ability_complement
+
+  win_condition_type:
+    type: score_threshold
+    description: 和声总分达到目标阈值
+
+  difficulty_budget:
+    element_count:
+      min: 4
+      max: 16
+    rule_count:
+      min: 1
+      max: 4
+    partition_complexity:
+      max: 4.0
+    weights:
+      element: 1.0
+      rule: 1.0
+      partition: 1.0
+    total_score:
+      min: 4.0
+      max: 20.0
+
+  communication_budget:
+    max_round_trips: 10
+    estimated_seconds_per_round: 8.0
+    time_limit_seconds: 240
+    safety_margin: 0.8
+
+  solver_strategy: exhaustive_path_search # small state space (bounded timeline slots × finite piece combos)
+  solver_timeout_ms: 5000 # provisional bound — calibration lands with spec design-debt "solver_strategy / solver_timeout_ms 校准"

--- a/packages/creation/fixtures/sound-garden/level.sg-demo-001.yaml
+++ b/packages/creation/fixtures/sound-garden/level.sg-demo-001.yaml
@@ -1,0 +1,125 @@
+# Sound Garden worked Level example (sg-demo-001), extracted verbatim from
+# the creation-schema design spec (docs/architecture/arch-component-creation-schema.md,
+# "工作关卡示例" under 实例化 C). Data values are spec-faithful; inline
+# commentary is translated to English per the repo language policy.
+Level:
+  metadata:
+    id: sg-demo-001
+    game_type: sound-garden
+    game_type_version: '1.0.0'
+    title: 四拍和声
+    author: ai-author-003
+    created_at: '2026-07-03T01:00:00+08:00'
+
+  # partition_complexity: both roles see everything → hidden=0, roles_term=0
+  # channels: 2 channels × 1 constraint each → channels_term = 2*1 = 2.0
+  # partition_complexity = 0 + 2.0 = 2.0
+  difficulty:
+    element_count: 8 # 4 rhythm_piece + 4 melody_piece
+    rule_count: 1 # harmony_rule
+    partition_complexity: 2.0
+    total_score: 11.0 # 8*1.0 + 1*1.0 + 2.0*1.0
+
+  # round_trips: harmony_rule(0.5)*1 = 0.5 → ceil = 1; co_build coordination
+  # (propose_plan turns) counts separately: 4 coordination + 1 scoring = 5
+  communication_estimate:
+    round_trips: 5
+    coordination_round_trips: 4 # 4 coordination turns — round_trips = ceil(0.5) + 4 = 5
+    estimated_seconds: 40
+    time_limit_seconds: 240
+    feasibility: feasible # 40 <= 240*0.8 = 192
+
+  # co_build construction model: initial_state declares the starting space,
+  # available_materials each role's pool. goal_reachability derives
+  # machine-checkable reachability from these + relation scores + target.
+  initial_state:
+    timeline_slots: 8 # 8-beat timeline, initially empty
+    occupied: [] # nothing placed at start
+  available_materials:
+    rhythm_builder: # rhythm builder's pool
+      - { archetype: rhythm_piece, rhythm_type: kick, count: 1 }
+      - { archetype: rhythm_piece, rhythm_type: snare, count: 1 }
+      - { archetype: rhythm_piece, rhythm_type: hihat, count: 1 }
+      - { archetype: rhythm_piece, rhythm_type: clap, count: 1 }
+    melody_builder: # melody builder's pool
+      - { archetype: melody_piece, melody_type: bell, count: 1 }
+      - { archetype: melody_piece, melody_type: chime, count: 1 }
+      - { archetype: melody_piece, melody_type: flute, count: 1 }
+      - { archetype: melody_piece, melody_type: harp, count: 1 }
+
+  elements: # design-time element declarations (AI-authored product)
+    - id: r1
+      archetype: rhythm_piece
+      params: { rhythm_type: kick, timeline_slot: 1 }
+    - id: r2
+      archetype: rhythm_piece
+      params: { rhythm_type: snare, timeline_slot: 3 }
+    - id: r3
+      archetype: rhythm_piece
+      params: { rhythm_type: hihat, timeline_slot: 5 }
+    - id: r4
+      archetype: rhythm_piece
+      params: { rhythm_type: clap, timeline_slot: 7 }
+    - id: m1
+      archetype: melody_piece
+      params: { melody_type: bell, timeline_slot: 1 }
+    - id: m2
+      archetype: melody_piece
+      params: { melody_type: chime, timeline_slot: 3 }
+    - id: m3
+      archetype: melody_piece
+      params: { melody_type: flute, timeline_slot: 5 }
+    - id: m4
+      archetype: melody_piece
+      params: { melody_type: harp, timeline_slot: 7 }
+
+  rules:
+    - id: rule-harmony
+      template: harmony_rule
+      bindings: # same-slot rhythm+melody pairs score via matrix relations (relation_scores)
+        matrix:
+          - [kick, bell, synergy]
+          - [kick, chime, neutral]
+          - [kick, flute, compatible]
+          - [kick, harp, compatible]
+          - [snare, bell, neutral]
+          - [snare, chime, synergy]
+          - [snare, flute, incompatible] # noise penalty
+          - [snare, harp, neutral]
+          - [hihat, bell, compatible]
+          - [hihat, chime, compatible]
+          - [hihat, flute, synergy]
+          - [hihat, harp, neutral]
+          - [clap, bell, neutral]
+          - [clap, chime, neutral]
+          - [clap, flute, neutral]
+          - [clap, harp, synergy]
+      target_elements: [r1, r2, r3, r4, m1, m2, m3, m4]
+
+  information_partition:
+    role_assignments:
+      - role: rhythm_builder
+        element_views:
+          - { element_id: r1, visible_attributes: [rhythm_type, timeline_slot], visible_states: [] }
+          - { element_id: r2, visible_attributes: [rhythm_type, timeline_slot], visible_states: [] }
+          - { element_id: r3, visible_attributes: [rhythm_type, timeline_slot], visible_states: [] }
+          - { element_id: r4, visible_attributes: [rhythm_type, timeline_slot], visible_states: [] }
+          - { element_id: m1, visible_attributes: [melody_type, timeline_slot], visible_states: [] }
+          - { element_id: m2, visible_attributes: [melody_type, timeline_slot], visible_states: [] }
+          - { element_id: m3, visible_attributes: [melody_type, timeline_slot], visible_states: [] }
+          - { element_id: m4, visible_attributes: [melody_type, timeline_slot], visible_states: [] }
+      - role: melody_builder
+        element_views:
+          - { element_id: r1, visible_attributes: [rhythm_type, timeline_slot], visible_states: [] }
+          - { element_id: r2, visible_attributes: [rhythm_type, timeline_slot], visible_states: [] }
+          - { element_id: r3, visible_attributes: [rhythm_type, timeline_slot], visible_states: [] }
+          - { element_id: r4, visible_attributes: [rhythm_type, timeline_slot], visible_states: [] }
+          - { element_id: m1, visible_attributes: [melody_type, timeline_slot], visible_states: [] }
+          - { element_id: m2, visible_attributes: [melody_type, timeline_slot], visible_states: [] }
+          - { element_id: m3, visible_attributes: [melody_type, timeline_slot], visible_states: [] }
+          - { element_id: m4, visible_attributes: [melody_type, timeline_slot], visible_states: [] }
+
+  win_condition:
+    type: score_threshold
+    params:
+      target_score: 10 # total harmony score >= 10 wins

--- a/packages/creation/package.json
+++ b/packages/creation/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@amiclaw/creation",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --config dev/vite.config.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "dependencies": {
+    "js-yaml": "^4.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^26.0.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "jsdom": "^29.1.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/creation/src/engine/botanical.test.ts
+++ b/packages/creation/src/engine/botanical.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Botanical Garden (hidden_info_coop) engine integration on the largest
+ * vocabulary, all through the SHARED rule core: per-instance initial states,
+ * the stateful multi-entity care loop (state_transition health/growth/light +
+ * condition_action healing), optimization_target win, wrong-care degradation,
+ * role-filtered views, and engine-backed csp search agreement.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../schema/load'
+import { searchSolution } from './search'
+import { GameSession } from './engine'
+
+const fixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'botanical-garden'
+)
+const gameType = loadGameType(readFileSync(join(fixturesDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(fixturesDir, 'level.bg-demo-001.yaml'), 'utf8'))
+
+describe('GameSession — per-instance initial states', () => {
+  it('applies each element’s initial_states over the archetype defaults', () => {
+    const session = new GameSession(gameType, level)
+    const s = session.getState().elements
+    // plant-1 (fern): wilting + inherited partial_shade; plant-3 (orchid):
+    // wilting + full_sun; plant-2 (succulent): stable + full_sun.
+    expect(s['plant-1'].health).toBe('wilting')
+    expect(s['plant-1'].effective_light).toBe('partial_shade')
+    expect(s['plant-2'].health).toBe('stable')
+    expect(s['plant-3'].health).toBe('wilting')
+    expect(s['plant-3'].effective_light).toBe('full_sun')
+    // growth defaults to the archetype initial (seedling) for all.
+    expect(s['plant-1'].growth_stage).toBe('seedling')
+  })
+})
+
+describe('GameSession — scripted care loop to win (bg-demo-001)', () => {
+  it('heals, shades, and grows plants to satisfy optimization_target', () => {
+    const session = new GameSession(gameType, level)
+    expect(session.isWon()).toBe(false)
+
+    // Fern is wilting: water heals it via health_response correct_care.
+    expect(
+      session.performAction('gardener', 'apply_care', {
+        element_id: 'plant-1',
+        action_type: 'water',
+      }).ok
+    ).toBe(true)
+    expect(session.getState().elements['plant-1'].health).toBe('stable')
+
+    // Orchid: shade sets effective_light partial_shade AND the condition_action
+    // rule-orchid-care heals it in the same care action.
+    session.performAction('gardener', 'apply_care', { element_id: 'plant-3', action_type: 'shade' })
+    expect(session.getState().elements['plant-3'].effective_light).toBe('partial_shade')
+    expect(session.getState().elements['plant-3'].health).toBe('stable')
+
+    // Grow the orchid to flowering.
+    session.performAction('gardener', 'apply_care', {
+      element_id: 'plant-3',
+      action_type: 'fertilize',
+    })
+    expect(session.getState().elements['plant-3'].growth_stage).toBe('juvenile')
+    session.performAction('gardener', 'apply_care', { element_id: 'plant-3', action_type: 'repot' })
+    expect(session.getState().elements['plant-3'].growth_stage).toBe('mature')
+    expect(session.isWon()).toBe(false) // not flowering yet
+    session.performAction('gardener', 'apply_care', { element_id: 'plant-3', action_type: 'bloom' })
+    expect(session.getState().elements['plant-3'].growth_stage).toBe('flowering')
+
+    // optimization_target: all plants >= stable AND >= 1 flowering.
+    expect(session.isWon()).toBe(true)
+    expect(session.getState().won).toBe(true)
+  })
+
+  it('wrong care degrades health per the health_response table', () => {
+    const session = new GameSession(gameType, level)
+    expect(session.getState().elements['plant-2'].health).toBe('stable')
+    // overwater maps to wrong_care: stable -> wilting.
+    session.performAction('gardener', 'apply_care', {
+      element_id: 'plant-2',
+      action_type: 'overwater',
+    })
+    expect(session.getState().elements['plant-2'].health).toBe('wilting')
+    expect(session.isWon()).toBe(false)
+  })
+
+  it('enforces role capability: the botanist cannot apply care', () => {
+    const session = new GameSession(gameType, level)
+    const wrong = session.performAction('botanist', 'apply_care', {
+      element_id: 'plant-1',
+      action_type: 'water',
+    })
+    expect(wrong.ok).toBe(false)
+  })
+
+  it('F4: apply_care without its declared action_type param is a malformed call', () => {
+    const session = new GameSession(gameType, level)
+    const missing = session.performAction('gardener', 'apply_care', { element_id: 'plant-1' })
+    expect(missing.ok).toBe(false)
+    expect(!missing.ok && missing.reason).toContain('action_type')
+    // No state drift from the rejected call.
+    expect(session.getState().elements['plant-1'].health).toBe('wilting')
+  })
+
+  it('does not mutate the GameType or Level inputs', () => {
+    const gameTypeBefore = JSON.stringify(gameType)
+    const levelBefore = JSON.stringify(level)
+    const session = new GameSession(gameType, level)
+    session.performAction('gardener', 'apply_care', { element_id: 'plant-1', action_type: 'water' })
+    session.getRoleView('gardener')
+    session.getRoleView('botanist')
+    expect(JSON.stringify(gameType)).toBe(gameTypeBefore)
+    expect(JSON.stringify(level)).toBe(levelBefore)
+  })
+})
+
+describe('B: describe/forged actions are inert on game state (F1 + non-forgeable action_type)', () => {
+  it('a bare describe_state (pure communication) NEVER heals a plant', () => {
+    const session = new GameSession(gameType, level)
+    // Shade the orchid so rule-orchid-care's condition holds (partial_shade).
+    session.performAction('gardener', 'apply_care', { element_id: 'plant-3', action_type: 'shade' })
+    expect(session.getState().elements['plant-3'].health).toBe('stable')
+    // The exploit: keep "describing" the plant — a params:[] communication
+    // action that triggers no rule — and it must never ratchet health up.
+    for (let i = 0; i < 4; i++) {
+      const result = session.performAction('gardener', 'describe_state', { element_id: 'plant-3' })
+      expect(result.ok).toBe(true)
+      expect(result.ok && result.effects).toEqual([])
+    }
+    expect(session.getState().elements['plant-3'].health).toBe('stable') // never thriving
+  })
+
+  it('a smuggled action_type on describe_state is rejected (non-forgeable)', () => {
+    const session = new GameSession(gameType, level)
+    const before = session.getState().elements['plant-1'].health
+    // describe_state declares no action_type param: smuggling water must fail…
+    const forged = session.performAction('gardener', 'describe_state', {
+      element_id: 'plant-1',
+      action_type: 'water',
+    })
+    expect(forged.ok).toBe(false)
+    expect(!forged.ok && forged.reason).toContain('action_type')
+    // …and leave the plant exactly as it was (no smuggled heal).
+    expect(session.getState().elements['plant-1'].health).toBe(before)
+  })
+
+  it('a mismatched action_type on apply_care fires no state_transition rule', () => {
+    const session = new GameSession(gameType, level)
+    // apply_care legitimately carries action_type, but a nonsense value maps
+    // to no action_event_mapping event, so no health/growth/light rule fires.
+    const result = session.performAction('gardener', 'apply_care', {
+      element_id: 'plant-1',
+      action_type: 'bogus_care',
+    })
+    expect(result.ok).toBe(true)
+    expect(result.ok && result.effects).toEqual([]) // no event → no transition
+    expect(session.getState().elements['plant-1'].health).toBe('wilting') // unchanged
+  })
+})
+
+describe('GameSession — botanical role-filtered views', () => {
+  const session = new GameSession(gameType, level)
+
+  it('the gardener sees the scene + live states but not soil_type', () => {
+    const view = session.getRoleView('gardener')
+    const plant1 = view.elements.find((e) => e.element_id === 'plant-1')
+    expect(plant1?.visible_params).toHaveProperty('species')
+    expect(plant1?.visible_params).toHaveProperty('pot_position')
+    expect(plant1?.visible_params).not.toHaveProperty('soil_type')
+    expect(plant1?.visible_states).toHaveProperty('health')
+    expect(plant1?.visible_states).toHaveProperty('effective_light')
+    expect(view.visible_rules).toEqual([]) // gardener holds no manual
+    expect(view.can_perform).toEqual(['apply_care', 'describe_state'])
+  })
+
+  it('the botanist sees species + soil + the care manual but no scene states', () => {
+    const view = session.getRoleView('botanist')
+    const plant1 = view.elements.find((e) => e.element_id === 'plant-1')
+    expect(plant1?.visible_params).toHaveProperty('soil_type')
+    expect(plant1?.visible_params).not.toHaveProperty('pot_position')
+    expect(plant1?.visible_states).toEqual({})
+    expect(view.visible_rules).toContain('rule-orchid-care')
+    expect(view.visible_rules).toContain('rule-health')
+  })
+
+  it('leak test: no cannot_see field appears on the wrong role’s view', () => {
+    const template = gameType.information_partition_template
+    if (!template) throw new Error('fixture partition template missing')
+    // The botanist must never see pot_position or any plant runtime state.
+    const botanist = session.getRoleView('botanist')
+    for (const element of botanist.elements) {
+      expect(element.visible_params).not.toHaveProperty('pot_position')
+      expect(element.visible_states).toEqual({})
+    }
+    // The gardener must never see soil_type.
+    const gardener = session.getRoleView('gardener')
+    for (const element of gardener.elements) {
+      expect(element.visible_params).not.toHaveProperty('soil_type')
+    }
+  })
+})
+
+describe('engine-backed csp search on bg-demo-001', () => {
+  it('finds a care path to the optimization target', () => {
+    const result = searchSolution(gameType, level)
+    expect(result.solvable).toBe(true)
+    expect(result.timedOut).toBe(false)
+    expect(result.path.length).toBeGreaterThan(0)
+  })
+
+  it('reports unsolvable (fast, clean exhaustion) when flowering is structurally unreachable', () => {
+    // Remove the growth rule: no rule advances growth_stage, so flowering can
+    // never be reached. The remaining search space (health × light) is small,
+    // so exhaustion is fast and deterministic (no timeout boundary flake).
+    const impossible = structuredClone(level)
+    impossible.rules = impossible.rules.filter((r) => r.id !== 'rule-growth')
+    const result = searchSolution(gameType, impossible)
+    expect(result.solvable).toBe(false)
+    expect(result.timedOut).toBe(false)
+  })
+})

--- a/packages/creation/src/engine/engine.test.ts
+++ b/packages/creation/src/engine/engine.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Engine tests: scripted full rc-demo-001 playthrough to win, wrong-action
+ * robustness (no crash, state consistent), role-view leak guarantee, input
+ * immutability, and the engine-backed solution search (a real found path).
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../schema/load'
+import { expandNames, startDeadline } from '../validate/helpers'
+import { GameSession } from './engine'
+import { searchSolution, solutionDriversForTarget } from './search'
+
+const fixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'radio-cipher'
+)
+
+const gameType = loadGameType(readFileSync(join(fixturesDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(fixturesDir, 'level.rc-demo-001.yaml'), 'utf8'))
+
+describe('GameSession — scripted rc-demo-001 playthrough', () => {
+  it('plays through to the win purely via declared vocabulary', () => {
+    const session = new GameSession(gameType, level)
+    expect(session.isWon()).toBe(false)
+    expect(session.getState().elements['seg-1'].decryption_progress).toBe('encrypted')
+
+    // The listener describes what they hear (no state effect), then executes
+    // decryption per the decoder's instructions.
+    expect(session.performAction('listener', 'describe_heard_content').ok).toBe(true)
+
+    // seg-1: caesar shift — apply_key advances one step per execution.
+    const first = session.performAction('listener', 'execute_decryption', {
+      element_id: 'seg-1',
+    })
+    expect(first.ok).toBe(true)
+    expect(session.getState().elements['seg-1'].decryption_progress).toBe('partial')
+    session.performAction('listener', 'execute_decryption', { element_id: 'seg-1' })
+    expect(session.getState().elements['seg-1'].decryption_progress).toBe('decrypted')
+    expect(session.isWon()).toBe(false) // seg-2 still encrypted
+
+    // seg-2: reverse decode — complete_state jumps to the terminal state.
+    session.performAction('listener', 'execute_decryption', { element_id: 'seg-2' })
+    expect(session.getState().elements['seg-2'].decryption_progress).toBe('decrypted')
+    expect(session.isWon()).toBe(true)
+    expect(session.getState().won).toBe(true)
+  })
+
+  it('handles wrong actions without crashing and without state drift', () => {
+    const session = new GameSession(gameType, level)
+    const before = JSON.stringify(session.getState())
+
+    expect(session.performAction('listener', 'give_instruction')).toEqual({
+      ok: false,
+      reason: 'role "listener" cannot perform "give_instruction"',
+    })
+    expect(session.performAction('decoder', 'execute_decryption', { element_id: 'seg-1' }).ok).toBe(
+      false
+    )
+    expect(session.performAction('listener', 'execute_decryption', { element_id: 'nope' }).ok).toBe(
+      false
+    )
+    expect(session.performAction('listener', 'apply_key', { element_id: 'seg-1' })).toEqual({
+      ok: false,
+      reason: '"apply_key" is engine-internal (scope rule_verb)',
+    })
+    expect(session.performAction('listener', 'teleport').ok).toBe(false)
+
+    expect(JSON.stringify(session.getState())).toBe(before)
+  })
+
+  it('F4: rejects malformed calls distinguishably from legitimate no-ops', () => {
+    const session = new GameSession(gameType, level)
+
+    // Unknown extra arg → malformed → reject (not a silent no-op).
+    const unknown = session.performAction('listener', 'execute_decryption', {
+      element_id: 'seg-1',
+      bogus: 1,
+    } as unknown as { element_id: string })
+    expect(unknown.ok).toBe(false)
+    expect(!unknown.ok && unknown.reason).toContain('unknown arg')
+
+    // Legitimate communication no-op (no declared params, no construction
+    // effect) → ok:true with empty effects (NOT a malformed rejection).
+    const describe = session.performAction('listener', 'describe_heard_content')
+    expect(describe.ok).toBe(true)
+    expect(describe.ok && describe.effects).toEqual([])
+  })
+
+  it('never mutates the GameType or Level inputs', () => {
+    const gameTypeBefore = JSON.stringify(gameType)
+    const levelBefore = JSON.stringify(level)
+    const session = new GameSession(gameType, level)
+    session.performAction('listener', 'execute_decryption', { element_id: 'seg-1' })
+    session.performAction('listener', 'execute_decryption', { element_id: 'seg-2' })
+    session.getRoleView('listener')
+    session.getRoleView('decoder')
+    expect(JSON.stringify(gameType)).toBe(gameTypeBefore)
+    expect(JSON.stringify(level)).toBe(levelBefore)
+  })
+})
+
+describe('B: rule firing depends on WHICH action triggered it (F1 closure)', () => {
+  it('spamming the pure-communication describe_heard_content NEVER advances a segment', () => {
+    const session = new GameSession(gameType, level)
+    // The exploit: call the params:[] communication action on seg-1 repeatedly.
+    // It targets a cipher_segment (capability allows it) but triggers no rule.
+    for (let i = 0; i < 5; i++) {
+      const result = session.performAction('listener', 'describe_heard_content', {
+        element_id: 'seg-1',
+      })
+      expect(result.ok).toBe(true) // a legitimate no-op, not a rejection…
+      expect(result.ok && result.effects).toEqual([]) // …but nothing fires
+    }
+    expect(session.getState().elements['seg-1'].decryption_progress).toBe('encrypted')
+    expect(session.isWon()).toBe(false) // no solo win
+  })
+
+  it('only the intended trigger action (execute_decryption) drives the pipeline', () => {
+    const session = new GameSession(gameType, level)
+    const decrypt = session.performAction('listener', 'execute_decryption', { element_id: 'seg-1' })
+    expect(decrypt.ok && decrypt.effects).toContain('rule-decrypt-1: step applied')
+    expect(session.getState().elements['seg-1'].decryption_progress).toBe('partial')
+  })
+})
+
+describe('GameSession — role-filtered views', () => {
+  const session = new GameSession(gameType, level)
+
+  it('exposes the partitioned views each role plays from', () => {
+    const listener = session.getRoleView('listener')
+    expect(listener.elements.map((e) => e.element_id)).toEqual(['seg-1', 'seg-2'])
+    expect(listener.elements[0].visible_params).toEqual({ content_length: 'short' })
+    expect(listener.elements[0].visible_states).toEqual({ decryption_progress: 'encrypted' })
+    expect(listener.visible_rules).toEqual([])
+    expect(listener.can_perform).toEqual(['describe_heard_content', 'execute_decryption'])
+
+    const decoder = session.getRoleView('decoder')
+    expect(decoder.elements.map((e) => e.element_id)).toEqual([
+      'key-1',
+      'hint-1',
+      'hint-2',
+      'seg-1',
+      'seg-2',
+    ])
+    expect(decoder.visible_rules).toEqual(['rule-decrypt-1', 'rule-reverse-2', 'rule-verify'])
+    expect(decoder.can_perform).toEqual(['give_instruction'])
+  })
+
+  it('leak test: a role view NEVER contains a cannot_see field', () => {
+    const template = gameType.information_partition_template
+    if (!template) throw new Error('fixture partition template missing')
+    for (const visibilityRule of template.visibility_rules) {
+      const view = session.getRoleView(visibilityRule.role)
+      for (const entry of visibilityRule.cannot_see) {
+        const archetype = gameType.element_archetypes.find((a) => a.id === entry.element_archetype)
+        if (!archetype) continue
+        const forbiddenAttrs = expandNames(
+          entry.attributes,
+          archetype.attributes.map((a) => a.name)
+        )
+        const forbiddenStates = expandNames(
+          entry.states,
+          (archetype.states ?? []).map((s) => s.name)
+        )
+        for (const elementView of view.elements) {
+          if (elementView.archetype !== entry.element_archetype) continue
+          for (const attr of forbiddenAttrs) {
+            expect(elementView.visible_params).not.toHaveProperty(attr)
+          }
+          for (const state of forbiddenStates) {
+            expect(elementView.visible_states).not.toHaveProperty(state)
+          }
+        }
+      }
+    }
+  })
+
+  it('excludes cannot_see fields even when a level view over-declares them', () => {
+    const leakyLevel = structuredClone(level)
+    const listenerAssignment = leakyLevel.information_partition.role_assignments.find(
+      (a) => a.role === 'listener'
+    )
+    if (!listenerAssignment) throw new Error('fixture role missing')
+    // A malicious/buggy level view over-declares the hidden field.
+    listenerAssignment.element_views[0].visible_attributes = [
+      'content_length',
+      'plaintext_category',
+    ]
+    const leakySession = new GameSession(gameType, leakyLevel)
+    const view = leakySession.getRoleView('listener')
+    expect(view.elements[0].visible_params).not.toHaveProperty('plaintext_category')
+  })
+})
+
+describe('engine-backed solution search', () => {
+  it('finds a real solution path for rc-demo-001', () => {
+    const result = searchSolution(gameType, level)
+    expect(result.solvable).toBe(true)
+    expect(result.timedOut).toBe(false)
+    expect(result.path.length).toBeGreaterThanOrEqual(3) // 2× decrypt steps + 1× reverse
+    const ruleIds = new Set(level.rules.map((rule) => rule.id))
+    for (const step of result.path) {
+      expect(ruleIds).toContain(step)
+    }
+    expect(result.path).toContain('rule-decrypt-1')
+    expect(result.path).toContain('rule-reverse-2')
+  })
+
+  it('counts exactly one independent driver per rc-demo target', () => {
+    for (const targetId of ['seg-1', 'seg-2']) {
+      const analysis = solutionDriversForTarget(gameType, level, targetId, startDeadline(5000))
+      expect(analysis.timedOut).toBe(false)
+      expect(analysis.drivers).toHaveLength(1)
+    }
+  })
+
+  it('times out instead of fake-passing under a zero deadline', () => {
+    const result = searchSolution(gameType, level, startDeadline(0))
+    expect(result.timedOut).toBe(true)
+    expect(result.solvable).toBe(false)
+  })
+})

--- a/packages/creation/src/engine/engine.ts
+++ b/packages/creation/src/engine/engine.ts
@@ -11,8 +11,8 @@
  * GameType inputs.
  */
 
-import type { ElementArchetype, GameType, Level } from '../schema/types'
-import { elementsById, expandNames, WILDCARD } from '../validate/helpers'
+import type { GameType, Level } from '../schema/types'
+import { elementsById, expandNames, forbiddenFieldsForRole, WILDCARD } from '../validate/helpers'
 import type { ElementStates, RuleContext } from './rules'
 import {
   actionEvent,
@@ -56,6 +56,14 @@ export interface PerformActionArgs {
   element_id?: string
   /** Param value driving action_event_mapping rows (e.g. apply_care's action_type). */
   action_type?: string
+  /**
+   * Any further arg must be a param the action DECLARES in its
+   * action_registry param_defs (e.g. sound-garden place_piece's `slot`).
+   * Declared params other than action_type are accepted as call payload but
+   * carry no engine semantics (placement reads the element's own params);
+   * undeclared keys are rejected as malformed.
+   */
+  [param: string]: unknown
 }
 
 /**
@@ -90,35 +98,9 @@ export class GameSession {
     const { gameType, level, archetypes } = this.ctx
     const elements = elementsById(level)
     const template = gameType.information_partition_template
-    const forbidden = new Map<string, { attributes: Set<string>; states: Set<string> }>()
-    const visibilityRule = template?.visibility_rules.find((entry) => entry.role === roleId)
-    for (const entry of visibilityRule?.cannot_see ?? []) {
-      const matched =
-        entry.element_archetype === WILDCARD
-          ? [...archetypes.values()]
-          : [archetypes.get(entry.element_archetype)].filter(
-              (a): a is ElementArchetype => a !== undefined
-            )
-      for (const archetype of matched) {
-        const bucket = forbidden.get(archetype.id) ?? {
-          attributes: new Set<string>(),
-          states: new Set<string>(),
-        }
-        for (const attr of expandNames(
-          entry.attributes,
-          archetype.attributes.map((a) => a.name)
-        )) {
-          bucket.attributes.add(attr)
-        }
-        for (const state of expandNames(
-          entry.states,
-          (archetype.states ?? []).map((s) => s.name)
-        )) {
-          bucket.states.add(state)
-        }
-        forbidden.set(archetype.id, bucket)
-      }
-    }
+    // Shared cannot_see subtraction — the same helper the validator's
+    // visibility model uses, so runtime and validator can never diverge.
+    const forbidden = forbiddenFieldsForRole(gameType, roleId)
 
     const assignment = level.information_partition.role_assignments.find((a) => a.role === roleId)
     const views: RoleElementView[] = []
@@ -181,21 +163,29 @@ export class GameSession {
       return { ok: false, reason: `role "${roleId}" cannot perform "${actionName}"` }
     }
 
-    // Arg validation. Distinguish a malformed call from a legitimate no-op,
-    // and keep action_type NON-FORGEABLE (B part 2): a MEANINGFUL action_type
-    // is honored only on an action that actually DECLARES an action_type param
+    // Arg validation honors the action's DECLARED param_defs: element_id and
+    // every declared param are legal call args; anything else is malformed.
+    // Distinguish a malformed call from a legitimate no-op, and keep
+    // action_type NON-FORGEABLE (B part 2): a MEANINGFUL action_type is
+    // honored only on an action that actually DECLARES an action_type param
     // — it can never be smuggled onto an unrelated action to claim an effect
     // that action does not have. An empty/absent action_type is "not provided"
-    // (a no-op), not a forgery. An unknown arg key, a missing declared
-    // action_type, and a construction action with no target are all malformed.
-    const declaresActionType = action.params.some((param) => param.name === 'action_type')
+    // (a no-op), not a forgery. Declared params other than action_type (e.g.
+    // sound-garden place_piece's slot) are accepted but engine-inert — only
+    // action_type is machine-consumed (it drives action_event_mapping).
+    const declaredParams = new Set(action.params.map((param) => param.name))
+    const declaresActionType = declaredParams.has('action_type')
     const providedActionType = args.action_type === '' ? undefined : args.action_type
-    for (const key of Object.keys(args)) {
-      if (key === 'element_id' || key === 'action_type') continue
-      return { ok: false, reason: `unknown arg "${key}" for action "${actionName}"` }
-    }
-    if (providedActionType !== undefined && !declaresActionType) {
-      return { ok: false, reason: `action "${actionName}" does not declare an action_type` }
+    for (const [key, value] of Object.entries(args)) {
+      if (key === 'element_id' || declaredParams.has(key)) continue
+      if (key === 'action_type' && (value === undefined || value === '')) continue
+      return {
+        ok: false,
+        reason:
+          key === 'action_type'
+            ? `action "${actionName}" does not declare an action_type`
+            : `unknown arg "${key}" for action "${actionName}"`,
+      }
     }
     if (declaresActionType && providedActionType === undefined) {
       return { ok: false, reason: `action "${actionName}" requires an action_type param` }

--- a/packages/creation/src/engine/engine.ts
+++ b/packages/creation/src/engine/engine.ts
@@ -1,0 +1,285 @@
+/**
+ * Minimal declarative rule engine session (spec Mechanism 1 semantics, R4).
+ *
+ * GameSession loads a (GameType, Level) pair into runtime state, accepts
+ * player actions, and determines the win condition — executing every rule
+ * through the SHARED core in rules.ts (the single semantics source also
+ * used by the solver). Zero game-specific logic: all case differences flow
+ * from vocabulary data.
+ *
+ * The engine mutates only its own runtime state — never the Level or
+ * GameType inputs.
+ */
+
+import type { ElementArchetype, GameType, Level } from '../schema/types'
+import { elementsById, expandNames, WILDCARD } from '../validate/helpers'
+import type { ElementStates, RuleContext } from './rules'
+import {
+  actionEvent,
+  actionTriggers,
+  applyConstruction,
+  buildRuleContext,
+  currentScore,
+  evaluateWin,
+  executeConditionAction,
+  executeInteractionMatrix,
+  executeStateTransition,
+  executeTemporalStep,
+  initialElementStates,
+  remainingSteps,
+} from './rules'
+
+export interface EngineSnapshot {
+  elements: Record<string, Record<string, unknown>>
+  won: boolean
+}
+
+export interface RoleElementView {
+  element_id: string
+  archetype: string
+  visible_params: Record<string, unknown>
+  visible_states: Record<string, unknown>
+}
+
+export interface RoleView {
+  role: string
+  elements: RoleElementView[]
+  /** Rule ids whose template this role may see (rule_visibility). */
+  visible_rules: string[]
+  /** Action names this role can perform (action_capability). */
+  can_perform: string[]
+}
+
+export type ActionResult = { ok: true; effects: string[] } | { ok: false; reason: string }
+
+export interface PerformActionArgs {
+  element_id?: string
+  /** Param value driving action_event_mapping rows (e.g. apply_care's action_type). */
+  action_type?: string
+}
+
+/**
+ * A live game session over one (GameType, Level) pair. R5's dev UI drives
+ * this API: getRoleView per player, performAction on interactions, isWon.
+ */
+export class GameSession {
+  private readonly ctx: RuleContext
+  private readonly states: ElementStates
+  private readonly stepsUsed = new Map<string, number>()
+
+  constructor(gameType: GameType, level: Level) {
+    this.ctx = buildRuleContext(gameType, level)
+    this.states = initialElementStates(gameType, level)
+  }
+
+  getState(): EngineSnapshot {
+    const elements: Record<string, Record<string, unknown>> = {}
+    for (const [elementId, machine] of this.states) {
+      elements[elementId] = Object.fromEntries(machine)
+    }
+    return { elements, won: this.isWon() }
+  }
+
+  /**
+   * Partition-filtered view for one role: starts from the level's
+   * element_views ("*" expanded) and additionally EXCLUDES every field the
+   * GameType template declares cannot_see for the role — a leaked field can
+   * never appear even if a level view over-declares.
+   */
+  getRoleView(roleId: string): RoleView {
+    const { gameType, level, archetypes } = this.ctx
+    const elements = elementsById(level)
+    const template = gameType.information_partition_template
+    const forbidden = new Map<string, { attributes: Set<string>; states: Set<string> }>()
+    const visibilityRule = template?.visibility_rules.find((entry) => entry.role === roleId)
+    for (const entry of visibilityRule?.cannot_see ?? []) {
+      const matched =
+        entry.element_archetype === WILDCARD
+          ? [...archetypes.values()]
+          : [archetypes.get(entry.element_archetype)].filter(
+              (a): a is ElementArchetype => a !== undefined
+            )
+      for (const archetype of matched) {
+        const bucket = forbidden.get(archetype.id) ?? {
+          attributes: new Set<string>(),
+          states: new Set<string>(),
+        }
+        for (const attr of expandNames(
+          entry.attributes,
+          archetype.attributes.map((a) => a.name)
+        )) {
+          bucket.attributes.add(attr)
+        }
+        for (const state of expandNames(
+          entry.states,
+          (archetype.states ?? []).map((s) => s.name)
+        )) {
+          bucket.states.add(state)
+        }
+        forbidden.set(archetype.id, bucket)
+      }
+    }
+
+    const assignment = level.information_partition.role_assignments.find((a) => a.role === roleId)
+    const views: RoleElementView[] = []
+    for (const view of assignment?.element_views ?? []) {
+      const element = elements.get(view.element_id)
+      const archetype = element ? archetypes.get(element.archetype) : undefined
+      if (!element || !archetype) continue
+      const bucket = forbidden.get(archetype.id)
+      const visibleAttrs = expandNames(
+        view.visible_attributes,
+        archetype.attributes.map((a) => a.name)
+      ).filter((attr) => !bucket?.attributes.has(attr))
+      const visibleStates = expandNames(
+        view.visible_states,
+        (archetype.states ?? []).map((s) => s.name)
+      ).filter((state) => !bucket?.states.has(state))
+      const machine = this.states.get(element.id) ?? new Map<string, unknown>()
+      views.push({
+        element_id: element.id,
+        archetype: element.archetype,
+        visible_params: Object.fromEntries(
+          visibleAttrs
+            .filter((attr) => element.params[attr] !== undefined)
+            .map((attr) => [attr, element.params[attr]])
+        ),
+        visible_states: Object.fromEntries(
+          visibleStates.filter((s) => machine.has(s)).map((s) => [s, machine.get(s)])
+        ),
+      })
+    }
+
+    const ruleEntry = template?.rule_visibility.find((entry) => entry.role === roleId)
+    const visibleTemplates = ruleEntry?.visible_rule_templates ?? []
+    const visibleRules = level.rules
+      .filter((rule) => {
+        if (visibleTemplates.includes(WILDCARD)) return this.ctx.templates.has(rule.template)
+        return visibleTemplates.includes(rule.template)
+      })
+      .map((rule) => rule.id)
+    const capability = template?.action_capability.find((entry) => entry.role === roleId)
+
+    return {
+      role: roleId,
+      elements: views,
+      visible_rules: visibleRules,
+      can_perform: capability?.can_perform ?? [],
+    }
+  }
+
+  performAction(roleId: string, actionName: string, args: PerformActionArgs = {}): ActionResult {
+    const action = this.ctx.actions.get(actionName)
+    if (!action) return { ok: false, reason: `unknown action "${actionName}"` }
+    if (action.scope === 'rule_verb') {
+      return { ok: false, reason: `"${actionName}" is engine-internal (scope rule_verb)` }
+    }
+    const capability = this.ctx.gameType.information_partition_template?.action_capability.find(
+      (entry) => entry.role === roleId
+    )
+    if (!capability || !capability.can_perform.includes(actionName)) {
+      return { ok: false, reason: `role "${roleId}" cannot perform "${actionName}"` }
+    }
+
+    // Arg validation. Distinguish a malformed call from a legitimate no-op,
+    // and keep action_type NON-FORGEABLE (B part 2): a MEANINGFUL action_type
+    // is honored only on an action that actually DECLARES an action_type param
+    // — it can never be smuggled onto an unrelated action to claim an effect
+    // that action does not have. An empty/absent action_type is "not provided"
+    // (a no-op), not a forgery. An unknown arg key, a missing declared
+    // action_type, and a construction action with no target are all malformed.
+    const declaresActionType = action.params.some((param) => param.name === 'action_type')
+    const providedActionType = args.action_type === '' ? undefined : args.action_type
+    for (const key of Object.keys(args)) {
+      if (key === 'element_id' || key === 'action_type') continue
+      return { ok: false, reason: `unknown arg "${key}" for action "${actionName}"` }
+    }
+    if (providedActionType !== undefined && !declaresActionType) {
+      return { ok: false, reason: `action "${actionName}" does not declare an action_type` }
+    }
+    if (declaresActionType && providedActionType === undefined) {
+      return { ok: false, reason: `action "${actionName}" requires an action_type param` }
+    }
+    if (action.construction_effect && args.element_id === undefined) {
+      return { ok: false, reason: `action "${actionName}" requires a target element` }
+    }
+
+    const effects: string[] = []
+    if (args.element_id !== undefined) {
+      const element = this.ctx.elements.get(args.element_id)
+      if (!element) return { ok: false, reason: `unknown element "${args.element_id}"` }
+      if (
+        capability.target_archetypes.length > 0 &&
+        !capability.target_archetypes.includes(element.archetype)
+      ) {
+        return {
+          ok: false,
+          reason: `role "${roleId}" cannot act on archetype "${element.archetype}"`,
+        }
+      }
+      if (
+        action.construction_effect &&
+        applyConstruction(this.states, args.element_id, action.construction_effect)
+      ) {
+        effects.push(`${actionName}: ${args.element_id} ${action.construction_effect}d`)
+      }
+      effects.push(...this.evaluateRulesFor(args.element_id, action, providedActionType))
+    }
+    return { ok: true, effects }
+  }
+
+  isWon(): boolean {
+    return evaluateWin(this.ctx, this.states)
+  }
+
+  /** Current score (score_threshold levels); undefined without a scoring rule. */
+  score(): number | undefined {
+    return currentScore(this.ctx, this.states)
+  }
+
+  /** Spec remaining-steps metric; undefined without a construction/slot model. */
+  remainingSteps(): number | undefined {
+    return remainingSteps(this.ctx, this.states)
+  }
+
+  /**
+   * Evaluate every rule targeting the element through the shared core, gated
+   * on the action actually performed. state_transition fires under the
+   * action_event_mapping event; temporal_sequence / condition_action /
+   * interaction_matrix fire only when the performed action declares the rule's
+   * template in its `triggers` — a pure-communication action never advances
+   * game state (B: rule firing depends on WHICH action triggered it).
+   */
+  private evaluateRulesFor(
+    elementId: string,
+    action: GameType['action_registry'][number],
+    actionType: string | undefined
+  ): string[] {
+    const effects: string[] = []
+    for (const rule of this.ctx.level.rules) {
+      if (!rule.target_elements.includes(elementId)) continue
+      const template = this.ctx.templates.get(rule.template)
+      if (!template) continue
+      if (template.type === 'state_transition') {
+        const event = actionEvent(this.ctx.gameType, template.id, actionType)
+        if (event && executeStateTransition(rule, this.states, event, elementId)) {
+          effects.push(`${rule.id}: event ${event}`)
+        }
+        continue
+      }
+      if (!actionTriggers(action, template.id)) continue
+      if (template.type === 'temporal_sequence') {
+        if (executeTemporalStep(this.ctx, rule, template, this.states, this.stepsUsed)) {
+          effects.push(`${rule.id}: step applied`)
+        }
+      } else if (template.type === 'condition_action') {
+        if (executeConditionAction(this.ctx, rule, this.states)) {
+          effects.push(`${rule.id}: fired`)
+        }
+      } else if (executeInteractionMatrix(this.ctx, rule, template, this.states)) {
+        effects.push(`${rule.id}: matrix applied`)
+      }
+    }
+    return effects
+  }
+}

--- a/packages/creation/src/engine/rules.ts
+++ b/packages/creation/src/engine/rules.ts
@@ -164,15 +164,18 @@ export function constructionEffectsForArchetype(
 }
 
 /**
- * Can some role act on this archetype — i.e. perform a player-performable
- * action (scope != rule_verb) whose target_archetypes covers it (empty list
- * = all)? This mirrors performAction's role + target_archetypes gate: a rule
- * fires only as a side effect of a successful action on one of its target
- * elements, so a rule targeting only un-actable archetypes can never fire in
- * the live engine. The solver uses this to keep rule-move reachability a
- * subset of engine reachability (no false-positive publishability).
+ * Can some role drive action_event_mapping events on this archetype — i.e.
+ * perform a player-performable action (scope != rule_verb) that DECLARES an
+ * `action_type` param AND may target the archetype (target_archetypes; empty
+ * list = all)? Mirrors performAction's event path exactly: only an action
+ * declaring an action_type param may carry one, and actionEvent() maps that
+ * value to a state_transition event. The action_type VALUE is a free string
+ * (param_def declares no value domain), so any such action can produce any
+ * mapping row's event — per-archetype granularity IS the engine's
+ * reachability. The solver uses this to keep state_transition moves a subset
+ * of engine reachability (no false-positive publishability).
  */
-export function elementArchetypeActable(gameType: GameType, archetypeId: string): boolean {
+export function eventDrivableOnArchetype(gameType: GameType, archetypeId: string): boolean {
   for (const capability of gameType.information_partition_template?.action_capability ?? []) {
     if (
       capability.target_archetypes.length > 0 &&
@@ -182,7 +185,13 @@ export function elementArchetypeActable(gameType: GameType, archetypeId: string)
     }
     for (const actionName of capability.can_perform) {
       const action = gameType.action_registry.find((entry) => entry.name === actionName)
-      if (action && action.scope !== 'rule_verb') return true
+      if (
+        action &&
+        action.scope !== 'rule_verb' &&
+        action.params.some((param) => param.name === 'action_type')
+      ) {
+        return true
+      }
     }
   }
   return false
@@ -201,7 +210,7 @@ export function actionTriggers(
  * player-performable action (scope != rule_verb) that BOTH triggers the
  * template (lists it in `triggers`) AND may target the archetype
  * (target_archetypes; empty list = all)? The trigger-gated counterpart of
- * elementArchetypeActable, mirroring performAction + the engine's per-kind
+ * eventDrivableOnArchetype, mirroring performAction + the engine's per-kind
  * trigger gate for temporal_sequence / condition_action / interaction_matrix:
  * such a rule fires only when a triggering action lands on one of its target
  * elements, so the solver keeps its move for the rule only when a real
@@ -390,6 +399,10 @@ export function applyStateEffect(
   }
   const current = machine.get(primary.name)
   const index = primary.values.indexOf(String(current))
+  // Unknown CURRENT value (e.g. a typo'd GameType state initial) is rejected
+  // as a no-op too — advance_state must never launder it into values[0], nor
+  // complete_state into the terminal value (same G6 discipline as effects).
+  if (index < 0) return false
   const lastIndex = primary.values.length - 1
   const nextIndex = effect === 'complete_state' ? lastIndex : Math.min(index + 1, lastIndex)
   if (index === nextIndex) return false

--- a/packages/creation/src/engine/rules.ts
+++ b/packages/creation/src/engine/rules.ts
@@ -1,0 +1,624 @@
+/**
+ * THE single rule-execution core (spec Mechanism 1 semantics). GameSession,
+ * searchSolution and solutionDriversForTarget all execute rules through the
+ * functions in this file — one semantics source, so the solver can never
+ * report solvable for a level the live engine cannot play (and vice versa).
+ *
+ * Execution semantics (all data-driven, zero game-specific logic):
+ * - Element runtime state initializes from the archetype's declared states
+ *   (`initial`, else the first declared value).
+ * - An action's `state_effect` applies to a stateful element's FIRST
+ *   declared state machine: advance_state moves one position along the
+ *   declared value order (clamped), complete_state jumps to the terminal
+ *   value. Unknown values are REJECTED as no-ops (never silently advance);
+ *   gametype_consistency flags them at registration.
+ * - temporal_sequence: one step per execution, bounded by max_steps per
+ *   rule instance; the step action's state_effect applies to the rule's
+ *   stateful target elements.
+ * - state_transition: fires only under an EVENT. Events come exclusively
+ *   from action_event_mapping rows via the spec-pinned
+ *   `<rule_template_id>_event` column convention — no mapping row, no
+ *   event, no transition (in the live engine AND in the solver).
+ * - temporal_sequence / condition_action / interaction_matrix: fire only via
+ *   their INTENDED trigger action — the performed action must list the rule's
+ *   template in its `triggers` (see actionTriggers). This completes for the
+ *   value-less rule kinds the same action-gating discipline state_transition
+ *   gets from events: a pure-communication action (no `triggers`) can never
+ *   advance game state, even on an element it may target.
+ * - condition_action: predicates evaluate structurally (inlined params
+ *   resolve by name against attributes / runtime states); semantic
+ *   predicates never auto-fire. Combinators: AND = all, OR = any,
+ *   NOT = none. A true condition applies the action tuple verb's
+ *   state_effect to the satisfying element.
+ * - interaction_matrix: entity types read from the spec-declared
+ *   matrix_schema.entity_type_attributes (first attribute present on the
+ *   element); unordered target pairs are considered only after the optional
+ *   pair_match_attributes eligibility filter passes (equal values on every
+ *   named param — all pairs only when the filter is omitted) and both
+ *   members are PLACED under the construction model; an eligible pair with
+ *   a matching matrix row gets the relation's effect action state_effect
+ *   applied to both members.
+ * - Construction (co_build): a Level with initial_state gets the reserved
+ *   PLACEMENT_STATE runtime key per element; actions declaring
+ *   construction_effect place/remove toggle it. Scoring
+ *   (matrix_schema.relation_scores) sums eligible PLACED pairs' relations.
+ * - Win: all_solved — every target element has some declared runtime state
+ *   equal to target_state; score_threshold — currentScore >= target_score;
+ *   optimization_target — the declarative all_states_at_least /
+ *   count_states_equal constraints, ranked by each state's declared value
+ *   order (see evaluateOptimizationTarget).
+ */
+
+import type {
+  ConstructionEffect,
+  ElementArchetype,
+  GameType,
+  Level,
+  LevelElement,
+  LevelRule,
+  RuleTemplate,
+  StateEffect,
+} from '../schema/types'
+import { archetypesById, elementsById, isMappingValue, templatesById } from '../validate/helpers'
+
+export type ElementStates = Map<string, Map<string, unknown>>
+
+/**
+ * Reserved engine-internal runtime key tracking the co_build construction
+ * model (Level.initial_state): present on every element's machine when the
+ * level declares initial_state, absent otherwise (radio-cipher unchanged).
+ * Never part of the declared state vocabulary, never exposed via role views.
+ */
+export const PLACEMENT_STATE = '__placed'
+
+export interface RuleContext {
+  gameType: GameType
+  level: Level
+  archetypes: Map<string, ElementArchetype>
+  elements: Map<string, LevelElement>
+  templates: Map<string, RuleTemplate>
+  actions: Map<string, GameType['action_registry'][number]>
+}
+
+export function buildRuleContext(gameType: GameType, level: Level): RuleContext {
+  return {
+    gameType,
+    level,
+    archetypes: archetypesById(gameType),
+    elements: elementsById(level),
+    templates: templatesById(gameType),
+    actions: new Map(gameType.action_registry.map((entry) => [entry.name, entry])),
+  }
+}
+
+/** Initialize runtime states for every stateful element instance. */
+export function initialElementStates(gameType: GameType, level: Level): ElementStates {
+  const archetypes = archetypesById(gameType)
+  const states: ElementStates = new Map()
+  for (const element of level.elements) {
+    const archetype = archetypes.get(element.archetype)
+    const machine = new Map<string, unknown>()
+    for (const state of archetype?.states ?? []) {
+      // Per-instance initial_states override the archetype initial.
+      const override = element.initial_states?.[state.name]
+      machine.set(state.name, override ?? state.initial ?? state.values?.[0])
+    }
+    if (level.initial_state) {
+      machine.set(
+        PLACEMENT_STATE,
+        level.initial_state.occupied.includes(element.id) ? 'placed' : 'unplaced'
+      )
+    }
+    states.set(element.id, machine)
+  }
+  return states
+}
+
+/** Placed = participating. Levels without a construction model count everything as placed. */
+export function isPlaced(states: ElementStates, elementId: string): boolean {
+  const machine = states.get(elementId)
+  if (!machine || !machine.has(PLACEMENT_STATE)) return true
+  return machine.get(PLACEMENT_STATE) === 'placed'
+}
+
+/** Apply a declarative construction effect; no-op without a construction model. */
+export function applyConstruction(
+  states: ElementStates,
+  elementId: string,
+  effect: ConstructionEffect
+): boolean {
+  const machine = states.get(elementId)
+  if (!machine || !machine.has(PLACEMENT_STATE)) return false
+  const next = effect === 'place' ? 'placed' : 'unplaced'
+  if (machine.get(PLACEMENT_STATE) === next) return false
+  machine.set(PLACEMENT_STATE, next)
+  return true
+}
+
+/**
+ * Construction effects some role can perform ON THIS ARCHETYPE — the
+ * solver's engine-playability gate, mirroring performAction exactly: the
+ * role must can_perform the construction action AND its target_archetypes
+ * must admit the element's archetype (an empty target_archetypes list
+ * admits every archetype, as in performAction).
+ */
+export function constructionEffectsForArchetype(
+  gameType: GameType,
+  archetypeId: string
+): Set<ConstructionEffect> {
+  const effects = new Set<ConstructionEffect>()
+  for (const capability of gameType.information_partition_template?.action_capability ?? []) {
+    if (
+      capability.target_archetypes.length > 0 &&
+      !capability.target_archetypes.includes(archetypeId)
+    ) {
+      continue
+    }
+    for (const actionName of capability.can_perform) {
+      const action = gameType.action_registry.find((entry) => entry.name === actionName)
+      if (!action || !action.construction_effect || action.scope === 'rule_verb') continue
+      effects.add(action.construction_effect)
+    }
+  }
+  return effects
+}
+
+/**
+ * Can some role act on this archetype — i.e. perform a player-performable
+ * action (scope != rule_verb) whose target_archetypes covers it (empty list
+ * = all)? This mirrors performAction's role + target_archetypes gate: a rule
+ * fires only as a side effect of a successful action on one of its target
+ * elements, so a rule targeting only un-actable archetypes can never fire in
+ * the live engine. The solver uses this to keep rule-move reachability a
+ * subset of engine reachability (no false-positive publishability).
+ */
+export function elementArchetypeActable(gameType: GameType, archetypeId: string): boolean {
+  for (const capability of gameType.information_partition_template?.action_capability ?? []) {
+    if (
+      capability.target_archetypes.length > 0 &&
+      !capability.target_archetypes.includes(archetypeId)
+    ) {
+      continue
+    }
+    for (const actionName of capability.can_perform) {
+      const action = gameType.action_registry.find((entry) => entry.name === actionName)
+      if (action && action.scope !== 'rule_verb') return true
+    }
+  }
+  return false
+}
+
+/** Does the performed action declare it fires this rule template (its `triggers`)? */
+export function actionTriggers(
+  action: GameType['action_registry'][number],
+  templateId: string
+): boolean {
+  return action.triggers?.includes(templateId) ?? false
+}
+
+/**
+ * Can some role fire this template ON THIS ARCHETYPE — i.e. perform a
+ * player-performable action (scope != rule_verb) that BOTH triggers the
+ * template (lists it in `triggers`) AND may target the archetype
+ * (target_archetypes; empty list = all)? The trigger-gated counterpart of
+ * elementArchetypeActable, mirroring performAction + the engine's per-kind
+ * trigger gate for temporal_sequence / condition_action / interaction_matrix:
+ * such a rule fires only when a triggering action lands on one of its target
+ * elements, so the solver keeps its move for the rule only when a real
+ * (role, action, target) triple exists — solver reachability stays a subset
+ * of engine reachability.
+ */
+export function templateTriggerableOnArchetype(
+  gameType: GameType,
+  templateId: string,
+  archetypeId: string
+): boolean {
+  for (const capability of gameType.information_partition_template?.action_capability ?? []) {
+    if (
+      capability.target_archetypes.length > 0 &&
+      !capability.target_archetypes.includes(archetypeId)
+    ) {
+      continue
+    }
+    for (const actionName of capability.can_perform) {
+      const action = gameType.action_registry.find((entry) => entry.name === actionName)
+      if (action && action.scope !== 'rule_verb' && actionTriggers(action, templateId)) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Current score from interaction_matrix rules carrying relation_scores:
+ * the sum over PLACED, pair-eligible target pairs' matrix relations.
+ * undefined when the level has no scoring rule (no score concept).
+ */
+export function currentScore(ctx: RuleContext, states: ElementStates): number | undefined {
+  let total: number | undefined
+  for (const rule of ctx.level.rules) {
+    const template = ctx.templates.get(rule.template)
+    if (!template || template.type !== 'interaction_matrix') continue
+    const scores = template.matrix_schema.relation_scores
+    if (!scores) continue
+    total = total ?? 0
+    for (const pair of eligibleMatrixPairs(ctx, rule, template, states)) {
+      total += scores[pair.relation] ?? 0
+    }
+  }
+  return total
+}
+
+/**
+ * remaining_steps (spec progress_measurability formula):
+ * |empty_slots_with_both_pieces_available| — still-empty slots that could
+ * receive a scoring pair, bounded by the pairs formable from the building
+ * roles' unplaced pieces. The slot key is the matrix rule's first
+ * pair_match attribute (data-driven). undefined without a construction
+ * model or slot key. Spec worked example: 3 pairs placed → empty slots 5,
+ * formable pairs 1 → remaining_steps 1.
+ */
+export function remainingSteps(ctx: RuleContext, states: ElementStates): number | undefined {
+  const totalSlots = ctx.level.initial_state?.timeline_slots
+  if (typeof totalSlots !== 'number') return undefined
+  let slotKey: string | undefined
+  for (const rule of ctx.level.rules) {
+    const template = ctx.templates.get(rule.template)
+    if (template?.type === 'interaction_matrix') {
+      slotKey = template.matrix_schema.pair_match_attributes?.[0]
+      if (slotKey) break
+    }
+  }
+  if (!slotKey) return undefined
+  const occupiedSlots = new Set<string>()
+  for (const element of ctx.level.elements) {
+    if (!isPlaced(states, element.id)) continue
+    const slot = element.params[slotKey]
+    if (slot !== undefined) occupiedSlots.add(String(slot))
+  }
+  const emptySlots = Math.max(totalSlots - occupiedSlots.size, 0)
+  const capabilities = ctx.gameType.information_partition_template?.action_capability ?? []
+  const unplacedCounts = capabilities.map(
+    (capability) =>
+      ctx.level.elements.filter((element) => {
+        if (isPlaced(states, element.id)) return false
+        return (
+          capability.target_archetypes.length === 0 ||
+          capability.target_archetypes.includes(element.archetype)
+        )
+      }).length
+  )
+  const formablePairs =
+    unplacedCounts.length >= 2 ? Math.min(...unplacedCounts) : (unplacedCounts[0] ?? 0)
+  return Math.min(emptySlots, formablePairs)
+}
+
+/** Declared value order of a state across the GameType (for ranked comparisons). */
+function stateValueOrder(ctx: RuleContext, stateName: string): string[] | undefined {
+  for (const archetype of ctx.gameType.element_archetypes) {
+    const state = (archetype.states ?? []).find((s) => s.name === stateName)
+    if (state?.values) return state.values
+  }
+  return undefined
+}
+
+/**
+ * Win evaluation over runtime states. Implemented: all_solved,
+ * score_threshold, and optimization_target (declarative constraints ranked
+ * by each state's declared value order). Any unrecognized win type is false
+ * here and rejected explicitly by the solvability check.
+ */
+export function evaluateWin(ctx: RuleContext, states: ElementStates): boolean {
+  const win = ctx.level.win_condition
+  if (win.type === 'all_solved') {
+    const targetState = win.params.target_state
+    const targets = Array.isArray(win.params.target_elements) ? win.params.target_elements : []
+    if (typeof targetState !== 'string' || targets.length === 0) return false
+    return (targets as unknown[]).every((targetId) => {
+      if (typeof targetId !== 'string') return false
+      const machine = states.get(targetId)
+      if (!machine) return false
+      return [...machine.entries()].some(
+        ([key, value]) => key !== PLACEMENT_STATE && value === targetState
+      )
+    })
+  }
+  if (win.type === 'score_threshold') {
+    const target = win.params.target_score
+    if (typeof target !== 'number') return false
+    const score = currentScore(ctx, states)
+    return score !== undefined && score >= target
+  }
+  if (win.type === 'optimization_target') {
+    return evaluateOptimizationTarget(ctx, states)
+  }
+  return false
+}
+
+function evaluateOptimizationTarget(ctx: RuleContext, states: ElementStates): boolean {
+  const params = ctx.level.win_condition.params
+  const atLeast = Array.isArray(params.all_states_at_least) ? params.all_states_at_least : []
+  const countEqual = Array.isArray(params.count_states_equal) ? params.count_states_equal : []
+
+  for (const raw of atLeast) {
+    if (!isMappingValue(raw)) return false
+    const stateName = raw.state
+    const minValue = raw.value
+    if (typeof stateName !== 'string' || typeof minValue !== 'string') return false
+    const order = stateValueOrder(ctx, stateName)
+    if (!order) return false
+    const minRank = order.indexOf(minValue)
+    // Every element that HAS this state must rank at least minValue.
+    for (const machine of states.values()) {
+      if (!machine.has(stateName)) continue
+      const rank = order.indexOf(String(machine.get(stateName)))
+      if (rank < minRank) return false
+    }
+  }
+
+  for (const raw of countEqual) {
+    if (!isMappingValue(raw)) return false
+    const stateName = raw.state
+    const value = raw.value
+    const count = raw.count
+    if (typeof stateName !== 'string' || typeof value !== 'string' || typeof count !== 'number') {
+      return false
+    }
+    let matches = 0
+    for (const machine of states.values()) {
+      if (machine.get(stateName) === value) matches++
+    }
+    if (matches < count) return false
+  }
+
+  return atLeast.length > 0 || countEqual.length > 0
+}
+
+/**
+ * Apply a declarative state effect to an element's FIRST declared state
+ * machine. Unknown effect values are rejected (no-op) — G6: a typo can
+ * never silently advance state.
+ */
+export function applyStateEffect(
+  archetype: ElementArchetype,
+  machine: Map<string, unknown>,
+  effect: StateEffect | undefined
+): boolean {
+  if (effect !== 'advance_state' && effect !== 'complete_state') return false
+  const primary = (archetype.states ?? [])[0]
+  if (!primary || primary.type !== 'enum' || !primary.values || primary.values.length === 0) {
+    return false
+  }
+  const current = machine.get(primary.name)
+  const index = primary.values.indexOf(String(current))
+  const lastIndex = primary.values.length - 1
+  const nextIndex = effect === 'complete_state' ? lastIndex : Math.min(index + 1, lastIndex)
+  if (index === nextIndex) return false
+  machine.set(primary.name, primary.values[nextIndex])
+  return true
+}
+
+/** Structural predicate evaluation: resolve each inlined param by name. */
+export function evaluatePredicates(
+  rule: LevelRule,
+  archetype: ElementArchetype,
+  params: Record<string, unknown>,
+  machine: Map<string, unknown>
+): boolean {
+  const bindings = rule.bindings
+  const entries = Array.isArray(bindings.predicates) ? bindings.predicates : []
+  if (entries.length === 0) return false
+  const attrNames = new Set(archetype.attributes.map((a) => a.name))
+  const stateNamesSet = new Set((archetype.states ?? []).map((s) => s.name))
+  const results: boolean[] = []
+  for (const entry of entries) {
+    if (!isMappingValue(entry)) return false
+    const { name: _name, ...inlined } = entry
+    let allResolved = true
+    let allMatch = true
+    for (const [paramName, expected] of Object.entries(inlined)) {
+      let actual: unknown
+      if (attrNames.has(paramName)) actual = params[paramName]
+      else if (stateNamesSet.has(paramName)) actual = machine.get(paramName)
+      else {
+        // Semantic predicate param (e.g. plaintext_is_valid_word's
+        // category): not machine-evaluable — the rule never auto-fires;
+        // confirmation belongs to the human layer.
+        allResolved = false
+        break
+      }
+      if (String(actual) !== String(expected)) allMatch = false
+    }
+    if (!allResolved) return false
+    results.push(allMatch)
+  }
+  const combinator = typeof bindings.combinator === 'string' ? bindings.combinator : 'AND'
+  if (combinator === 'OR') return results.some(Boolean)
+  if (combinator === 'NOT') return results.every((r) => !r)
+  return results.every(Boolean)
+}
+
+/**
+ * Events a player action can produce for the given rule template — the
+ * spec-pinned `<rule_template_id>_event` column of action_event_mapping.
+ */
+export function producibleEvents(gameType: GameType, templateId: string): string[] {
+  const events = new Set<string>()
+  for (const row of gameType.action_event_mapping ?? []) {
+    const event = row[`${templateId}_event`]
+    if (typeof event === 'string') events.add(event)
+  }
+  return [...events]
+}
+
+/** The event a specific player action_type produces for a template, if any. */
+export function actionEvent(
+  gameType: GameType,
+  templateId: string,
+  actionType: string | undefined
+): string | undefined {
+  if (!actionType) return undefined
+  const row = (gameType.action_event_mapping ?? []).find(
+    (entry) => entry.action_type === actionType
+  )
+  const event = row?.[`${templateId}_event`]
+  return typeof event === 'string' ? event : undefined
+}
+
+/** Execute one temporal_sequence step (bounded by max_steps per rule instance). */
+export function executeTemporalStep(
+  ctx: RuleContext,
+  rule: LevelRule,
+  template: Extract<RuleTemplate, { type: 'temporal_sequence' }>,
+  states: ElementStates,
+  stepsUsed: Map<string, number>
+): boolean {
+  const used = stepsUsed.get(rule.id) ?? 0
+  if (used >= template.sequence_schema.max_steps) return false
+  const stepAction = ctx.actions.get(template.sequence_schema.step_schema.action)
+  let changed = false
+  for (const targetId of rule.target_elements) {
+    const target = ctx.elements.get(targetId)
+    const archetype = target ? ctx.archetypes.get(target.archetype) : undefined
+    const machine = states.get(targetId)
+    if (!target || !archetype || !machine) continue
+    if (applyStateEffect(archetype, machine, stepAction?.state_effect)) changed = true
+  }
+  stepsUsed.set(rule.id, used + 1)
+  return changed
+}
+
+/** Fire a state_transition rule on one element under one event. */
+export function executeStateTransition(
+  rule: LevelRule,
+  states: ElementStates,
+  event: string,
+  elementId: string
+): boolean {
+  const machine = states.get(elementId)
+  if (!machine) return false
+  const rows = Array.isArray(rule.bindings.transitions)
+    ? (rule.bindings.transitions as unknown[])
+    : []
+  for (const row of rows) {
+    if (!Array.isArray(row) || row.length !== 3) continue
+    const [from, rowEvent, to] = row as [unknown, unknown, unknown]
+    if (rowEvent !== event) continue
+    const current = [...machine.entries()].find(([, value]) => value === from)
+    if (current && typeof to === 'string') {
+      machine.set(current[0], to)
+      return true
+    }
+  }
+  return false
+}
+
+/** Evaluate + fire a condition_action rule over its target elements. */
+export function executeConditionAction(
+  ctx: RuleContext,
+  rule: LevelRule,
+  states: ElementStates
+): boolean {
+  const actionBinding = rule.bindings.action
+  const verb =
+    isMappingValue(actionBinding) && typeof actionBinding.verb === 'string'
+      ? actionBinding.verb
+      : undefined
+  const verbAction = verb ? ctx.actions.get(verb) : undefined
+  let changed = false
+  for (const targetId of rule.target_elements) {
+    const target = ctx.elements.get(targetId)
+    const archetype = target ? ctx.archetypes.get(target.archetype) : undefined
+    const machine = states.get(targetId)
+    if (!target || !archetype || !machine) continue
+    if (!evaluatePredicates(rule, archetype, target.params, machine)) continue
+    if (applyStateEffect(archetype, machine, verbAction?.state_effect)) changed = true
+  }
+  return changed
+}
+
+export interface MatrixPair {
+  aId: string
+  bId: string
+  relation: string
+}
+
+/**
+ * Unordered target pairs eligible for a matrix rule: both elements PLACED
+ * (construction model honored; everything counts as placed without one),
+ * passing the optional pair_match_attributes filter (equal values on every
+ * named param — all pairs only when the filter is omitted), with a matching
+ * matrix row. Shared by rule execution and score computation.
+ */
+export function eligibleMatrixPairs(
+  ctx: RuleContext,
+  rule: LevelRule,
+  template: Extract<RuleTemplate, { type: 'interaction_matrix' }>,
+  states: ElementStates
+): MatrixPair[] {
+  const rows = Array.isArray(rule.bindings.matrix) ? (rule.bindings.matrix as unknown[]) : []
+  const attributes = template.matrix_schema.entity_type_attributes ?? []
+  const pairMatch = template.matrix_schema.pair_match_attributes ?? []
+  const entityTypeOf = (id: string): string | undefined => {
+    const element = ctx.elements.get(id)
+    if (!element) return undefined
+    for (const attribute of attributes) {
+      const value = element.params[attribute]
+      if (typeof value === 'string') return value
+    }
+    return undefined
+  }
+  const pairEligible = (aId: string, bId: string): boolean => {
+    if (pairMatch.length === 0) return true
+    const a = ctx.elements.get(aId)
+    const b = ctx.elements.get(bId)
+    if (!a || !b) return false
+    return pairMatch.every((name) => String(a.params[name]) === String(b.params[name]))
+  }
+  const pairs: MatrixPair[] = []
+  for (const [i, aId] of rule.target_elements.entries()) {
+    for (const bId of rule.target_elements.slice(i + 1)) {
+      if (!isPlaced(states, aId) || !isPlaced(states, bId)) continue
+      if (!pairEligible(aId, bId)) continue
+      const aType = entityTypeOf(aId)
+      const bType = entityTypeOf(bId)
+      if (!aType || !bType) continue
+      const row = rows.find(
+        (r) =>
+          Array.isArray(r) &&
+          r.length === 3 &&
+          ((r[0] === aType && r[1] === bType) || (r[0] === bType && r[1] === aType))
+      ) as [string, string, string] | undefined
+      if (!row) continue
+      pairs.push({ aId, bId, relation: row[2] })
+    }
+  }
+  return pairs
+}
+
+/**
+ * Apply an interaction_matrix rule over its eligible pairs (see
+ * eligibleMatrixPairs): the matched relation's effect action state_effect
+ * applies to both pair members.
+ */
+export function executeInteractionMatrix(
+  ctx: RuleContext,
+  rule: LevelRule,
+  template: Extract<RuleTemplate, { type: 'interaction_matrix' }>,
+  states: ElementStates
+): boolean {
+  let changed = false
+  for (const pair of eligibleMatrixPairs(ctx, rule, template, states)) {
+    const effect = template.matrix_schema.effect_schema.find(
+      (entry) => entry.relation === pair.relation
+    )
+    const effectAction = effect ? ctx.actions.get(effect.effect) : undefined
+    for (const memberId of [pair.aId, pair.bId]) {
+      const member = ctx.elements.get(memberId)
+      const archetype = member ? ctx.archetypes.get(member.archetype) : undefined
+      const machine = states.get(memberId)
+      if (!member || !archetype || !machine) continue
+      if (applyStateEffect(archetype, machine, effectAction?.state_effect)) changed = true
+    }
+  }
+  return changed
+}

--- a/packages/creation/src/engine/search.ts
+++ b/packages/creation/src/engine/search.ts
@@ -6,7 +6,9 @@
  * rules.ts (the same semantics the live GameSession plays), so the solver
  * can never report solvable for a level the engine cannot play.
  * state_transition moves are EVENT-GATED (only action_event_mapping
- * producible events); construction moves are CAPABILITY-GATED PER ELEMENT
+ * producible events, and only on elements whose archetype some role can
+ * target with an action_type-declaring action — the engine's sole event
+ * path); construction moves are CAPABILITY-GATED PER ELEMENT
  * ARCHETYPE — a place/remove move exists only when some role both
  * can_perform the construction action AND may target the element's
  * archetype (target_archetypes; empty list admits all), exactly mirroring
@@ -27,8 +29,8 @@ import {
   applyConstruction,
   buildRuleContext,
   constructionEffectsForArchetype,
-  elementArchetypeActable,
   evaluateWin,
+  eventDrivableOnArchetype,
   executeConditionAction,
   executeInteractionMatrix,
   executeStateTransition,
@@ -70,10 +72,10 @@ function hashNode(states: ElementStates, stepsUsed: Map<string, number>): string
   return JSON.stringify([stateEntries, stepEntries])
 }
 
-/** Is this element's archetype actable by some role (mirrors performAction)? */
-function targetActable(ctx: RuleContext, elementId: string): boolean {
+/** Can some role drive mapping events on this element (mirrors performAction)? */
+function targetEventDrivable(ctx: RuleContext, elementId: string): boolean {
   const archetype = ctx.elements.get(elementId)?.archetype
-  return archetype !== undefined && elementArchetypeActable(ctx.gameType, archetype)
+  return archetype !== undefined && eventDrivableOnArchetype(ctx.gameType, archetype)
 }
 
 /** Can some role fire this template on the element's archetype (trigger gate)? */
@@ -89,8 +91,9 @@ function targetTriggerable(ctx: RuleContext, templateId: string, elementId: stri
  * Rule moves are gated exactly as the live engine fires them (keeping solver
  * reachability ⊆ engine reachability):
  * - state_transition: EVENT-gated (no producible action_event_mapping row →
- *   no move) AND capability-gated per element — the move acts on one element,
- *   so that element must be actable.
+ *   no move) AND event-drivable per element — the move acts on one element,
+ *   so some role must be able to perform an action_type-declaring action on
+ *   that element's archetype (the engine's only path to a mapping event).
  * - temporal_sequence / condition_action / interaction_matrix: TRIGGER-gated —
  *   they fire only when a player action that lists this template in its
  *   `triggers` lands on one of the rule's target elements, so the move is
@@ -105,7 +108,7 @@ function movesForRule(ctx: RuleContext, rule: LevelRule, template: RuleTemplate)
       const moves: MoveFn[] = []
       for (const event of producibleEvents(ctx.gameType, template.id)) {
         for (const elementId of rule.target_elements) {
-          if (!targetActable(ctx, elementId)) continue
+          if (!targetEventDrivable(ctx, elementId)) continue
           moves.push((states) => executeStateTransition(rule, states, event, elementId))
         }
       }

--- a/packages/creation/src/engine/search.ts
+++ b/packages/creation/src/engine/search.ts
@@ -1,0 +1,243 @@
+/**
+ * Engine-backed bounded solution search (spec solvability contract).
+ *
+ * searchSolution: BFS over rule executions AND construction moves from the
+ * Level's initial state — every move executes through the SHARED core in
+ * rules.ts (the same semantics the live GameSession plays), so the solver
+ * can never report solvable for a level the engine cannot play.
+ * state_transition moves are EVENT-GATED (only action_event_mapping
+ * producible events); construction moves are CAPABILITY-GATED PER ELEMENT
+ * ARCHETYPE — a place/remove move exists only when some role both
+ * can_perform the construction action AND may target the element's
+ * archetype (target_archetypes; empty list admits all), exactly mirroring
+ * performAction. States deduplicate by hash; the shared solver_timeout_ms
+ * deadline bounds the search.
+ *
+ * solutionDriversForTarget: the uniqueness primitive — which rules can,
+ * executed ALONE from the initial state, drive one win target to the target
+ * state. Returns an explicit timedOut flag so an interrupted analysis is
+ * never mistaken for a clean count (G3).
+ */
+
+import type { GameType, Level, LevelRule, RuleTemplate } from '../schema/types'
+import type { Deadline } from '../validate/helpers'
+import { startDeadline } from '../validate/helpers'
+import type { ElementStates, RuleContext } from './rules'
+import {
+  applyConstruction,
+  buildRuleContext,
+  constructionEffectsForArchetype,
+  elementArchetypeActable,
+  evaluateWin,
+  executeConditionAction,
+  executeInteractionMatrix,
+  executeStateTransition,
+  executeTemporalStep,
+  initialElementStates,
+  isPlaced,
+  producibleEvents,
+  templateTriggerableOnArchetype,
+} from './rules'
+
+export interface SolutionSearchResult {
+  solvable: boolean
+  /** Rule ids in execution order (empty when unsolvable or timed out). */
+  path: string[]
+  timedOut: boolean
+}
+
+export interface SolutionDrivers {
+  drivers: LevelRule[]
+  /** True when the deadline interrupted the analysis — the count is partial. */
+  timedOut: boolean
+}
+
+interface SearchNode {
+  states: ElementStates
+  stepsUsed: Map<string, number>
+  path: string[]
+}
+
+type MoveFn = (states: ElementStates, stepsUsed: Map<string, number>) => boolean
+
+function cloneStates(states: ElementStates): ElementStates {
+  return new Map([...states].map(([id, machine]) => [id, new Map(machine)]))
+}
+
+function hashNode(states: ElementStates, stepsUsed: Map<string, number>): string {
+  const stateEntries = [...states].map(([id, machine]) => [id, [...machine].sort()] as const).sort()
+  const stepEntries = [...stepsUsed].sort()
+  return JSON.stringify([stateEntries, stepEntries])
+}
+
+/** Is this element's archetype actable by some role (mirrors performAction)? */
+function targetActable(ctx: RuleContext, elementId: string): boolean {
+  const archetype = ctx.elements.get(elementId)?.archetype
+  return archetype !== undefined && elementArchetypeActable(ctx.gameType, archetype)
+}
+
+/** Can some role fire this template on the element's archetype (trigger gate)? */
+function targetTriggerable(ctx: RuleContext, templateId: string, elementId: string): boolean {
+  const archetype = ctx.elements.get(elementId)?.archetype
+  return (
+    archetype !== undefined && templateTriggerableOnArchetype(ctx.gameType, templateId, archetype)
+  )
+}
+
+/**
+ * All legal moves a rule contributes, through the shared execution core.
+ * Rule moves are gated exactly as the live engine fires them (keeping solver
+ * reachability ⊆ engine reachability):
+ * - state_transition: EVENT-gated (no producible action_event_mapping row →
+ *   no move) AND capability-gated per element — the move acts on one element,
+ *   so that element must be actable.
+ * - temporal_sequence / condition_action / interaction_matrix: TRIGGER-gated —
+ *   they fire only when a player action that lists this template in its
+ *   `triggers` lands on one of the rule's target elements, so the move is
+ *   emitted iff at least one target's archetype is triggerable by some role.
+ */
+function movesForRule(ctx: RuleContext, rule: LevelRule, template: RuleTemplate): MoveFn[] {
+  switch (template.type) {
+    case 'temporal_sequence':
+      if (!rule.target_elements.some((id) => targetTriggerable(ctx, template.id, id))) return []
+      return [(states, stepsUsed) => executeTemporalStep(ctx, rule, template, states, stepsUsed)]
+    case 'state_transition': {
+      const moves: MoveFn[] = []
+      for (const event of producibleEvents(ctx.gameType, template.id)) {
+        for (const elementId of rule.target_elements) {
+          if (!targetActable(ctx, elementId)) continue
+          moves.push((states) => executeStateTransition(rule, states, event, elementId))
+        }
+      }
+      return moves
+    }
+    case 'condition_action':
+      if (!rule.target_elements.some((id) => targetTriggerable(ctx, template.id, id))) return []
+      return [(states) => executeConditionAction(ctx, rule, states)]
+    case 'interaction_matrix':
+      if (!rule.target_elements.some((id) => targetTriggerable(ctx, template.id, id))) return []
+      return [(states) => executeInteractionMatrix(ctx, rule, template, states)]
+  }
+}
+
+/**
+ * Construction moves (co_build): place/remove each element, gated PER
+ * ELEMENT on a role that can perform the construction action AND may target
+ * the element's archetype — mirroring performAction exactly, so the solver
+ * never builds what no role can play (same engine-playability principle as
+ * event gating).
+ */
+function constructionMoves(
+  ctx: RuleContext,
+  node: SearchNode
+): Array<{ id: string; move: MoveFn }> {
+  if (!ctx.level.initial_state) return []
+  const moves: Array<{ id: string; move: MoveFn }> = []
+  for (const element of ctx.level.elements) {
+    const effects = constructionEffectsForArchetype(ctx.gameType, element.archetype)
+    if (effects.has('place') && !isPlaced(node.states, element.id)) {
+      moves.push({
+        id: `place:${element.id}`,
+        move: (states) => applyConstruction(states, element.id, 'place'),
+      })
+    }
+    if (effects.has('remove') && isPlaced(node.states, element.id)) {
+      moves.push({
+        id: `remove:${element.id}`,
+        move: (states) => applyConstruction(states, element.id, 'remove'),
+      })
+    }
+  }
+  return moves
+}
+
+/**
+ * Bounded BFS over rule executions and construction moves; returns a
+ * solution path when found. Path entries are rule ids or construction move
+ * ids ("place:<elementId>" / "remove:<elementId>").
+ */
+export function searchSolution(
+  gameType: GameType,
+  level: Level,
+  deadline: Deadline = startDeadline(gameType.solver_timeout_ms)
+): SolutionSearchResult {
+  const ctx = buildRuleContext(gameType, level)
+  const initial: SearchNode = {
+    states: initialElementStates(gameType, level),
+    stepsUsed: new Map(),
+    path: [],
+  }
+  if (evaluateWin(ctx, initial.states)) return { solvable: true, path: [], timedOut: false }
+
+  const queue: SearchNode[] = [initial]
+  const visited = new Set<string>([hashNode(initial.states, initial.stepsUsed)])
+
+  while (queue.length > 0) {
+    if (deadline.timedOut()) return { solvable: false, path: [], timedOut: true }
+    const node = queue.shift() as SearchNode
+    const moves: Array<{ id: string; move: MoveFn }> = constructionMoves(ctx, node)
+    for (const rule of level.rules) {
+      const template = ctx.templates.get(rule.template)
+      if (!template) continue
+      for (const move of movesForRule(ctx, rule, template)) {
+        moves.push({ id: rule.id, move })
+      }
+    }
+    for (const { id, move } of moves) {
+      const states = cloneStates(node.states)
+      const stepsUsed = new Map(node.stepsUsed)
+      if (!move(states, stepsUsed)) continue
+      const hash = hashNode(states, stepsUsed)
+      if (visited.has(hash)) continue
+      visited.add(hash)
+      const path = [...node.path, id]
+      if (evaluateWin(ctx, states)) return { solvable: true, path, timedOut: false }
+      queue.push({ states, stepsUsed, path })
+    }
+  }
+  return { solvable: false, path: [], timedOut: false }
+}
+
+/**
+ * Rules that, executed alone from the initial state, drive the given win
+ * target to the win-condition target state (bounded repeated application
+ * through the shared core).
+ */
+export function solutionDriversForTarget(
+  gameType: GameType,
+  level: Level,
+  targetId: string,
+  deadline: Deadline
+): SolutionDrivers {
+  const ctx = buildRuleContext(gameType, level)
+  const targetState = level.win_condition.params.target_state
+  if (typeof targetState !== 'string') return { drivers: [], timedOut: false }
+  const drivers: LevelRule[] = []
+  for (const rule of level.rules) {
+    if (deadline.timedOut()) return { drivers, timedOut: true }
+    if (!rule.target_elements.includes(targetId)) continue
+    const template = ctx.templates.get(rule.template)
+    if (!template) continue
+    const states = initialElementStates(gameType, level)
+    const stepsUsed = new Map<string, number>()
+    const moves = movesForRule(ctx, rule, template)
+    const bound = boundFor(template)
+    let reached = false
+    for (let i = 0; i < bound && !reached; i++) {
+      const changed = moves.some((move) => move(states, stepsUsed))
+      if (!changed) break
+      const machine = states.get(targetId)
+      reached = !!machine && [...machine.values()].some((value) => value === targetState)
+    }
+    if (reached) drivers.push(rule)
+  }
+  return { drivers, timedOut: false }
+}
+
+function boundFor(template: RuleTemplate): number {
+  if (template.type === 'temporal_sequence') return template.sequence_schema.max_steps
+  if (template.type === 'state_transition') {
+    return template.transition_table_schema.states.length + 1
+  }
+  return 4
+}

--- a/packages/creation/src/engine/sound-garden.test.ts
+++ b/packages/creation/src/engine/sound-garden.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Sound Garden (co_build) engine integration on the REAL vocabulary:
+ * scripted placement sequence to the winning score, noise-pair penalty,
+ * capability-split enforcement, construction-model isolation from role
+ * views, and engine-backed search agreement.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../schema/load'
+import { startDeadline } from '../validate/helpers'
+import { GameSession } from './engine'
+import { PLACEMENT_STATE } from './rules'
+import { searchSolution } from './search'
+
+const fixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'sound-garden'
+)
+const gameType = loadGameType(readFileSync(join(fixturesDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(fixturesDir, 'level.sg-demo-001.yaml'), 'utf8'))
+
+describe('GameSession — scripted sg-demo-001 build to win', () => {
+  it('builds the garden to the winning score through paired placements', () => {
+    const session = new GameSession(gameType, level)
+    expect(session.isWon()).toBe(false)
+    expect(session.score()).toBe(0)
+
+    // Step 1: kick + bell on slot 1 — synergy (+3).
+    expect(session.performAction('rhythm_builder', 'place_piece', { element_id: 'r1' }).ok).toBe(
+      true
+    )
+    expect(session.score()).toBe(0) // rhythm alone: no pair yet
+    session.performAction('melody_builder', 'place_piece', { element_id: 'm1' })
+    expect(session.score()).toBe(3)
+
+    // Steps 2-3: snare+chime, hihat+flute — two more synergies.
+    session.performAction('rhythm_builder', 'place_piece', { element_id: 'r2' })
+    session.performAction('melody_builder', 'place_piece', { element_id: 'm2' })
+    session.performAction('rhythm_builder', 'place_piece', { element_id: 'r3' })
+    session.performAction('melody_builder', 'place_piece', { element_id: 'm3' })
+    expect(session.score()).toBe(9)
+    expect(session.isWon()).toBe(false) // 9 < 10
+
+    // Step 4: clap + harp — crosses the threshold.
+    session.performAction('rhythm_builder', 'place_piece', { element_id: 'r4' })
+    session.performAction('melody_builder', 'place_piece', { element_id: 'm4' })
+    expect(session.score()).toBe(12)
+    expect(session.isWon()).toBe(true)
+  })
+
+  it('enforces the ability split: builders cannot place the other role’s pieces', () => {
+    const session = new GameSession(gameType, level)
+    const wrong = session.performAction('rhythm_builder', 'place_piece', { element_id: 'm1' })
+    expect(wrong.ok).toBe(false)
+    expect(!wrong.ok && wrong.reason).toContain('melody_piece')
+  })
+
+  it('F4: place_piece (a construction action) without a target element is malformed', () => {
+    const session = new GameSession(gameType, level)
+    const missing = session.performAction('rhythm_builder', 'place_piece', {})
+    expect(missing.ok).toBe(false)
+    expect(!missing.ok && missing.reason).toContain('target element')
+  })
+
+  it('a noise pair (snare+flute on one slot) reduces the score per the matrix', () => {
+    const noisy = structuredClone(level)
+    const m3 = noisy.elements.find((element) => element.id === 'm3')
+    if (!m3) throw new Error('fixture element missing')
+    m3.params.timeline_slot = 3 // move the flute onto the snare's slot
+    const session = new GameSession(gameType, noisy)
+    session.performAction('rhythm_builder', 'place_piece', { element_id: 'r1' })
+    session.performAction('melody_builder', 'place_piece', { element_id: 'm1' })
+    expect(session.score()).toBe(3)
+    session.performAction('rhythm_builder', 'place_piece', { element_id: 'r2' })
+    session.performAction('melody_builder', 'place_piece', { element_id: 'm3' })
+    expect(session.score()).toBe(2) // 3 + (snare×flute incompatible = -1)
+  })
+
+  it('remove_piece takes a placement back', () => {
+    const session = new GameSession(gameType, level)
+    session.performAction('rhythm_builder', 'place_piece', { element_id: 'r1' })
+    session.performAction('melody_builder', 'place_piece', { element_id: 'm1' })
+    expect(session.score()).toBe(3)
+    session.performAction('melody_builder', 'remove_piece', { element_id: 'm1' })
+    expect(session.score()).toBe(0)
+  })
+
+  it('computes the spec remaining-steps metric (M4)', () => {
+    const session = new GameSession(gameType, level)
+    expect(session.remainingSteps()).toBe(4) // 8 empty slots, 4 formable pairs
+    session.performAction('rhythm_builder', 'place_piece', { element_id: 'r1' })
+    session.performAction('melody_builder', 'place_piece', { element_id: 'm1' })
+    session.performAction('rhythm_builder', 'place_piece', { element_id: 'r2' })
+    session.performAction('melody_builder', 'place_piece', { element_id: 'm2' })
+    session.performAction('rhythm_builder', 'place_piece', { element_id: 'r3' })
+    session.performAction('melody_builder', 'place_piece', { element_id: 'm3' })
+    // Spec worked example: 3 pairs placed scoring 9 → remaining_steps = 1.
+    expect(session.score()).toBe(9)
+    expect(session.remainingSteps()).toBe(1)
+  })
+
+  it('never exposes the reserved placement key through role views', () => {
+    const session = new GameSession(gameType, level)
+    for (const roleId of ['rhythm_builder', 'melody_builder']) {
+      for (const element of session.getRoleView(roleId).elements) {
+        expect(element.visible_states).not.toHaveProperty(PLACEMENT_STATE)
+      }
+    }
+  })
+})
+
+describe('engine-backed search on sg-demo-001', () => {
+  it('finds a construction path to the winning score', () => {
+    const result = searchSolution(gameType, level)
+    expect(result.solvable).toBe(true)
+    expect(result.timedOut).toBe(false)
+    expect(result.path.length).toBe(8) // all four pairs must land to cross 10
+    for (const step of result.path) {
+      expect(step.startsWith('place:')).toBe(true)
+    }
+  })
+
+  it('reports unsolvable when the target exceeds the best possible build', () => {
+    const impossible = structuredClone(level)
+    impossible.win_condition.params.target_score = 99
+    const result = searchSolution(gameType, impossible, startDeadline(5000))
+    expect(result.solvable).toBe(false)
+    expect(result.timedOut).toBe(false)
+  })
+})

--- a/packages/creation/src/engine/sound-garden.test.ts
+++ b/packages/creation/src/engine/sound-garden.test.ts
@@ -68,6 +68,38 @@ describe('GameSession — scripted sg-demo-001 build to win', () => {
     expect(!missing.ok && missing.reason).toContain('target element')
   })
 
+  it('honors declared action params: place_piece accepts its declared slot arg', () => {
+    // place_piece declares {slot: int} in the action_registry; a caller
+    // supplying it is schema-conformant and must NOT be rejected (pre-fix the
+    // engine hardcoded element_id/action_type and errored on "slot"). The
+    // arg is call payload — placement still reads the element's own
+    // timeline_slot, so the pair scores as usual.
+    const session = new GameSession(gameType, level)
+    const placed = session.performAction('rhythm_builder', 'place_piece', {
+      element_id: 'r1',
+      slot: 1,
+    })
+    expect(placed.ok).toBe(true)
+    session.performAction('melody_builder', 'place_piece', { element_id: 'm1', slot: 1 })
+    expect(session.score()).toBe(3)
+    const removed = session.performAction('melody_builder', 'remove_piece', {
+      element_id: 'm1',
+      slot: 1,
+    })
+    expect(removed.ok).toBe(true)
+    expect(session.score()).toBe(0)
+  })
+
+  it('still rejects a truly-unknown arg key', () => {
+    const session = new GameSession(gameType, level)
+    const unknown = session.performAction('rhythm_builder', 'place_piece', {
+      element_id: 'r1',
+      velocity: 9,
+    })
+    expect(unknown.ok).toBe(false)
+    expect(!unknown.ok && unknown.reason).toContain('velocity')
+  })
+
   it('a noise pair (snare+flute on one slot) reduces the score per the matrix', () => {
     const noisy = structuredClone(level)
     const m3 = noisy.elements.find((element) => element.id === 'm3')

--- a/packages/creation/src/engine/synthetic.test.ts
+++ b/packages/creation/src/engine/synthetic.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Synthetic-fixture coverage for the two rule kinds rc-demo never exercises
+ * (G5): a state_transition win driven by event-gated transitions, and an
+ * interaction_matrix scoring path — both executed through the SHARED rule
+ * core, asserting engine and solver agreement (G2). Also pins the G2
+ * negative (no producible event → engine cannot play → solvability FAILS)
+ * and the G6 state_effect guard (typo never silently advances).
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { GameType, Level, StateEffect } from '../schema/types'
+import { checkSolvability } from '../validate/solvability'
+import { validateGameType } from '../validate/validate'
+import { startDeadline } from '../validate/helpers'
+import { GameSession } from './engine'
+import { searchSolution, solutionDriversForTarget } from './search'
+
+// --- Synthetic fixture A: event-gated state_transition ("gate-lab") ---
+
+const gateGameType: GameType = {
+  id: 'gate-lab',
+  version: '0.1.0',
+  display_name: 'Gate Lab',
+  description: 'Synthetic state_transition coverage fixture',
+  co_play_form: 'co_build',
+  element_archetypes: [
+    {
+      id: 'gate',
+      category: 'spatial',
+      verbal_label: { canonical: 'gate', phonetic_pinyin: 'zhá mén' },
+      description: 'A switchable gate',
+      attributes: [{ name: 'color', type: 'enum', required: true, values: ['red', 'blue'] }],
+      states: [{ name: 'gate_state', type: 'enum', values: ['closed', 'open'], initial: 'closed' }],
+      interaction_model: 'stateful',
+    },
+  ],
+  rule_templates: [
+    {
+      id: 'gate_rule',
+      type: 'state_transition',
+      transition_table_schema: { states: ['closed', 'open'], events: ['switch_pressed'] },
+      communication_weight: 1,
+    },
+  ],
+  action_registry: [
+    {
+      name: 'press_switch',
+      description: 'Press the gate switch',
+      params: [{ name: 'action_type', type: 'string' }],
+      scope: 'player_action',
+    },
+  ],
+  action_event_mapping: [{ action_type: 'press', gate_rule_event: 'switch_pressed' }],
+  information_partition_template: {
+    roles: [
+      {
+        id: 'operator',
+        display_name: 'Operator',
+        verbal_label: 'operator',
+        description: 'Presses switches',
+        input_modality: 'visual',
+        output_modality: 'action',
+      },
+    ],
+    visibility_rules: [],
+    rule_visibility: [],
+    shared_label_attributes: [],
+    action_capability: [
+      { role: 'operator', can_perform: ['press_switch'], target_archetypes: ['gate'] },
+    ],
+    communication_channels: [],
+    partition_pattern: 'ability_complement',
+  },
+  win_condition_type: { type: 'all_solved', description: 'Gate open' },
+  difficulty_budget: {
+    element_count: { min: 1, max: 4 },
+    rule_count: { min: 1, max: 4 },
+    partition_complexity: { max: 5 },
+    weights: { element: 1, rule: 1, partition: 1 },
+    total_score: { min: 0, max: 100 },
+  },
+  communication_budget: {
+    max_round_trips: 5,
+    estimated_seconds_per_round: 5,
+    time_limit_seconds: 60,
+    safety_margin: 0.8,
+  },
+  solver_strategy: 'exhaustive_path_search',
+  solver_timeout_ms: 5000,
+}
+
+const gateLevel: Level = {
+  metadata: {
+    id: 'gate-001',
+    game_type: 'gate-lab',
+    game_type_version: '0.1.0',
+    title: 'One gate',
+    author: 'synthetic-test',
+    created_at: '2026-07-04T00:00:00+08:00',
+  },
+  difficulty: { element_count: 1, rule_count: 1, partition_complexity: 0, total_score: 2 },
+  communication_estimate: {
+    round_trips: 1,
+    estimated_seconds: 5,
+    time_limit_seconds: 60,
+    feasibility: 'feasible',
+  },
+  elements: [{ id: 'g1', archetype: 'gate', params: { color: 'red' } }],
+  rules: [
+    {
+      id: 'r-gate',
+      template: 'gate_rule',
+      bindings: { transitions: [['closed', 'switch_pressed', 'open']] },
+      target_elements: ['g1'],
+    },
+  ],
+  information_partition: {
+    role_assignments: [
+      {
+        role: 'operator',
+        element_views: [{ element_id: 'g1', visible_attributes: ['*'], visible_states: ['*'] }],
+      },
+    ],
+  },
+  win_condition: { type: 'all_solved', params: { target_state: 'open', target_elements: ['g1'] } },
+}
+
+// --- Synthetic fixture B: interaction_matrix scoring path ("duet-lab") ---
+
+const duetGameType: GameType = {
+  id: 'duet-lab',
+  version: '0.1.0',
+  display_name: 'Duet Lab',
+  description: 'Synthetic interaction_matrix coverage fixture',
+  co_play_form: 'co_build',
+  element_archetypes: [
+    {
+      id: 'piece',
+      category: 'auditory',
+      verbal_label: { canonical: 'piece', phonetic_pinyin: 'yuè jiàn' },
+      description: 'A sound piece',
+      attributes: [
+        { name: 'kind', type: 'enum', required: true, values: ['drum', 'bell'] },
+        { name: 'slot', type: 'enum', required: true, values: ['1', '2'] },
+      ],
+      states: [
+        { name: 'resonance', type: 'enum', values: ['silent', 'resonant'], initial: 'silent' },
+      ],
+      interaction_model: 'reactive',
+    },
+  ],
+  rule_templates: [
+    {
+      id: 'duet_rule',
+      type: 'interaction_matrix',
+      matrix_schema: {
+        entity_types: ['drum', 'bell'],
+        entity_type_attributes: ['kind'],
+        pair_match_attributes: ['slot'], // only same-slot pairs are eligible (H2)
+        relation_types: ['synergy'],
+        effect_schema: [{ relation: 'synergy', effect: 'resonate', params: [] }],
+      },
+      communication_weight: 0.5,
+    },
+  ],
+  action_registry: [
+    {
+      name: 'resonate',
+      description: 'Resonance effect (engine-internal)',
+      params: [],
+      scope: 'rule_verb',
+      state_effect: 'complete_state',
+    },
+    {
+      name: 'strike',
+      description: 'Strike a piece',
+      params: [],
+      scope: 'player_action',
+      triggers: ['duet_rule'],
+    },
+  ],
+  information_partition_template: {
+    roles: [
+      {
+        id: 'player',
+        display_name: 'Player',
+        verbal_label: 'player',
+        description: 'Strikes pieces',
+        input_modality: 'auditory',
+        output_modality: 'action',
+      },
+    ],
+    visibility_rules: [],
+    rule_visibility: [],
+    shared_label_attributes: [],
+    action_capability: [{ role: 'player', can_perform: ['strike'], target_archetypes: ['piece'] }],
+    communication_channels: [],
+    partition_pattern: 'ability_complement',
+  },
+  win_condition_type: { type: 'all_solved', description: 'All pieces resonant' },
+  difficulty_budget: {
+    element_count: { min: 1, max: 4 },
+    rule_count: { min: 1, max: 4 },
+    partition_complexity: { max: 5 },
+    weights: { element: 1, rule: 1, partition: 1 },
+    total_score: { min: 0, max: 100 },
+  },
+  communication_budget: {
+    max_round_trips: 5,
+    estimated_seconds_per_round: 5,
+    time_limit_seconds: 60,
+    safety_margin: 0.8,
+  },
+  solver_strategy: 'exhaustive_path_search',
+  solver_timeout_ms: 5000,
+}
+
+const duetLevel: Level = {
+  metadata: {
+    id: 'duet-001',
+    game_type: 'duet-lab',
+    game_type_version: '0.1.0',
+    title: 'Drum and bell',
+    author: 'synthetic-test',
+    created_at: '2026-07-04T00:00:00+08:00',
+  },
+  difficulty: { element_count: 3, rule_count: 1, partition_complexity: 0, total_score: 4 },
+  communication_estimate: {
+    round_trips: 1,
+    estimated_seconds: 5,
+    time_limit_seconds: 60,
+    feasibility: 'feasible',
+  },
+  elements: [
+    { id: 'p1', archetype: 'piece', params: { kind: 'drum', slot: '1' } },
+    { id: 'p2', archetype: 'piece', params: { kind: 'bell', slot: '1' } },
+    // Same kinds as p2 but a DIFFERENT slot: the (p1, p3) pair matches a
+    // matrix row yet is pair-filter ineligible — it must never score.
+    { id: 'p3', archetype: 'piece', params: { kind: 'bell', slot: '2' } },
+  ],
+  rules: [
+    {
+      id: 'r-duet',
+      template: 'duet_rule',
+      bindings: { matrix: [['drum', 'bell', 'synergy']] },
+      target_elements: ['p1', 'p2', 'p3'],
+    },
+  ],
+  information_partition: {
+    role_assignments: [
+      {
+        role: 'player',
+        element_views: [
+          { element_id: 'p1', visible_attributes: ['*'], visible_states: ['*'] },
+          { element_id: 'p2', visible_attributes: ['*'], visible_states: ['*'] },
+          { element_id: 'p3', visible_attributes: ['*'], visible_states: ['*'] },
+        ],
+      },
+    ],
+  },
+  win_condition: {
+    type: 'all_solved',
+    params: { target_state: 'resonant', target_elements: ['p1', 'p2'] },
+  },
+}
+
+describe('synthetic state_transition (gate-lab)', () => {
+  it('engine plays the event-gated transition to the win', () => {
+    const session = new GameSession(gateGameType, gateLevel)
+    expect(session.getState().elements.g1.gate_state).toBe('closed')
+    const result = session.performAction('operator', 'press_switch', {
+      element_id: 'g1',
+      action_type: 'press',
+    })
+    expect(result.ok).toBe(true)
+    expect(session.getState().elements.g1.gate_state).toBe('open')
+    expect(session.isWon()).toBe(true)
+  })
+
+  it('solver agrees with the engine through the shared core', () => {
+    const search = searchSolution(gateGameType, gateLevel)
+    expect(search.solvable).toBe(true)
+    expect(search.path).toEqual(['r-gate'])
+    expect(checkSolvability(gateGameType, gateLevel).verdict).toBe('pass')
+  })
+
+  it('G2: no producible event → engine cannot play AND solvability fails', () => {
+    const unplayable = structuredClone(gateGameType)
+    unplayable.action_event_mapping = []
+    // Engine: the action succeeds but nothing can fire the transition.
+    const session = new GameSession(unplayable, gateLevel)
+    const result = session.performAction('operator', 'press_switch', {
+      element_id: 'g1',
+      action_type: 'press',
+    })
+    expect(result.ok).toBe(true)
+    expect(result.ok && result.effects).toEqual([])
+    expect(session.getState().elements.g1.gate_state).toBe('closed')
+    expect(session.isWon()).toBe(false)
+    // Solver: event-gated moves mean the search agrees — NOT solvable.
+    expect(searchSolution(unplayable, gateLevel).solvable).toBe(false)
+    const check = checkSolvability(unplayable, gateLevel)
+    expect(check.verdict).toBe('fail')
+    expect(check.violations.some((v) => v.constraint === 'solution_path_exists')).toBe(true)
+  })
+
+  it('G3: driver analysis reports timeout instead of a partial count', () => {
+    const analysis = solutionDriversForTarget(gateGameType, gateLevel, 'g1', startDeadline(0))
+    expect(analysis.timedOut).toBe(true)
+  })
+})
+
+describe('synthetic interaction_matrix (duet-lab)', () => {
+  it('engine applies the pair effect to both members and wins', () => {
+    const session = new GameSession(duetGameType, duetLevel)
+    const result = session.performAction('player', 'strike', { element_id: 'p1' })
+    expect(result.ok).toBe(true)
+    expect(session.getState().elements.p1.resonance).toBe('resonant')
+    expect(session.getState().elements.p2.resonance).toBe('resonant')
+    expect(session.isWon()).toBe(true)
+  })
+
+  it('H2: the pair filter blocks cross-slot pairs (same kinds, different slot)', () => {
+    const session = new GameSession(duetGameType, duetLevel)
+    session.performAction('player', 'strike', { element_id: 'p1' })
+    // (p1, p3) matches the drum×bell matrix row but sits on another slot:
+    // pair_match_attributes [slot] keeps it out of the lookup.
+    expect(session.getState().elements.p1.resonance).toBe('resonant')
+    expect(session.getState().elements.p2.resonance).toBe('resonant')
+    expect(session.getState().elements.p3.resonance).toBe('silent')
+  })
+
+  it('solver agrees with the engine through the shared core', () => {
+    const search = searchSolution(duetGameType, duetLevel)
+    expect(search.solvable).toBe(true)
+    expect(search.path).toEqual(['r-duet'])
+    expect(checkSolvability(duetGameType, duetLevel).verdict).toBe('pass')
+  })
+
+  it('H2: pair_match_attributes must exist on the participating archetypes', () => {
+    const badGameType = structuredClone(duetGameType)
+    const template = badGameType.rule_templates[0]
+    if (template.type !== 'interaction_matrix') throw new Error('fixture template kind')
+    template.matrix_schema.pair_match_attributes = ['tempo']
+    const result = validateGameType(badGameType)
+    expect(result.verdict).toBe('fail')
+    const violation = result.violations.find(
+      (v) => v.field_path === 'game_type.rule_templates[0].matrix_schema.pair_match_attributes[0]'
+    )
+    expect(violation?.constraint).toBe('attribute_defined')
+    expect(violation?.actual).toContain('piece')
+  })
+
+  it('G6: a typo’d state_effect never silently advances state', () => {
+    const badGameType = structuredClone(duetGameType)
+    badGameType.action_registry[0].state_effect = 'complte_state' as StateEffect
+    const session = new GameSession(badGameType, duetLevel)
+    session.performAction('player', 'strike', { element_id: 'p1' })
+    expect(session.getState().elements.p1.resonance).toBe('silent')
+    expect(session.isWon()).toBe(false)
+    // The solver, sharing the core, agrees the level is now unplayable.
+    expect(searchSolution(badGameType, duetLevel).solvable).toBe(false)
+  })
+})

--- a/packages/creation/src/engine/synthetic.test.ts
+++ b/packages/creation/src/engine/synthetic.test.ts
@@ -13,6 +13,7 @@ import { checkSolvability } from '../validate/solvability'
 import { validateGameType } from '../validate/validate'
 import { startDeadline } from '../validate/helpers'
 import { GameSession } from './engine'
+import { applyStateEffect } from './rules'
 import { searchSolution, solutionDriversForTarget } from './search'
 
 // --- Synthetic fixture A: event-gated state_transition ("gate-lab") ---
@@ -308,6 +309,35 @@ describe('synthetic state_transition (gate-lab)', () => {
     const analysis = solutionDriversForTarget(gateGameType, gateLevel, 'g1', startDeadline(0))
     expect(analysis.timedOut).toBe(true)
   })
+
+  it('F1: a mapping row alone is not producible — the event needs an action_type-declaring action on the archetype', () => {
+    // press_switch stops declaring an action_type param: the mapping row
+    // (press → switch_pressed) survives, but the engine has NO path to carry
+    // an action_type, so the event can never fire. Pre-fix the solver treated
+    // every mapping event as producible whenever SOME action could target the
+    // gate — a false-positive publishability hole for state_transition.
+    const undrivable = structuredClone(gateGameType)
+    undrivable.action_registry[0].params = []
+
+    // Engine: a smuggled action_type is rejected; a bare press fires nothing.
+    const session = new GameSession(undrivable, gateLevel)
+    const smuggled = session.performAction('operator', 'press_switch', {
+      element_id: 'g1',
+      action_type: 'press',
+    })
+    expect(smuggled.ok).toBe(false)
+    expect(!smuggled.ok && smuggled.reason).toContain('action_type')
+    const bare = session.performAction('operator', 'press_switch', { element_id: 'g1' })
+    expect(bare.ok).toBe(true)
+    expect(bare.ok && bare.effects).toEqual([])
+    expect(session.getState().elements.g1.gate_state).toBe('closed')
+
+    // Solver agrees through the event-drivable gate: NOT solvable.
+    expect(searchSolution(undrivable, gateLevel).solvable).toBe(false)
+    const check = checkSolvability(undrivable, gateLevel)
+    expect(check.verdict).toBe('fail')
+    expect(check.violations.some((v) => v.constraint === 'solution_path_exists')).toBe(true)
+  })
 })
 
 describe('synthetic interaction_matrix (duet-lab)', () => {
@@ -360,5 +390,26 @@ describe('synthetic interaction_matrix (duet-lab)', () => {
     expect(session.isWon()).toBe(false)
     // The solver, sharing the core, agrees the level is now unplayable.
     expect(searchSolution(badGameType, duetLevel).solvable).toBe(false)
+  })
+
+  it('G6: an unknown CURRENT state value is a no-op, never laundered into progress', () => {
+    // A typo'd GameType state initial ('siilent' ∉ values) used to become
+    // real progress: advance_state computed index -1 → values[0], and
+    // complete_state jumped straight to the terminal value.
+    const badGameType = structuredClone(duetGameType)
+    const typoState = badGameType.element_archetypes[0].states?.[0]
+    if (!typoState) throw new Error('fixture state missing')
+    typoState.initial = 'siilent'
+    const session = new GameSession(badGameType, duetLevel)
+    session.performAction('player', 'strike', { element_id: 'p1' }) // resonate = complete_state
+    expect(session.getState().elements.p1.resonance).toBe('siilent') // NOT 'resonant'
+    expect(session.isWon()).toBe(false)
+    expect(searchSolution(badGameType, duetLevel).solvable).toBe(false)
+
+    // advance_state unit: unknown current must not launder into values[0].
+    const archetype = duetGameType.element_archetypes[0]
+    const machine = new Map<string, unknown>([['resonance', 'siilent']])
+    expect(applyStateEffect(archetype, machine, 'advance_state')).toBe(false)
+    expect(machine.get('resonance')).toBe('siilent')
   })
 })

--- a/packages/creation/src/schema/load.test.ts
+++ b/packages/creation/src/schema/load.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Fixture-loading tests: the Radio Cipher fixtures load without error and
+ * conform to the meta-model type contracts (spot-asserted on key fields per
+ * the R1 acceptance sketch); malformed documents produce clear load errors.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel, SchemaLoadError } from './load'
+import { SEED_CO_PLAY_FORM_CATALOG } from './types'
+import type { GameType, Level } from './types'
+
+const fixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'radio-cipher'
+)
+
+const gameTypeYaml = readFileSync(join(fixturesDir, 'game-type.yaml'), 'utf8')
+const levelYaml = readFileSync(join(fixturesDir, 'level.rc-demo-001.yaml'), 'utf8')
+
+describe('loadGameType (radio-cipher fixture)', () => {
+  const gameType: GameType = loadGameType(gameTypeYaml)
+
+  it('loads the vocabulary and identifies the game type', () => {
+    expect(gameType.id).toBe('radio-cipher')
+    expect(gameType.version).toBe('1.0.0')
+    expect(gameType.display_name).toBe('密码电台')
+  })
+
+  it('declares the hidden_info_coop co-play form, present in the seed catalog', () => {
+    expect(gameType.co_play_form).toBe('hidden_info_coop')
+    const form = SEED_CO_PLAY_FORM_CATALOG.find((f) => f.id === gameType.co_play_form)
+    expect(form?.floor_checks).toEqual(['communication_completeness', 'verbal_distinguishability'])
+  })
+
+  it('registers the three element archetypes', () => {
+    expect(gameType.element_archetypes.map((a) => a.id)).toEqual([
+      'cipher_segment',
+      'cipher_key',
+      'frequency_hint',
+    ])
+    const segment = gameType.element_archetypes[0]
+    expect(segment.category).toBe('auditory')
+    expect(segment.verbal_label.canonical).toBe('密文段')
+    expect(segment.interaction_model).toBe('stateful')
+    const contentLength = segment.attributes.find((a) => a.name === 'content_length')
+    expect(contentLength?.type).toBe('enum')
+    expect(contentLength?.values).toEqual(['short', 'medium', 'long'])
+    expect(contentLength?.display_labels).toEqual({ short: '短', medium: '中等', long: '长' })
+  })
+
+  it('registers the rule templates with their declarative kinds', () => {
+    const kinds = Object.fromEntries(gameType.rule_templates.map((t) => [t.id, t.type]))
+    expect(kinds).toEqual({
+      decrypt_step: 'temporal_sequence',
+      reverse_decrypt: 'temporal_sequence',
+      verification_check: 'condition_action',
+    })
+  })
+
+  it('narrows rule templates through the discriminated union', () => {
+    const decryptStep = gameType.rule_templates.find((t) => t.id === 'decrypt_step')
+    expect(decryptStep?.type).toBe('temporal_sequence')
+    if (decryptStep?.type === 'temporal_sequence') {
+      expect(decryptStep.sequence_schema.max_steps).toBe(5)
+      expect(decryptStep.sequence_schema.ordering).toBe('strict')
+      expect(decryptStep.sequence_schema.step_schema.action).toBe('apply_key')
+      expect(decryptStep.communication_weight).toBe(2.0)
+    }
+    const verify = gameType.rule_templates.find((t) => t.id === 'verification_check')
+    expect(verify?.type).toBe('condition_action')
+    if (verify?.type === 'condition_action') {
+      expect(verify.condition_schema.predicates[0].name).toBe('plaintext_is_valid_word')
+      expect(verify.condition_schema.combinators).toEqual(['AND'])
+      expect(verify.action_schema.verbs).toEqual(['confirm_decryption', 'retry_decryption'])
+    }
+  })
+
+  it('declares the information partition roles and pattern', () => {
+    const partition = gameType.information_partition_template
+    expect(partition?.roles.map((r) => r.id)).toEqual(['listener', 'decoder'])
+    expect(partition?.partition_pattern).toBe('describe_execute')
+    expect(partition?.shared_label_attributes).toEqual([
+      { element_archetype: 'cipher_segment', attributes: ['content_length'] },
+    ])
+  })
+
+  it('declares the action registry with scopes and the budgets', () => {
+    const applyKey = gameType.action_registry.find((a) => a.name === 'apply_key')
+    expect(applyKey?.scope).toBe('rule_verb')
+    expect(applyKey?.params).toEqual([
+      { name: 'cipher_segment_id', type: 'string' },
+      { name: 'cipher_key_id', type: 'string' },
+    ])
+    expect(gameType.win_condition_type.type).toBe('all_solved')
+    expect(gameType.difficulty_budget.element_count).toEqual({ min: 3, max: 12 })
+    expect(gameType.communication_budget.max_round_trips).toBe(15)
+    expect(gameType.communication_budget.safety_margin).toBe(0.8)
+  })
+})
+
+describe('loadGameType (partition-optional forms)', () => {
+  // Minimal synthetic co_build vocabulary: shared-state forms may omit
+  // information_partition_template entirely (spec Mechanism 1). Guards
+  // against a regression re-adding it to GAME_TYPE_REQUIRED_FIELDS.
+  const coBuildYaml = [
+    'GameType:',
+    '  id: co-build-minimal',
+    "  version: '0.1.0'",
+    '  display_name: Minimal Co-Build',
+    '  description: Synthetic minimal co_build vocabulary for loader tests',
+    '  co_play_form: co_build',
+    '  element_archetypes:',
+    '    - id: block',
+    '      category: spatial',
+    '      verbal_label:',
+    '        canonical: block',
+    "        phonetic_pinyin: 'fāng kuài'",
+    '      description: A stackable building block',
+    '      attributes:',
+    '        - name: size',
+    '          type: enum',
+    '          required: true',
+    '          values: [small, large]',
+    '      interaction_model: stateless',
+    '  rule_templates:',
+    '    - id: stack_step',
+    '      type: temporal_sequence',
+    '      sequence_schema:',
+    '        max_steps: 3',
+    '        step_schema:',
+    '          action: place_block',
+    '          params: []',
+    '        ordering: flexible',
+    '      communication_weight: 1.0',
+    '  win_condition_type:',
+    '    type: score_threshold',
+    '    description: Structure height reaches the target score',
+    '  difficulty_budget:',
+    '    element_count: { min: 1, max: 4 }',
+    '    rule_count: { min: 1, max: 2 }',
+    '    partition_complexity: { max: 1.0 }',
+    '    weights: { element: 1.0, rule: 1.0, partition: 1.0 }',
+    '    total_score: { min: 1.0, max: 10.0 }',
+    '  action_registry:',
+    '    - name: place_block',
+    '      description: Place a block on the structure',
+    '      params: []',
+    '      scope: both',
+    '  communication_budget:',
+    '    max_round_trips: 5',
+    '    estimated_seconds_per_round: 10.0',
+    '    time_limit_seconds: 120',
+    '    safety_margin: 0.8',
+    '  solver_strategy: exhaustive_path_search',
+    '  solver_timeout_ms: 5000',
+    '',
+  ].join('\n')
+
+  it('loads a GameType without information_partition_template', () => {
+    const gameType: GameType = loadGameType(coBuildYaml)
+    expect(gameType.id).toBe('co-build-minimal')
+    expect(gameType.co_play_form).toBe('co_build')
+    expect(gameType.information_partition_template).toBeUndefined()
+    expect(gameType.element_archetypes.map((a) => a.id)).toEqual(['block'])
+    expect(gameType.rule_templates[0].type).toBe('temporal_sequence')
+    expect(gameType.win_condition_type.type).toBe('score_threshold')
+  })
+})
+
+describe('loadLevel (rc-demo-001 fixture)', () => {
+  const gameType: GameType = loadGameType(gameTypeYaml)
+  const level: Level = loadLevel(levelYaml)
+
+  it('loads the level metadata with an exact game-type version binding', () => {
+    expect(level.metadata.id).toBe('rc-demo-001')
+    expect(level.metadata.game_type).toBe(gameType.id)
+    expect(level.metadata.game_type_version).toBe(gameType.version)
+  })
+
+  it('instantiates elements from registered archetypes', () => {
+    expect(level.elements.map((e) => e.id)).toEqual(['seg-1', 'seg-2', 'key-1', 'hint-1', 'hint-2'])
+    const archetypeIds = new Set(gameType.element_archetypes.map((a) => a.id))
+    for (const element of level.elements) {
+      expect(archetypeIds).toContain(element.archetype)
+    }
+    const seg1 = level.elements[0]
+    expect(seg1.params).toEqual({ content_length: 'short', plaintext_category: 'animal' })
+    expect(seg1.position).toEqual({ slot: 1 })
+    const key1 = level.elements.find((e) => e.id === 'key-1')
+    expect(key1?.params).toEqual({ target_method: 'caesar_shift', shift_amount: 3 })
+    expect(key1?.position).toBeUndefined()
+  })
+
+  it('binds rules to registered templates', () => {
+    expect(level.rules.map((r) => r.template)).toEqual([
+      'decrypt_step',
+      'reverse_decrypt',
+      'verification_check',
+    ])
+    const verify = level.rules.find((r) => r.id === 'rule-verify')
+    expect(verify?.bindings).toEqual({
+      predicates: [{ name: 'plaintext_is_valid_word', category: 'animal' }],
+      combinator: 'AND',
+      action: { verb: 'confirm_decryption' },
+    })
+    expect(verify?.target_elements).toEqual(['seg-1'])
+  })
+
+  it('assigns per-role element views in the information partition', () => {
+    const roles = level.information_partition.role_assignments.map((a) => a.role)
+    expect(roles).toEqual(['listener', 'decoder'])
+    const listener = level.information_partition.role_assignments[0]
+    expect(listener.element_views).toHaveLength(2)
+    expect(listener.element_views[0]).toEqual({
+      element_id: 'seg-1',
+      visible_attributes: ['content_length'],
+      visible_states: ['decryption_progress'],
+    })
+  })
+
+  it('carries the difficulty, communication estimate, and win condition', () => {
+    expect(level.difficulty).toEqual({
+      element_count: 5,
+      rule_count: 3,
+      partition_complexity: 3.71,
+      total_score: 16.92,
+    })
+    expect(level.communication_estimate.feasibility).toBe('feasible')
+    expect(level.win_condition.type).toBe('all_solved')
+    expect(level.win_condition.params).toEqual({
+      target_state: 'decrypted',
+      target_elements: ['seg-1', 'seg-2'],
+    })
+  })
+})
+
+describe('malformed documents', () => {
+  it('rejects a GameType document missing required top-level fields', () => {
+    const malformed = ['GameType:', '  id: broken-game', '  display_name: Broken', ''].join('\n')
+    expect(() => loadGameType(malformed)).toThrow(SchemaLoadError)
+    expect(() => loadGameType(malformed)).toThrow(/missing required field\(s\).*version/)
+  })
+
+  it('rejects a document without the expected root key', () => {
+    expect(() => loadGameType(levelYaml)).toThrow(/Missing top-level "GameType" key/)
+    expect(() => loadLevel(gameTypeYaml)).toThrow(/Missing top-level "Level" key/)
+  })
+
+  it('rejects a document with extra sibling root keys', () => {
+    const malformed = ['GameType:', '  id: broken-game', 'Sidecar:', '  stray: true', ''].join('\n')
+    expect(() => loadGameType(malformed)).toThrow(SchemaLoadError)
+    expect(() => loadGameType(malformed)).toThrow(
+      /Expected "GameType" to be the only root key, found extra root key\(s\): Sidecar/
+    )
+  })
+
+  it('rejects a Level document missing required top-level fields', () => {
+    const malformed = [
+      'Level:',
+      '  metadata:',
+      '    id: broken-level',
+      '    game_type: radio-cipher',
+      "    game_type_version: '1.0.0'",
+      '    title: Broken',
+      '    author: nobody',
+      "    created_at: '2026-07-02T22:00:00+08:00'",
+      '',
+    ].join('\n')
+    expect(() => loadLevel(malformed)).toThrow(SchemaLoadError)
+    expect(() => loadLevel(malformed)).toThrow(
+      /missing required field\(s\).*elements.*rules.*win_condition/
+    )
+  })
+
+  it('rejects a Level document with incomplete metadata', () => {
+    const malformed = [
+      'Level:',
+      '  metadata:',
+      '    id: broken-level',
+      '  difficulty: {}',
+      '  communication_estimate: {}',
+      '  elements: []',
+      '  rules: []',
+      '  information_partition: {}',
+      '  win_condition: {}',
+      '',
+    ].join('\n')
+    expect(() => loadLevel(malformed)).toThrow(/Level metadata.*game_type_version/)
+  })
+
+  it('rejects non-mapping and syntactically invalid YAML with clear errors', () => {
+    expect(() => loadGameType('just a scalar')).toThrow(
+      /Expected a YAML mapping with a top-level "GameType" key/
+    )
+    expect(() => loadGameType('GameType: [not, a, mapping]')).toThrow(
+      /"GameType" must be a mapping, got a sequence/
+    )
+    expect(() => loadGameType('a: [unclosed')).toThrow(/Invalid YAML/)
+  })
+})

--- a/packages/creation/src/schema/load.ts
+++ b/packages/creation/src/schema/load.ts
@@ -1,0 +1,134 @@
+/**
+ * YAML loader for creation-schema GameType and Level documents.
+ *
+ * Parses a YAML document and performs minimal structural narrowing (required
+ * top-level fields present) with clear errors. It deliberately does NOT
+ * validate semantics — enum membership, cross-references, budgets, and all
+ * co-play-form floor checks belong to the validator (a later round).
+ *
+ * Document form follows the spec's worked examples: the document root is a
+ * mapping whose single key is `GameType:` or `Level:`, wrapping the payload.
+ * Extra sibling root keys are rejected.
+ */
+
+import { load as parseYaml, YAMLException } from 'js-yaml'
+import type { GameType, Level } from './types'
+
+/** Thrown for any structural problem while loading a schema document. */
+export class SchemaLoadError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SchemaLoadError'
+  }
+}
+
+const GAME_TYPE_REQUIRED_FIELDS = [
+  'id',
+  'version',
+  'display_name',
+  'description',
+  'co_play_form',
+  'element_archetypes',
+  'rule_templates',
+  'win_condition_type',
+  'difficulty_budget',
+  'action_registry',
+  'communication_budget',
+  'solver_strategy',
+  'solver_timeout_ms',
+] as const
+// information_partition_template is intentionally not required: co-play forms
+// other than hidden_info_coop may simplify or omit it (spec Mechanism 1).
+
+const LEVEL_REQUIRED_FIELDS = [
+  'metadata',
+  'difficulty',
+  'communication_estimate',
+  'elements',
+  'rules',
+  'information_partition',
+  'win_condition',
+] as const
+
+const LEVEL_METADATA_REQUIRED_FIELDS = [
+  'id',
+  'game_type',
+  'game_type_version',
+  'title',
+  'author',
+  'created_at',
+] as const
+
+function isMapping(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function describeValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'a sequence'
+  return `a ${typeof value}`
+}
+
+function unwrapDocument(yamlText: string, rootKey: 'GameType' | 'Level'): Record<string, unknown> {
+  let parsed: unknown
+  try {
+    parsed = parseYaml(yamlText)
+  } catch (err) {
+    const detail = err instanceof YAMLException ? err.message : String(err)
+    throw new SchemaLoadError(`Invalid YAML: ${detail}`)
+  }
+  if (!isMapping(parsed)) {
+    throw new SchemaLoadError(
+      `Expected a YAML mapping with a top-level "${rootKey}" key, got ${describeValue(parsed)}`
+    )
+  }
+  const rootKeys = Object.keys(parsed)
+  const payload = parsed[rootKey]
+  if (payload === undefined) {
+    throw new SchemaLoadError(
+      `Missing top-level "${rootKey}" key; document root keys: ${rootKeys.join(', ') || '(none)'}`
+    )
+  }
+  if (rootKeys.length !== 1) {
+    const extras = rootKeys.filter((key) => key !== rootKey)
+    throw new SchemaLoadError(
+      `Expected "${rootKey}" to be the only root key, found extra root key(s): ${extras.join(', ')}`
+    )
+  }
+  if (!isMapping(payload)) {
+    throw new SchemaLoadError(`"${rootKey}" must be a mapping, got ${describeValue(payload)}`)
+  }
+  return payload
+}
+
+function assertRequiredFields(
+  doc: Record<string, unknown>,
+  fields: readonly string[],
+  context: string
+): void {
+  const missing = fields.filter((field) => doc[field] === undefined || doc[field] === null)
+  if (missing.length > 0) {
+    throw new SchemaLoadError(
+      `${context} document is missing required field(s): ${missing.join(', ')}`
+    )
+  }
+}
+
+/** Parse a GameType YAML document and narrow it structurally. */
+export function loadGameType(yamlText: string): GameType {
+  const doc = unwrapDocument(yamlText, 'GameType')
+  assertRequiredFields(doc, GAME_TYPE_REQUIRED_FIELDS, 'GameType')
+  return doc as unknown as GameType
+}
+
+/** Parse a Level YAML document and narrow it structurally. */
+export function loadLevel(yamlText: string): Level {
+  const doc = unwrapDocument(yamlText, 'Level')
+  assertRequiredFields(doc, LEVEL_REQUIRED_FIELDS, 'Level')
+  const metadata = doc.metadata
+  if (!isMapping(metadata)) {
+    throw new SchemaLoadError(`Level "metadata" must be a mapping, got ${describeValue(metadata)}`)
+  }
+  assertRequiredFields(metadata, LEVEL_METADATA_REQUIRED_FIELDS, 'Level metadata')
+  return doc as unknown as Level
+}

--- a/packages/creation/src/schema/types.ts
+++ b/packages/creation/src/schema/types.ts
@@ -1,0 +1,762 @@
+/**
+ * Creation-schema meta-model type definitions.
+ *
+ * Mirrors the YAML schema in the design spec
+ * (docs/architecture/arch-component-creation-schema.md, "Mechanism" section)
+ * field-for-field. All identifiers are the spec's snake_case ASCII schema
+ * identifiers. Types only — no validation logic lives here (the validator is
+ * a later round; see ValidationReport below for its output contract).
+ */
+
+// ---------------------------------------------------------------------------
+// Shared primitives
+// ---------------------------------------------------------------------------
+
+/** Semantic version string, e.g. "1.0.0". */
+export type Semver = string
+
+/**
+ * Parameter definition used by action-registry entries, rule predicates,
+ * sequence steps, and matrix effects.
+ *
+ * SPEC-DEFECT: the spec references `param_def[]` throughout the Mechanism
+ * schemas but never formally defines the shape. This is the minimal shape
+ * inferred from the Radio Cipher instantiation, where params are
+ * `{name, type}` pairs with type values such as "string" and "int".
+ */
+export interface ParamDef {
+  name: string
+  type: string
+}
+
+/**
+ * Open enum: keeps autocomplete for the known ids while allowing registry
+ * extension (the co-play form catalog and its floor checks are open
+ * registries per the spec — new forms register like new archetypes).
+ */
+type OpenId<Known extends string> = Known | (string & Record<never, never>)
+
+// ---------------------------------------------------------------------------
+// Co-play form catalog (spec Mechanism 2)
+// ---------------------------------------------------------------------------
+
+/** Seed co-play forms shipped with the catalog. The catalog is open. */
+export type SeedCoPlayFormId =
+  | 'hidden_info_coop'
+  | 'co_build'
+  | 'ai_performs_human_coaches'
+  | 'rapport_contest'
+  | 'ai_assistant'
+
+export type CoPlayFormId = OpenId<SeedCoPlayFormId>
+
+/** Universal validator checks — apply to every co-play form. */
+export type UniversalCheckId =
+  | 'schema_conformance'
+  | 'solvability'
+  | 'fairness'
+  | 'budget_compliance'
+
+/** Per-form validator floor checks for the seed catalog forms. */
+export type SeedFormFloorCheckId =
+  // hidden_info_coop
+  | 'communication_completeness'
+  | 'verbal_distinguishability'
+  // co_build
+  | 'goal_reachability'
+  | 'progress_measurability'
+  | 'construction_visibility'
+  // ai_performs_human_coaches
+  | 'coaching_effectiveness'
+  | 'solvability_under_coaching'
+  // rapport_contest
+  | 'sync_metric_computability'
+  | 'answer_space_symmetry'
+  // ai_assistant
+  | 'base_solvability'
+  | 'assist_value_measurability'
+
+/** Check id — open, since newly registered forms bring new floor checks. */
+export type CheckId = OpenId<UniversalCheckId | SeedFormFloorCheckId>
+
+/** One entry of the co-play form registry: form id → activated floor checks. */
+export interface CoPlayFormDefinition {
+  id: CoPlayFormId
+  floor_checks: readonly CheckId[]
+}
+
+export type CoPlayFormCatalog = readonly CoPlayFormDefinition[]
+
+/** Seed catalog per spec Mechanism 2 (form → validator floor checks). */
+export const SEED_CO_PLAY_FORM_CATALOG: CoPlayFormCatalog = [
+  {
+    id: 'hidden_info_coop',
+    floor_checks: ['communication_completeness', 'verbal_distinguishability'],
+  },
+  {
+    id: 'co_build',
+    floor_checks: ['goal_reachability', 'progress_measurability', 'construction_visibility'],
+  },
+  {
+    id: 'ai_performs_human_coaches',
+    floor_checks: ['coaching_effectiveness', 'solvability_under_coaching'],
+  },
+  { id: 'rapport_contest', floor_checks: ['sync_metric_computability', 'answer_space_symmetry'] },
+  { id: 'ai_assistant', floor_checks: ['base_solvability', 'assist_value_measurability'] },
+]
+
+// ---------------------------------------------------------------------------
+// ElementArchetype
+// ---------------------------------------------------------------------------
+
+export type ElementCategory = 'visual' | 'auditory' | 'spatial' | 'temporal' | 'hybrid'
+export type InteractionModel = 'stateless' | 'stateful' | 'reactive'
+export type AttributeType = 'enum' | 'range' | 'boolean' | 'set'
+export type StateType = 'enum' | 'range'
+
+export interface VerbalLabel {
+  /** Canonical verbal name — unique reference for the archetype. */
+  canonical: string
+  /** Toned pinyin, the unit for auditory-distinguishability distance checks. */
+  phonetic_pinyin: string
+  aliases?: string[]
+  forbidden_terms?: string[]
+}
+
+export interface AttributeDefinition {
+  name: string
+  type: AttributeType
+  required: boolean
+  /** Legal value set when type=enum. */
+  values?: string[]
+  /** ASCII value → target-language display label (type=enum). */
+  display_labels?: Record<string, string>
+  /** Lower bound when type=range. */
+  min?: number
+  /** Upper bound when type=range. */
+  max?: number
+  /** Step when type=range (continuous → discretized). */
+  step?: number
+  default?: unknown
+  /** Verbal description template, e.g. "{color}色的{shape}". */
+  verbal_template?: string
+}
+
+export interface StateDefinition {
+  name: string
+  type: StateType
+  values?: string[]
+  min?: number
+  max?: number
+  step?: number
+  initial?: unknown
+  verbal_template?: string
+}
+
+export interface ElementArchetype {
+  id: string
+  category: ElementCategory
+  verbal_label: VerbalLabel
+  description: string
+  attributes: AttributeDefinition[]
+  /** Possible runtime states (optional per spec). */
+  states?: StateDefinition[]
+  interaction_model: InteractionModel
+}
+
+// ---------------------------------------------------------------------------
+// RuleTemplate — four declarative template kinds (discriminated union)
+// ---------------------------------------------------------------------------
+
+export type RuleTemplateKind =
+  | 'condition_action'
+  | 'state_transition'
+  | 'temporal_sequence'
+  | 'interaction_matrix'
+
+export type Combinator = 'AND' | 'OR' | 'NOT'
+export type SequenceOrdering = 'strict' | 'flexible'
+export type RelationType = 'compatible' | 'incompatible' | 'synergy' | 'modifies' | 'neutral'
+
+export interface PredicateDefinition {
+  name: string
+  params: ParamDef[]
+  description: string
+}
+
+export interface ConditionSchema {
+  predicates: PredicateDefinition[]
+  combinators: Combinator[]
+}
+
+/** Action subset a condition_action template may trigger. */
+export interface ActionSchema {
+  /** References GameType.action_registry names with scope rule_verb|both. */
+  verbs: string[]
+}
+
+export interface TransitionTableSchema {
+  states: string[]
+  events: string[]
+}
+
+export interface SequenceStepSchema {
+  /** References an action_registry name. */
+  action: string
+  params: ParamDef[]
+}
+
+export interface SequenceSchema {
+  max_steps: number
+  step_schema: SequenceStepSchema
+  ordering: SequenceOrdering
+}
+
+export interface MatrixEffectSchema {
+  relation: string
+  /** References an action_registry name. */
+  effect: string
+  params: ParamDef[]
+}
+
+export interface MatrixSchema {
+  entity_types: string[]
+  /**
+   * Element attribute names carrying the entity type — an element's entity
+   * type is the value of its first present attribute in this list (spec
+   * Mechanism 1; e.g. botanical [species], sound-garden
+   * [rhythm_type, melody_type]). The engine reads this declaration, never a
+   * heuristic.
+   */
+  entity_type_attributes: string[]
+  /**
+   * Optional pair-eligibility filter: a target pair participates in the
+   * matrix lookup only when both elements carry EQUAL values on every named
+   * param (spec Mechanism 1; e.g. sound-garden [timeline_slot] — only
+   * same-slot rhythm×melody pairs score). Omitted = all target pairs.
+   */
+  pair_match_attributes?: string[]
+  relation_types: RelationType[]
+  /**
+   * Optional relation → score map: the machine scoring source for
+   * score_threshold GameTypes (spec Mechanism 1). The engine sums eligible
+   * pairs' matrix relations through this map.
+   */
+  relation_scores?: Record<string, number>
+  effect_schema: MatrixEffectSchema[]
+}
+
+interface RuleTemplateBase {
+  id: string
+  /**
+   * Template-level declared weight: how many communication round trips
+   * executing this rule costs against the communication budget.
+   */
+  communication_weight: number
+}
+
+export interface ConditionActionRuleTemplate extends RuleTemplateBase {
+  type: 'condition_action'
+  condition_schema: ConditionSchema
+  action_schema: ActionSchema
+}
+
+export interface StateTransitionRuleTemplate extends RuleTemplateBase {
+  type: 'state_transition'
+  transition_table_schema: TransitionTableSchema
+}
+
+export interface TemporalSequenceRuleTemplate extends RuleTemplateBase {
+  type: 'temporal_sequence'
+  sequence_schema: SequenceSchema
+}
+
+export interface InteractionMatrixRuleTemplate extends RuleTemplateBase {
+  type: 'interaction_matrix'
+  matrix_schema: MatrixSchema
+}
+
+export type RuleTemplate =
+  | ConditionActionRuleTemplate
+  | StateTransitionRuleTemplate
+  | TemporalSequenceRuleTemplate
+  | InteractionMatrixRuleTemplate
+
+// ---------------------------------------------------------------------------
+// InformationPartitionTemplate
+// ---------------------------------------------------------------------------
+
+export type InputModality = 'visual' | 'auditory' | 'tactile' | 'mixed'
+export type OutputModality = 'voice' | 'gesture' | 'action' | 'mixed'
+export type ChannelModality = 'voice' | 'text' | 'structured_signal'
+
+export type PartitionPattern =
+  | 'dual_half'
+  | 'know_unknown'
+  | 'restricted_clue'
+  | 'ability_complement'
+  | 'describe_execute'
+  | 'sequential_reveal'
+
+export interface RoleDefinition {
+  id: string
+  display_name: string
+  verbal_label: string
+  description: string
+  input_modality: InputModality
+  output_modality: OutputModality
+}
+
+/** Role-observable element fields ("*" wildcards allowed per spec). */
+export interface FieldVisibility {
+  element_archetype: string
+  attributes: string[]
+  states: string[]
+}
+
+export interface VisibilityRule {
+  role: string
+  can_see: FieldVisibility[]
+  cannot_see: FieldVisibility[]
+}
+
+export interface RuleVisibility {
+  role: string
+  /** Visible RuleTemplate ids ("*" = all). */
+  visible_rule_templates: string[]
+}
+
+/**
+ * Cross-role shared reference label source. Only archetypes that need
+ * cross-role verbal communication are listed; the attributes must be in
+ * every communicating role's can_see set (gametype_consistency gate).
+ */
+export interface SharedLabelAttributes {
+  element_archetype: string
+  attributes: string[]
+}
+
+export interface ActionCapability {
+  role: string
+  /** Performable action verbs (references action_registry names). */
+  can_perform: string[]
+  /** Element archetype ids this role can act on. */
+  target_archetypes: string[]
+}
+
+export interface ChannelConstraints {
+  max_words_per_turn?: number
+  forbidden_content?: string[]
+  turn_time_limit_seconds?: number
+}
+
+export interface CommunicationChannel {
+  from: string
+  to: string
+  modality: ChannelModality
+  constraints: ChannelConstraints
+}
+
+export interface InformationPartitionTemplate {
+  roles: RoleDefinition[]
+  visibility_rules: VisibilityRule[]
+  rule_visibility: RuleVisibility[]
+  shared_label_attributes: SharedLabelAttributes[]
+  action_capability: ActionCapability[]
+  communication_channels: CommunicationChannel[]
+  partition_pattern: PartitionPattern
+}
+
+// ---------------------------------------------------------------------------
+// GameType
+// ---------------------------------------------------------------------------
+
+export type WinConditionTypeId = 'all_solved' | 'score_threshold' | 'optimization_target'
+export type ActionScope = 'rule_verb' | 'player_action' | 'both'
+
+/**
+ * Declarative effect of an action on a stateful target element's FIRST
+ * declared state machine (spec Mechanism 1): advance one position along the
+ * declared value order, jump to the terminal value, or no effect (default).
+ */
+export type StateEffect = 'advance_state' | 'complete_state' | 'none'
+
+/**
+ * Declarative construction effect on the Level.initial_state construction
+ * model (spec Mechanism 1): place = put the target element on its declared
+ * slot, remove = take it off. co_build placement actions declare this; the
+ * engine and the solver both execute it.
+ */
+export type ConstructionEffect = 'place' | 'remove'
+
+export interface WinConditionType {
+  type: WinConditionTypeId
+  description: string
+}
+
+/** One entry of the GameType-global action verb registry. */
+export interface ActionDefinition {
+  name: string
+  description: string
+  params: ParamDef[]
+  scope: ActionScope
+  /** Optional declarative state effect; the rule engine executes it. */
+  state_effect?: StateEffect
+  /** Optional declarative construction effect (co_build placement actions). */
+  construction_effect?: ConstructionEffect
+  /**
+   * Optional rule-template trigger bindings: the ids of the condition_action
+   * / temporal_sequence / interaction_matrix templates this player action
+   * fires. A rule of those three kinds fires only when the action actually
+   * performed lists its template here — completing the action-gating
+   * discipline state_transition already gets from action_event_mapping, so an
+   * unrelated poke (a pure-communication action) can never advance game
+   * state. state_transition templates are driven by action_event_mapping
+   * events, NOT by this field (gametype_consistency rejects a state_transition
+   * id here as a silent no-op). Empty/absent = a pure-communication action
+   * that triggers no rule.
+   */
+  triggers?: string[]
+}
+
+export interface DifficultyBudget {
+  element_count: { min: number; max: number }
+  rule_count: { min: number; max: number }
+  partition_complexity: { max: number }
+  weights: { element: number; rule: number; partition: number }
+  total_score: { min: number; max: number }
+}
+
+export interface CommunicationBudget {
+  max_round_trips: number
+  estimated_seconds_per_round: number
+  time_limit_seconds: number
+  safety_margin: number
+  // Feasibility rule: round_trips * seconds_per_round <= time_limit * safety_margin
+}
+
+/**
+ * One row of the optional action_event_mapping table: `action_type` plus
+ * `<rule_template_id>_event` columns (e.g. health_response_event). ONLY the
+ * `_event` columns are machine-consumed (see rules.ts producibleEvents /
+ * actionEvent); the open Record type permits other columns, but any
+ * non-event column carries no current machine semantics (illustrative only).
+ */
+export type ActionEventMappingEntry = { action_type: string } & Record<string, string>
+
+export interface GameType {
+  /** Unique id, kebab-case. */
+  id: string
+  version: Semver
+  display_name: string
+  description: string
+  element_archetypes: ElementArchetype[]
+  rule_templates: RuleTemplate[]
+  /** Exactly one primary co-play form — decides the validator floor checks. */
+  co_play_form: CoPlayFormId
+  /**
+   * Heavily used by hidden_info_coop; other forms may simplify or omit it
+   * (e.g. co_build shares all state, the partition degenerates to symmetric
+   * visibility) — hence optional.
+   */
+  information_partition_template?: InformationPartitionTemplate
+  win_condition_type: WinConditionType
+  difficulty_budget: DifficultyBudget
+  action_registry: ActionDefinition[]
+  /**
+   * Optional player-action → rule-event mapping table (GameTypes with
+   * state_transition rules use it; spec Mechanism 1). Each row's
+   * action_type carries one or more `<rule_template_id>_event` columns —
+   * the sole machine-consumed columns; the engine and solver translate a
+   * player action into the named event for each state_transition template.
+   */
+  action_event_mapping?: ActionEventMappingEntry[]
+  communication_budget: CommunicationBudget
+  /**
+   * Solvability solver strategy id (e.g. "exhaustive_path_search", "csp").
+   * Every GameType must declare one (spec Mechanism 3, solvability
+   * computability assumption).
+   */
+  solver_strategy: string
+  /** Solvability solver timeout upper bound in milliseconds. */
+  solver_timeout_ms: number
+}
+
+// ---------------------------------------------------------------------------
+// Level
+// ---------------------------------------------------------------------------
+
+export type Feasibility = 'feasible' | 'tight' | 'infeasible'
+
+export interface LevelMetadata {
+  id: string
+  /** References GameType.id. */
+  game_type: string
+  /** References GameType.version — exact version binding. */
+  game_type_version: Semver
+  title: string
+  author: string
+  created_at: string
+}
+
+/** Actual complexity values (must fall within GameType.difficulty_budget). */
+export interface LevelDifficulty {
+  element_count: number
+  rule_count: number
+  partition_complexity: number
+  total_score: number
+}
+
+export interface CommunicationEstimate {
+  round_trips: number
+  /**
+   * Optional coordination rounds beyond rule evaluation (co_build
+   * proposal / division-of-labor turns) — included in the round_trips
+   * derivation (spec Mechanism 4).
+   */
+  coordination_round_trips?: number
+  estimated_seconds: number
+  time_limit_seconds: number
+  feasibility: Feasibility
+}
+
+/**
+ * co_build construction model: the starting space (spec Mechanism 1;
+ * goal_reachability's machine-derivation input). The timeline_slots field
+ * name follows the sound-garden instantiation — generalized naming is
+ * deferred to a second co_build instance (spec note).
+ */
+export interface InitialState {
+  timeline_slots?: number
+  /** Element instance ids already placed at start. */
+  occupied: string[]
+}
+
+/** One material-pool entry: archetype + count + the type-carrying param(s). */
+export type MaterialEntry = { archetype: string; count: number } & Record<string, unknown>
+
+export type ElementPosition = { slot: number } | { x: number; y: number }
+
+export interface LevelElement {
+  id: string
+  /** References ElementArchetype.id. */
+  archetype: string
+  /**
+   * Attribute values for this instance (must be within the archetype's
+   * attribute definitions). Kept flat: Level → elements[] → params{} is the
+   * third and deepest nesting level allowed for AI-authored content.
+   */
+  params: Record<string, unknown>
+  /**
+   * Optional per-instance starting state overrides (spec Mechanism 1). Each
+   * key names a declared state of the archetype; the value replaces that
+   * state's archetype `initial` for THIS instance (e.g. a plant's health or
+   * inherited effective_light). Omitted states fall back to the archetype
+   * initial.
+   */
+  initial_states?: Record<string, unknown>
+  position?: ElementPosition
+}
+
+export interface LevelRule {
+  id: string
+  /** References RuleTemplate.id. */
+  template: string
+  bindings: Record<string, unknown>
+  /** Element instance ids this rule acts on. */
+  target_elements: string[]
+}
+
+export interface ElementView {
+  element_id: string
+  visible_attributes: string[]
+  visible_states: string[]
+}
+
+export interface RoleAssignment {
+  role: string
+  element_views: ElementView[]
+}
+
+export interface LevelInformationPartition {
+  role_assignments: RoleAssignment[]
+}
+
+export interface WinCondition {
+  /** References GameType.win_condition_type. */
+  type: string
+  params: Record<string, unknown>
+}
+
+/** optimization_target: every element with `state` must rank >= `value`. */
+export interface StateAtLeastConstraint {
+  state: string
+  value: string
+}
+
+/** optimization_target: at least `count` elements have `state` == `value`. */
+export interface StateCountConstraint {
+  state: string
+  value: string
+  count: number
+}
+
+/**
+ * Declarative optimization_target params (spec Mechanism 1, formalized R7):
+ * a conjunction of "every element with this state ranks at least X" and
+ * "at least N elements reach state == Y" constraints, ranked by each
+ * state's declared value order. Game-agnostic — no hardcoded state names.
+ */
+export interface OptimizationTargetParams {
+  all_states_at_least?: StateAtLeastConstraint[]
+  count_states_equal?: StateCountConstraint[]
+}
+
+export interface Level {
+  metadata: LevelMetadata
+  difficulty: LevelDifficulty
+  communication_estimate: CommunicationEstimate
+  /** Optional co_build construction model (see InitialState). */
+  initial_state?: InitialState
+  /** Optional per-role material pools (goal_reachability input). */
+  available_materials?: Record<string, MaterialEntry[]>
+  elements: LevelElement[]
+  rules: LevelRule[]
+  information_partition: LevelInformationPartition
+  win_condition: WinCondition
+  /**
+   * Optional — auto-generated for hidden_info_coop (surface generation
+   * contract); shared-state forms may omit or generate symmetric surfaces.
+   */
+  communication_surfaces?: CommunicationSurface[]
+}
+
+// ---------------------------------------------------------------------------
+// CommunicationSurface (spec Mechanism 3 — surface generation contract)
+// ---------------------------------------------------------------------------
+
+export type SurfaceType = 'structured_description' | 'reference_manual' | 'audio_cue_list'
+export type WorkflowAction = 'describe_state' | 'request_info' | 'give_instruction' | 'execute'
+
+export interface SurfaceElementVisible {
+  element_id: string
+  /** Archetype-level verbal label (e.g. 「密文段」). */
+  archetype_label: string
+  /**
+   * Instance-level unique verbal reference, rendered from the
+   * shared_label_attributes verbal_template (e.g. 「短密文段」).
+   */
+  instance_label: string
+  visible_attributes?: Record<string, unknown>
+  visible_states?: Record<string, unknown>
+}
+
+export interface SurfaceRuleVisible {
+  rule_id: string
+  /** Natural-language description auto-translated from the declarative rule. */
+  description: string
+  relevant_elements: string[]
+}
+
+export interface SurfaceAction {
+  action: string
+  description: string
+  target_elements: string[]
+}
+
+export interface WorkflowStep {
+  step: number
+  action: WorkflowAction
+  description: string
+}
+
+export interface CommunicationProtocol {
+  partner_role: string
+  /** Channel constraints from the partition template. */
+  channel_constraints?: ChannelConstraints
+  suggested_workflow: WorkflowStep[]
+}
+
+export interface SurfaceContent {
+  elements_visible: SurfaceElementVisible[]
+  rules_visible: SurfaceRuleVisible[]
+  action_vocabulary: SurfaceAction[]
+  communication_protocol: CommunicationProtocol
+}
+
+export interface CommunicationSurface {
+  /** Target role id. */
+  role: string
+  game_type: string
+  /** Version binding — must equal the Level's game_type_version. */
+  game_type_version: Semver
+  surface_type: SurfaceType
+  content: SurfaceContent
+}
+
+// ---------------------------------------------------------------------------
+// Validator output contract (spec Mechanism 3 — validator interface).
+// Types only; the validator implementation is a later round.
+// ---------------------------------------------------------------------------
+
+export type Verdict = 'pass' | 'fail' | 'warn'
+
+/**
+ * Per-check verdict — the spec enum (pass|fail|warn) extended with 'skipped'
+ * for floor checks that are catalog-registered but not yet implemented.
+ * 'skipped' is never treated as pass: it is excluded from overall_verdict
+ * aggregation, and publish gating must treat a skipped floor check as
+ * not-yet-passed (spec invariant: publish requires ALL floor checks to pass).
+ */
+export type CheckVerdict = Verdict | 'skipped'
+
+export type ViolationSeverity = 'error' | 'warning'
+
+export interface Violation {
+  severity: ViolationSeverity
+  /**
+   * REQUIRED (spec invariant): path locating the offending field,
+   * e.g. "elements[2].params.color".
+   */
+  field_path: string
+  /** Which constraint was violated, e.g. "enum_membership". */
+  constraint: string
+  /** Expected value or range. */
+  expected: string
+  /** Actual value. */
+  actual: string
+  /** REQUIRED (spec invariant): fix suggestion for AI consumption. */
+  suggestion: string
+  /** Related element ids (cross-element violations). */
+  related_elements?: string[]
+}
+
+export interface CheckResult {
+  /**
+   * Universal checks always apply; form floor checks are activated by the
+   * GameType's co_play_form (see SEED_CO_PLAY_FORM_CATALOG). The enum is
+   * extended when new forms register.
+   */
+  check_type: CheckId
+  verdict: CheckVerdict
+  /** Non-empty only when verdict is fail|warn. */
+  violations: Violation[]
+}
+
+export interface ValidationReport {
+  level_id: string
+  game_type: string
+  game_type_version: Semver
+  /** Never 'pass' while any activated floor check is skipped (capped at 'warn'). */
+  overall_verdict: Verdict
+  /**
+   * True only when every universal check AND every activated floor check is
+   * a literal 'pass'. The publish gate reads this field; a skipped floor
+   * check keeps it false (skipped ≠ passed).
+   */
+  publish_ready: boolean
+  checks: CheckResult[]
+}
+
+/** Alias — the spec names this shape ValidationReport. */
+export type ValidationResult = ValidationReport

--- a/packages/creation/src/schema/types.ts
+++ b/packages/creation/src/schema/types.ts
@@ -87,6 +87,18 @@ export interface CoPlayFormDefinition {
 
 export type CoPlayFormCatalog = readonly CoPlayFormDefinition[]
 
+/**
+ * Co-play forms whose floor checks REQUIRE an information partition:
+ * hidden_info_coop's floors (communication_completeness /
+ * verbal_distinguishability's cross-role model) are meaningless without the
+ * template's role visibility, rule visibility, channels, and action
+ * capabilities. gametype_consistency rejects registration of these forms
+ * without an information_partition_template; shared-state forms (co_build
+ * etc.) may omit or simplify it (spec Mechanism 1). Registry constant — a
+ * newly registered form that needs a partition adds itself here.
+ */
+export const PARTITION_REQUIRED_CO_PLAY_FORMS: readonly CoPlayFormId[] = ['hidden_info_coop']
+
 /** Seed catalog per spec Mechanism 2 (form → validator floor checks). */
 export const SEED_CO_PLAY_FORM_CATALOG: CoPlayFormCatalog = [
   {

--- a/packages/creation/src/validate/botanical.test.ts
+++ b/packages/creation/src/validate/botanical.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Botanical Garden validator tests: the third case game, hidden_info_coop
+ * (same form as radio-cipher, floors REUSED). Golden gate: all universal
+ * checks + BOTH hidden_info floors pass (overall 'pass' + publish_ready);
+ * the report contains ONLY hidden_info's floors (never co_build's). csp
+ * solver strategy registered + optimization_target executed. Bad samples
+ * for csp registration, optimization_target params, and unsolvable care.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { GameSession } from '../engine/engine'
+import { searchSolution } from '../engine/search'
+import { loadGameType, loadLevel } from '../schema/load'
+import type { CheckId, CheckResult, GameType, Level, ValidationReport } from '../schema/types'
+import { validateGameType, validateLevel } from './validate'
+
+const fixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'botanical-garden'
+)
+const gameType = loadGameType(readFileSync(join(fixturesDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(fixturesDir, 'level.bg-demo-001.yaml'), 'utf8'))
+
+function checkOf(report: ValidationReport, checkType: CheckId): CheckResult {
+  const check = report.checks.find((c) => c.check_type === checkType)
+  if (!check) throw new Error(`check ${checkType} missing from report`)
+  return check
+}
+
+function cloneLevel(): Level {
+  return structuredClone(level)
+}
+
+function cloneGameType(): GameType {
+  return structuredClone(gameType)
+}
+
+describe('botanical golden gate (bg-demo-001)', () => {
+  const report = validateLevel(gameType, level)
+
+  it('reaches overall pass + publish_ready with every activated check passing', () => {
+    for (const check of report.checks) {
+      expect(`${String(check.check_type)}:${check.verdict}`).toBe(
+        `${String(check.check_type)}:pass`
+      )
+    }
+    expect(report.overall_verdict).toBe('pass')
+    expect(report.publish_ready).toBe(true)
+  })
+
+  it('activates the hidden_info_coop floors (reused) — never co_build’s', () => {
+    const checkTypes = report.checks.map((check) => check.check_type)
+    expect(checkTypes).toContain('communication_completeness')
+    expect(checkTypes).toContain('verbal_distinguishability')
+    expect(checkTypes).not.toContain('goal_reachability')
+    expect(checkTypes).not.toContain('progress_measurability')
+    expect(report.checks).toHaveLength(6)
+  })
+
+  it('verbal_distinguishability passes on the larger vocabulary', () => {
+    // 植株 (zhí zhū) vs 环境区 (huán jìng qū) are far apart; species instance
+    // labels (蕨类植株 …) are all distinct rendered strings.
+    expect(checkOf(report, 'verbal_distinguishability').verdict).toBe('pass')
+  })
+
+  it('passes the registration-time gametype_consistency gate', () => {
+    expect(validateGameType(gameType).verdict).toBe('pass')
+  })
+})
+
+describe('F2 solver rule-move capability gate (solver reachability ⊆ engine reachability)', () => {
+  it('a mis-scoped level where no role can act on the rule-targeted archetype fails solvability', () => {
+    // Scope BOTH roles' target_archetypes to environment_zone → no role can
+    // act on plant, so the care rules (all plant-targeting) can never fire in
+    // the live engine. Pre-fix this published clean (false positive).
+    const badGameType = cloneGameType()
+    const template = badGameType.information_partition_template
+    if (!template) throw new Error('fixture partition template missing')
+    for (const capability of template.action_capability) {
+      capability.target_archetypes = ['environment_zone']
+    }
+
+    // Solver: rule moves on plants are pruned → win unreachable → fail.
+    expect(searchSolution(badGameType, level).solvable).toBe(false)
+    const report = validateLevel(badGameType, level)
+    expect(checkOf(report, 'solvability').verdict).toBe('fail')
+    expect(report.publish_ready).toBe(false)
+
+    // Engine mirror: the live engine rejects every winning move.
+    const session = new GameSession(badGameType, level)
+    const attempt = session.performAction('gardener', 'apply_care', {
+      element_id: 'plant-1',
+      action_type: 'water',
+    })
+    expect(attempt.ok).toBe(false)
+    expect(!attempt.ok && attempt.reason).toContain('plant')
+  })
+})
+
+describe('csp solver strategy', () => {
+  it('is registered: the csp GameType runs a real search, not a strategy rejection', () => {
+    expect(gameType.solver_strategy).toBe('csp')
+    const check = checkOf(validateLevel(gameType, level), 'solvability')
+    expect(check.verdict).toBe('pass')
+    expect(check.violations.some((v) => v.constraint === 'solver_strategy_registered')).toBe(false)
+  })
+
+  it('still rejects an unregistered strategy', () => {
+    const badGameType = cloneGameType()
+    badGameType.solver_strategy = 'quantum_annealing'
+    const check = checkOf(validateLevel(badGameType, level), 'solvability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'solver_strategy_registered')
+    expect(violation?.expected).toContain('csp')
+  })
+
+  it('reports a timeout instead of fake-passing under a zero bound', () => {
+    const badGameType = cloneGameType()
+    badGameType.solver_timeout_ms = 0
+    const check = checkOf(validateLevel(badGameType, level), 'solvability')
+    expect(check.verdict).toBe('fail')
+    expect(check.violations.some((v) => v.constraint === 'solver_timeout')).toBe(true)
+  })
+})
+
+describe('schema_conformance validates per-instance initial_states', () => {
+  it('flags an initial_states key that names no declared state', () => {
+    const bad = cloneLevel()
+    const plant = bad.elements.find((e) => e.id === 'plant-1')
+    if (!plant) throw new Error('fixture element missing')
+    plant.initial_states = { ...plant.initial_states, vigor: 'high' }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'state_defined')
+    expect(violation?.field_path).toBe('elements[0].initial_states.vigor')
+    expect(violation?.expected).toContain('health')
+    expect(violation?.suggestion).toContain('plant')
+  })
+
+  it('flags an initial_states value outside the state’s declared enum', () => {
+    const bad = cloneLevel()
+    const plant = bad.elements.find((e) => e.id === 'plant-1')
+    if (!plant) throw new Error('fixture element missing')
+    plant.initial_states = { ...plant.initial_states, health: 'radiant' }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find(
+      (v) =>
+        v.constraint === 'enum_membership' && v.field_path === 'elements[0].initial_states.health'
+    )
+    expect(violation?.expected).toContain('stable')
+    expect(violation?.actual).toBe('radiant')
+  })
+})
+
+describe('optimization_target solvability', () => {
+  it('fails an undeclared state in a constraint', () => {
+    const bad = cloneLevel()
+    ;(bad.win_condition.params.all_states_at_least as { state: string }[])[0].state = 'vitality'
+    const check = checkOf(validateLevel(gameType, bad), 'solvability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find(
+      (v) => v.constraint === 'state_declared' && v.field_path.includes('all_states_at_least')
+    )
+    expect(violation?.actual).toBe('vitality')
+  })
+
+  it('fails an unsatisfiable care goal (flowering structurally unreachable)', () => {
+    // Drop the growth rule so no care sequence reaches flowering; the search
+    // exhausts the small remaining space fast and deterministically.
+    const bad = cloneLevel()
+    bad.rules = bad.rules.filter((r) => r.id !== 'rule-growth')
+    const check = checkOf(validateLevel(gameType, bad), 'solvability')
+    expect(check.verdict).toBe('fail')
+    expect(check.violations.some((v) => v.constraint === 'solution_path_exists')).toBe(true)
+  })
+
+  it('fails when no optimization constraints are declared', () => {
+    const bad = cloneLevel()
+    bad.win_condition.params = {}
+    const check = checkOf(validateLevel(gameType, bad), 'solvability')
+    expect(check.verdict).toBe('fail')
+    expect(check.violations.some((v) => v.constraint === 'optimization_constraints_declared')).toBe(
+      true
+    )
+  })
+})

--- a/packages/creation/src/validate/botanical.test.ts
+++ b/packages/creation/src/validate/botanical.test.ts
@@ -103,6 +103,93 @@ describe('F2 solver rule-move capability gate (solver reachability ⊆ engine re
   })
 })
 
+describe('state_transition solver gate mirrors the engine event path', () => {
+  it('fails solvability when no performable action can carry an action_type', () => {
+    // Strip apply_care's declared action_type param: the mapping rows
+    // survive, but the engine's ONLY event path (an action_type-declaring
+    // performable action) is gone — no state_transition can ever fire.
+    // Pre-fix the solver treated every mapping event as producible whenever
+    // SOME action could target the plant, and published this level.
+    const badGameType = cloneGameType()
+    const applyCare = badGameType.action_registry.find((a) => a.name === 'apply_care')
+    if (!applyCare) throw new Error('fixture action missing')
+    applyCare.params = []
+
+    expect(searchSolution(badGameType, level).solvable).toBe(false)
+    const report = validateLevel(badGameType, level)
+    expect(checkOf(report, 'solvability').verdict).toBe('fail')
+    expect(report.publish_ready).toBe(false)
+
+    // Engine mirror: a smuggled action_type is rejected; bare care is inert
+    // on the state tables.
+    const session = new GameSession(badGameType, level)
+    const smuggled = session.performAction('gardener', 'apply_care', {
+      element_id: 'plant-1',
+      action_type: 'water',
+    })
+    expect(smuggled.ok).toBe(false)
+    expect(session.getState().elements['plant-1'].health).toBe('wilting')
+  })
+})
+
+describe('solve-relevant runtime states (hidden-state coverage)', () => {
+  it('fails fairness + coverage when every role hides a consumed state', () => {
+    // rule-orchid-care / rule-fern-needs predicates consume the RUNTIME
+    // state effective_light (light_is). Hiding it from every gardener view
+    // (the botanist never sees plant states) forces the players to guess the
+    // current light — pre-fix the helpers only scanned element.params, so
+    // this level published clean.
+    const bad = cloneLevel()
+    const gardener = bad.information_partition.role_assignments.find((a) => a.role === 'gardener')
+    if (!gardener) throw new Error('fixture role missing')
+    for (const view of gardener.element_views) {
+      view.visible_states = view.visible_states.filter((state) => state !== 'effective_light')
+    }
+    const report = validateLevel(gameType, bad)
+
+    const fairness = checkOf(report, 'fairness')
+    expect(fairness.verdict).toBe('fail')
+    expect(
+      fairness.violations.some(
+        (v) =>
+          v.constraint === 'solution_information_observable' &&
+          v.actual.includes('hidden states: effective_light')
+      )
+    ).toBe(true)
+
+    const communication = checkOf(report, 'communication_completeness')
+    expect(communication.verdict).toBe('fail')
+    const coverage = communication.violations.find(
+      (v) => v.constraint === 'communication_coverage' && v.expected.includes('effective_light')
+    )
+    expect(coverage?.expected).toContain('state')
+    expect(coverage?.suggestion).toContain('visible_states')
+    expect(report.publish_ready).toBe(false)
+  })
+
+  it('still passes the golden: effective_light is gardener-visible and channeled to the botanist', () => {
+    const report = validateLevel(gameType, level)
+    expect(checkOf(report, 'fairness').verdict).toBe('pass')
+    expect(checkOf(report, 'communication_completeness').verdict).toBe('pass')
+  })
+})
+
+describe('condition_action action tuple requires declared params', () => {
+  it('rejects an action binding missing a declared param', () => {
+    // change_health declares {delta}; dropping it used to pass (only present
+    // keys were validated).
+    const bad = cloneLevel()
+    const fern = bad.rules.find((r) => r.id === 'rule-fern-needs')
+    if (!fern) throw new Error('fixture rule missing')
+    fern.bindings = { ...fern.bindings, action: { verb: 'change_health' } }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'binding_param_required')
+    expect(violation?.field_path).toBe('rules[2].bindings.action.delta')
+    expect(violation?.suggestion).toContain('change_health')
+  })
+})
+
 describe('csp solver strategy', () => {
   it('is registered: the csp GameType runs a real search, not a strategy rejection', () => {
     expect(gameType.solver_strategy).toBe('csp')

--- a/packages/creation/src/validate/budget-compliance.ts
+++ b/packages/creation/src/validate/budget-compliance.ts
@@ -1,0 +1,361 @@
+/**
+ * budget_compliance — DifficultyBudget + CommunicationBudget bounds from the
+ * GameType against the Level instance, per the spec's precise-count
+ * partition-complexity formula and communication derivation. Includes the
+ * per-instance shared-label uniqueness check the spec places inside
+ * budget_compliance.
+ *
+ * Declared-value rounding convention (pinned in spec Mechanism 4): declared
+ * difficulty values are rounded half-up to 2 decimals; the validator rounds
+ * its recomputed values the same way and compares within ±0.005. Seconds
+ * estimates keep a pragmatic ±0.5s bound.
+ */
+
+import type { CheckResult, ElementArchetype, GameType, Level, Violation } from '../schema/types'
+import {
+  archetypesById,
+  attributeNames,
+  buildCheckResult,
+  expandNames,
+  formatValue,
+  stateNames,
+  templatesById,
+  WILDCARD,
+} from './helpers'
+
+/** ±0.005 — matches the spec's round-half-up-to-2-decimals declaration rule. */
+const ROUNDING_TOLERANCE = 0.005
+const SECONDS_TOLERANCE = 0.5
+
+/** Spec rounding convention for declared values: round half-up, 2 decimals. */
+function roundHalfUp2(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100
+}
+
+export function checkBudgetCompliance(gameType: GameType, level: Level): CheckResult {
+  const violations: Violation[] = []
+  const budget = gameType.difficulty_budget
+
+  // --- Difficulty: declared vs actual, and actual vs budget bounds ---
+  const actualElements = level.elements.length
+  const actualRules = level.rules.length
+  checkDeclaredCount(
+    'difficulty.element_count',
+    level.difficulty.element_count,
+    actualElements,
+    violations
+  )
+  checkDeclaredCount('difficulty.rule_count', level.difficulty.rule_count, actualRules, violations)
+  checkBudgetRange(
+    'difficulty.element_count',
+    actualElements,
+    budget.element_count.min,
+    budget.element_count.max,
+    violations
+  )
+  checkBudgetRange(
+    'difficulty.rule_count',
+    actualRules,
+    budget.rule_count.min,
+    budget.rule_count.max,
+    violations
+  )
+
+  const computedComplexity = partitionComplexity(gameType)
+  const roundedComplexity =
+    computedComplexity === undefined ? undefined : roundHalfUp2(computedComplexity)
+  if (computedComplexity !== undefined && roundedComplexity !== undefined) {
+    if (Math.abs(roundedComplexity - level.difficulty.partition_complexity) > ROUNDING_TOLERANCE) {
+      violations.push({
+        severity: 'error',
+        field_path: 'difficulty.partition_complexity',
+        constraint: 'declared_matches_actual',
+        expected: `${roundedComplexity} (recomputed per the spec formula, rounded half-up to 2 decimals)`,
+        actual: String(level.difficulty.partition_complexity),
+        suggestion:
+          'Recompute partition_complexity from the GameType partition template (roles hidden ratios + channel constraint counts)',
+      })
+    }
+    if (computedComplexity > budget.partition_complexity.max) {
+      violations.push({
+        severity: 'error',
+        field_path: 'difficulty.partition_complexity',
+        constraint: 'budget_range',
+        expected: `<= ${budget.partition_complexity.max}`,
+        actual: computedComplexity.toFixed(4),
+        suggestion:
+          'Simplify the information partition (fewer hidden fields or channel constraints) to fit the budget',
+      })
+    }
+  }
+
+  // Score recomputation uses the ROUNDED complexity — the spec's declaration
+  // convention composes rounded values, so 5 + 4.5 + 3.71*2 = 16.92 exactly.
+  const complexityForScore = roundedComplexity ?? level.difficulty.partition_complexity
+  const computedScore = roundHalfUp2(
+    actualElements * budget.weights.element +
+      actualRules * budget.weights.rule +
+      complexityForScore * budget.weights.partition
+  )
+  if (Math.abs(computedScore - level.difficulty.total_score) > ROUNDING_TOLERANCE) {
+    violations.push({
+      severity: 'error',
+      field_path: 'difficulty.total_score',
+      constraint: 'declared_matches_actual',
+      expected: `${computedScore} (weighted sum of actual counts and rounded partition complexity)`,
+      actual: String(level.difficulty.total_score),
+      suggestion:
+        'Recompute total_score = element_count*w.element + rule_count*w.rule + partition_complexity*w.partition',
+    })
+  }
+  if (computedScore < budget.total_score.min || computedScore > budget.total_score.max) {
+    violations.push({
+      severity: 'error',
+      field_path: 'difficulty.total_score',
+      constraint: 'budget_range',
+      expected: `${budget.total_score.min}..${budget.total_score.max}`,
+      actual: computedScore.toFixed(4),
+      suggestion:
+        'Adjust element/rule/partition complexity so the weighted total lands inside the budget',
+    })
+  }
+
+  checkSharedLabelUniqueness(gameType, level, violations)
+  checkCommunicationBudget(gameType, level, violations)
+
+  return buildCheckResult('budget_compliance', violations)
+}
+
+function checkDeclaredCount(
+  path: string,
+  declared: number,
+  actual: number,
+  violations: Violation[]
+): void {
+  if (declared !== actual) {
+    violations.push({
+      severity: 'error',
+      field_path: path,
+      constraint: 'declared_matches_actual',
+      expected: String(actual),
+      actual: String(declared),
+      suggestion: `Set ${path} to the actual count (${actual})`,
+    })
+  }
+}
+
+function checkBudgetRange(
+  path: string,
+  actual: number,
+  min: number,
+  max: number,
+  violations: Violation[]
+): void {
+  if (actual < min || actual > max) {
+    violations.push({
+      severity: 'error',
+      field_path: path,
+      constraint: 'budget_range',
+      expected: `${min}..${max}`,
+      actual: String(actual),
+      suggestion: `Bring the count within the GameType difficulty budget (${min}..${max})`,
+    })
+  }
+}
+
+/**
+ * Spec Mechanism 4 precise-count semantics:
+ * partition_complexity = |roles| * mean(hidden_ratio(role))
+ *                      + |channels| * mean(constraint_count(channel))
+ * Wildcards in cannot_see expand to the archetype's full attribute/state
+ * name lists. Returns undefined when the GameType has no partition template.
+ */
+export function partitionComplexity(gameType: GameType): number | undefined {
+  const template = gameType.information_partition_template
+  if (!template || template.roles.length === 0) return undefined
+  const archetypes = archetypesById(gameType)
+
+  const totalFields = gameType.element_archetypes.reduce(
+    (sum, archetype) => sum + archetype.attributes.length + (archetype.states ?? []).length,
+    0
+  )
+
+  const hiddenRatios = template.roles.map((role) => {
+    const rule = template.visibility_rules.find((entry) => entry.role === role.id)
+    let hidden = 0
+    for (const entry of rule?.cannot_see ?? []) {
+      const matched: ElementArchetype[] = []
+      if (entry.element_archetype === WILDCARD) {
+        matched.push(...archetypes.values())
+      } else {
+        const single = archetypes.get(entry.element_archetype)
+        if (single) matched.push(single)
+      }
+      for (const archetype of matched) {
+        hidden += expandNames(entry.attributes, attributeNames(archetype)).length
+        hidden += expandNames(entry.states, stateNames(archetype)).length
+      }
+    }
+    return totalFields > 0 ? hidden / totalFields : 0
+  })
+  const rolesTerm = template.roles.length * mean(hiddenRatios)
+
+  const constraintCounts = template.communication_channels.map((channel) => {
+    const constraints = channel.constraints
+    return (
+      (constraints.forbidden_content?.length ?? 0) +
+      (constraints.max_words_per_turn !== undefined ? 1 : 0) +
+      (constraints.turn_time_limit_seconds !== undefined ? 1 : 0)
+    )
+  })
+  const channelsTerm =
+    template.communication_channels.length === 0
+      ? 0
+      : template.communication_channels.length * mean(constraintCounts)
+
+  return rolesTerm + channelsTerm
+}
+
+function mean(values: number[]): number {
+  return values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length
+}
+
+/**
+ * Per-instance label uniqueness (spec places it inside budget_compliance):
+ * for every shared_label_attributes archetype, all level instances must have
+ * pairwise-distinct value combinations of the declared attributes —
+ * otherwise the rendered instance_labels collide and voice co-reference
+ * breaks.
+ */
+function checkSharedLabelUniqueness(
+  gameType: GameType,
+  level: Level,
+  violations: Violation[]
+): void {
+  const entries = gameType.information_partition_template?.shared_label_attributes ?? []
+  for (const entry of entries) {
+    const seen = new Map<string, { id: string; index: number }>()
+    level.elements.forEach((element, i) => {
+      if (element.archetype !== entry.element_archetype) return
+      const combo = entry.attributes.map((attr) => formatValue(element.params[attr])).join('|')
+      const first = seen.get(combo)
+      if (first) {
+        violations.push({
+          severity: 'error',
+          field_path: `elements[${i}].params.${entry.attributes[0]}`,
+          constraint: 'instance_label_unique',
+          expected: `pairwise-distinct ${entry.attributes.join('+')} combinations across "${entry.element_archetype}" instances`,
+          actual: `"${first.id}" and "${element.id}" share ${entry.attributes.join('+')} = ${combo}`,
+          suggestion:
+            'Add a mutually visible disambiguating attribute or reduce the number of instances sharing the same attribute values',
+          related_elements: [first.id, element.id],
+        })
+      } else {
+        seen.set(combo, { id: element.id, index: i })
+      }
+    })
+  }
+}
+
+function checkCommunicationBudget(gameType: GameType, level: Level, violations: Violation[]): void {
+  const templates = templatesById(gameType)
+  const rawWeight = level.rules.reduce((sum, rule) => {
+    const template = templates.get(rule.template)
+    return template ? sum + template.communication_weight : sum
+  }, 0)
+  const estimate = level.communication_estimate
+  // Spec Mechanism 4: rule weights cover rule evaluation only; declared
+  // coordination rounds (co_build proposal/division turns) add on top.
+  const coordination = estimate.coordination_round_trips ?? 0
+  const computedRoundTrips = Math.ceil(rawWeight - 1e-9) + coordination
+  const communicationBudget = gameType.communication_budget
+
+  if (computedRoundTrips !== estimate.round_trips) {
+    violations.push({
+      severity: 'error',
+      field_path: 'communication_estimate.round_trips',
+      constraint: 'declared_matches_actual',
+      expected: `${computedRoundTrips} (ceil of summed template communication_weight ${rawWeight} + coordination_round_trips ${coordination})`,
+      actual: String(estimate.round_trips),
+      suggestion:
+        'Recompute round_trips = ceil(sum of rule template communication_weight) + coordination_round_trips',
+    })
+  }
+  if (computedRoundTrips > communicationBudget.max_round_trips) {
+    violations.push({
+      severity: 'error',
+      field_path: 'communication_estimate.round_trips',
+      constraint: 'budget_range',
+      expected: `<= ${communicationBudget.max_round_trips}`,
+      actual: String(computedRoundTrips),
+      suggestion:
+        'Remove or simplify rules until the derived round trips fit the communication budget',
+    })
+  }
+
+  const computedSeconds = computedRoundTrips * communicationBudget.estimated_seconds_per_round
+  if (Math.abs(computedSeconds - estimate.estimated_seconds) > SECONDS_TOLERANCE) {
+    violations.push({
+      severity: 'error',
+      field_path: 'communication_estimate.estimated_seconds',
+      constraint: 'declared_matches_actual',
+      expected: `${computedSeconds} (round_trips * estimated_seconds_per_round)`,
+      actual: String(estimate.estimated_seconds),
+      suggestion:
+        'Recompute estimated_seconds = round_trips * communication_budget.estimated_seconds_per_round',
+    })
+  }
+
+  // The GameType communication budget is authoritative for the time limit;
+  // a Level-authored time_limit_seconds must match it, and feasibility is
+  // computed from the GameType value (an inflated Level limit cannot buy
+  // feasibility).
+  const timeLimit = communicationBudget.time_limit_seconds
+  if (estimate.time_limit_seconds !== timeLimit) {
+    violations.push({
+      severity: 'error',
+      field_path: 'communication_estimate.time_limit_seconds',
+      constraint: 'declared_matches_actual',
+      expected: String(timeLimit),
+      actual: String(estimate.time_limit_seconds),
+      suggestion:
+        'Use the GameType communication_budget.time_limit_seconds — Level-side overrides are not budget-authoritative',
+    })
+  }
+  const computedFeasibility =
+    computedSeconds <= timeLimit * communicationBudget.safety_margin
+      ? 'feasible'
+      : computedSeconds <= timeLimit
+        ? 'tight'
+        : 'infeasible'
+  if (computedFeasibility !== estimate.feasibility) {
+    violations.push({
+      severity: 'error',
+      field_path: 'communication_estimate.feasibility',
+      constraint: 'declared_matches_actual',
+      expected: computedFeasibility,
+      actual: estimate.feasibility,
+      suggestion:
+        'Recompute feasibility from estimated_seconds vs time_limit_seconds * safety_margin',
+    })
+  }
+  if (computedFeasibility === 'infeasible') {
+    violations.push({
+      severity: 'error',
+      field_path: 'communication_estimate.feasibility',
+      constraint: 'communication_feasible',
+      expected: `estimated communication (${computedSeconds}s) within the game time limit (${timeLimit}s)`,
+      actual: 'infeasible',
+      suggestion: 'Reduce rule communication weight or raise the time limit',
+    })
+  } else if (computedFeasibility === 'tight') {
+    violations.push({
+      severity: 'warning',
+      field_path: 'communication_estimate.feasibility',
+      constraint: 'communication_feasible',
+      expected: `estimated communication within time_limit * safety_margin (${timeLimit * communicationBudget.safety_margin}s)`,
+      actual: `tight: ${computedSeconds}s of ${timeLimit}s with no safety margin left`,
+      suggestion: 'Leave safety margin: trim a rule or raise the time limit',
+    })
+  }
+}

--- a/packages/creation/src/validate/communication-completeness.ts
+++ b/packages/creation/src/validate/communication-completeness.ts
@@ -41,9 +41,11 @@ import type { CheckResult, GameType, Level, Violation } from '../schema/types'
 import {
   buildCheckResult,
   consumedParamsForRule,
+  consumedStatesForRule,
   elementsById,
   startDeadline,
   visibleAttributesByRole,
+  visibleStatesByRole,
   WILDCARD,
 } from './helpers'
 
@@ -51,6 +53,15 @@ export function checkCommunicationCompleteness(gameType: GameType, level: Level)
   const violations: Violation[] = []
   const assignments = level.information_partition.role_assignments
 
+  // Scope gate: exactly the two DISTINCT communicating roles the GameType
+  // declares, each assigned exactly once. Counting alone is not enough — two
+  // assignments for the SAME role would silently drop the other role's
+  // rule-consumption requirements (consumers filter on assigned role ids) and
+  // leave that runtime role with no level view at all.
+  const declaredRoles = (gameType.information_partition_template?.roles ?? []).map(
+    (role) => role.id
+  )
+  const assignedRoles = assignments.map((assignment) => assignment.role)
   if (assignments.length !== 2) {
     violations.push({
       severity: 'error',
@@ -60,6 +71,19 @@ export function checkCommunicationCompleteness(gameType: GameType, level: Level)
       actual: `${assignments.length} role assignment(s)`,
       suggestion:
         'Model the level with exactly two communicating roles, or defer to the multi-role extension',
+    })
+  } else if (
+    declaredRoles.length !== 2 ||
+    !declaredRoles.every((id) => assignedRoles.filter((role) => role === id).length === 1)
+  ) {
+    violations.push({
+      severity: 'error',
+      field_path: 'information_partition.role_assignments',
+      constraint: 'distinct_communicating_roles',
+      expected: `one assignment for each declared communicating role [${declaredRoles.join(', ')}]`,
+      actual: `assignments for [${assignedRoles.join(', ')}]`,
+      suggestion:
+        'Assign each GameType-declared communicating role exactly once in information_partition.role_assignments',
     })
   } else {
     checkStaticCoverage(gameType, level, violations)
@@ -83,10 +107,16 @@ export function checkCommunicationCompleteness(gameType: GameType, level: Level)
   return buildCheckResult('communication_completeness', violations)
 }
 
-/** Sub-check (i): per-consuming-role observable-or-transmissible coverage. */
+/**
+ * Sub-check (i): per-consuming-role observable-or-transmissible coverage,
+ * over consumed instance params AND consumed runtime states (condition
+ * predicates read live states — e.g. botanical effective_light). Visibility
+ * is cannot_see-filtered (helpers), matching the runtime role views.
+ */
 function checkStaticCoverage(gameType: GameType, level: Level, violations: Violation[]): void {
   const roleIds = level.information_partition.role_assignments.map((a) => a.role)
-  const views = visibleAttributesByRole(gameType, level)
+  const attrViews = visibleAttributesByRole(gameType, level)
+  const stateViews = visibleStatesByRole(gameType, level)
   const template = gameType.information_partition_template
   const channels = template?.communication_channels ?? []
   const ruleVisibility = template?.rule_visibility ?? []
@@ -102,15 +132,18 @@ function checkStaticCoverage(gameType: GameType, level: Level, violations: Viola
       )
       .map((entry) => entry.role)
 
-  for (const rule of level.rules) {
-    const consumers = rolesKnowing(rule.template).filter((role) => roleIds.includes(role))
-    if (consumers.length === 0) continue // engine-internal rule: no human consumption
-    for (const [elementId, attrs] of consumedParamsForRule(gameType, level, rule)) {
+  const coverFields = (
+    consumed: Map<string, Set<string>>,
+    views: Map<string, Map<string, Set<string>>>,
+    kind: 'attribute' | 'state',
+    consumers: string[]
+  ): void => {
+    for (const [elementId, fields] of consumed) {
       const k = elementIndex.get(elementId)
-      for (const attr of attrs) {
-        const seers = roleIds.filter((role) => views.get(role)?.get(elementId)?.has(attr) ?? false)
+      for (const field of fields) {
+        const seers = roleIds.filter((role) => views.get(role)?.get(elementId)?.has(field) ?? false)
         for (const role of consumers) {
-          const key = `${elementId}|${attr}|${role}`
+          const key = `${kind}|${elementId}|${field}|${role}`
           if (reported.has(key) || seers.includes(role)) continue
           const reachable = channels.some(
             (channel) => channel.to === role && seers.includes(channel.from)
@@ -119,20 +152,30 @@ function checkStaticCoverage(gameType: GameType, level: Level, violations: Viola
             reported.add(key)
             violations.push({
               severity: 'error',
-              field_path: `elements[${k}].params.${attr}`,
+              field_path:
+                kind === 'attribute' ? `elements[${k}].params.${field}` : `elements[${k}]`,
               constraint: 'communication_coverage',
-              expected: `"${attr}" observable by its consuming role "${role}" or transmissible to it through a declared legal channel`,
+              expected: `${kind} "${field}" observable by its consuming role "${role}" or transmissible to it through a declared legal channel`,
               actual:
                 seers.length === 0
-                  ? 'no role can observe the field'
+                  ? `no role can observe the ${kind}`
                   : `only [${seers.join(', ')}] observe it and no declared channel reaches "${role}"`,
-              suggestion: `Expose "${attr}" of "${elementId}" to role "${role}" in information_partition.role_assignments, or declare a communication channel from an observing role to "${role}"`,
+              suggestion: `Expose ${kind} "${field}" of "${elementId}" to role "${role}" in information_partition.role_assignments (${
+                kind === 'attribute' ? 'visible_attributes' : 'visible_states'
+              }), or declare a communication channel from an observing role to "${role}"`,
               related_elements: [elementId],
             })
           }
         }
       }
     }
+  }
+
+  for (const rule of level.rules) {
+    const consumers = rolesKnowing(rule.template).filter((role) => roleIds.includes(role))
+    if (consumers.length === 0) continue // engine-internal rule: no human consumption
+    coverFields(consumedParamsForRule(gameType, level, rule), attrViews, 'attribute', consumers)
+    coverFields(consumedStatesForRule(gameType, level, rule), stateViews, 'state', consumers)
   }
 }
 

--- a/packages/creation/src/validate/communication-completeness.ts
+++ b/packages/creation/src/validate/communication-completeness.ts
@@ -1,0 +1,182 @@
+/**
+ * communication_completeness — hidden_info_coop floor check (spec Mechanism 3
+ * contract: static coverage + bounded solution uniqueness + surface version
+ * binding).
+ *
+ * Sub-check (i) STATIC COVERAGE — per-consuming-role sufficiency: every
+ * solve-relevant field must be visible to, or transmissible to, the role(s)
+ * that actually CONSUME it. Consuming roles derive from the partition
+ * template's rule_visibility: the roles that can see a rule (hold its
+ * "manual" entry) consume that rule's solve-relevant fields (per
+ * helpers.consumedParamsForRule); the acting role receives derived
+ * INSTRUCTIONS, not raw field values — radio-cipher's plaintext_category is
+ * decoder-consumed, the listener never needs the field itself. Rules
+ * visible to no role (engine-internal passive rules) impose no coverage
+ * requirement. Channel forbidden_content entries are opaque content-type
+ * tags with no schema link to fields (documented spec gap / Open Questions),
+ * so a declared channel counts as transmissible. Achieved complexity:
+ * O(|rules| × F × R × C) with R = 2 — inside the spec's
+ * O(|elements| × |visible_fields|²) envelope.
+ *
+ * Sub-check (ii) SOLUTION UNIQUENESS (bounded) — under the merged two-role
+ * information, each win-condition target must admit AT MOST one independent
+ * solution pipeline (existence is solvability's concern). Counted through
+ * the rule ENGINE: engine/search.ts's solutionDriversForTarget simulates
+ * each rule alone from the initial state and counts the rules that drive
+ * the target to the win state — the same declarative execution core that
+ * powers solvability's path search (the earlier pipeline-counting vs
+ * coverage divergence is dissolved). A rule that cannot change state — e.g.
+ * a condition_action whose semantic predicates never auto-fire — is
+ * naturally not a driver. Bounded by the shared solver_timeout_ms deadline;
+ * a trip emits its own violation, never a fake pass.
+ *
+ * Scope: exactly 2 communicating roles (spec design debt: multi-role
+ * extension is an open question) — any other count is an explicit
+ * violation. Surface version binding (spec item 3) runs regardless of the
+ * role count so both defects surface in one pass.
+ */
+
+import { solutionDriversForTarget } from '../engine/search'
+import type { CheckResult, GameType, Level, Violation } from '../schema/types'
+import {
+  buildCheckResult,
+  consumedParamsForRule,
+  elementsById,
+  startDeadline,
+  visibleAttributesByRole,
+  WILDCARD,
+} from './helpers'
+
+export function checkCommunicationCompleteness(gameType: GameType, level: Level): CheckResult {
+  const violations: Violation[] = []
+  const assignments = level.information_partition.role_assignments
+
+  if (assignments.length !== 2) {
+    violations.push({
+      severity: 'error',
+      field_path: 'information_partition.role_assignments',
+      constraint: 'two_role_scope',
+      expected: 'exactly 2 communicating roles (multi-role extension is declared spec design debt)',
+      actual: `${assignments.length} role assignment(s)`,
+      suggestion:
+        'Model the level with exactly two communicating roles, or defer to the multi-role extension',
+    })
+  } else {
+    checkStaticCoverage(gameType, level, violations)
+    checkSolutionUniqueness(gameType, level, violations)
+  }
+
+  const levelVersion = level.metadata.game_type_version
+  ;(level.communication_surfaces ?? []).forEach((surface, s) => {
+    if (surface.game_type_version !== levelVersion) {
+      violations.push({
+        severity: 'error',
+        field_path: `communication_surfaces[${s}].game_type_version`,
+        constraint: 'version_binding',
+        expected: levelVersion,
+        actual: surface.game_type_version,
+        suggestion: 'Regenerate the communication surface against the level game_type_version',
+      })
+    }
+  })
+
+  return buildCheckResult('communication_completeness', violations)
+}
+
+/** Sub-check (i): per-consuming-role observable-or-transmissible coverage. */
+function checkStaticCoverage(gameType: GameType, level: Level, violations: Violation[]): void {
+  const roleIds = level.information_partition.role_assignments.map((a) => a.role)
+  const views = visibleAttributesByRole(gameType, level)
+  const template = gameType.information_partition_template
+  const channels = template?.communication_channels ?? []
+  const ruleVisibility = template?.rule_visibility ?? []
+  const elementIndex = new Map(level.elements.map((element, i) => [element.id, i]))
+  const reported = new Set<string>()
+
+  const rolesKnowing = (templateId: string): string[] =>
+    ruleVisibility
+      .filter(
+        (entry) =>
+          entry.visible_rule_templates.includes(WILDCARD) ||
+          entry.visible_rule_templates.includes(templateId)
+      )
+      .map((entry) => entry.role)
+
+  for (const rule of level.rules) {
+    const consumers = rolesKnowing(rule.template).filter((role) => roleIds.includes(role))
+    if (consumers.length === 0) continue // engine-internal rule: no human consumption
+    for (const [elementId, attrs] of consumedParamsForRule(gameType, level, rule)) {
+      const k = elementIndex.get(elementId)
+      for (const attr of attrs) {
+        const seers = roleIds.filter((role) => views.get(role)?.get(elementId)?.has(attr) ?? false)
+        for (const role of consumers) {
+          const key = `${elementId}|${attr}|${role}`
+          if (reported.has(key) || seers.includes(role)) continue
+          const reachable = channels.some(
+            (channel) => channel.to === role && seers.includes(channel.from)
+          )
+          if (!reachable) {
+            reported.add(key)
+            violations.push({
+              severity: 'error',
+              field_path: `elements[${k}].params.${attr}`,
+              constraint: 'communication_coverage',
+              expected: `"${attr}" observable by its consuming role "${role}" or transmissible to it through a declared legal channel`,
+              actual:
+                seers.length === 0
+                  ? 'no role can observe the field'
+                  : `only [${seers.join(', ')}] observe it and no declared channel reaches "${role}"`,
+              suggestion: `Expose "${attr}" of "${elementId}" to role "${role}" in information_partition.role_assignments, or declare a communication channel from an observing role to "${role}"`,
+              related_elements: [elementId],
+            })
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Sub-check (ii): merged-information solution uniqueness (engine-backed,
+ * bounded). Deadline policy (H3): ONE deadline per check invocation —
+ * solver_timeout_ms bounds this whole sub-check; all targets share it.
+ */
+function checkSolutionUniqueness(gameType: GameType, level: Level, violations: Violation[]): void {
+  const deadline = startDeadline(gameType.solver_timeout_ms)
+  const elements = elementsById(level)
+  const targets = Array.isArray(level.win_condition.params.target_elements)
+    ? (level.win_condition.params.target_elements as unknown[])
+    : []
+
+  for (const [j, targetId] of targets.entries()) {
+    if (deadline.timedOut()) {
+      violations.push(deadline.violation())
+      return
+    }
+    if (typeof targetId !== 'string' || !elements.has(targetId)) continue // solvability reports
+    const analysis = solutionDriversForTarget(gameType, level, targetId, deadline)
+    if (analysis.timedOut) {
+      // An interrupted count is partial — surface the deadline, never a
+      // silent uniqueness pass (G3).
+      violations.push(deadline.violation())
+      return
+    }
+    const drivers = analysis.drivers
+    if (drivers.length > 1) {
+      violations.push({
+        severity: 'error',
+        field_path: `win_condition.params.target_elements[${j}]`,
+        constraint: 'solution_unique',
+        expected:
+          "at most one independent solution pipeline per target under the merged two-role information (existence is solvability's concern)",
+        actual: `${drivers.length} independent solution pipelines drive "${targetId}": ${drivers
+          .map((rule) => rule.id)
+          .join(', ')}`,
+        suggestion: `Remove or re-target one of [${drivers
+          .map((rule) => rule.id)
+          .join(', ')}] so the merged information admits a single solution`,
+        related_elements: [targetId],
+      })
+    }
+  }
+}

--- a/packages/creation/src/validate/construction-visibility.ts
+++ b/packages/creation/src/validate/construction-visibility.ts
@@ -1,0 +1,82 @@
+/**
+ * construction_visibility — co_build floor check (F5). co_build is a
+ * shared-construction form: every participating BUILDER role coordinates by
+ * observing the shared construction space. This floor requires each builder
+ * role to see a non-empty slice of that space — its Level element_views must
+ * cover every construction archetype (the archetypes any builder can place).
+ *
+ * A builder role is one whose action_capability.can_perform includes a
+ * player-performable construction action (construction_effect set). The
+ * construction archetypes are the union of archetypes those construction
+ * actions may target (target_archetypes; empty list = all). A builder blind
+ * to (part of) the construction space cannot coordinate the cross-role
+ * pairing the co_build score depends on, so the level must not publish.
+ *
+ * Interface: (level, role_capabilities) → {each builder covers the
+ * construction archetypes}. Read-only over both inputs.
+ */
+
+import type { CheckResult, GameType, Level, Violation } from '../schema/types'
+import { buildCheckResult } from './helpers'
+
+export function checkConstructionVisibility(gameType: GameType, level: Level): CheckResult {
+  const violations: Violation[] = []
+  const template = gameType.information_partition_template
+  const registry = new Map(gameType.action_registry.map((action) => [action.name, action]))
+  const allArchetypeIds = gameType.element_archetypes.map((archetype) => archetype.id)
+
+  // Builder roles + the construction archetypes some role can place/remove.
+  const builderRoles: string[] = []
+  const constructionArchetypes = new Set<string>()
+  for (const capability of template?.action_capability ?? []) {
+    let isBuilder = false
+    const placeable = new Set<string>()
+    for (const actionName of capability.can_perform) {
+      const action = registry.get(actionName)
+      if (!action || action.scope === 'rule_verb' || !action.construction_effect) continue
+      isBuilder = true
+      const targets =
+        capability.target_archetypes.length > 0 ? capability.target_archetypes : allArchetypeIds
+      for (const archetypeId of targets) placeable.add(archetypeId)
+    }
+    if (isBuilder) {
+      builderRoles.push(capability.role)
+      for (const archetypeId of placeable) constructionArchetypes.add(archetypeId)
+    }
+  }
+
+  const archetypeOf = new Map(level.elements.map((element) => [element.id, element.archetype]))
+  const assignmentIndex = new Map(
+    level.information_partition.role_assignments.map((assignment, i) => [assignment.role, i])
+  )
+  const required = [...constructionArchetypes]
+
+  for (const role of builderRoles) {
+    const i = assignmentIndex.get(role)
+    const assignment = i !== undefined ? level.information_partition.role_assignments[i] : undefined
+    const seen = new Set<string>()
+    for (const view of assignment?.element_views ?? []) {
+      const archetype = archetypeOf.get(view.element_id)
+      if (archetype) seen.add(archetype)
+    }
+    const missing = required.filter((archetypeId) => !seen.has(archetypeId))
+    if (missing.length > 0) {
+      violations.push({
+        severity: 'error',
+        field_path:
+          i !== undefined
+            ? `information_partition.role_assignments[${i}].element_views`
+            : 'information_partition.role_assignments',
+        constraint: 'builder_sees_construction_space',
+        expected: `builder role "${role}" to observe every construction archetype [${required.join(', ')}]`,
+        actual:
+          assignment === undefined
+            ? `role "${role}" has no element views`
+            : `role "${role}" sees [${[...seen].join(', ') || 'nothing'}]; missing [${missing.join(', ')}]`,
+        suggestion: `Give builder role "${role}" element views covering [${missing.join(', ')}] so it can coordinate over the shared construction space`,
+      })
+    }
+  }
+
+  return buildCheckResult('construction_visibility', violations)
+}

--- a/packages/creation/src/validate/fairness.ts
+++ b/packages/creation/src/validate/fairness.ts
@@ -1,0 +1,78 @@
+/**
+ * fairness — the universal, partition-aware core of the spec's fairness
+ * check: no solution step may depend on unreasoned guessing. Machine-checked
+ * here: every param a rule actually CONSUMES must be observable by at least
+ * one role. A hidden consumed param forces a guess over its attribute's
+ * value domain; if the combined guess space exceeds the fairness threshold
+ * (spec default 2), the level is unfair.
+ *
+ * Consumption follows the shared v1 approximation in
+ * helpers.solveRelevantParams (material elements expose all params;
+ * target-only elements only value-matched params). Unconsumed cosmetic
+ * params may stay hidden without a fairness violation.
+ *
+ * The deeper, per-role deduction — whether observable information can
+ * actually travel through the allowed channels to the acting role — is
+ * form-specific and lives in the hidden_info_coop floor check
+ * communication_completeness (R3), per the spec's check taxonomy.
+ *
+ * Levels with no role assignments (shared-state forms like co_build) pass
+ * vacuously: with symmetric visibility there is no partition to hide behind.
+ */
+
+import type { CheckResult, GameType, Level, Violation } from '../schema/types'
+import {
+  archetypesById,
+  attributeDomainSize,
+  buildCheckResult,
+  solveRelevantParams,
+  visibleAttributesByElement,
+} from './helpers'
+
+/** Spec default: guessing among more than 2 equally likely options is unfair. */
+const FAIRNESS_THRESHOLD = 2
+
+export function checkFairness(gameType: GameType, level: Level): CheckResult {
+  const violations: Violation[] = []
+  if (level.information_partition.role_assignments.length === 0) {
+    return buildCheckResult('fairness', violations)
+  }
+
+  const archetypes = archetypesById(gameType)
+  const visible = visibleAttributesByElement(gameType, level)
+  const relevant = solveRelevantParams(gameType, level)
+
+  level.elements.forEach((element, i) => {
+    const relevantParams = relevant.get(element.id)
+    if (!relevantParams) return // not solution-relevant
+    const archetype = archetypes.get(element.archetype)
+    if (!archetype) return // schema_conformance reports the broken reference
+    const attributesByName = new Map(archetype.attributes.map((a) => [a.name, a]))
+    const visibleNames = visible.get(element.id) ?? new Set<string>()
+
+    const hidden: string[] = []
+    let guessSpace = 1
+    for (const key of relevantParams) {
+      const attribute = attributesByName.get(key)
+      if (!attribute || visibleNames.has(key)) continue
+      hidden.push(key)
+      const domain = attributeDomainSize(attribute)
+      guessSpace = domain === undefined ? Number.POSITIVE_INFINITY : guessSpace * domain
+    }
+
+    if (hidden.length > 0 && guessSpace > FAIRNESS_THRESHOLD) {
+      const guessLabel = Number.isFinite(guessSpace) ? String(guessSpace) : 'unbounded'
+      violations.push({
+        severity: 'error',
+        field_path: `elements[${i}]`,
+        constraint: 'solution_information_observable',
+        expected: `solution-relevant params observable by at least one role (guess space <= ${FAIRNESS_THRESHOLD})`,
+        actual: `hidden params: ${hidden.join(', ')} (guess space ${guessLabel})`,
+        suggestion: `Expose ${hidden.join(', ')} of "${element.id}" to at least one role in information_partition.role_assignments, or remove the element from solution-relevant rules`,
+        related_elements: [element.id],
+      })
+    }
+  })
+
+  return buildCheckResult('fairness', violations)
+}

--- a/packages/creation/src/validate/fairness.ts
+++ b/packages/creation/src/validate/fairness.ts
@@ -1,15 +1,19 @@
 /**
  * fairness — the universal, partition-aware core of the spec's fairness
  * check: no solution step may depend on unreasoned guessing. Machine-checked
- * here: every param a rule actually CONSUMES must be observable by at least
- * one role. A hidden consumed param forces a guess over its attribute's
- * value domain; if the combined guess space exceeds the fairness threshold
- * (spec default 2), the level is unfair.
+ * here: every param AND every runtime state a rule actually CONSUMES must be
+ * observable by at least one role. A hidden consumed field forces a guess
+ * over its declared value domain; if the combined guess space exceeds the
+ * fairness threshold (spec default 2), the level is unfair.
  *
  * Consumption follows the shared v1 approximation in
  * helpers.solveRelevantParams (material elements expose all params;
- * target-only elements only value-matched params). Unconsumed cosmetic
- * params may stay hidden without a fairness violation.
+ * target-only elements only value-matched params) plus
+ * helpers.solveRelevantStates (condition predicates that resolve against
+ * declared runtime states — e.g. botanical effective_light / growth_stage).
+ * Unconsumed cosmetic params may stay hidden without a fairness violation.
+ * Visibility is cannot_see-filtered (helpers) so an over-declared level view
+ * the runtime hides never counts as observable.
  *
  * The deeper, per-role deduction — whether observable information can
  * actually travel through the allowed channels to the acting role — is
@@ -26,7 +30,10 @@ import {
   attributeDomainSize,
   buildCheckResult,
   solveRelevantParams,
+  solveRelevantStates,
+  stateDomainSize,
   visibleAttributesByElement,
+  visibleStatesByElement,
 } from './helpers'
 
 /** Spec default: guessing among more than 2 equally likely options is unfair. */
@@ -40,17 +47,23 @@ export function checkFairness(gameType: GameType, level: Level): CheckResult {
 
   const archetypes = archetypesById(gameType)
   const visible = visibleAttributesByElement(gameType, level)
+  const visibleStates = visibleStatesByElement(gameType, level)
   const relevant = solveRelevantParams(gameType, level)
+  const relevantStates = solveRelevantStates(gameType, level)
 
   level.elements.forEach((element, i) => {
-    const relevantParams = relevant.get(element.id)
-    if (!relevantParams) return // not solution-relevant
+    const relevantParams = relevant.get(element.id) ?? new Set<string>()
+    const relevantStateNames = relevantStates.get(element.id) ?? new Set<string>()
+    if (relevantParams.size === 0 && relevantStateNames.size === 0) return // not solution-relevant
     const archetype = archetypes.get(element.archetype)
     if (!archetype) return // schema_conformance reports the broken reference
     const attributesByName = new Map(archetype.attributes.map((a) => [a.name, a]))
+    const statesByName = new Map((archetype.states ?? []).map((s) => [s.name, s]))
     const visibleNames = visible.get(element.id) ?? new Set<string>()
+    const visibleStateNames = visibleStates.get(element.id) ?? new Set<string>()
 
     const hidden: string[] = []
+    const hiddenStates: string[] = []
     let guessSpace = 1
     for (const key of relevantParams) {
       const attribute = attributesByName.get(key)
@@ -59,16 +72,30 @@ export function checkFairness(gameType: GameType, level: Level): CheckResult {
       const domain = attributeDomainSize(attribute)
       guessSpace = domain === undefined ? Number.POSITIVE_INFINITY : guessSpace * domain
     }
+    for (const key of relevantStateNames) {
+      const state = statesByName.get(key)
+      if (!state || visibleStateNames.has(key)) continue
+      hiddenStates.push(key)
+      const domain = stateDomainSize(state)
+      guessSpace = domain === undefined ? Number.POSITIVE_INFINITY : guessSpace * domain
+    }
 
-    if (hidden.length > 0 && guessSpace > FAIRNESS_THRESHOLD) {
+    if (hidden.length + hiddenStates.length > 0 && guessSpace > FAIRNESS_THRESHOLD) {
       const guessLabel = Number.isFinite(guessSpace) ? String(guessSpace) : 'unbounded'
+      const hiddenLabel = [
+        hidden.length > 0 ? `hidden params: ${hidden.join(', ')}` : undefined,
+        hiddenStates.length > 0 ? `hidden states: ${hiddenStates.join(', ')}` : undefined,
+      ]
+        .filter((part) => part !== undefined)
+        .join('; ')
+      const allHidden = [...hidden, ...hiddenStates]
       violations.push({
         severity: 'error',
         field_path: `elements[${i}]`,
         constraint: 'solution_information_observable',
-        expected: `solution-relevant params observable by at least one role (guess space <= ${FAIRNESS_THRESHOLD})`,
-        actual: `hidden params: ${hidden.join(', ')} (guess space ${guessLabel})`,
-        suggestion: `Expose ${hidden.join(', ')} of "${element.id}" to at least one role in information_partition.role_assignments, or remove the element from solution-relevant rules`,
+        expected: `solution-relevant fields observable by at least one role (guess space <= ${FAIRNESS_THRESHOLD})`,
+        actual: `${hiddenLabel} (guess space ${guessLabel})`,
+        suggestion: `Expose ${allHidden.join(', ')} of "${element.id}" to at least one role in information_partition.role_assignments, or remove the element from solution-relevant rules`,
         related_elements: [element.id],
       })
     }

--- a/packages/creation/src/validate/gametype-consistency.ts
+++ b/packages/creation/src/validate/gametype-consistency.ts
@@ -20,6 +20,7 @@ import type {
   GameType,
   Violation,
 } from '../schema/types'
+import { PARTITION_REQUIRED_CO_PLAY_FORMS } from '../schema/types'
 import { archetypesById, attributeNames, buildCheckResult, stateNames, WILDCARD } from './helpers'
 
 export function validateGameType(gameType: GameType): CheckResult {
@@ -143,7 +144,24 @@ export function validateGameType(gameType: GameType): CheckResult {
   })
 
   const template = gameType.information_partition_template
-  if (!template) return buildCheckResult('gametype_consistency', violations)
+  if (!template) {
+    // Forms whose floor checks NEED the partition may not omit it: without
+    // role visibility / rule visibility / channels / action capabilities the
+    // hidden-info floors have no basis, and degenerate levels (e.g.
+    // initially-solved) could publish without a real information partition.
+    if (PARTITION_REQUIRED_CO_PLAY_FORMS.includes(gameType.co_play_form)) {
+      violations.push({
+        severity: 'error',
+        field_path: 'game_type.information_partition_template',
+        constraint: 'partition_template_required',
+        expected: `an information_partition_template (co_play_form "${gameType.co_play_form}" floor checks need role/rule visibility, channels, and action capabilities)`,
+        actual: 'missing',
+        suggestion:
+          'Declare information_partition_template on the GameType, or use a shared-state co-play form that may omit it',
+      })
+    }
+    return buildCheckResult('gametype_consistency', violations)
+  }
 
   const roleIds = new Set(template.roles.map((role) => role.id))
   const requireRole = (role: string, path: string): void => {

--- a/packages/creation/src/validate/gametype-consistency.ts
+++ b/packages/creation/src/validate/gametype-consistency.ts
@@ -1,0 +1,321 @@
+/**
+ * gametype_consistency — the registration-time gate over a GameType's
+ * internal referential integrity (spec Mechanism 3). Housed as its own entry
+ * (validateGameType) rather than inside validateLevel: the spec pins this
+ * check to GameType registration/update time, and every Level-scoped check
+ * (universal + floor) assumes the GameType already passed it.
+ *
+ * Checks: rule-template action references resolve in action_registry with a
+ * compatible scope; partition template roles/archetypes/attributes/actions
+ * all resolve ("*" wildcards legal where the spec allows them); and every
+ * shared_label_attributes attribute is visible (can_see) to every
+ * communicating role — the structural guarantee behind cross-role
+ * co-reference.
+ */
+
+import type {
+  ActionScope,
+  CheckResult,
+  ElementArchetype,
+  GameType,
+  Violation,
+} from '../schema/types'
+import { archetypesById, attributeNames, buildCheckResult, stateNames, WILDCARD } from './helpers'
+
+export function validateGameType(gameType: GameType): CheckResult {
+  const violations: Violation[] = []
+  const archetypes = archetypesById(gameType)
+  const actionScopes = new Map(gameType.action_registry.map((a) => [a.name, a.scope]))
+  const templateIds = new Set(gameType.rule_templates.map((t) => t.id))
+
+  const checkAction = (name: string, allowed: ActionScope[], path: string): void => {
+    const scope = actionScopes.get(name)
+    if (scope === undefined) {
+      violations.push({
+        severity: 'error',
+        field_path: path,
+        constraint: 'action_registered',
+        expected: `one of [${[...actionScopes.keys()].join(', ')}]`,
+        actual: name,
+        suggestion: 'Register the action in action_registry or reference a registered action name',
+      })
+    } else if (scope !== 'both' && !allowed.includes(scope)) {
+      violations.push({
+        severity: 'error',
+        field_path: path,
+        constraint: 'action_scope_compatible',
+        expected: `an action with scope ${allowed.join('|')} or both`,
+        actual: `"${name}" has scope ${scope}`,
+        suggestion: `Use an action whose scope allows this reference, or widen "${name}" to scope both`,
+      })
+    }
+  }
+
+  // state_effect enum guard (G6): a typo'd value must be rejected at
+  // registration — the engine also refuses to execute unknown values.
+  const legalStateEffects = ['advance_state', 'complete_state', 'none']
+  const templateKinds = new Map(gameType.rule_templates.map((t) => [t.id, t.type]))
+  gameType.action_registry.forEach((action, i) => {
+    if (action.state_effect !== undefined && !legalStateEffects.includes(action.state_effect)) {
+      violations.push({
+        severity: 'error',
+        field_path: `game_type.action_registry[${i}].state_effect`,
+        constraint: 'state_effect_registered',
+        expected: `one of [${legalStateEffects.join(', ')}]`,
+        actual: String(action.state_effect),
+        suggestion:
+          'Use a declared state_effect value (advance_state / complete_state / none) or omit the field',
+      })
+    }
+    // trigger bindings: each id must resolve to a registered rule template,
+    // and must NOT be a state_transition template — those fire via
+    // action_event_mapping events, so a state_transition id in `triggers`
+    // would be a silent no-op (same G6 no-silent-typo discipline).
+    ;(action.triggers ?? []).forEach((templateId, j) => {
+      const path = `game_type.action_registry[${i}].triggers[${j}]`
+      const kind = templateKinds.get(templateId)
+      if (kind === undefined) {
+        violations.push({
+          severity: 'error',
+          field_path: path,
+          constraint: 'trigger_template_registered',
+          expected: `one of [${[...templateIds].join(', ')}]`,
+          actual: templateId,
+          suggestion: 'Reference a registered RuleTemplate id, or remove it from triggers',
+        })
+      } else if (kind === 'state_transition') {
+        violations.push({
+          severity: 'error',
+          field_path: path,
+          constraint: 'trigger_template_kind',
+          expected:
+            'a condition_action / temporal_sequence / interaction_matrix template (state_transition is event-driven via action_event_mapping)',
+          actual: `"${templateId}" is a state_transition template`,
+          suggestion:
+            'Drive state_transition rules through action_event_mapping events, not triggers; remove this id from triggers',
+        })
+      }
+    })
+  })
+
+  gameType.rule_templates.forEach((template, i) => {
+    const base = `game_type.rule_templates[${i}]`
+    if (template.type === 'temporal_sequence') {
+      checkAction(
+        template.sequence_schema.step_schema.action,
+        ['rule_verb'],
+        `${base}.sequence_schema.step_schema.action`
+      )
+    } else if (template.type === 'condition_action') {
+      template.action_schema.verbs.forEach((verb, j) => {
+        checkAction(verb, ['rule_verb'], `${base}.action_schema.verbs[${j}]`)
+      })
+    } else if (template.type === 'interaction_matrix') {
+      template.matrix_schema.effect_schema.forEach((effect, j) => {
+        checkAction(
+          effect.effect,
+          ['rule_verb'],
+          `${base}.matrix_schema.effect_schema[${j}].effect`
+        )
+      })
+      // pair_match_attributes must exist on every participating archetype
+      // (one carrying at least one entity_type_attribute) — H2.
+      const entityAttrs = template.matrix_schema.entity_type_attributes ?? []
+      const participating = [...archetypes.values()].filter((archetype) =>
+        archetype.attributes.some((attr) => entityAttrs.includes(attr.name))
+      )
+      ;(template.matrix_schema.pair_match_attributes ?? []).forEach((name, j) => {
+        const missingOn = participating.filter(
+          (archetype) => !archetype.attributes.some((attr) => attr.name === name)
+        )
+        if (missingOn.length > 0) {
+          violations.push({
+            severity: 'error',
+            field_path: `${base}.matrix_schema.pair_match_attributes[${j}]`,
+            constraint: 'attribute_defined',
+            expected: 'an attribute present on every participating archetype',
+            actual: `"${name}" missing on [${missingOn.map((a) => a.id).join(', ')}]`,
+            suggestion: `Declare attribute "${name}" on the participating archetypes or remove it from pair_match_attributes`,
+          })
+        }
+      })
+    }
+  })
+
+  const template = gameType.information_partition_template
+  if (!template) return buildCheckResult('gametype_consistency', violations)
+
+  const roleIds = new Set(template.roles.map((role) => role.id))
+  const requireRole = (role: string, path: string): void => {
+    if (!roleIds.has(role)) {
+      violations.push({
+        severity: 'error',
+        field_path: path,
+        constraint: 'role_defined',
+        expected: `one of [${[...roleIds].join(', ')}]`,
+        actual: role,
+        suggestion: 'Reference a role declared in information_partition_template.roles',
+      })
+    }
+  }
+  const requireArchetypeNames = (
+    archetype: ElementArchetype,
+    listed: string[],
+    all: string[],
+    path: string,
+    kind: 'attribute' | 'state'
+  ): void => {
+    listed.forEach((name, k) => {
+      if (name !== WILDCARD && !all.includes(name)) {
+        violations.push({
+          severity: 'error',
+          field_path: `${path}[${k}]`,
+          constraint: `${kind}_defined`,
+          expected: `"${WILDCARD}" or one of [${all.join(', ')}]`,
+          actual: name,
+          suggestion: `Use ${kind} names defined on archetype "${archetype.id}" (or "${WILDCARD}")`,
+        })
+      }
+    })
+  }
+
+  const base = 'game_type.information_partition_template'
+  template.visibility_rules.forEach((rule, i) => {
+    requireRole(rule.role, `${base}.visibility_rules[${i}].role`)
+    const sides = [
+      { entries: rule.can_see, key: 'can_see' },
+      { entries: rule.cannot_see, key: 'cannot_see' },
+    ]
+    for (const side of sides) {
+      side.entries.forEach((entry, j) => {
+        const entryPath = `${base}.visibility_rules[${i}].${side.key}[${j}]`
+        if (entry.element_archetype === WILDCARD) return
+        const archetype = archetypes.get(entry.element_archetype)
+        if (!archetype) {
+          violations.push({
+            severity: 'error',
+            field_path: `${entryPath}.element_archetype`,
+            constraint: 'archetype_registered',
+            expected: `"${WILDCARD}" or one of [${[...archetypes.keys()].join(', ')}]`,
+            actual: entry.element_archetype,
+            suggestion: 'Reference a registered ElementArchetype id (or "*" for all)',
+          })
+          return
+        }
+        requireArchetypeNames(
+          archetype,
+          entry.attributes,
+          attributeNames(archetype),
+          `${entryPath}.attributes`,
+          'attribute'
+        )
+        requireArchetypeNames(
+          archetype,
+          entry.states,
+          stateNames(archetype),
+          `${entryPath}.states`,
+          'state'
+        )
+      })
+    }
+  })
+
+  template.rule_visibility.forEach((entry, i) => {
+    requireRole(entry.role, `${base}.rule_visibility[${i}].role`)
+    entry.visible_rule_templates.forEach((id, j) => {
+      if (id !== WILDCARD && !templateIds.has(id)) {
+        violations.push({
+          severity: 'error',
+          field_path: `${base}.rule_visibility[${i}].visible_rule_templates[${j}]`,
+          constraint: 'template_registered',
+          expected: `"${WILDCARD}" or one of [${[...templateIds].join(', ')}]`,
+          actual: id,
+          suggestion: 'Reference a registered RuleTemplate id (or "*" for all)',
+        })
+      }
+    })
+  })
+
+  template.action_capability.forEach((capability, i) => {
+    requireRole(capability.role, `${base}.action_capability[${i}].role`)
+    capability.can_perform.forEach((name, j) => {
+      checkAction(name, ['player_action'], `${base}.action_capability[${i}].can_perform[${j}]`)
+    })
+    capability.target_archetypes.forEach((id, j) => {
+      if (!archetypes.has(id)) {
+        violations.push({
+          severity: 'error',
+          field_path: `${base}.action_capability[${i}].target_archetypes[${j}]`,
+          constraint: 'archetype_registered',
+          expected: `one of [${[...archetypes.keys()].join(', ')}]`,
+          actual: id,
+          suggestion: 'Reference a registered ElementArchetype id',
+        })
+      }
+    })
+  })
+
+  template.communication_channels.forEach((channel, i) => {
+    requireRole(channel.from, `${base}.communication_channels[${i}].from`)
+    requireRole(channel.to, `${base}.communication_channels[${i}].to`)
+  })
+
+  // shared_label_attributes: archetype + attributes exist, and every
+  // communicating role can_see each attribute (cross-role co-reference).
+  const communicatingRoles = new Set<string>()
+  for (const channel of template.communication_channels) {
+    communicatingRoles.add(channel.from)
+    communicatingRoles.add(channel.to)
+  }
+  const roleCanSee = (role: string, archetypeId: string, attribute: string): boolean => {
+    const rule = template.visibility_rules.find((entry) => entry.role === role)
+    return (rule?.can_see ?? []).some(
+      (entry) =>
+        (entry.element_archetype === WILDCARD || entry.element_archetype === archetypeId) &&
+        (entry.attributes.includes(WILDCARD) || entry.attributes.includes(attribute))
+    )
+  }
+  template.shared_label_attributes.forEach((entry, i) => {
+    const entryPath = `${base}.shared_label_attributes[${i}]`
+    const archetype = archetypes.get(entry.element_archetype)
+    if (!archetype) {
+      violations.push({
+        severity: 'error',
+        field_path: `${entryPath}.element_archetype`,
+        constraint: 'archetype_registered',
+        expected: `one of [${[...archetypes.keys()].join(', ')}]`,
+        actual: entry.element_archetype,
+        suggestion: 'Reference a registered ElementArchetype id',
+      })
+      return
+    }
+    entry.attributes.forEach((attribute, j) => {
+      const attrPath = `${entryPath}.attributes[${j}]`
+      if (!attributeNames(archetype).includes(attribute)) {
+        violations.push({
+          severity: 'error',
+          field_path: attrPath,
+          constraint: 'attribute_defined',
+          expected: `one of [${attributeNames(archetype).join(', ')}]`,
+          actual: attribute,
+          suggestion: `Use an attribute defined on archetype "${archetype.id}"`,
+        })
+        return
+      }
+      for (const role of communicatingRoles) {
+        if (!roleCanSee(role, entry.element_archetype, attribute)) {
+          violations.push({
+            severity: 'error',
+            field_path: attrPath,
+            constraint: 'shared_label_visible_to_all',
+            expected: `"${attribute}" in every communicating role's can_see for "${entry.element_archetype}"`,
+            actual: `role "${role}" cannot see it`,
+            suggestion: `Add "${attribute}" of "${entry.element_archetype}" to role "${role}"'s can_see, or drop it from shared_label_attributes`,
+          })
+        }
+      }
+    })
+  })
+
+  return buildCheckResult('gametype_consistency', violations)
+}

--- a/packages/creation/src/validate/goal-reachability.ts
+++ b/packages/creation/src/validate/goal-reachability.ts
@@ -1,0 +1,222 @@
+/**
+ * goal_reachability — co_build floor check (spec interface:
+ * `(level, role_capabilities) → {reachable, blocking_resource?}`, machine
+ * derivation per the sound-garden worked example): from
+ * Level.initial_state + available_materials + the scoring matrix
+ * (matrix rows × relation_scores) + win_condition.target_score, compute the
+ * best and worst achievable total over assignments of one role's materials
+ * to the other's, and require max_possible_score >= target_score.
+ *
+ * Also emits the spec's non-triviality signal: when even the WORST
+ * assignment reaches the target (min_possible_score >= target), the goal
+ * needs no coordination — a warning, not an error.
+ *
+ * Deadline policy (H3): ONE deadline per check invocation; the assignment
+ * enumeration (n! for n <= 8 materials per pool) is bounded by it.
+ *
+ * NOTE (M5): this is a cheap NECESSARY-condition floor — it optimizes over
+ * a free bijective assignment of materials and ignores fixed timeline slots
+ * and placement order, so it over-approximates what a real build can do.
+ * solvability's engine search is the authoritative reachability gate; this
+ * floor exists for fast, field-precise diagnostics.
+ */
+
+import type { GameType, Level, CheckResult, Violation, RuleTemplate } from '../schema/types'
+import { buildCheckResult, startDeadline, templatesById } from './helpers'
+
+const MAX_POOL_SIZE = 8
+
+interface ScoringModel {
+  rows: [string, string, string][]
+  scores: Record<string, number>
+}
+
+/** The level's matrix scoring model (rows from the rule instance, scores from the template). */
+export function scoringModel(gameType: GameType, level: Level): ScoringModel | undefined {
+  const templates = templatesById(gameType)
+  for (const rule of level.rules) {
+    const template = templates.get(rule.template)
+    if (!template || template.type !== 'interaction_matrix') continue
+    const scores = template.matrix_schema.relation_scores
+    if (!scores) continue
+    const rows = (Array.isArray(rule.bindings.matrix) ? rule.bindings.matrix : []).filter(
+      (row): row is [string, string, string] => Array.isArray(row) && row.length === 3
+    )
+    return { rows, scores }
+  }
+  return undefined
+}
+
+function pairScore(model: ScoringModel, a: string, b: string): number {
+  const row = model.rows.find((r) => (r[0] === a && r[1] === b) || (r[0] === b && r[1] === a))
+  return row ? (model.scores[row[2]] ?? 0) : 0
+}
+
+/** Entity types in a material pool, expanded by count. */
+function expandPool(
+  pool: { archetype: string; count: number; [key: string]: unknown }[],
+  typeAttributes: string[]
+): string[] {
+  const types: string[] = []
+  for (const entry of pool) {
+    const type = typeAttributes
+      .map((attribute) => entry[attribute])
+      .find((value): value is string => typeof value === 'string')
+    if (!type) continue
+    for (let i = 0; i < entry.count; i++) types.push(type)
+  }
+  return types
+}
+
+export function checkGoalReachability(gameType: GameType, level: Level): CheckResult {
+  const violations: Violation[] = []
+  const deadline = startDeadline(gameType.solver_timeout_ms)
+
+  const target = level.win_condition.params.target_score
+  if (typeof target !== 'number') {
+    violations.push({
+      severity: 'error',
+      field_path: 'win_condition.params.target_score',
+      constraint: 'target_score_declared',
+      expected: 'a numeric target score',
+      actual: JSON.stringify(target),
+      suggestion: 'Declare the score threshold the build must reach',
+    })
+  }
+  if (!level.initial_state) {
+    violations.push(constructionModelViolation('initial_state'))
+  }
+  const materials = level.available_materials
+  if (!materials || Object.keys(materials).length !== 2) {
+    violations.push({
+      severity: 'error',
+      field_path: 'available_materials',
+      constraint: 'material_pools_declared',
+      expected: 'exactly two role material pools (co_build)',
+      actual: materials ? `${Object.keys(materials).length} pool(s)` : 'missing',
+      suggestion: 'Declare available_materials with one pool per building role',
+    })
+  }
+  const model = scoringModel(gameType, level)
+  const matrixTemplateIndex = gameType.rule_templates.findIndex(
+    (template): template is Extract<RuleTemplate, { type: 'interaction_matrix' }> =>
+      template.type === 'interaction_matrix'
+  )
+  if (!model) {
+    violations.push({
+      severity: 'error',
+      field_path:
+        matrixTemplateIndex >= 0
+          ? `game_type.rule_templates[${matrixTemplateIndex}].matrix_schema.relation_scores`
+          : 'game_type.rule_templates',
+      constraint: 'score_source_declared',
+      expected: 'an interaction_matrix rule with matrix_schema.relation_scores',
+      actual: 'no scoring source found',
+      suggestion:
+        'Declare relation_scores on the matrix template and bind a matrix rule in the level',
+    })
+  }
+  if (violations.length > 0 || !model || !materials || typeof target !== 'number') {
+    return buildCheckResult('goal_reachability', violations)
+  }
+
+  const typeAttributes =
+    matrixTemplateIndex >= 0
+      ? ((
+          gameType.rule_templates[matrixTemplateIndex] as Extract<
+            RuleTemplate,
+            { type: 'interaction_matrix' }
+          >
+        ).matrix_schema.entity_type_attributes ?? [])
+      : []
+  const [poolA, poolB] = Object.values(materials).map((pool) => expandPool(pool, typeAttributes))
+  if (poolA.length > MAX_POOL_SIZE || poolB.length > MAX_POOL_SIZE) {
+    violations.push({
+      severity: 'error',
+      field_path: 'available_materials',
+      constraint: 'material_pool_bounded',
+      expected: `at most ${MAX_POOL_SIZE} materials per pool for exhaustive assignment analysis`,
+      actual: `${poolA.length} × ${poolB.length}`,
+      suggestion: 'Reduce the material pools or extend the reachability analysis strategy',
+    })
+    return buildCheckResult('goal_reachability', violations)
+  }
+
+  const { best, worst, timedOut } = assignmentExtremes(model, poolA, poolB, deadline)
+  if (timedOut) {
+    violations.push(deadline.violation())
+    return buildCheckResult('goal_reachability', violations)
+  }
+
+  if (best < target) {
+    violations.push({
+      severity: 'error',
+      field_path: 'win_condition.params.target_score',
+      constraint: 'goal_reachable',
+      expected: `target_score <= max_possible_score (${best})`,
+      actual: `target_score ${target} exceeds the best achievable build`,
+      suggestion:
+        'Lower target_score, extend the material pools, or improve the scoring matrix relations',
+    })
+  } else if (worst >= target) {
+    violations.push({
+      severity: 'warning',
+      field_path: 'win_condition.params.target_score',
+      constraint: 'goal_non_trivial',
+      expected: `min_possible_score (${worst}) < target_score — the goal should require coordination`,
+      actual: `even the worst assignment scores ${worst} >= ${target}`,
+      suggestion: 'Raise target_score so the build requires actual coordination between the roles',
+    })
+  }
+
+  return buildCheckResult('goal_reachability', violations)
+}
+
+function constructionModelViolation(path: string): Violation {
+  return {
+    severity: 'error',
+    field_path: path,
+    constraint: 'construction_model_declared',
+    expected: 'the co_build construction model (initial_state + available_materials)',
+    actual: 'missing',
+    suggestion: 'Declare the construction starting space and per-role material pools',
+  }
+}
+
+/** Best/worst total over assignments of pool B onto pool A (bounded permutations). */
+function assignmentExtremes(
+  model: ScoringModel,
+  poolA: string[],
+  poolB: string[],
+  deadline: { timedOut(): boolean }
+): { best: number; worst: number; timedOut: boolean } {
+  let best = Number.NEGATIVE_INFINITY
+  let worst = Number.POSITIVE_INFINITY
+  let timedOut = false
+  const used = new Array<boolean>(poolB.length).fill(false)
+  const pairs = Math.min(poolA.length, poolB.length)
+
+  const recurse = (index: number, total: number): void => {
+    if (timedOut || deadline.timedOut()) {
+      timedOut = true
+      return
+    }
+    if (index === pairs) {
+      best = Math.max(best, total)
+      worst = Math.min(worst, total)
+      return
+    }
+    for (let j = 0; j < poolB.length; j++) {
+      if (used[j]) continue
+      used[j] = true
+      recurse(index + 1, total + pairScore(model, poolA[index], poolB[j]))
+      used[j] = false
+    }
+  }
+  recurse(0, 0)
+  if (best === Number.NEGATIVE_INFINITY) {
+    best = 0
+    worst = 0
+  }
+  return { best, worst, timedOut }
+}

--- a/packages/creation/src/validate/helpers.ts
+++ b/packages/creation/src/validate/helpers.ts
@@ -19,6 +19,7 @@ import type {
   LevelElement,
   LevelRule,
   RuleTemplate,
+  StateDefinition,
   Verdict,
   Violation,
 } from '../schema/types'
@@ -96,52 +97,94 @@ export function attributeDomainSize(attr: AttributeDefinition): number | undefin
   return undefined
 }
 
-/**
- * Attribute-level visibility across ALL roles: element id → set of attribute
- * names at least one role can observe (from Level.information_partition,
- * with "*" expanded against the element's archetype).
- */
-export function visibleAttributesByElement(
-  gameType: GameType,
-  level: Level
-): Map<string, Set<string>> {
-  const archetypes = archetypesById(gameType)
-  const elements = elementsById(level)
-  const visible = new Map<string, Set<string>>()
-  for (const assignment of level.information_partition.role_assignments) {
-    for (const view of assignment.element_views) {
-      const element = elements.get(view.element_id)
-      const archetype = element ? archetypes.get(element.archetype) : undefined
-      const names = archetype
-        ? expandNames(view.visible_attributes, attributeNames(archetype))
-        : view.visible_attributes
-      const set = visible.get(view.element_id) ?? new Set<string>()
-      for (const name of names) set.add(name)
-      visible.set(view.element_id, set)
-    }
+/** Size of a runtime state's value domain; undefined when unknown/unbounded. */
+export function stateDomainSize(state: StateDefinition): number | undefined {
+  if (state.type === 'enum') return state.values?.length
+  if (state.min !== undefined && state.max !== undefined) {
+    const step = state.step ?? 1
+    return Math.floor((state.max - state.min) / step) + 1
   }
-  return visible
+  return undefined
+}
+
+/** Per-archetype fields a role is forbidden from observing (cannot_see). */
+export interface ForbiddenFields {
+  attributes: Set<string>
+  states: Set<string>
 }
 
 /**
- * Per-role attribute-level visibility: role id → element id → observable
- * attribute names (with "*" expanded against the element's archetype).
+ * The GameType template's cannot_see subtraction for one role, expanded per
+ * archetype ("*" wildcards resolved). This is the SINGLE semantics source
+ * for runtime visibility subtraction: GameSession.getRoleView filters every
+ * level view through it, and the validator visibility helpers below apply
+ * the same subtraction — so the validator can never count a field as
+ * observable that the runtime hides (a level view over-declaring a forbidden
+ * field is silently ineffective in BOTH models).
  */
-export function visibleAttributesByRole(
+export function forbiddenFieldsForRole(
   gameType: GameType,
-  level: Level
+  roleId: string
+): Map<string, ForbiddenFields> {
+  const archetypes = archetypesById(gameType)
+  const forbidden = new Map<string, ForbiddenFields>()
+  const visibilityRule = gameType.information_partition_template?.visibility_rules.find(
+    (entry) => entry.role === roleId
+  )
+  for (const entry of visibilityRule?.cannot_see ?? []) {
+    const matched =
+      entry.element_archetype === WILDCARD
+        ? [...archetypes.values()]
+        : [archetypes.get(entry.element_archetype)].filter(
+            (a): a is ElementArchetype => a !== undefined
+          )
+    for (const archetype of matched) {
+      const bucket = forbidden.get(archetype.id) ?? {
+        attributes: new Set<string>(),
+        states: new Set<string>(),
+      }
+      for (const attr of expandNames(entry.attributes, attributeNames(archetype))) {
+        bucket.attributes.add(attr)
+      }
+      for (const state of expandNames(entry.states, stateNames(archetype))) {
+        bucket.states.add(state)
+      }
+      forbidden.set(archetype.id, bucket)
+    }
+  }
+  return forbidden
+}
+
+type FieldKind = 'attributes' | 'states'
+
+/**
+ * Per-role field-level visibility: role id → element id → observable field
+ * names of the given kind, with "*" expanded against the element's archetype
+ * AND the GameType cannot_see subtraction applied (see forbiddenFieldsForRole
+ * — the validator's visibility model must match GameSession.getRoleView).
+ */
+function visibleFieldsByRole(
+  gameType: GameType,
+  level: Level,
+  kind: FieldKind
 ): Map<string, Map<string, Set<string>>> {
   const archetypes = archetypesById(gameType)
   const elements = elementsById(level)
   const byRole = new Map<string, Map<string, Set<string>>>()
   for (const assignment of level.information_partition.role_assignments) {
     const roleMap = byRole.get(assignment.role) ?? new Map<string, Set<string>>()
+    const forbidden = forbiddenFieldsForRole(gameType, assignment.role)
     for (const view of assignment.element_views) {
       const element = elements.get(view.element_id)
       const archetype = element ? archetypes.get(element.archetype) : undefined
-      const names = archetype
-        ? expandNames(view.visible_attributes, attributeNames(archetype))
-        : view.visible_attributes
+      const listed = kind === 'attributes' ? view.visible_attributes : view.visible_states
+      const all = archetype
+        ? kind === 'attributes'
+          ? attributeNames(archetype)
+          : stateNames(archetype)
+        : undefined
+      const bucket = archetype ? forbidden.get(archetype.id)?.[kind] : undefined
+      const names = (all ? expandNames(listed, all) : listed).filter((name) => !bucket?.has(name))
       const set = roleMap.get(view.element_id) ?? new Set<string>()
       for (const name of names) set.add(name)
       roleMap.set(view.element_id, set)
@@ -149,6 +192,54 @@ export function visibleAttributesByRole(
     byRole.set(assignment.role, roleMap)
   }
   return byRole
+}
+
+/** Union of a per-role visibility map across all roles: element id → names. */
+function unionAcrossRoles(byRole: Map<string, Map<string, Set<string>>>): Map<string, Set<string>> {
+  const visible = new Map<string, Set<string>>()
+  for (const roleMap of byRole.values()) {
+    for (const [elementId, names] of roleMap) {
+      const set = visible.get(elementId) ?? new Set<string>()
+      for (const name of names) set.add(name)
+      visible.set(elementId, set)
+    }
+  }
+  return visible
+}
+
+/**
+ * Attribute-level visibility across ALL roles: element id → set of attribute
+ * names at least one role can observe (cannot_see-filtered, "*" expanded).
+ */
+export function visibleAttributesByElement(
+  gameType: GameType,
+  level: Level
+): Map<string, Set<string>> {
+  return unionAcrossRoles(visibleAttributesByRole(gameType, level))
+}
+
+/** Per-role attribute-level visibility (cannot_see-filtered, "*" expanded). */
+export function visibleAttributesByRole(
+  gameType: GameType,
+  level: Level
+): Map<string, Map<string, Set<string>>> {
+  return visibleFieldsByRole(gameType, level, 'attributes')
+}
+
+/**
+ * Runtime-state visibility across ALL roles: element id → set of state names
+ * at least one role can observe (cannot_see-filtered, "*" expanded).
+ */
+export function visibleStatesByElement(gameType: GameType, level: Level): Map<string, Set<string>> {
+  return unionAcrossRoles(visibleStatesByRole(gameType, level))
+}
+
+/** Per-role runtime-state visibility (cannot_see-filtered, "*" expanded). */
+export function visibleStatesByRole(
+  gameType: GameType,
+  level: Level
+): Map<string, Map<string, Set<string>>> {
+  return visibleFieldsByRole(gameType, level, 'states')
 }
 
 /** Shared bounded-search deadline (solver_timeout_ms bounds every solver-routed check). */
@@ -227,6 +318,64 @@ export function solveRelevantParams(gameType: GameType, level: Level): Map<strin
     for (const [elementId, params] of consumedParamsForRule(gameType, level, rule)) {
       const set = relevant.get(elementId) ?? new Set<string>()
       for (const param of params) set.add(param)
+      relevant.set(elementId, set)
+    }
+  }
+  return relevant
+}
+
+/**
+ * Runtime STATES consumed by ONE rule: condition predicates resolve each
+ * inlined param name against the target archetype's attributes THEN states
+ * (rules.ts evaluatePredicates) — a param name that names a declared state
+ * reads the element's live state at evaluation time (e.g. botanical
+ * `light_is: {effective_light: …}`, `growth_is: {growth_stage: …}`). Such a
+ * state is solve-relevant on every target element carrying it: deciding when
+ * the rule applies requires knowing the current state value.
+ */
+export function consumedStatesForRule(
+  gameType: GameType,
+  level: Level,
+  rule: LevelRule
+): Map<string, Set<string>> {
+  const entries = Array.isArray(rule.bindings.predicates) ? rule.bindings.predicates : []
+  const paramNames = new Set<string>()
+  for (const entry of entries) {
+    if (!isMappingValue(entry)) continue
+    for (const key of Object.keys(entry)) {
+      if (key !== 'name') paramNames.add(key)
+    }
+  }
+  if (paramNames.size === 0) return new Map()
+  const elements = elementsById(level)
+  const archetypes = archetypesById(gameType)
+  const consumed = new Map<string, Set<string>>()
+  for (const targetId of rule.target_elements) {
+    const element = elements.get(targetId)
+    const archetype = element ? archetypes.get(element.archetype) : undefined
+    if (!archetype) continue
+    const attrNames = new Set(attributeNames(archetype))
+    const declaredStates = new Set(stateNames(archetype))
+    const states = new Set<string>()
+    for (const name of paramNames) {
+      // Attribute names shadow state names, mirroring evaluatePredicates.
+      if (!attrNames.has(name) && declaredStates.has(name)) states.add(name)
+    }
+    if (states.size > 0) consumed.set(targetId, states)
+  }
+  return consumed
+}
+
+/**
+ * Solve-relevant runtime states across all rules — union of
+ * consumedStatesForRule. The state-side sibling of solveRelevantParams.
+ */
+export function solveRelevantStates(gameType: GameType, level: Level): Map<string, Set<string>> {
+  const relevant = new Map<string, Set<string>>()
+  for (const rule of level.rules) {
+    for (const [elementId, states] of consumedStatesForRule(gameType, level, rule)) {
+      const set = relevant.get(elementId) ?? new Set<string>()
+      for (const state of states) set.add(state)
       relevant.set(elementId, set)
     }
   }

--- a/packages/creation/src/validate/helpers.ts
+++ b/packages/creation/src/validate/helpers.ts
@@ -1,0 +1,248 @@
+/**
+ * Shared internals for the validator checks. All helpers are read-only over
+ * their inputs (spec invariant: validators never modify the Level).
+ *
+ * Field-path convention: violations locate Level-side fields with the spec's
+ * index format ("elements[2].params.color"). Fields that live on the GameType
+ * side of the (GameType, Level) pair are prefixed with "game_type."
+ * (e.g. "game_type.solver_strategy") — the spec only exemplifies Level-side
+ * paths, so the prefix is this implementation's documented extension.
+ */
+
+import type {
+  AttributeDefinition,
+  CheckId,
+  CheckResult,
+  ElementArchetype,
+  GameType,
+  Level,
+  LevelElement,
+  LevelRule,
+  RuleTemplate,
+  Verdict,
+  Violation,
+} from '../schema/types'
+
+export const WILDCARD = '*'
+
+export function archetypesById(gameType: GameType): Map<string, ElementArchetype> {
+  return new Map(gameType.element_archetypes.map((a) => [a.id, a]))
+}
+
+export function templatesById(gameType: GameType): Map<string, RuleTemplate> {
+  return new Map(gameType.rule_templates.map((t) => [t.id, t]))
+}
+
+export function elementsById(level: Level): Map<string, LevelElement> {
+  return new Map(level.elements.map((e) => [e.id, e]))
+}
+
+export function attributeNames(archetype: ElementArchetype): string[] {
+  return archetype.attributes.map((a) => a.name)
+}
+
+export function stateNames(archetype: ElementArchetype): string[] {
+  return (archetype.states ?? []).map((s) => s.name)
+}
+
+/** Expand a visibility name list: "*" means every name in `all`. */
+export function expandNames(listed: string[], all: string[]): string[] {
+  return listed.includes(WILDCARD) ? all : listed
+}
+
+export function isMappingValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function isScalar(value: unknown): boolean {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  )
+}
+
+/**
+ * Legal leaf value for AI-authored params/bindings under the ≤3-level
+ * nesting invariant: a scalar, or an array of scalars (required by the
+ * "set" attribute type). Mappings and nested arrays exceed the ceiling.
+ */
+export function isFlatValue(value: unknown): boolean {
+  if (isScalar(value)) return true
+  if (Array.isArray(value)) return value.every((item) => isScalar(item))
+  return false
+}
+
+/** All non-null scalar leaves of a nested binding structure, depth-first. */
+export function collectScalarLeaves(value: unknown): (string | number | boolean)[] {
+  if (value === null || value === undefined) return []
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return [value]
+  }
+  if (Array.isArray(value)) return value.flatMap(collectScalarLeaves)
+  if (typeof value === 'object') return Object.values(value).flatMap(collectScalarLeaves)
+  return []
+}
+
+/** Size of an attribute's value domain; undefined when unknown/unbounded. */
+export function attributeDomainSize(attr: AttributeDefinition): number | undefined {
+  if (attr.type === 'enum' || attr.type === 'set') return attr.values?.length
+  if (attr.type === 'boolean') return 2
+  if (attr.type === 'range' && attr.min !== undefined && attr.max !== undefined) {
+    const step = attr.step ?? 1
+    return Math.floor((attr.max - attr.min) / step) + 1
+  }
+  return undefined
+}
+
+/**
+ * Attribute-level visibility across ALL roles: element id → set of attribute
+ * names at least one role can observe (from Level.information_partition,
+ * with "*" expanded against the element's archetype).
+ */
+export function visibleAttributesByElement(
+  gameType: GameType,
+  level: Level
+): Map<string, Set<string>> {
+  const archetypes = archetypesById(gameType)
+  const elements = elementsById(level)
+  const visible = new Map<string, Set<string>>()
+  for (const assignment of level.information_partition.role_assignments) {
+    for (const view of assignment.element_views) {
+      const element = elements.get(view.element_id)
+      const archetype = element ? archetypes.get(element.archetype) : undefined
+      const names = archetype
+        ? expandNames(view.visible_attributes, attributeNames(archetype))
+        : view.visible_attributes
+      const set = visible.get(view.element_id) ?? new Set<string>()
+      for (const name of names) set.add(name)
+      visible.set(view.element_id, set)
+    }
+  }
+  return visible
+}
+
+/**
+ * Per-role attribute-level visibility: role id → element id → observable
+ * attribute names (with "*" expanded against the element's archetype).
+ */
+export function visibleAttributesByRole(
+  gameType: GameType,
+  level: Level
+): Map<string, Map<string, Set<string>>> {
+  const archetypes = archetypesById(gameType)
+  const elements = elementsById(level)
+  const byRole = new Map<string, Map<string, Set<string>>>()
+  for (const assignment of level.information_partition.role_assignments) {
+    const roleMap = byRole.get(assignment.role) ?? new Map<string, Set<string>>()
+    for (const view of assignment.element_views) {
+      const element = elements.get(view.element_id)
+      const archetype = element ? archetypes.get(element.archetype) : undefined
+      const names = archetype
+        ? expandNames(view.visible_attributes, attributeNames(archetype))
+        : view.visible_attributes
+      const set = roleMap.get(view.element_id) ?? new Set<string>()
+      for (const name of names) set.add(name)
+      roleMap.set(view.element_id, set)
+    }
+    byRole.set(assignment.role, roleMap)
+  }
+  return byRole
+}
+
+/** Shared bounded-search deadline (solver_timeout_ms bounds every solver-routed check). */
+export interface Deadline {
+  timedOut(): boolean
+  violation(): Violation
+}
+
+/**
+ * Deadline policy (H3): ONE deadline per check invocation —
+ * solver_timeout_ms bounds the ENTIRE check (all targets and sub-phases
+ * share the same budget). Consumers create exactly one deadline at check
+ * entry and thread it through every bounded sub-step.
+ */
+export function startDeadline(timeoutMs: number): Deadline {
+  const start = Date.now()
+  return {
+    timedOut: () => Date.now() - start >= timeoutMs,
+    violation: () => ({
+      severity: 'error',
+      field_path: 'game_type.solver_timeout_ms',
+      constraint: 'solver_timeout',
+      expected: `the whole check completing within ${timeoutMs}ms (one deadline per check invocation)`,
+      actual: 'the bounded search exceeded the check budget',
+      suggestion: 'Raise solver_timeout_ms on the GameType or reduce the level complexity',
+    }),
+  }
+}
+
+/**
+ * Instance params consumed by ONE rule — the v1 consumption approximation
+ * (refined when the rule engine declares effect semantics): an element
+ * referenced through an element-valued binding is rule MATERIAL — all its
+ * params are consumed; an element referenced only as a target contributes
+ * only params whose values appear among the rule's binding scalar leaves.
+ */
+export function consumedParamsForRule(
+  gameType: GameType,
+  level: Level,
+  rule: LevelRule
+): Map<string, Set<string>> {
+  const elements = elementsById(level)
+  const archetypes = archetypesById(gameType)
+  const scalars = collectScalarLeaves(rule.bindings)
+  const material = new Set<string>()
+  for (const scalar of scalars) {
+    if (typeof scalar === 'string' && elements.has(scalar)) material.add(scalar)
+  }
+  const valueSet = new Set(scalars.map(formatValue))
+  const targets = new Set(rule.target_elements.filter((id) => elements.has(id)))
+  const consumed = new Map<string, Set<string>>()
+  for (const element of level.elements) {
+    const isMaterial = material.has(element.id)
+    if (!isMaterial && !targets.has(element.id)) continue
+    const archetype = archetypes.get(element.archetype)
+    if (!archetype) continue
+    const attrNames = new Set(attributeNames(archetype))
+    const params = new Set<string>()
+    for (const [key, value] of Object.entries(element.params)) {
+      if (!attrNames.has(key)) continue
+      if (isMaterial || valueSet.has(formatValue(value))) params.add(key)
+    }
+    if (params.size > 0) consumed.set(element.id, params)
+  }
+  return consumed
+}
+
+/**
+ * Solve-relevant instance params across all rules — union of
+ * consumedParamsForRule. Shared by fairness and communication_completeness
+ * (verbal_distinguishability does not consume it).
+ */
+export function solveRelevantParams(gameType: GameType, level: Level): Map<string, Set<string>> {
+  const relevant = new Map<string, Set<string>>()
+  for (const rule of level.rules) {
+    for (const [elementId, params] of consumedParamsForRule(gameType, level, rule)) {
+      const set = relevant.get(elementId) ?? new Set<string>()
+      for (const param of params) set.add(param)
+      relevant.set(elementId, set)
+    }
+  }
+  return relevant
+}
+
+export function verdictOf(violations: Violation[]): Verdict {
+  if (violations.some((v) => v.severity === 'error')) return 'fail'
+  if (violations.length > 0) return 'warn'
+  return 'pass'
+}
+
+export function buildCheckResult(checkType: CheckId, violations: Violation[]): CheckResult {
+  return { check_type: checkType, verdict: verdictOf(violations), violations }
+}
+
+export function formatValue(value: unknown): string {
+  return typeof value === 'string' ? value : JSON.stringify(value)
+}

--- a/packages/creation/src/validate/progress-measurability.ts
+++ b/packages/creation/src/validate/progress-measurability.ts
@@ -1,0 +1,116 @@
+/**
+ * progress_measurability — co_build floor check (spec interface:
+ * `(level_state, win_condition) → {progress: float[0,1],
+ * remaining_steps_estimate: int}`; the spec pins ONE formula:
+ * `progress = min(current_score / target_score, 1.0)` and
+ * `remaining_steps = |empty_slots_with_both_pieces_available|`).
+ *
+ * As a design-time floor check this verifies BOTH terms are computable for
+ * the level: a positive numeric target (the progress divisor), a declared
+ * scoring source (matrix relation_scores), the construction slot model
+ * (initial_state.timeline_slots), the remaining-steps metric itself
+ * (engine/rules.remainingSteps, which needs the matrix pair_match slot
+ * key) — and that the fully-built designed configuration yields a finite
+ * score that reaches the target (progress can hit 1.0).
+ */
+
+import type { CheckResult, GameType, Level, Violation } from '../schema/types'
+import {
+  buildRuleContext,
+  currentScore,
+  initialElementStates,
+  PLACEMENT_STATE,
+  remainingSteps,
+} from '../engine/rules'
+import { buildCheckResult } from './helpers'
+import { scoringModel } from './goal-reachability'
+
+export function checkProgressMeasurability(gameType: GameType, level: Level): CheckResult {
+  const violations: Violation[] = []
+
+  const target = level.win_condition.params.target_score
+  if (typeof target !== 'number' || target <= 0) {
+    violations.push({
+      severity: 'error',
+      field_path: 'win_condition.params.target_score',
+      constraint: 'progress_computable',
+      expected: 'a positive numeric target score (the progress denominator)',
+      actual: JSON.stringify(target),
+      suggestion: 'Declare a positive target_score so progress = min(current/target, 1) is defined',
+    })
+  }
+
+  if (!scoringModel(gameType, level)) {
+    violations.push({
+      severity: 'error',
+      field_path: 'game_type.rule_templates',
+      constraint: 'score_source_declared',
+      expected:
+        'an interaction_matrix rule with matrix_schema.relation_scores (the current_score source)',
+      actual: 'no scoring source found',
+      suggestion:
+        'Declare relation_scores on the matrix template and bind a matrix rule in the level',
+    })
+  }
+
+  if (!level.initial_state || typeof level.initial_state.timeline_slots !== 'number') {
+    violations.push({
+      severity: 'error',
+      field_path: 'initial_state',
+      constraint: 'construction_model_declared',
+      expected: 'initial_state with a numeric timeline_slots (the remaining-steps slot model)',
+      actual: level.initial_state ? 'timeline_slots missing' : 'missing',
+      suggestion: 'Declare the construction starting space so remaining steps are countable',
+    })
+  }
+
+  if (violations.length === 0) {
+    const ctx = buildRuleContext(gameType, level)
+
+    // remaining_steps term: must be computable from the initial state
+    // (needs the matrix pair_match slot key besides timeline_slots).
+    const initialStates = initialElementStates(gameType, level)
+    if (remainingSteps(ctx, initialStates) === undefined) {
+      violations.push({
+        severity: 'error',
+        field_path: 'initial_state',
+        constraint: 'progress_computable',
+        expected:
+          'a computable remaining_steps metric (timeline_slots + a matrix pair_match slot key)',
+        actual: 'remaining_steps is not computable for this level',
+        suggestion:
+          'Declare pair_match_attributes on the matrix template so empty slots can be counted',
+      })
+    }
+
+    // Progress must be able to REACH 1.0: the fully-built designed
+    // configuration must yield a finite score at or above the target.
+    const states = initialElementStates(gameType, level)
+    for (const machine of states.values()) {
+      if (machine.has(PLACEMENT_STATE)) machine.set(PLACEMENT_STATE, 'placed')
+    }
+    const designedScore = currentScore(ctx, states)
+    if (designedScore === undefined || !Number.isFinite(designedScore)) {
+      violations.push({
+        severity: 'error',
+        field_path: 'elements',
+        constraint: 'progress_computable',
+        expected: 'a finite current_score over the designed configuration',
+        actual: String(designedScore),
+        suggestion: 'Check the matrix rule bindings and relation_scores cover the designed pairs',
+      })
+    } else if (typeof target === 'number' && designedScore < target) {
+      violations.push({
+        severity: 'error',
+        field_path: 'elements',
+        constraint: 'designed_goal_score',
+        expected: `the designed configuration scoring >= target_score (${target})`,
+        actual: `the designed configuration scores ${designedScore}`,
+        suggestion:
+          'Fix the matrix rows / relation scores or the designed pairings so the authored layout can reach the win',
+      })
+    }
+  }
+
+  return buildCheckResult('progress_measurability', violations)
+}

--- a/packages/creation/src/validate/schema-conformance.ts
+++ b/packages/creation/src/validate/schema-conformance.ts
@@ -1,0 +1,805 @@
+/**
+ * schema_conformance — everything the loader's structural narrowing lets
+ * through: id cross-references (archetypes, templates, elements), enum/range
+ * membership, required attributes, binding params, partition view references
+ * with "*" wildcard expansion, win-condition type match, the exact
+ * game_type_version binding, co_play_form catalog registration, and the
+ * AI-authored nesting ceiling (Level → elements[] → params{} is the deepest
+ * legal level; spec Invariants). Rule bindings follow the canonical per-kind
+ * shapes of the spec Mechanism binding contract: template-instantiated
+ * structures — condition_action predicates[]/combinator/action tuples,
+ * state_transition transitions[] rows, interaction_matrix matrix[] rows —
+ * are CONTROLLED nesting validated against the owning template's schemas,
+ * exempt from the free-value flatness rule; temporal_sequence binds flat
+ * step params.
+ *
+ * Assumes the GameType itself already passed the registration-time
+ * gametype_consistency gate (see gametype-consistency.ts).
+ */
+
+import type {
+  AttributeDefinition,
+  CheckResult,
+  ConditionActionRuleTemplate,
+  CoPlayFormCatalog,
+  GameType,
+  InteractionMatrixRuleTemplate,
+  Level,
+  LevelRule,
+  ParamDef,
+  RuleTemplate,
+  StateDefinition,
+  StateTransitionRuleTemplate,
+  Violation,
+} from '../schema/types'
+import {
+  archetypesById,
+  attributeNames,
+  buildCheckResult,
+  elementsById,
+  formatValue,
+  isFlatValue,
+  isMappingValue,
+  stateNames,
+  templatesById,
+  WILDCARD,
+} from './helpers'
+
+export function checkSchemaConformance(
+  gameType: GameType,
+  level: Level,
+  catalog: CoPlayFormCatalog
+): CheckResult {
+  const violations: Violation[] = []
+  const archetypes = archetypesById(gameType)
+  const templates = templatesById(gameType)
+  const elements = elementsById(level)
+
+  if (level.metadata.game_type !== gameType.id) {
+    violations.push({
+      severity: 'error',
+      field_path: 'metadata.game_type',
+      constraint: 'game_type_reference',
+      expected: gameType.id,
+      actual: level.metadata.game_type,
+      suggestion: `Validate this level against its own GameType, or set metadata.game_type to "${gameType.id}"`,
+    })
+  }
+
+  if (level.metadata.game_type_version !== gameType.version) {
+    violations.push({
+      severity: 'error',
+      field_path: 'metadata.game_type_version',
+      constraint: 'version_binding',
+      expected: gameType.version,
+      actual: level.metadata.game_type_version,
+      suggestion: `Set metadata.game_type_version to the exact GameType version "${gameType.version}" (spec invariant: exact match)`,
+    })
+  }
+
+  if (!catalog.some((form) => form.id === gameType.co_play_form)) {
+    violations.push({
+      severity: 'error',
+      field_path: 'game_type.co_play_form',
+      constraint: 'co_play_form_registered',
+      expected: `one of [${catalog.map((form) => form.id).join(', ')}]`,
+      actual: gameType.co_play_form,
+      suggestion:
+        'Register the new co-play form (with its floor checks) in the CoPlayFormCatalog, or declare a registered form',
+    })
+  }
+
+  level.elements.forEach((element, i) => {
+    const archetype = archetypes.get(element.archetype)
+    if (!archetype) {
+      violations.push({
+        severity: 'error',
+        field_path: `elements[${i}].archetype`,
+        constraint: 'archetype_registered',
+        expected: `one of [${[...archetypes.keys()].join(', ')}]`,
+        actual: element.archetype,
+        suggestion: 'Reference a registered ElementArchetype id from the GameType vocabulary',
+      })
+      return
+    }
+    const attributesByName = new Map(archetype.attributes.map((a) => [a.name, a]))
+    for (const [key, value] of Object.entries(element.params)) {
+      const path = `elements[${i}].params.${key}`
+      const attribute = attributesByName.get(key)
+      if (!attribute) {
+        violations.push({
+          severity: 'error',
+          field_path: path,
+          constraint: 'attribute_defined',
+          expected: `one of [${attributeNames(archetype).join(', ')}]`,
+          actual: key,
+          suggestion: `Remove "${key}" or use an attribute defined on archetype "${archetype.id}"`,
+        })
+        continue
+      }
+      if (!isFlatValue(value)) {
+        violations.push({
+          severity: 'error',
+          field_path: path,
+          constraint: 'max_nesting_depth',
+          expected:
+            'a scalar (or array of scalars for type=set) — params{} is the deepest AI-authored level',
+          actual: formatValue(value),
+          suggestion:
+            'Flatten the value: AI-authored Level content must not nest beyond Level → elements[] → params{}',
+        })
+        continue
+      }
+      const valueViolation = checkAttributeValue(attribute, value, path)
+      if (valueViolation) violations.push(valueViolation)
+    }
+    for (const attribute of archetype.attributes) {
+      if (attribute.required && element.params[attribute.name] === undefined) {
+        violations.push({
+          severity: 'error',
+          field_path: `elements[${i}].params.${attribute.name}`,
+          constraint: 'required_attribute_present',
+          expected: `a value for required attribute "${attribute.name}"`,
+          actual: 'missing',
+          suggestion: `Set params.${attribute.name} on element "${element.id}" (archetype "${archetype.id}" requires it)`,
+        })
+      }
+    }
+    // Per-instance initial_states overrides: each key must name a declared
+    // state of the archetype, and (for enum/range states) its value must be
+    // within the declared value domain — mirroring the params enum path.
+    const statesByName = new Map((archetype.states ?? []).map((s) => [s.name, s]))
+    for (const [key, value] of Object.entries(element.initial_states ?? {})) {
+      const path = `elements[${i}].initial_states.${key}`
+      const state = statesByName.get(key)
+      if (!state) {
+        violations.push({
+          severity: 'error',
+          field_path: path,
+          constraint: 'state_defined',
+          expected: `one of [${stateNames(archetype).join(', ')}]`,
+          actual: key,
+          suggestion: `Remove "${key}" or use a state declared on archetype "${archetype.id}"`,
+        })
+        continue
+      }
+      // Parity with the params path: initial_states are AI-authorable, so a
+      // nested value is a nesting-ceiling violation before the domain check.
+      if (!isFlatValue(value)) {
+        violations.push({
+          severity: 'error',
+          field_path: path,
+          constraint: 'max_nesting_depth',
+          expected: 'a scalar — initial_states values are the deepest AI-authored level',
+          actual: formatValue(value),
+          suggestion:
+            'Flatten the value: AI-authored Level content must not nest beyond elements[].initial_states',
+        })
+        continue
+      }
+      const stateViolation = checkStateValue(state, value, path)
+      if (stateViolation) violations.push(stateViolation)
+    }
+  })
+
+  level.rules.forEach((rule, i) => {
+    const template = templates.get(rule.template)
+    if (!template) {
+      violations.push({
+        severity: 'error',
+        field_path: `rules[${i}].template`,
+        constraint: 'template_registered',
+        expected: `one of [${[...templates.keys()].join(', ')}]`,
+        actual: rule.template,
+        suggestion: 'Reference a registered RuleTemplate id from the GameType vocabulary',
+      })
+    } else {
+      validateRuleBindings(template, rule, i, gameType, violations)
+    }
+    rule.target_elements.forEach((targetId, j) => {
+      if (!elements.has(targetId)) {
+        violations.push({
+          severity: 'error',
+          field_path: `rules[${i}].target_elements[${j}]`,
+          constraint: 'element_reference',
+          expected: `one of [${[...elements.keys()].join(', ')}]`,
+          actual: targetId,
+          suggestion: `Reference an element instance declared in this level`,
+        })
+      }
+    })
+  })
+
+  const roles = new Set(
+    (gameType.information_partition_template?.roles ?? []).map((role) => role.id)
+  )
+  level.information_partition.role_assignments.forEach((assignment, i) => {
+    const basePath = `information_partition.role_assignments[${i}]`
+    if (gameType.information_partition_template && !roles.has(assignment.role)) {
+      violations.push({
+        severity: 'error',
+        field_path: `${basePath}.role`,
+        constraint: 'role_defined',
+        expected: `one of [${[...roles].join(', ')}]`,
+        actual: assignment.role,
+        suggestion:
+          'Assign views only to roles declared in the GameType information partition template',
+      })
+    }
+    assignment.element_views.forEach((view, j) => {
+      const viewPath = `${basePath}.element_views[${j}]`
+      const element = elements.get(view.element_id)
+      if (!element) {
+        violations.push({
+          severity: 'error',
+          field_path: `${viewPath}.element_id`,
+          constraint: 'element_reference',
+          expected: `one of [${[...elements.keys()].join(', ')}]`,
+          actual: view.element_id,
+          suggestion: 'Reference an element instance declared in this level',
+        })
+        return
+      }
+      const archetype = archetypes.get(element.archetype)
+      if (!archetype) return // already reported on the element itself
+      checkViewNames(
+        view.visible_attributes,
+        attributeNames(archetype),
+        `${viewPath}.visible_attributes`,
+        archetype.id,
+        'attribute',
+        violations
+      )
+      checkViewNames(
+        view.visible_states,
+        stateNames(archetype),
+        `${viewPath}.visible_states`,
+        archetype.id,
+        'state',
+        violations
+      )
+    })
+  })
+
+  if (level.win_condition.type !== gameType.win_condition_type.type) {
+    violations.push({
+      severity: 'error',
+      field_path: 'win_condition.type',
+      constraint: 'win_condition_type_match',
+      expected: gameType.win_condition_type.type,
+      actual: level.win_condition.type,
+      suggestion: `Use the GameType's declared win condition type "${gameType.win_condition_type.type}"`,
+    })
+  }
+
+  return buildCheckResult('schema_conformance', violations)
+}
+
+function checkAttributeValue(
+  attribute: AttributeDefinition,
+  value: unknown,
+  path: string
+): Violation | undefined {
+  switch (attribute.type) {
+    case 'enum': {
+      const values = attribute.values ?? []
+      if (typeof value !== 'string' || !values.includes(value)) {
+        return {
+          severity: 'error',
+          field_path: path,
+          constraint: 'enum_membership',
+          expected: `one of [${values.join(', ')}]`,
+          actual: formatValue(value),
+          suggestion: `Set the value to one of the legal enum values: ${values.join(', ')}`,
+        }
+      }
+      return undefined
+    }
+    case 'range': {
+      if (typeof value !== 'number') {
+        return rangeViolation(attribute, value, path)
+      }
+      const { min, max, step } = attribute
+      if ((min !== undefined && value < min) || (max !== undefined && value > max)) {
+        return rangeViolation(attribute, value, path)
+      }
+      if (min !== undefined && step !== undefined) {
+        const steps = (value - min) / step
+        if (Math.abs(Math.round(steps) - steps) > 1e-9) {
+          return rangeViolation(attribute, value, path)
+        }
+      }
+      return undefined
+    }
+    case 'boolean': {
+      if (typeof value !== 'boolean') {
+        return {
+          severity: 'error',
+          field_path: path,
+          constraint: 'type_match',
+          expected: 'a boolean',
+          actual: formatValue(value),
+          suggestion: 'Set the value to true or false',
+        }
+      }
+      return undefined
+    }
+    case 'set': {
+      const values = attribute.values ?? []
+      const members = Array.isArray(value) ? value : undefined
+      if (!members || members.some((m) => typeof m !== 'string' || !values.includes(m))) {
+        return {
+          severity: 'error',
+          field_path: path,
+          constraint: 'set_membership',
+          expected: `an array drawn from [${values.join(', ')}]`,
+          actual: formatValue(value),
+          suggestion: `Use an array whose members are legal values: ${values.join(', ')}`,
+        }
+      }
+      return undefined
+    }
+  }
+}
+
+function rangeViolation(attribute: AttributeDefinition, value: unknown, path: string): Violation {
+  const bounds = `${attribute.min ?? '-inf'}..${attribute.max ?? 'inf'}${
+    attribute.step !== undefined ? ` step ${attribute.step}` : ''
+  }`
+  return {
+    severity: 'error',
+    field_path: path,
+    constraint: 'range_membership',
+    expected: `a number in ${bounds}`,
+    actual: formatValue(value),
+    suggestion: `Set the value to a number within ${bounds}`,
+  }
+}
+
+/** Validate a per-instance initial_states value against its declared state domain. */
+function checkStateValue(
+  state: StateDefinition,
+  value: unknown,
+  path: string
+): Violation | undefined {
+  if (state.type === 'enum') {
+    const values = state.values ?? []
+    if (typeof value !== 'string' || !values.includes(value)) {
+      return {
+        severity: 'error',
+        field_path: path,
+        constraint: 'enum_membership',
+        expected: `one of [${values.join(', ')}]`,
+        actual: formatValue(value),
+        suggestion: `Set the value to one of the legal state values: ${values.join(', ')}`,
+      }
+    }
+    return undefined
+  }
+  // range state
+  const { min, max, step } = state
+  const bounds = `${min ?? '-inf'}..${max ?? 'inf'}${step !== undefined ? ` step ${step}` : ''}`
+  if (
+    typeof value !== 'number' ||
+    (min !== undefined && value < min) ||
+    (max !== undefined && value > max) ||
+    (min !== undefined &&
+      step !== undefined &&
+      Math.abs(Math.round((value - min) / step) - (value - min) / step) > 1e-9)
+  ) {
+    return {
+      severity: 'error',
+      field_path: path,
+      constraint: 'range_membership',
+      expected: `a number in ${bounds}`,
+      actual: formatValue(value),
+      suggestion: `Set the value to a number within ${bounds}`,
+    }
+  }
+  return undefined
+}
+
+/**
+ * Known param_def type vocabulary observed in the spec ("string", "int").
+ * Unknown type ids are skipped — the spec leaves the vocabulary open
+ * (SPEC-DEFECT #1 in the R1 report).
+ */
+function checkParamValueType(
+  paramType: string,
+  value: unknown,
+  path: string
+): Violation | undefined {
+  const violate = (expected: string): Violation => ({
+    severity: 'error',
+    field_path: path,
+    constraint: 'type_match',
+    expected,
+    actual: formatValue(value),
+    suggestion: `Set the binding to ${expected}`,
+  })
+  if (paramType === 'string' && typeof value !== 'string') return violate('a string')
+  if (paramType === 'int' && !Number.isInteger(value)) return violate('an integer')
+  if ((paramType === 'float' || paramType === 'number') && typeof value !== 'number') {
+    return violate('a number')
+  }
+  if ((paramType === 'boolean' || paramType === 'bool') && typeof value !== 'boolean') {
+    return violate('a boolean')
+  }
+  return undefined
+}
+
+function checkViewNames(
+  listed: string[],
+  all: string[],
+  path: string,
+  archetypeId: string,
+  kind: 'attribute' | 'state',
+  violations: Violation[]
+): void {
+  listed.forEach((name, k) => {
+    if (name !== WILDCARD && !all.includes(name)) {
+      violations.push({
+        severity: 'error',
+        field_path: `${path}[${k}]`,
+        constraint: `${kind}_defined`,
+        expected: `"${WILDCARD}" or one of [${all.join(', ')}]`,
+        actual: name,
+        suggestion: `Use ${kind} names defined on archetype "${archetypeId}" (or "${WILDCARD}" for all)`,
+      })
+    }
+  })
+}
+
+/**
+ * Binding instantiation contract (spec Mechanism, RuleTemplate binding
+ * contract): each template kind admits exactly ONE canonical binding shape.
+ * Template-instantiated structures — predicates[] lists, action tuples,
+ * transitions[] rows, matrix[] rows — are CONTROLLED nesting validated
+ * against the owning template's schemas; only temporal_sequence binds flat
+ * free params, which keep the flatness ceiling.
+ */
+function validateRuleBindings(
+  template: RuleTemplate,
+  rule: LevelRule,
+  ruleIndex: number,
+  gameType: GameType,
+  violations: Violation[]
+): void {
+  const basePath = `rules[${ruleIndex}].bindings`
+  switch (template.type) {
+    case 'condition_action': {
+      for (const [key, value] of Object.entries(rule.bindings)) {
+        const path = `${basePath}.${key}`
+        if (key === 'predicates') {
+          validatePredicatesBinding(template, value, path, violations)
+        } else if (key === 'combinator') {
+          validateCombinatorBinding(template, value, path, violations)
+        } else if (key === 'action') {
+          validateActionBinding(template, gameType, value, path, violations)
+        } else {
+          violations.push(
+            unknownBindingKey(path, key, ['predicates', 'combinator', 'action'], template.id)
+          )
+        }
+      }
+      return
+    }
+    case 'state_transition': {
+      for (const [key, value] of Object.entries(rule.bindings)) {
+        const path = `${basePath}.${key}`
+        if (key === 'transitions') validateTransitionsBinding(template, value, path, violations)
+        else violations.push(unknownBindingKey(path, key, ['transitions'], template.id))
+      }
+      return
+    }
+    case 'interaction_matrix': {
+      for (const [key, value] of Object.entries(rule.bindings)) {
+        const path = `${basePath}.${key}`
+        if (key === 'matrix') validateMatrixBinding(template, value, path, violations)
+        else violations.push(unknownBindingKey(path, key, ['matrix'], template.id))
+      }
+      return
+    }
+    case 'temporal_sequence': {
+      const params = new Map(template.sequence_schema.step_schema.params.map((p) => [p.name, p]))
+      for (const [key, value] of Object.entries(rule.bindings)) {
+        const path = `${basePath}.${key}`
+        const param = params.get(key)
+        if (!param) {
+          violations.push(unknownBindingKey(path, key, [...params.keys()], template.id))
+          continue
+        }
+        if (!isFlatValue(value)) {
+          violations.push({
+            severity: 'error',
+            field_path: path,
+            constraint: 'max_nesting_depth',
+            expected: 'a scalar binding value — bindings are the deepest AI-authored level',
+            actual: formatValue(value),
+            suggestion:
+              'Flatten the binding value: AI-authored Level content must not nest beyond rules[].bindings',
+          })
+          continue
+        }
+        const typeViolation = checkParamValueType(param.type, value, path)
+        if (typeViolation) violations.push(typeViolation)
+      }
+      return
+    }
+  }
+}
+
+function unknownBindingKey(
+  path: string,
+  key: string,
+  legalKeys: string[],
+  templateId: string
+): Violation {
+  return {
+    severity: 'error',
+    field_path: path,
+    constraint: 'binding_param_defined',
+    expected: `one of [${legalKeys.join(', ')}]`,
+    actual: key,
+    suggestion: `Use the canonical binding shape for template "${templateId}" (spec Mechanism binding contract)`,
+  }
+}
+
+/**
+ * Controlled predicates[] binding: each entry instantiates a predicate
+ * declared by the template's condition_schema, with the predicate's params
+ * INLINED in the entry (canonical shape: {name: species_is, species: fern}).
+ */
+function validatePredicatesBinding(
+  template: ConditionActionRuleTemplate,
+  value: unknown,
+  path: string,
+  violations: Violation[]
+): void {
+  if (!Array.isArray(value)) {
+    violations.push(
+      controlledStructureViolation(
+        path,
+        'a predicates[] list instantiating condition_schema',
+        value
+      )
+    )
+    return
+  }
+  const declared = new Map(template.condition_schema.predicates.map((p) => [p.name, p]))
+  value.forEach((entry, j) => {
+    const entryPath = `${path}[${j}]`
+    if (!isMappingValue(entry)) {
+      violations.push(
+        controlledStructureViolation(
+          entryPath,
+          'a {name, <param>: <value>} predicate instantiation',
+          entry
+        )
+      )
+      return
+    }
+    const { name, ...inlined } = entry
+    const predicate = typeof name === 'string' ? declared.get(name) : undefined
+    if (!predicate) {
+      violations.push({
+        severity: 'error',
+        field_path: `${entryPath}.name`,
+        constraint: 'predicate_registered',
+        expected: `one of [${[...declared.keys()].join(', ')}]`,
+        actual: formatValue(name),
+        suggestion: 'Instantiate a predicate declared by the template condition_schema',
+      })
+      return
+    }
+    validateInlinedParams(predicate.params, inlined, entryPath, violations)
+  })
+}
+
+/**
+ * Optional single combinator over the predicates[] list. Legal values come
+ * from the template's condition_schema.combinators; omitting it defaults to
+ * AND (spec Mechanism binding contract).
+ */
+function validateCombinatorBinding(
+  template: ConditionActionRuleTemplate,
+  value: unknown,
+  path: string,
+  violations: Violation[]
+): void {
+  const legal = template.condition_schema.combinators
+  if (typeof value !== 'string' || !(legal as string[]).includes(value)) {
+    violations.push({
+      severity: 'error',
+      field_path: path,
+      constraint: 'combinator_registered',
+      expected: `one of [${legal.join(', ')}] (optional; defaults to AND when omitted)`,
+      actual: formatValue(value),
+      suggestion: `Use a combinator declared by template "${template.id}" condition_schema.combinators, or omit it to default to AND`,
+    })
+  }
+}
+
+/**
+ * Controlled action tuple binding: {verb, <param>: <value>} — the verb comes
+ * from the template's action_schema.verbs, the inlined params validate
+ * against the registered action's param_defs.
+ */
+function validateActionBinding(
+  template: ConditionActionRuleTemplate,
+  gameType: GameType,
+  value: unknown,
+  path: string,
+  violations: Violation[]
+): void {
+  if (!isMappingValue(value)) {
+    violations.push(
+      controlledStructureViolation(
+        path,
+        'an action tuple {verb, <param>: <value>} instantiating action_schema',
+        value
+      )
+    )
+    return
+  }
+  const { verb, ...inlined } = value
+  if (typeof verb !== 'string' || !template.action_schema.verbs.includes(verb)) {
+    violations.push({
+      severity: 'error',
+      field_path: `${path}.verb`,
+      constraint: 'verb_registered',
+      expected: `one of [${template.action_schema.verbs.join(', ')}]`,
+      actual: formatValue(verb),
+      suggestion: 'Instantiate a verb declared by the template action_schema',
+    })
+    return
+  }
+  const registryEntry = gameType.action_registry.find((action) => action.name === verb)
+  validateInlinedParams(registryEntry?.params ?? [], inlined, path, violations)
+}
+
+/** Controlled transitions[] binding: [state, event, next_state] rows. */
+function validateTransitionsBinding(
+  template: StateTransitionRuleTemplate,
+  value: unknown,
+  path: string,
+  violations: Violation[]
+): void {
+  if (!Array.isArray(value)) {
+    violations.push(
+      controlledStructureViolation(
+        path,
+        'a transitions[] list of [state, event, next_state] rows',
+        value
+      )
+    )
+    return
+  }
+  const { states, events } = template.transition_table_schema
+  value.forEach((row, j) => {
+    const rowPath = `${path}[${j}]`
+    if (!Array.isArray(row) || row.length !== 3) {
+      violations.push(
+        controlledStructureViolation(rowPath, 'a [state, event, next_state] triple', row)
+      )
+      return
+    }
+    const [from, event, to] = row as unknown[]
+    if (typeof from !== 'string' || !states.includes(from)) {
+      violations.push(rowValueViolation(`${rowPath}[0]`, 'state_declared', states, from))
+    }
+    if (typeof event !== 'string' || !events.includes(event)) {
+      violations.push(rowValueViolation(`${rowPath}[1]`, 'event_declared', events, event))
+    }
+    if (typeof to !== 'string' || !states.includes(to)) {
+      violations.push(rowValueViolation(`${rowPath}[2]`, 'state_declared', states, to))
+    }
+  })
+}
+
+/** Controlled matrix[] binding: [entity_a, entity_b, relation] rows. */
+function validateMatrixBinding(
+  template: InteractionMatrixRuleTemplate,
+  value: unknown,
+  path: string,
+  violations: Violation[]
+): void {
+  if (!Array.isArray(value)) {
+    violations.push(
+      controlledStructureViolation(
+        path,
+        'a matrix[] list of [entity_a, entity_b, relation] rows',
+        value
+      )
+    )
+    return
+  }
+  const { entity_types, relation_types } = template.matrix_schema
+  value.forEach((row, j) => {
+    const rowPath = `${path}[${j}]`
+    if (!Array.isArray(row) || row.length !== 3) {
+      violations.push(
+        controlledStructureViolation(rowPath, 'an [entity_a, entity_b, relation] triple', row)
+      )
+      return
+    }
+    const [a, b, relation] = row as unknown[]
+    if (typeof a !== 'string' || !entity_types.includes(a)) {
+      violations.push(rowValueViolation(`${rowPath}[0]`, 'entity_type_declared', entity_types, a))
+    }
+    if (typeof b !== 'string' || !entity_types.includes(b)) {
+      violations.push(rowValueViolation(`${rowPath}[1]`, 'entity_type_declared', entity_types, b))
+    }
+    if (typeof relation !== 'string' || !(relation_types as string[]).includes(relation)) {
+      violations.push(
+        rowValueViolation(`${rowPath}[2]`, 'relation_type_declared', relation_types, relation)
+      )
+    }
+  })
+}
+
+function rowValueViolation(
+  path: string,
+  constraint: string,
+  legal: readonly string[],
+  actual: unknown
+): Violation {
+  return {
+    severity: 'error',
+    field_path: path,
+    constraint,
+    expected: `one of [${legal.join(', ')}]`,
+    actual: formatValue(actual),
+    suggestion: 'Use a value declared by the owning template schema',
+  }
+}
+
+/** Inlined controlled params: unknown keys rejected, leaf values stay flat. */
+function validateInlinedParams(
+  paramDefs: ParamDef[],
+  inlined: Record<string, unknown>,
+  basePath: string,
+  violations: Violation[]
+): void {
+  const defs = new Map(paramDefs.map((p) => [p.name, p]))
+  for (const [paramName, paramValue] of Object.entries(inlined)) {
+    const paramPath = `${basePath}.${paramName}`
+    const def = defs.get(paramName)
+    if (!def) {
+      violations.push({
+        severity: 'error',
+        field_path: paramPath,
+        constraint: 'binding_param_defined',
+        expected: `one of [${[...defs.keys()].join(', ')}]`,
+        actual: paramName,
+        suggestion: `Remove "${paramName}" or use a declared param name`,
+      })
+      continue
+    }
+    if (!isFlatValue(paramValue)) {
+      violations.push({
+        severity: 'error',
+        field_path: paramPath,
+        constraint: 'max_nesting_depth',
+        expected: 'a flat leaf value — controlled structures bottom out in inlined scalar params',
+        actual: formatValue(paramValue),
+        suggestion:
+          'Flatten the param value: controlled nesting ends at the template-declared params',
+      })
+      continue
+    }
+    const typeViolation = checkParamValueType(def.type, paramValue, paramPath)
+    if (typeViolation) violations.push(typeViolation)
+  }
+}
+
+function controlledStructureViolation(path: string, expected: string, value: unknown): Violation {
+  return {
+    severity: 'error',
+    field_path: path,
+    constraint: 'controlled_structure',
+    expected,
+    actual: formatValue(value),
+    suggestion: 'Follow the template-declared structure for this controlled binding',
+  }
+}

--- a/packages/creation/src/validate/schema-conformance.ts
+++ b/packages/creation/src/validate/schema-conformance.ts
@@ -45,6 +45,198 @@ import {
   WILDCARD,
 } from './helpers'
 
+/**
+ * Structural shape gate (pre-check). The loader's narrowing only asserts
+ * top-level fields PRESENT, so a malformed document (`elements: {}`,
+ * `rules: "x"`, …) can reach the validator typed as a Level — and every
+ * check iterates these collections, so it would THROW instead of reporting.
+ * Validating shape first turns those exceptions into the report contract
+ * (schema_conformance violations with field_path), keeping the public
+ * validator total over adversarial AI-authored input. validateLevel runs
+ * this FIRST and short-circuits on any violation — the semantic checks
+ * assume the shapes below.
+ */
+export function levelShapeViolations(level: Level): Violation[] {
+  const violations: Violation[] = []
+  const describeShape = (value: unknown): string => {
+    if (value === null) return 'null'
+    if (value === undefined) return 'missing'
+    if (Array.isArray(value)) return 'a sequence'
+    return `a ${typeof value}`
+  }
+  const requireShape = (ok: boolean, path: string, expected: string, actual: unknown): boolean => {
+    if (ok) return true
+    violations.push({
+      severity: 'error',
+      field_path: path,
+      constraint: 'structural_shape',
+      expected,
+      actual: describeShape(actual),
+      suggestion: `Rewrite ${path} as ${expected} — the validator cannot interpret this shape`,
+    })
+    return false
+  }
+
+  requireShape(isMappingValue(level.metadata), 'metadata', 'a mapping', level.metadata)
+  requireShape(isMappingValue(level.difficulty), 'difficulty', 'a mapping', level.difficulty)
+  requireShape(
+    isMappingValue(level.communication_estimate),
+    'communication_estimate',
+    'a mapping',
+    level.communication_estimate
+  )
+
+  if (requireShape(Array.isArray(level.elements), 'elements', 'an array', level.elements)) {
+    level.elements.forEach((element, i) => {
+      if (!requireShape(isMappingValue(element), `elements[${i}]`, 'a mapping', element)) return
+      requireShape(
+        isMappingValue(element.params),
+        `elements[${i}].params`,
+        'a mapping',
+        element.params
+      )
+      if (element.initial_states !== undefined) {
+        requireShape(
+          isMappingValue(element.initial_states),
+          `elements[${i}].initial_states`,
+          'a mapping',
+          element.initial_states
+        )
+      }
+    })
+  }
+
+  if (requireShape(Array.isArray(level.rules), 'rules', 'an array', level.rules)) {
+    level.rules.forEach((rule, i) => {
+      if (!requireShape(isMappingValue(rule), `rules[${i}]`, 'a mapping', rule)) return
+      requireShape(
+        isMappingValue(rule.bindings),
+        `rules[${i}].bindings`,
+        'a mapping',
+        rule.bindings
+      )
+      requireShape(
+        Array.isArray(rule.target_elements),
+        `rules[${i}].target_elements`,
+        'an array',
+        rule.target_elements
+      )
+    })
+  }
+
+  if (
+    requireShape(
+      isMappingValue(level.information_partition),
+      'information_partition',
+      'a mapping',
+      level.information_partition
+    ) &&
+    requireShape(
+      Array.isArray(level.information_partition.role_assignments),
+      'information_partition.role_assignments',
+      'an array',
+      level.information_partition.role_assignments
+    )
+  ) {
+    level.information_partition.role_assignments.forEach((assignment, i) => {
+      const base = `information_partition.role_assignments[${i}]`
+      if (!requireShape(isMappingValue(assignment), base, 'a mapping', assignment)) return
+      if (
+        !requireShape(
+          Array.isArray(assignment.element_views),
+          `${base}.element_views`,
+          'an array',
+          assignment.element_views
+        )
+      ) {
+        return
+      }
+      assignment.element_views.forEach((view, j) => {
+        const viewPath = `${base}.element_views[${j}]`
+        if (!requireShape(isMappingValue(view), viewPath, 'a mapping', view)) return
+        requireShape(
+          Array.isArray(view.visible_attributes),
+          `${viewPath}.visible_attributes`,
+          'an array',
+          view.visible_attributes
+        )
+        requireShape(
+          Array.isArray(view.visible_states),
+          `${viewPath}.visible_states`,
+          'an array',
+          view.visible_states
+        )
+      })
+    })
+  }
+
+  if (
+    requireShape(
+      isMappingValue(level.win_condition),
+      'win_condition',
+      'a mapping',
+      level.win_condition
+    )
+  ) {
+    requireShape(
+      isMappingValue(level.win_condition.params),
+      'win_condition.params',
+      'a mapping',
+      level.win_condition.params
+    )
+  }
+
+  if (level.initial_state !== undefined) {
+    if (
+      requireShape(
+        isMappingValue(level.initial_state),
+        'initial_state',
+        'a mapping',
+        level.initial_state
+      )
+    ) {
+      requireShape(
+        Array.isArray(level.initial_state.occupied),
+        'initial_state.occupied',
+        'an array',
+        level.initial_state.occupied
+      )
+    }
+  }
+
+  if (level.available_materials !== undefined) {
+    if (
+      requireShape(
+        isMappingValue(level.available_materials),
+        'available_materials',
+        'a mapping',
+        level.available_materials
+      )
+    ) {
+      for (const [role, entries] of Object.entries(level.available_materials)) {
+        requireShape(Array.isArray(entries), `available_materials.${role}`, 'an array', entries)
+      }
+    }
+  }
+
+  if (level.communication_surfaces !== undefined) {
+    if (
+      requireShape(
+        Array.isArray(level.communication_surfaces),
+        'communication_surfaces',
+        'an array',
+        level.communication_surfaces
+      )
+    ) {
+      level.communication_surfaces.forEach((surface, i) => {
+        requireShape(isMappingValue(surface), `communication_surfaces[${i}]`, 'a mapping', surface)
+      })
+    }
+  }
+
+  return violations
+}
+
 export function checkSchemaConformance(
   gameType: GameType,
   level: Level,
@@ -88,6 +280,27 @@ export function checkSchemaConformance(
         'Register the new co-play form (with its floor checks) in the CoPlayFormCatalog, or declare a registered form',
     })
   }
+
+  // Element instance ids must be unique BEFORE any reference resolution:
+  // elementsById keeps only the last duplicate, so rules / win-condition /
+  // view references would silently collapse onto one instance.
+  const seenElementIds = new Map<string, number>()
+  level.elements.forEach((element, i) => {
+    const first = seenElementIds.get(element.id)
+    if (first !== undefined) {
+      violations.push({
+        severity: 'error',
+        field_path: `elements[${i}].id`,
+        constraint: 'element_id_unique',
+        expected: 'a level-unique element instance id',
+        actual: `"${element.id}" already declared at elements[${first}]`,
+        suggestion: `Rename one of the "${element.id}" instances — duplicate ids make rule and win-condition references ambiguous`,
+        related_elements: [element.id],
+      })
+    } else {
+      seenElementIds.set(element.id, i)
+    }
+  })
 
   level.elements.forEach((element, i) => {
     const archetype = archetypes.get(element.archetype)
@@ -524,6 +737,15 @@ function validateRuleBindings(
         const typeViolation = checkParamValueType(param.type, value, path)
         if (typeViolation) violations.push(typeViolation)
       }
+      // Every declared step param is REQUIRED (param_def has no optional
+      // marker): a missing binding (e.g. decrypt_step without cipher_key_id)
+      // would strip the level of its material/solution data yet still play
+      // structurally — reject it before it can publish.
+      for (const name of params.keys()) {
+        if (rule.bindings[name] === undefined || rule.bindings[name] === null) {
+          violations.push(missingBindingParam(`${basePath}.${name}`, name, template.id))
+        }
+      }
       return
     }
   }
@@ -542,6 +764,18 @@ function unknownBindingKey(
     expected: `one of [${legalKeys.join(', ')}]`,
     actual: key,
     suggestion: `Use the canonical binding shape for template "${templateId}" (spec Mechanism binding contract)`,
+  }
+}
+
+/** A declared param with no bound value (param_def has no optional marker). */
+function missingBindingParam(path: string, name: string, owner: string): Violation {
+  return {
+    severity: 'error',
+    field_path: path,
+    constraint: 'binding_param_required',
+    expected: `a value for declared param "${name}"`,
+    actual: 'missing',
+    suggestion: `Bind "${name}" (declared by "${owner}") — every declared param is required until the schema grows an optional marker`,
   }
 }
 
@@ -592,7 +826,7 @@ function validatePredicatesBinding(
       })
       return
     }
-    validateInlinedParams(predicate.params, inlined, entryPath, violations)
+    validateInlinedParams(predicate.params, inlined, entryPath, violations, predicate.name)
   })
 }
 
@@ -655,7 +889,7 @@ function validateActionBinding(
     return
   }
   const registryEntry = gameType.action_registry.find((action) => action.name === verb)
-  validateInlinedParams(registryEntry?.params ?? [], inlined, path, violations)
+  validateInlinedParams(registryEntry?.params ?? [], inlined, path, violations, verb)
 }
 
 /** Controlled transitions[] binding: [state, event, next_state] rows. */
@@ -754,14 +988,26 @@ function rowValueViolation(
   }
 }
 
-/** Inlined controlled params: unknown keys rejected, leaf values stay flat. */
+/**
+ * Inlined controlled params: unknown keys rejected, leaf values stay flat,
+ * and EVERY declared param must be present (param_def has no optional
+ * marker) — a predicate instantiated without its params would evaluate
+ * unconditionally (evaluatePredicates has nothing to compare), turning e.g.
+ * `{name: species_is}` into an always-true condition.
+ */
 function validateInlinedParams(
   paramDefs: ParamDef[],
   inlined: Record<string, unknown>,
   basePath: string,
-  violations: Violation[]
+  violations: Violation[],
+  owner: string
 ): void {
   const defs = new Map(paramDefs.map((p) => [p.name, p]))
+  for (const name of defs.keys()) {
+    if (inlined[name] === undefined || inlined[name] === null) {
+      violations.push(missingBindingParam(`${basePath}.${name}`, name, owner))
+    }
+  }
   for (const [paramName, paramValue] of Object.entries(inlined)) {
     const paramPath = `${basePath}.${paramName}`
     const def = defs.get(paramName)

--- a/packages/creation/src/validate/solvability.ts
+++ b/packages/creation/src/validate/solvability.ts
@@ -1,0 +1,387 @@
+/**
+ * solvability — dispatches the GameType-declared solver_strategy under the
+ * declared solver_timeout_ms bound (spec Mechanism 3, solvability
+ * computability assumption).
+ *
+ * STRUCTURAL, NOT SEMANTIC (boundary). The solver verifies that a legal
+ * sequence of declared operations reaches the win state — a solution PATH
+ * exists structurally. It does NOT verify semantic answer-correctness: e.g.
+ * apply_key advances a cipher_segment's decryption_progress regardless of
+ * whether the caesar shift_amount actually decodes the plaintext, so a level
+ * with a "wrong" key still passes structural solvability. Answer computation
+ * is client-side / human-layer by project constraint ("Puzzle answer
+ * calculation is client-side in the MVP", repo CLAUDE.md). The publish gate
+ * therefore means "a legal operation sequence reaches the win", NOT "a human
+ * can compute the correct answer".
+ *
+ * Implemented strategies (both run the same engine-backed bounded search —
+ * the strategy id records the DECLARED approach for the GameType's state
+ * space, the realization is one shared search core):
+ * - exhaustive_path_search: BFS over declarative rule executions from the
+ *   Level's initial state (../engine/search.ts), state-hash deduplicated,
+ *   bounded by solver_timeout_ms. Declared for small state spaces.
+ * - csp: same engine-backed bounded search — the state-hash frontier IS the
+ *   constraint-propagation the spec's L492 CSP prose calls for on larger
+ *   spaces (a reachable configuration satisfying the win constraints).
+ *   Declared for larger state spaces (e.g. botanical-garden). A true
+ *   constraint-model encoding remains a future optimization; the V0
+ *   realization is measured to solve the botanical golden in ~99ms median /
+ *   119ms max (R7 calibration).
+ *
+ * A found path proves reachability; exhaustion within the declared
+ * vocabulary proves unsolvability. Structural pre-checks (win type, target
+ * references, declared target state) run first for sharper diagnostics;
+ * when the search fails, per-target driver analysis names the unreached
+ * targets with near-miss binding suggestions. solvability and
+ * communication_completeness's uniqueness sub-check share this one core.
+ *
+ * Diagnostic convention (provisional, documented since R2): a binding param
+ * of type "string" whose name ends in "_id" is treated as an element
+ * reference and must resolve to a level element instance. The spec's
+ * param_def has no element-reference marker yet (R1 SPEC-DEFECT #1).
+ */
+
+import type {
+  CheckResult,
+  GameType,
+  Level,
+  LevelElement,
+  LevelRule,
+  RuleTemplate,
+  Violation,
+} from '../schema/types'
+import { searchSolution, solutionDriversForTarget } from '../engine/search'
+import {
+  buildCheckResult,
+  elementsById,
+  isMappingValue,
+  startDeadline,
+  templatesById,
+} from './helpers'
+
+/** Registered solver strategies, both realized by the shared engine search. */
+const IMPLEMENTED_STRATEGIES = ['exhaustive_path_search', 'csp'] as const
+
+export function checkSolvability(gameType: GameType, level: Level): CheckResult {
+  const violations: Violation[] = []
+  if (!(IMPLEMENTED_STRATEGIES as readonly string[]).includes(gameType.solver_strategy)) {
+    violations.push({
+      severity: 'error',
+      field_path: 'game_type.solver_strategy',
+      constraint: 'solver_strategy_registered',
+      expected: `one of [${IMPLEMENTED_STRATEGIES.join(', ')}]`,
+      actual: gameType.solver_strategy,
+      suggestion:
+        'Declare an implemented solver strategy on the GameType, or register a solver for this strategy id',
+    })
+  } else {
+    violations.push(...exhaustivePathSearch(gameType, level))
+  }
+  return buildCheckResult('solvability', violations)
+}
+
+function exhaustivePathSearch(gameType: GameType, level: Level): Violation[] {
+  const violations: Violation[] = []
+  const deadline = startDeadline(gameType.solver_timeout_ms)
+
+  const winType = level.win_condition.type
+  const SUPPORTED_WIN = ['all_solved', 'score_threshold', 'optimization_target']
+  if (!SUPPORTED_WIN.includes(winType)) {
+    // Any unrecognized win type stays typed-but-rejected — an explicit
+    // violation, never a silently wrong verdict.
+    violations.push({
+      severity: 'error',
+      field_path: 'win_condition.type',
+      constraint: 'win_condition_supported',
+      expected: `one of [${SUPPORTED_WIN.join(', ')}]`,
+      actual: winType,
+      suggestion:
+        'Extend the solver registry with a strategy for this win condition type, or use a supported one',
+    })
+    return violations
+  }
+
+  const params = level.win_condition.params
+  const archetypes = new Map(gameType.element_archetypes.map((a) => [a.id, a]))
+  const templates = templatesById(gameType)
+  const elements = elementsById(level)
+
+  let targetIds: unknown[] = []
+  if (winType === 'all_solved') {
+    const declared = Array.isArray(params.target_elements)
+      ? (params.target_elements as unknown[])
+      : undefined
+    if (!declared || declared.length === 0) {
+      violations.push({
+        severity: 'error',
+        field_path: 'win_condition.params.target_elements',
+        constraint: 'target_elements_declared',
+        expected: 'a non-empty array of element instance ids',
+        actual: JSON.stringify(params.target_elements),
+        suggestion: 'Declare which element instances must reach the target state',
+      })
+      return violations
+    }
+    targetIds = declared
+    const targetState = params.target_state
+
+    // Structural pre-checks: broken references produce sharper diagnostics
+    // than a failed search would.
+    targetIds.forEach((targetId, j) => {
+      const targetPath = `win_condition.params.target_elements[${j}]`
+      if (typeof targetId !== 'string' || !elements.has(targetId)) {
+        violations.push({
+          severity: 'error',
+          field_path: targetPath,
+          constraint: 'element_reference',
+          expected: `one of [${[...elements.keys()].join(', ')}]`,
+          actual: String(targetId),
+          suggestion: 'Reference an element instance declared in this level',
+        })
+        return
+      }
+      const element = elements.get(targetId)
+      const archetype = element ? archetypes.get(element.archetype) : undefined
+      if (typeof targetState === 'string' && archetype) {
+        const stateReachable = (archetype.states ?? []).some(
+          (state) => state.values?.includes(targetState) ?? false
+        )
+        if (!stateReachable) {
+          violations.push({
+            severity: 'error',
+            field_path: 'win_condition.params.target_state',
+            constraint: 'state_declared',
+            expected: `a declared state value of archetype "${archetype.id}"`,
+            actual: targetState,
+            suggestion: `Use a state value declared on archetype "${archetype.id}" states`,
+          })
+        }
+      }
+    })
+  } else if (winType === 'score_threshold') {
+    if (typeof params.target_score !== 'number') {
+      violations.push({
+        severity: 'error',
+        field_path: 'win_condition.params.target_score',
+        constraint: 'target_score_declared',
+        expected: 'a numeric target score',
+        actual: JSON.stringify(params.target_score),
+        suggestion: 'Declare the score threshold the build must reach',
+      })
+      return violations
+    }
+  } else {
+    // optimization_target: at least one declarative constraint, and every
+    // referenced state + value must exist in the vocabulary.
+    violations.push(...validateOptimizationTargetParams(gameType, params))
+  }
+  if (violations.length > 0) return violations
+
+  // Real bounded path search through the declarative rule engine.
+  const result = searchSolution(gameType, level, deadline)
+  if (result.timedOut) {
+    violations.push(deadline.violation())
+    return violations
+  }
+  if (result.solvable) return violations
+
+  if (winType === 'score_threshold') {
+    // Unsolvable build: no placement sequence within the vocabulary
+    // reaches the threshold.
+    violations.push({
+      severity: 'error',
+      field_path: 'win_condition.params.target_score',
+      constraint: 'solution_path_exists',
+      expected: 'a construction sequence reaching the target score',
+      actual: `no reachable configuration scores >= ${String(params.target_score)}`,
+      suggestion:
+        'Lower target_score, extend the material pools, or improve the scoring matrix relations',
+    })
+    return violations
+  }
+
+  if (winType === 'optimization_target') {
+    // Unsolvable care loop: no care sequence within the vocabulary satisfies
+    // the optimization constraints.
+    violations.push({
+      severity: 'error',
+      field_path: 'win_condition.params',
+      constraint: 'solution_path_exists',
+      expected: 'a care sequence reaching all optimization_target constraints',
+      actual: 'no reachable configuration satisfies the win constraints',
+      suggestion:
+        'Relax the constraints, add action_event_mapping / rules that advance the required states, or fix the starting states',
+    })
+    return violations
+  }
+
+  // all_solved unsolvable: name each undrivable target with near-miss
+  // diagnostics. Deadline policy (H3): ONE deadline per check invocation —
+  // solver_timeout_ms bounds the whole solvability check; the driver
+  // analysis spends whatever budget the search left, never a fresh one.
+  let driverAnalysisTimedOut = false
+  targetIds.forEach((targetId, j) => {
+    if (driverAnalysisTimedOut || typeof targetId !== 'string') return
+    const analysis = solutionDriversForTarget(gameType, level, targetId, deadline)
+    if (analysis.timedOut) {
+      // Partial driver analysis must never look like a clean verdict (G3).
+      driverAnalysisTimedOut = true
+      violations.push(deadline.violation())
+      return
+    }
+    if (analysis.drivers.length > 0) return
+    const nearMisses: string[] = []
+    for (const rule of level.rules) {
+      if (!rule.target_elements.includes(targetId)) continue
+      const template = templates.get(rule.template)
+      if (!template) continue
+      const missing = missingBindings(template, rule, elements)
+      if (missing.length > 0) nearMisses.push(`bind ${missing.join(', ')} on rule "${rule.id}"`)
+    }
+    violations.push({
+      severity: 'error',
+      field_path: `win_condition.params.target_elements[${j}]`,
+      constraint: 'solution_path_exists',
+      expected: 'a rule execution path driving this element to the win state',
+      actual: `no rule execution drives "${targetId}" to the win state`,
+      suggestion:
+        nearMisses.length > 0
+          ? nearMisses.join('; ')
+          : `Add a rule instance targeting "${targetId}" with complete bindings`,
+      related_elements: [targetId],
+    })
+  })
+
+  return violations
+}
+
+/** Structural checks for optimization_target params: constraints present, states/values declared. */
+function validateOptimizationTargetParams(
+  gameType: GameType,
+  params: Record<string, unknown>
+): Violation[] {
+  const violations: Violation[] = []
+  const atLeast = Array.isArray(params.all_states_at_least) ? params.all_states_at_least : []
+  const countEqual = Array.isArray(params.count_states_equal) ? params.count_states_equal : []
+  if (atLeast.length === 0 && countEqual.length === 0) {
+    violations.push({
+      severity: 'error',
+      field_path: 'win_condition.params',
+      constraint: 'optimization_constraints_declared',
+      expected: 'at least one all_states_at_least or count_states_equal constraint',
+      actual: 'no optimization constraints declared',
+      suggestion: 'Declare the states + target values the care loop must reach',
+    })
+    return violations
+  }
+  const stateValues = (stateName: string): string[] | undefined => {
+    for (const archetype of gameType.element_archetypes) {
+      const state = (archetype.states ?? []).find((s) => s.name === stateName)
+      if (state?.values) return state.values
+    }
+    return undefined
+  }
+  const checkConstraint = (raw: unknown, path: string): void => {
+    if (!isMappingValue(raw)) return
+    const stateName = raw.state
+    const value = raw.value
+    if (typeof stateName !== 'string') return
+    const values = stateValues(stateName)
+    if (!values) {
+      violations.push({
+        severity: 'error',
+        field_path: `${path}.state`,
+        constraint: 'state_declared',
+        expected: 'a declared enum state name of some archetype',
+        actual: stateName,
+        suggestion: 'Reference a state declared in the GameType vocabulary',
+      })
+    } else if (typeof value === 'string' && !values.includes(value)) {
+      violations.push({
+        severity: 'error',
+        field_path: `${path}.value`,
+        constraint: 'state_declared',
+        expected: `one of [${values.join(', ')}]`,
+        actual: value,
+        suggestion: `Use a declared value of state "${stateName}"`,
+      })
+    }
+  }
+  atLeast.forEach((raw, j) =>
+    checkConstraint(raw, `win_condition.params.all_states_at_least[${j}]`)
+  )
+  countEqual.forEach((raw, j) =>
+    checkConstraint(raw, `win_condition.params.count_states_equal[${j}]`)
+  )
+  return violations
+}
+
+/**
+ * Per-kind binding completeness — near-miss DIAGNOSTICS for failed
+ * searches, following the canonical binding shapes of the spec Mechanism
+ * binding contract: temporal_sequence needs every step param bound (element
+ * refs resolving); condition_action needs a non-empty predicates[] with
+ * declared params inlined; state_transition / interaction_matrix need a
+ * non-empty transitions[] / matrix[].
+ */
+function missingBindings(
+  template: RuleTemplate,
+  rule: LevelRule,
+  elements: Map<string, LevelElement>
+): string[] {
+  switch (template.type) {
+    case 'temporal_sequence': {
+      const missing: string[] = []
+      for (const param of template.sequence_schema.step_schema.params) {
+        const value = rule.bindings[param.name]
+        if (value === undefined || value === null) {
+          missing.push(param.name)
+          continue
+        }
+        if (param.type === 'string' && param.name.endsWith('_id')) {
+          if (typeof value !== 'string' || !elements.has(value)) missing.push(param.name)
+        }
+      }
+      return missing
+    }
+    case 'condition_action': {
+      const predicates = rule.bindings.predicates
+      if (!Array.isArray(predicates) || predicates.length === 0) return ['predicates']
+      const declared = new Map(template.condition_schema.predicates.map((p) => [p.name, p]))
+      const missing: string[] = []
+      predicates.forEach((entry, j) => {
+        if (!isMappingValue(entry)) {
+          missing.push(`predicates[${j}]`)
+          return
+        }
+        const { name, ...inlined } = entry
+        const predicate = typeof name === 'string' ? declared.get(name) : undefined
+        if (!predicate) {
+          missing.push(`predicates[${j}].name`)
+          return
+        }
+        for (const param of predicate.params) {
+          const value = inlined[param.name]
+          if (value === undefined || value === null) {
+            missing.push(`predicates[${j}].${param.name}`)
+          } else if (
+            param.type === 'string' &&
+            param.name.endsWith('_id') &&
+            (typeof value !== 'string' || !elements.has(value))
+          ) {
+            missing.push(`predicates[${j}].${param.name}`)
+          }
+        }
+      })
+      return missing
+    }
+    case 'state_transition':
+      return Array.isArray(rule.bindings.transitions) && rule.bindings.transitions.length > 0
+        ? []
+        : ['transitions']
+    case 'interaction_matrix':
+      return Array.isArray(rule.bindings.matrix) && rule.bindings.matrix.length > 0
+        ? []
+        : ['matrix']
+  }
+}

--- a/packages/creation/src/validate/sound-garden.test.ts
+++ b/packages/creation/src/validate/sound-garden.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Sound Garden validator tests: the second co-play form flowing through the
+ * catalog-enumerated floor mechanism. Golden gate: all universal checks +
+ * BOTH co_build floors literally pass (overall 'pass' + publish_ready), and
+ * the report contains ONLY co_build's floors — the hidden_info pair must
+ * not activate. Bad samples per floor check.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { GameSession } from '../engine/engine'
+import { searchSolution } from '../engine/search'
+import { loadGameType, loadLevel } from '../schema/load'
+import type { CheckId, CheckResult, GameType, Level, ValidationReport } from '../schema/types'
+import { validateGameType, validateLevel } from './validate'
+
+const fixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'sound-garden'
+)
+const gameType = loadGameType(readFileSync(join(fixturesDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(fixturesDir, 'level.sg-demo-001.yaml'), 'utf8'))
+
+function checkOf(report: ValidationReport, checkType: CheckId): CheckResult {
+  const check = report.checks.find((c) => c.check_type === checkType)
+  if (!check) throw new Error(`check ${checkType} missing from report`)
+  return check
+}
+
+function cloneLevel(): Level {
+  return structuredClone(level)
+}
+
+function cloneGameType(): GameType {
+  return structuredClone(gameType)
+}
+
+describe('sound-garden golden gate (sg-demo-001)', () => {
+  const report = validateLevel(gameType, level)
+
+  it('reaches overall pass + publish_ready with every activated check passing', () => {
+    for (const check of report.checks) {
+      expect(`${String(check.check_type)}:${check.verdict}`).toBe(
+        `${String(check.check_type)}:pass`
+      )
+    }
+    expect(report.overall_verdict).toBe('pass')
+    expect(report.publish_ready).toBe(true)
+  })
+
+  it('activates ONLY the co_build floors — never the hidden_info pair', () => {
+    const checkTypes = report.checks.map((check) => check.check_type)
+    expect(checkTypes).toContain('goal_reachability')
+    expect(checkTypes).toContain('progress_measurability')
+    expect(checkTypes).toContain('construction_visibility')
+    expect(checkTypes).not.toContain('communication_completeness')
+    expect(checkTypes).not.toContain('verbal_distinguishability')
+    expect(report.checks).toHaveLength(7)
+  })
+
+  it('passes the registration-time gametype_consistency gate', () => {
+    expect(validateGameType(gameType).verdict).toBe('pass')
+  })
+})
+
+describe('goal_reachability failures', () => {
+  it('flags a target beyond the best achievable build', () => {
+    const bad = cloneLevel()
+    bad.win_condition.params.target_score = 99
+    const check = checkOf(validateLevel(gameType, bad), 'goal_reachability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'goal_reachable')
+    expect(violation?.field_path).toBe('win_condition.params.target_score')
+    expect(violation?.expected).toContain('12') // max_possible_score per the spec worked example
+    expect(violation?.suggestion).toContain('target_score')
+  })
+
+  it('warns when even the worst assignment reaches the target (trivial goal)', () => {
+    const bad = cloneLevel()
+    bad.win_condition.params.target_score = 1 // min_possible_score is 2
+    const report = validateLevel(gameType, bad)
+    const check = checkOf(report, 'goal_reachability')
+    expect(check.verdict).toBe('warn')
+    const violation = check.violations.find((v) => v.constraint === 'goal_non_trivial')
+    expect(violation?.severity).toBe('warning')
+    expect(violation?.actual).toContain('2')
+    expect(report.publish_ready).toBe(false)
+  })
+
+  it('flags a missing material-pool declaration', () => {
+    const bad = cloneLevel()
+    delete bad.available_materials
+    const check = checkOf(validateLevel(gameType, bad), 'goal_reachability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'material_pools_declared')
+    expect(violation?.field_path).toBe('available_materials')
+  })
+
+  it('flags an oversized material pool (bounded assignment analysis)', () => {
+    const bad = cloneLevel()
+    if (!bad.available_materials) throw new Error('fixture materials missing')
+    bad.available_materials.rhythm_builder[0].count = 9 // 9 + 3 = 12 > 8
+    const check = checkOf(validateLevel(gameType, bad), 'goal_reachability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'material_pool_bounded')
+    expect(violation?.field_path).toBe('available_materials')
+    expect(violation?.actual).toContain('12')
+  })
+
+  it('flags a third material pool (co_build two-pool scope)', () => {
+    const bad = cloneLevel()
+    if (!bad.available_materials) throw new Error('fixture materials missing')
+    bad.available_materials.observer = []
+    const check = checkOf(validateLevel(gameType, bad), 'goal_reachability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'material_pools_declared')
+    expect(violation?.actual).toContain('3')
+  })
+
+  it('flags a stripped scoring source (relation_scores removed)', () => {
+    const badGameType = cloneGameType()
+    const template = badGameType.rule_templates[0]
+    if (template.type !== 'interaction_matrix') throw new Error('fixture template kind')
+    delete template.matrix_schema.relation_scores
+    const report = validateLevel(badGameType, level)
+    expect(
+      checkOf(report, 'goal_reachability').violations.some(
+        (v) => v.constraint === 'score_source_declared'
+      )
+    ).toBe(true)
+    expect(
+      checkOf(report, 'progress_measurability').violations.some(
+        (v) => v.constraint === 'score_source_declared'
+      )
+    ).toBe(true)
+  })
+})
+
+describe('progress_measurability failures', () => {
+  it('flags a non-positive target score (progress denominator)', () => {
+    const bad = cloneLevel()
+    bad.win_condition.params.target_score = 0
+    const check = checkOf(validateLevel(gameType, bad), 'progress_measurability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'progress_computable')
+    expect(violation?.field_path).toBe('win_condition.params.target_score')
+  })
+
+  it('flags a missing construction slot model', () => {
+    const bad = cloneLevel()
+    delete bad.initial_state
+    const check = checkOf(validateLevel(gameType, bad), 'progress_measurability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'construction_model_declared')
+    expect(violation?.field_path).toBe('initial_state')
+  })
+
+  it('flags a designed configuration that cannot reach the target (matrix rows omitted)', () => {
+    const bad = cloneLevel()
+    bad.rules[0].bindings.matrix = [] // no scoring rows — designed build scores 0
+    const check = checkOf(validateLevel(gameType, bad), 'progress_measurability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'designed_goal_score')
+    expect(violation?.actual).toContain('0')
+    expect(violation?.expected).toContain('10')
+  })
+})
+
+describe('construction_visibility failures (F5 co_build floor)', () => {
+  it('passes when both builders see the whole construction space (golden)', () => {
+    const check = checkOf(validateLevel(gameType, level), 'construction_visibility')
+    expect(check.verdict).toBe('pass')
+    expect(check.violations).toEqual([])
+  })
+
+  it('fails a blind builder whose element_views are emptied → publish closed', () => {
+    const bad = cloneLevel()
+    const melody = bad.information_partition.role_assignments.find(
+      (assignment) => assignment.role === 'melody_builder'
+    )
+    if (!melody) throw new Error('fixture role missing')
+    melody.element_views = [] // the melody builder can see nothing of the shared timeline
+    const report = validateLevel(gameType, bad)
+    const check = checkOf(report, 'construction_visibility')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find(
+      (v) => v.constraint === 'builder_sees_construction_space'
+    )
+    expect(violation?.actual).toContain('melody_builder')
+    expect(violation?.actual).toContain('rhythm_piece') // missing coverage names the archetypes
+    expect(violation?.actual).toContain('melody_piece')
+    expect(report.publish_ready).toBe(false)
+  })
+
+  it('fails a builder that sees only its own pieces (misses the partner archetype)', () => {
+    const bad = cloneLevel()
+    const rhythm = bad.information_partition.role_assignments.find(
+      (assignment) => assignment.role === 'rhythm_builder'
+    )
+    if (!rhythm) throw new Error('fixture role missing')
+    // Rhythm builder keeps only rhythm pieces: it cannot observe the melody
+    // half of the shared construction space it must coordinate with.
+    rhythm.element_views = rhythm.element_views.filter((view) => view.element_id.startsWith('r'))
+    const check = checkOf(validateLevel(gameType, bad), 'construction_visibility')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find(
+      (v) => v.constraint === 'builder_sees_construction_space'
+    )
+    expect(violation?.actual).toContain('missing [melody_piece]')
+  })
+})
+
+describe('solver-engine lockstep on construction (M2)', () => {
+  it('a level whose melody pieces no role can place fails solvability AND is engine-unplayable', () => {
+    const badGameType = cloneGameType()
+    const template = badGameType.information_partition_template
+    if (!template) throw new Error('fixture partition template missing')
+    // melody_builder may now only target rhythm pieces: melody pieces
+    // become unplaceable by everyone.
+    const melodyCapability = template.action_capability.find(
+      (entry) => entry.role === 'melody_builder'
+    )
+    if (!melodyCapability) throw new Error('fixture capability missing')
+    melodyCapability.target_archetypes = ['rhythm_piece']
+
+    // Engine cannot play it…
+    const session = new GameSession(badGameType, level)
+    expect(session.performAction('melody_builder', 'place_piece', { element_id: 'm1' }).ok).toBe(
+      false
+    )
+    // …and the solver agrees through the per-archetype capability gate.
+    expect(searchSolution(badGameType, level).solvable).toBe(false)
+    const check = checkOf(validateLevel(badGameType, level), 'solvability')
+    expect(check.verdict).toBe('fail')
+    expect(check.violations.some((v) => v.constraint === 'solution_path_exists')).toBe(true)
+  })
+})

--- a/packages/creation/src/validate/validate.test.ts
+++ b/packages/creation/src/validate/validate.test.ts
@@ -241,6 +241,69 @@ describe('schema_conformance failures', () => {
     expect(violation?.field_path).toBe('rules[0].bindings.cipher_segment_id')
   })
 
+  it('requires every declared temporal_sequence step param to be bound', () => {
+    // decrypt_step declares cipher_segment_id + cipher_key_id; dropping the
+    // key binding used to pass (only PRESENT keys were checked) and still
+    // publish — the level then plays without its solution material.
+    const bad = cloneLevel()
+    delete bad.rules[0].bindings.cipher_key_id
+    const report = validateLevel(gameType, bad)
+    const check = checkOf(report, 'schema_conformance')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'binding_param_required')
+    expect(violation?.field_path).toBe('rules[0].bindings.cipher_key_id')
+    expect(violation?.suggestion).toContain('cipher_key_id')
+    expect(report.publish_ready).toBe(false)
+  })
+
+  it('requires a predicate instantiation to inline every declared param', () => {
+    // {name: plaintext_is_valid_word} with no category used to be accepted —
+    // evaluatePredicates then has nothing to compare and the condition_action
+    // becomes unconditional.
+    const bad = cloneLevel()
+    const verify = bad.rules.find((r) => r.id === 'rule-verify')
+    if (!verify) throw new Error('fixture rule missing')
+    verify.bindings = { ...verify.bindings, predicates: [{ name: 'plaintext_is_valid_word' }] }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'binding_param_required')
+    expect(violation?.field_path).toBe('rules[2].bindings.predicates[0].category')
+    expect(violation?.suggestion).toContain('plaintext_is_valid_word')
+  })
+
+  it('rejects duplicate element instance ids before reference resolution', () => {
+    // A repeated id collapses the element index: rules / win-condition / view
+    // references silently resolve to the LAST instance.
+    const bad = cloneLevel()
+    bad.elements.push({ ...structuredClone(bad.elements[0]) }) // second "seg-1"
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'element_id_unique')
+    expect(violation?.field_path).toBe('elements[5].id')
+    expect(violation?.actual).toContain('elements[0]')
+    expect(violation?.related_elements).toEqual(['seg-1'])
+  })
+
+  it('returns a structural-shape failure (never throws) on malformed collections', () => {
+    // loadLevel only asserts top-level fields PRESENT: `elements: {}` reaches
+    // the validator typed as a Level and used to CRASH the forEach. The
+    // public validator must return the report contract instead.
+    const bad = cloneLevel()
+    bad.elements = {} as unknown as Level['elements']
+    bad.rules = 'nope' as unknown as Level['rules']
+    const report = validateLevel(gameType, bad)
+    expect(report.overall_verdict).toBe('fail')
+    expect(report.publish_ready).toBe(false)
+    expect(report.checks).toHaveLength(1)
+    const check = checkOf(report, 'schema_conformance')
+    expect(check.verdict).toBe('fail')
+    const elementsViolation = check.violations.find((v) => v.field_path === 'elements')
+    expect(elementsViolation?.constraint).toBe('structural_shape')
+    expect(elementsViolation?.suggestion).toContain('elements')
+    expect(check.violations.some((v) => v.field_path === 'rules')).toBe(true)
+    expect(report.level_id).toBe('rc-demo-001')
+  })
+
   it('flags an unregistered co_play_form and appends no floor checks', () => {
     const badGameType = cloneGameType()
     badGameType.co_play_form = 'freeform_jam'
@@ -430,6 +493,24 @@ describe('gametype_consistency failures (registration gate)', () => {
     expect(violation?.field_path).toBe('game_type.action_registry[0].state_effect')
     expect(violation?.expected).toContain('advance_state')
   })
+
+  it('requires an information partition template for hidden_info_coop', () => {
+    // Registering the form without a partition leaves the hidden-info floor
+    // checks with no basis (no role/rule visibility, channels, capabilities).
+    const badGameType = cloneGameType()
+    delete badGameType.information_partition_template
+    const result = validateGameType(badGameType)
+    expect(result.verdict).toBe('fail')
+    const violation = result.violations.find((v) => v.constraint === 'partition_template_required')
+    expect(violation?.field_path).toBe('game_type.information_partition_template')
+    expect(violation?.suggestion).toContain('information_partition_template')
+
+    // Shared-state forms may still omit it (spec: co_build shares all state).
+    const sharedState = cloneGameType()
+    delete sharedState.information_partition_template
+    sharedState.co_play_form = 'co_build'
+    expect(validateGameType(sharedState).verdict).toBe('pass')
+  })
 })
 
 describe('communication_completeness failures', () => {
@@ -452,13 +533,21 @@ describe('communication_completeness failures', () => {
     // Move seg-1's plaintext_category from the decoder (its consuming role)
     // to the listener, and drop the listener→decoder channel: the consumer
     // can neither observe the field nor receive it. fairness still passes —
-    // the listener observes the field, so it is not a guess.
+    // the listener observes the field, so it is not a guess. The listener's
+    // cannot_see entry for the field is lifted so its view is LEGITIMATE
+    // (an over-declared forbidden view is runtime-hidden and filtered — that
+    // case has its own regression below).
     const badGameType = cloneGameType()
     const template = badGameType.information_partition_template
     if (!template) throw new Error('fixture partition template missing')
     template.communication_channels = template.communication_channels.filter(
       (channel) => !(channel.from === 'listener' && channel.to === 'decoder')
     )
+    const listenerRule = template.visibility_rules.find((entry) => entry.role === 'listener')
+    if (!listenerRule) throw new Error('fixture visibility rule missing')
+    for (const entry of listenerRule.cannot_see) {
+      entry.attributes = entry.attributes.filter((attr) => attr !== 'plaintext_category')
+    }
     const bad = cloneLevel()
     const roles = bad.information_partition.role_assignments
     const listenerView = roles
@@ -483,6 +572,64 @@ describe('communication_completeness failures', () => {
     expect(violation?.expected).toContain('decoder')
     expect(violation?.actual).toContain('listener')
     expect(checkOf(report, 'fairness').verdict).toBe('pass')
+  })
+
+  it('rejects two assignments for the SAME role (distinct communicating roles required)', () => {
+    // Two listener assignments (decoder omitted) used to pass the count-only
+    // scope check; decoder-consumed rules were then silently filtered out and
+    // the runtime decoder role had no level view at all.
+    const bad = cloneLevel()
+    bad.information_partition.role_assignments[1].role = 'listener'
+    const report = validateLevel(gameType, bad)
+    const check = checkOf(report, 'communication_completeness')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'distinct_communicating_roles')
+    expect(violation?.field_path).toBe('information_partition.role_assignments')
+    expect(violation?.expected).toContain('decoder')
+    expect(violation?.actual).toContain('listener')
+    expect(report.publish_ready).toBe(false)
+  })
+
+  it('ignores a level view over-declaring a cannot_see field (runtime hides it)', () => {
+    // Move plaintext_category from the decoder to the LISTENER's view while
+    // the GameType cannot_see still forbids the listener from seeing it:
+    // GameSession.getRoleView subtracts cannot_see, so NO runtime view shows
+    // the field. Pre-fix the validator trusted the level view, counted the
+    // listener as a seer, and published a level whose runtime hides the
+    // solve-relevant field from everyone.
+    const bad = cloneLevel()
+    const roles = bad.information_partition.role_assignments
+    const listenerView = roles
+      .find((a) => a.role === 'listener')
+      ?.element_views.find((view) => view.element_id === 'seg-1')
+    const decoderView = roles
+      .find((a) => a.role === 'decoder')
+      ?.element_views.find((view) => view.element_id === 'seg-1')
+    if (!listenerView || !decoderView) throw new Error('fixture views missing')
+    listenerView.visible_attributes = [...listenerView.visible_attributes, 'plaintext_category']
+    decoderView.visible_attributes = decoderView.visible_attributes.filter(
+      (attr) => attr !== 'plaintext_category'
+    )
+    const report = validateLevel(gameType, bad)
+    // fairness: the consumed field is observable by NO role → a guess.
+    const fairness = checkOf(report, 'fairness')
+    expect(fairness.verdict).toBe('fail')
+    expect(
+      fairness.violations.some(
+        (v) =>
+          v.constraint === 'solution_information_observable' &&
+          v.actual.includes('plaintext_category')
+      )
+    ).toBe(true)
+    // coverage: its consuming role can neither see nor receive it.
+    const communication = checkOf(report, 'communication_completeness')
+    expect(communication.verdict).toBe('fail')
+    const coverage = communication.violations.find(
+      (v) =>
+        v.constraint === 'communication_coverage' && v.field_path.includes('plaintext_category')
+    )
+    expect(coverage?.actual).toContain('no role can observe')
+    expect(report.publish_ready).toBe(false)
   })
 
   it('flags merged information admitting two solutions for one target', () => {

--- a/packages/creation/src/validate/validate.test.ts
+++ b/packages/creation/src/validate/validate.test.ts
@@ -1,0 +1,655 @@
+/**
+ * Validator tests: the golden pair (radio-cipher GameType + rc-demo-001
+ * Level) passes all four universal checks AND both hidden_info_coop floor
+ * checks (overall pass + publish_ready); per check at least one injected bad
+ * sample fails with a precise field_path + actionable suggestion;
+ * unimplemented floor ids still surface as explicit 'skipped' results; the
+ * validator never mutates its inputs.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../schema/load'
+import type {
+  CheckId,
+  CheckResult,
+  GameType,
+  Level,
+  StateEffect,
+  ValidationReport,
+} from '../schema/types'
+import { validateGameType, validateLevel } from './validate'
+import { pinyinDistance } from './verbal-distinguishability'
+
+const fixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'radio-cipher'
+)
+
+const gameType = loadGameType(readFileSync(join(fixturesDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(fixturesDir, 'level.rc-demo-001.yaml'), 'utf8'))
+
+function checkOf(report: ValidationReport, checkType: CheckId): CheckResult {
+  const check = report.checks.find((c) => c.check_type === checkType)
+  if (!check) throw new Error(`check ${checkType} missing from report`)
+  return check
+}
+
+function cloneLevel(): Level {
+  return structuredClone(level)
+}
+
+function cloneGameType(): GameType {
+  return structuredClone(gameType)
+}
+
+describe('golden sample (rc-demo-001)', () => {
+  const report = validateLevel(gameType, level)
+
+  it('passes all four universal checks', () => {
+    expect(checkOf(report, 'schema_conformance').verdict).toBe('pass')
+    expect(checkOf(report, 'solvability').verdict).toBe('pass')
+    expect(checkOf(report, 'fairness').verdict).toBe('pass')
+    expect(checkOf(report, 'budget_compliance').verdict).toBe('pass')
+    expect(report.level_id).toBe('rc-demo-001')
+    expect(report.game_type_version).toBe(gameType.version)
+  })
+
+  it('executes the hidden_info_coop floor checks and they pass', () => {
+    expect(report.checks).toHaveLength(6)
+    const communication = checkOf(report, 'communication_completeness')
+    const verbal = checkOf(report, 'verbal_distinguishability')
+    expect(communication.verdict).toBe('pass')
+    expect(verbal.verdict).toBe('pass')
+    expect(communication.violations).toEqual([])
+    expect(verbal.violations).toEqual([])
+  })
+
+  it('reaches the R3 milestone: overall pass + publish_ready with all activated checks passing', () => {
+    expect(report.checks.every((check) => check.verdict === 'pass')).toBe(true)
+    expect(report.overall_verdict).toBe('pass')
+    expect(report.publish_ready).toBe(true)
+  })
+
+  it('still caps overall_verdict at warn while an activated floor check is unimplemented', () => {
+    // A catalog entry naming a floor check with no implementation: it must
+    // surface as 'skipped', cap overall at 'warn', and hold publish closed.
+    const phantomCatalog = [
+      {
+        id: 'hidden_info_coop',
+        floor_checks: ['communication_completeness', 'verbal_distinguishability', 'future_floor'],
+      },
+    ]
+    const phantomReport = validateLevel(gameType, level, phantomCatalog)
+    expect(checkOf(phantomReport, 'future_floor').verdict).toBe('skipped')
+    expect(phantomReport.overall_verdict).toBe('warn')
+    expect(phantomReport.publish_ready).toBe(false)
+  })
+
+  it('reaches pass + publish_ready only when every activated check literally passes', () => {
+    // A catalog whose hidden_info_coop entry activates no floor checks:
+    // all activated checks (the four universal) are literal 'pass'.
+    const floorFreeCatalog = [{ id: 'hidden_info_coop', floor_checks: [] }]
+    const floorFreeReport = validateLevel(gameType, level, floorFreeCatalog)
+    expect(floorFreeReport.checks).toHaveLength(4)
+    expect(floorFreeReport.overall_verdict).toBe('pass')
+    expect(floorFreeReport.publish_ready).toBe(true)
+  })
+
+  it('does not mutate its inputs (read-only invariant)', () => {
+    const gameTypeBefore = JSON.stringify(gameType)
+    const levelBefore = JSON.stringify(level)
+    validateLevel(gameType, level)
+    validateGameType(gameType)
+    expect(JSON.stringify(gameType)).toBe(gameTypeBefore)
+    expect(JSON.stringify(level)).toBe(levelBefore)
+  })
+
+  it('passes the registration-time gametype_consistency gate', () => {
+    const result = validateGameType(gameType)
+    expect(result.check_type).toBe('gametype_consistency')
+    expect(result.verdict).toBe('pass')
+  })
+})
+
+describe('schema_conformance failures', () => {
+  it('flags an enum violation with a precise field path', () => {
+    const bad = cloneLevel()
+    bad.elements[0].params.content_length = 'gigantic'
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'enum_membership')
+    expect(violation?.field_path).toBe('elements[0].params.content_length')
+    expect(violation?.expected).toContain('short')
+    expect(violation?.suggestion).toContain('short')
+  })
+
+  it('flags a game_type_version mismatch (exact version binding)', () => {
+    const bad = cloneLevel()
+    bad.metadata.game_type_version = '9.9.9'
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    const violation = check.violations.find((v) => v.constraint === 'version_binding')
+    expect(violation?.field_path).toBe('metadata.game_type_version')
+    expect(violation?.expected).toBe('1.0.0')
+  })
+
+  it('flags AI-authored nesting beyond the 3-level ceiling', () => {
+    const bad = cloneLevel()
+    bad.elements[0].params.content_length = { deep: 'structure' } as unknown as string
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    const violation = check.violations.find((v) => v.constraint === 'max_nesting_depth')
+    expect(violation?.field_path).toBe('elements[0].params.content_length')
+    expect(violation?.suggestion).toContain('Flatten')
+  })
+
+  it('accepts a botanical-garden-style rule binding verbatim from the spec example', () => {
+    // Template context mirrors the spec's botanical needs_rule; the binding
+    // block below is VERBATIM from the spec's rule-fern-needs worked example.
+    const extendedGameType = cloneGameType()
+    extendedGameType.rule_templates.push({
+      id: 'needs_rule',
+      type: 'condition_action',
+      condition_schema: {
+        predicates: [
+          {
+            name: 'species_is',
+            params: [{ name: 'species', type: 'string' }],
+            description: 'Species equals the given value',
+          },
+          {
+            name: 'in_zone_where',
+            params: [
+              { name: 'zone_attribute', type: 'string' },
+              { name: 'value', type: 'string' },
+            ],
+            description: 'Zone attribute equals the given value',
+          },
+        ],
+        combinators: ['AND', 'OR', 'NOT'],
+      },
+      action_schema: { verbs: ['change_health'] },
+      communication_weight: 2.0,
+    })
+    extendedGameType.action_registry.push({
+      name: 'change_health',
+      description: 'Health state change (engine-internal effect)',
+      params: [{ name: 'new_state', type: 'string' }],
+      scope: 'rule_verb',
+    })
+    const modified = cloneLevel()
+    modified.rules.push({
+      id: 'rule-fern-needs',
+      template: 'needs_rule',
+      bindings: {
+        predicates: [
+          { name: 'species_is', species: 'fern' },
+          { name: 'in_zone_where', zone_attribute: 'light_level', value: 'full_sun' },
+        ],
+        combinator: 'AND',
+        action: { verb: 'change_health', new_state: 'wilting' },
+      },
+      target_elements: ['seg-1'],
+    })
+    const check = checkOf(validateLevel(extendedGameType, modified), 'schema_conformance')
+    expect(check.verdict).toBe('pass')
+  })
+
+  it('rejects a predicates[] entry instantiating an undeclared predicate', () => {
+    const bad = cloneLevel()
+    const verify = bad.rules.find((r) => r.id === 'rule-verify')
+    if (!verify) throw new Error('fixture rule missing')
+    verify.bindings = { predicates: [{ name: 'is_palindrome' }] }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    const violation = check.violations.find((v) => v.constraint === 'predicate_registered')
+    expect(violation?.field_path).toBe('rules[2].bindings.predicates[0].name')
+    expect(violation?.expected).toContain('plaintext_is_valid_word')
+  })
+
+  it('rejects a combinator outside the template-declared set', () => {
+    const bad = cloneLevel()
+    const verify = bad.rules.find((r) => r.id === 'rule-verify')
+    if (!verify) throw new Error('fixture rule missing')
+    verify.bindings = { ...verify.bindings, combinator: 'XOR' }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    const violation = check.violations.find((v) => v.constraint === 'combinator_registered')
+    expect(violation?.field_path).toBe('rules[2].bindings.combinator')
+    expect(violation?.expected).toContain('AND')
+    expect(violation?.suggestion).toContain('default')
+  })
+
+  it('rejects a non-canonical flat binding key on a condition_action rule', () => {
+    const bad = cloneLevel()
+    const verify = bad.rules.find((r) => r.id === 'rule-verify')
+    if (!verify) throw new Error('fixture rule missing')
+    verify.bindings = { category: 'animal' } // pre-canonical flat shape
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    const violation = check.violations.find((v) => v.constraint === 'binding_param_defined')
+    expect(violation?.field_path).toBe('rules[2].bindings.category')
+    expect(violation?.expected).toBe('one of [predicates, combinator, action]')
+  })
+
+  it('rejects an over-deep free value on a declared scalar binding param', () => {
+    const bad = cloneLevel()
+    bad.rules[0].bindings.cipher_segment_id = { deep: { deeper: true } }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    const violation = check.violations.find((v) => v.constraint === 'max_nesting_depth')
+    expect(violation?.field_path).toBe('rules[0].bindings.cipher_segment_id')
+  })
+
+  it('flags an unregistered co_play_form and appends no floor checks', () => {
+    const badGameType = cloneGameType()
+    badGameType.co_play_form = 'freeform_jam'
+    const report = validateLevel(badGameType, level)
+    const violation = checkOf(report, 'schema_conformance').violations.find(
+      (v) => v.constraint === 'co_play_form_registered'
+    )
+    expect(violation?.field_path).toBe('game_type.co_play_form')
+    expect(report.checks).toHaveLength(4)
+    expect(report.overall_verdict).toBe('fail')
+  })
+})
+
+describe('solvability failures', () => {
+  it('flags an uncovered win-condition target element', () => {
+    const bad = cloneLevel()
+    // Retarget the reverse rule at seg-1: seg-2 keeps no rule while every
+    // other check's inputs stay untouched.
+    const reverseRule = bad.rules.find((r) => r.id === 'rule-reverse-2')
+    if (!reverseRule) throw new Error('fixture rule missing')
+    reverseRule.target_elements = ['seg-1']
+    reverseRule.bindings.cipher_segment_id = 'seg-1'
+    const report = validateLevel(gameType, bad)
+    const check = checkOf(report, 'solvability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'solution_path_exists')
+    expect(violation?.field_path).toBe('win_condition.params.target_elements[1]')
+    expect(violation?.actual).toContain('seg-2')
+    expect(violation?.suggestion).toContain('seg-2')
+    // isolation: the other universal checks still pass
+    expect(checkOf(report, 'schema_conformance').verdict).toBe('pass')
+    expect(checkOf(report, 'budget_compliance').verdict).toBe('pass')
+  })
+
+  it('flags an unregistered solver strategy', () => {
+    const badGameType = cloneGameType()
+    badGameType.solver_strategy = 'quantum_annealing'
+    const check = checkOf(validateLevel(badGameType, level), 'solvability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'solver_strategy_registered')
+    expect(violation?.field_path).toBe('game_type.solver_strategy')
+    expect(violation?.actual).toBe('quantum_annealing')
+  })
+
+  it('reports a timeout when the bound is exhausted', () => {
+    const badGameType = cloneGameType()
+    badGameType.solver_timeout_ms = 0
+    const check = checkOf(validateLevel(badGameType, level), 'solvability')
+    expect(check.verdict).toBe('fail')
+    const violations = check.violations.filter((v) => v.constraint === 'solver_timeout')
+    expect(violations).toHaveLength(1)
+    expect(violations[0].field_path).toBe('game_type.solver_timeout_ms')
+  })
+})
+
+describe('fairness failures', () => {
+  it('flags solution-relevant information no role can observe', () => {
+    const bad = cloneLevel()
+    const decoder = bad.information_partition.role_assignments.find((a) => a.role === 'decoder')
+    if (!decoder) throw new Error('fixture role missing')
+    decoder.element_views = decoder.element_views.filter((view) => view.element_id !== 'key-1')
+    const report = validateLevel(gameType, bad)
+    const check = checkOf(report, 'fairness')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find(
+      (v) => v.constraint === 'solution_information_observable'
+    )
+    expect(violation?.field_path).toBe('elements[2]') // key-1
+    expect(violation?.actual).toContain('shift_amount')
+    expect(violation?.actual).toContain('50') // 2 methods x 25 shift values
+    expect(violation?.suggestion).toContain('key-1')
+    expect(violation?.related_elements).toEqual(['key-1'])
+    // isolation: schema and budget do not consult level-side views
+    expect(checkOf(report, 'schema_conformance').verdict).toBe('pass')
+    expect(checkOf(report, 'budget_compliance').verdict).toBe('pass')
+  })
+
+  it('ignores hidden params no referencing rule consumes (cosmetic information)', () => {
+    const modified = cloneLevel()
+    // Reference hint-2 as a target of the verify rule and hide it entirely:
+    // its params (hint_type / target_syllable) never appear among the rule's
+    // binding values, so hiding them costs no fairness violation.
+    const verify = modified.rules.find((r) => r.id === 'rule-verify')
+    if (!verify) throw new Error('fixture rule missing')
+    verify.target_elements = [...verify.target_elements, 'hint-2']
+    const decoder = modified.information_partition.role_assignments.find(
+      (a) => a.role === 'decoder'
+    )
+    if (!decoder) throw new Error('fixture role missing')
+    decoder.element_views = decoder.element_views.filter((view) => view.element_id !== 'hint-2')
+    const report = validateLevel(gameType, modified)
+    expect(checkOf(report, 'fairness').verdict).toBe('pass')
+  })
+})
+
+describe('budget_compliance failures', () => {
+  it('flags a shared-label instance collision with the spec suggestion', () => {
+    const bad = cloneLevel()
+    bad.elements[1].params.content_length = 'short' // collides with seg-1
+    const report = validateLevel(gameType, bad)
+    const check = checkOf(report, 'budget_compliance')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'instance_label_unique')
+    expect(violation?.field_path).toBe('elements[1].params.content_length')
+    expect(violation?.related_elements).toEqual(['seg-1', 'seg-2'])
+    expect(violation?.suggestion).toContain('disambiguating attribute')
+    // isolation: 'short' is a legal enum value, so schema still passes
+    expect(checkOf(report, 'schema_conformance').verdict).toBe('pass')
+    expect(checkOf(report, 'fairness').verdict).toBe('pass')
+    expect(checkOf(report, 'solvability').verdict).toBe('pass')
+  })
+
+  it('flags declared counts that diverge from the actual level content', () => {
+    const bad = cloneLevel()
+    bad.difficulty.element_count = 7
+    const check = checkOf(validateLevel(gameType, bad), 'budget_compliance')
+    const violation = check.violations.find(
+      (v) =>
+        v.field_path === 'difficulty.element_count' && v.constraint === 'declared_matches_actual'
+    )
+    expect(violation?.expected).toBe('5')
+    expect(violation?.actual).toBe('7')
+  })
+
+  it('flags a stale communication estimate', () => {
+    const bad = cloneLevel()
+    bad.communication_estimate.round_trips = 9
+    const check = checkOf(validateLevel(gameType, bad), 'budget_compliance')
+    const violation = check.violations.find(
+      (v) =>
+        v.field_path === 'communication_estimate.round_trips' &&
+        v.constraint === 'declared_matches_actual'
+    )
+    expect(violation?.expected).toContain('5')
+    expect(violation?.suggestion).toContain('communication_weight')
+  })
+
+  it('flags a Level time limit diverging from the GameType communication budget', () => {
+    const bad = cloneLevel()
+    bad.communication_estimate.time_limit_seconds = 600 // inflated — cannot buy feasibility
+    const check = checkOf(validateLevel(gameType, bad), 'budget_compliance')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find(
+      (v) => v.field_path === 'communication_estimate.time_limit_seconds'
+    )
+    expect(violation?.expected).toBe('300')
+    expect(violation?.actual).toBe('600')
+    expect(violation?.suggestion).toContain('communication_budget')
+  })
+})
+
+describe('gametype_consistency failures (registration gate)', () => {
+  it('flags an action_capability referencing an unregistered action', () => {
+    const badGameType = cloneGameType()
+    const template = badGameType.information_partition_template
+    if (!template) throw new Error('fixture partition template missing')
+    template.action_capability[0].can_perform.push('fly')
+    const result = validateGameType(badGameType)
+    expect(result.verdict).toBe('fail')
+    const violation = result.violations.find((v) => v.constraint === 'action_registered')
+    expect(violation?.field_path).toBe(
+      'game_type.information_partition_template.action_capability[0].can_perform[2]'
+    )
+    expect(violation?.suggestion).toContain('action_registry')
+  })
+
+  it('flags a shared-label attribute invisible to a communicating role', () => {
+    const badGameType = cloneGameType()
+    const template = badGameType.information_partition_template
+    if (!template) throw new Error('fixture partition template missing')
+    // Declare plaintext_category as a shared label source — the listener
+    // cannot see it, so cross-role co-reference would break.
+    template.shared_label_attributes[0].attributes.push('plaintext_category')
+    const result = validateGameType(badGameType)
+    expect(result.verdict).toBe('fail')
+    const violation = result.violations.find((v) => v.constraint === 'shared_label_visible_to_all')
+    expect(violation?.actual).toContain('listener')
+    expect(violation?.suggestion).toContain('can_see')
+  })
+
+  it('flags an undeclared state_effect value (G6 enum guard)', () => {
+    const badGameType = cloneGameType()
+    badGameType.action_registry[0].state_effect = 'advnce_state' as StateEffect
+    const result = validateGameType(badGameType)
+    expect(result.verdict).toBe('fail')
+    const violation = result.violations.find((v) => v.constraint === 'state_effect_registered')
+    expect(violation?.field_path).toBe('game_type.action_registry[0].state_effect')
+    expect(violation?.expected).toContain('advance_state')
+  })
+})
+
+describe('communication_completeness failures', () => {
+  it('passes when a decoder-only field has no reverse channel (per-consuming-role model)', () => {
+    // key-1's fields are decoder-consumed (the decoder holds the rules per
+    // rule_visibility) and decoder-visible: the listener receives derived
+    // instructions, never the raw fields. Removing the decoder→listener
+    // channel therefore must NOT produce a coverage violation.
+    const badGameType = cloneGameType()
+    const template = badGameType.information_partition_template
+    if (!template) throw new Error('fixture partition template missing')
+    template.communication_channels = template.communication_channels.filter(
+      (channel) => !(channel.from === 'decoder' && channel.to === 'listener')
+    )
+    const check = checkOf(validateLevel(badGameType, level), 'communication_completeness')
+    expect(check.verdict).toBe('pass')
+  })
+
+  it('flags a consumed field its consuming role can neither see nor receive', () => {
+    // Move seg-1's plaintext_category from the decoder (its consuming role)
+    // to the listener, and drop the listener→decoder channel: the consumer
+    // can neither observe the field nor receive it. fairness still passes —
+    // the listener observes the field, so it is not a guess.
+    const badGameType = cloneGameType()
+    const template = badGameType.information_partition_template
+    if (!template) throw new Error('fixture partition template missing')
+    template.communication_channels = template.communication_channels.filter(
+      (channel) => !(channel.from === 'listener' && channel.to === 'decoder')
+    )
+    const bad = cloneLevel()
+    const roles = bad.information_partition.role_assignments
+    const listenerView = roles
+      .find((a) => a.role === 'listener')
+      ?.element_views.find((view) => view.element_id === 'seg-1')
+    const decoderView = roles
+      .find((a) => a.role === 'decoder')
+      ?.element_views.find((view) => view.element_id === 'seg-1')
+    if (!listenerView || !decoderView) throw new Error('fixture views missing')
+    listenerView.visible_attributes = [...listenerView.visible_attributes, 'plaintext_category']
+    decoderView.visible_attributes = decoderView.visible_attributes.filter(
+      (attr) => attr !== 'plaintext_category'
+    )
+    const report = validateLevel(badGameType, bad)
+    const check = checkOf(report, 'communication_completeness')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find(
+      (v) =>
+        v.constraint === 'communication_coverage' && v.field_path.includes('plaintext_category')
+    )
+    expect(violation?.field_path).toBe('elements[0].params.plaintext_category')
+    expect(violation?.expected).toContain('decoder')
+    expect(violation?.actual).toContain('listener')
+    expect(checkOf(report, 'fairness').verdict).toBe('pass')
+  })
+
+  it('flags merged information admitting two solutions for one target', () => {
+    const bad = cloneLevel()
+    // A second executable advancing pipeline on seg-1: caesar decryption AND
+    // reverse decryption both fit the merged information.
+    bad.rules.push({
+      id: 'rule-reverse-1b',
+      template: 'reverse_decrypt',
+      bindings: { cipher_segment_id: 'seg-1' },
+      target_elements: ['seg-1'],
+    })
+    const check = checkOf(validateLevel(gameType, bad), 'communication_completeness')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'solution_unique')
+    expect(violation?.field_path).toBe('win_condition.params.target_elements[0]')
+    expect(violation?.actual).toContain('rule-decrypt-1')
+    expect(violation?.actual).toContain('rule-reverse-1b')
+    expect(violation?.suggestion).toContain('single solution')
+  })
+
+  it('rejects partitions outside the two-role scope and still checks surface versions', () => {
+    const bad = cloneLevel()
+    bad.information_partition.role_assignments.push({ role: 'observer', element_views: [] })
+    bad.communication_surfaces = [
+      {
+        role: 'listener',
+        game_type: 'radio-cipher',
+        game_type_version: '0.9.0',
+        surface_type: 'audio_cue_list',
+        content: {
+          elements_visible: [],
+          rules_visible: [],
+          action_vocabulary: [],
+          communication_protocol: { partner_role: 'decoder', suggested_workflow: [] },
+        },
+      },
+    ]
+    const check = checkOf(validateLevel(gameType, bad), 'communication_completeness')
+    expect(check.verdict).toBe('fail')
+    const scopeViolation = check.violations.find((v) => v.constraint === 'two_role_scope')
+    expect(scopeViolation?.field_path).toBe('information_partition.role_assignments')
+    expect(scopeViolation?.actual).toContain('3')
+    // Both defects surface in one pass: version binding is not short-circuited.
+    const versionViolation = check.violations.find((v) => v.constraint === 'version_binding')
+    expect(versionViolation?.field_path).toBe('communication_surfaces[0].game_type_version')
+  })
+
+  it('reports a timeout from the uniqueness sub-check instead of fake-passing', () => {
+    const badGameType = cloneGameType()
+    badGameType.solver_timeout_ms = 0
+    const check = checkOf(validateLevel(badGameType, level), 'communication_completeness')
+    expect(check.verdict).toBe('fail')
+    const violations = check.violations.filter((v) => v.constraint === 'solver_timeout')
+    expect(violations).toHaveLength(1)
+    expect(violations[0].field_path).toBe('game_type.solver_timeout_ms')
+  })
+
+  it('flags a communication surface bound to a stale game-type version', () => {
+    const bad = cloneLevel()
+    bad.communication_surfaces = [
+      {
+        role: 'listener',
+        game_type: 'radio-cipher',
+        game_type_version: '0.9.0',
+        surface_type: 'audio_cue_list',
+        content: {
+          elements_visible: [],
+          rules_visible: [],
+          action_vocabulary: [],
+          communication_protocol: { partner_role: 'decoder', suggested_workflow: [] },
+        },
+      },
+    ]
+    const check = checkOf(validateLevel(gameType, bad), 'communication_completeness')
+    const violation = check.violations.find((v) => v.constraint === 'version_binding')
+    expect(violation?.field_path).toBe('communication_surfaces[0].game_type_version')
+    expect(violation?.expected).toBe('1.0.0')
+  })
+})
+
+describe('verbal_distinguishability', () => {
+  it('measures syllable+tone edit distance with tone differences extra-weighted', () => {
+    expect(pinyinDistance('mì yào', 'mì yào')).toBe(0)
+    expect(pinyinDistance('mì yào', 'mì yáo')).toBeCloseTo(0.4) // tone-only: near-homophone
+    expect(pinyinDistance('mì wén duàn', 'mì yào')).toBe(2) // one substitution + one deletion
+    expect(pinyinDistance('mì yào', 'pín lǜ tí shì')).toBe(4)
+  })
+
+  it('normalizes numeric-tone pinyin to the tone-marked form', () => {
+    expect(pinyinDistance('mi4 yao4', 'mì yào')).toBe(0)
+    expect(pinyinDistance('lv4', 'lǜ')).toBe(0)
+    expect(pinyinDistance('mi4 yao2', 'mì yào')).toBeCloseTo(0.4) // numeric tone still scores
+  })
+
+  it('warns on near-homophone archetype labels (archetype layer)', () => {
+    const badGameType = cloneGameType()
+    // 密药 (mì yào) collides with 密钥 (mì yào) at distance 0.
+    badGameType.element_archetypes[2].verbal_label = {
+      canonical: '密药',
+      phonetic_pinyin: 'mì yào',
+      aliases: [],
+      forbidden_terms: [],
+    }
+    const report = validateLevel(badGameType, level)
+    const check = checkOf(report, 'verbal_distinguishability')
+    expect(check.verdict).toBe('warn')
+    const violation = check.violations.find((v) => v.constraint === 'verbal_distance_threshold')
+    expect(violation?.severity).toBe('warning')
+    expect(violation?.field_path).toBe(
+      'game_type.element_archetypes[2].verbal_label.phonetic_pinyin'
+    )
+    expect(violation?.actual).toContain('密药')
+    // A warn-level floor check keeps overall at warn and publish closed.
+    expect(report.overall_verdict).toBe('warn')
+    expect(report.publish_ready).toBe(false)
+  })
+
+  it('errors on colliding rendered instance labels (instance layer)', () => {
+    const bad = cloneLevel()
+    bad.elements[1].params.content_length = 'short' // both segments render 短密文段
+    const check = checkOf(validateLevel(gameType, bad), 'verbal_distinguishability')
+    expect(check.verdict).toBe('fail')
+    const violation = check.violations.find((v) => v.constraint === 'rendered_label_unique')
+    expect(violation?.field_path).toBe('elements[1]')
+    expect(violation?.actual).toContain('短密文段')
+    expect(violation?.related_elements).toEqual(['seg-1', 'seg-2'])
+  })
+
+  it('catches distinct raw values whose display labels collide — and only at the rendered layer', () => {
+    // Two DISTINCT raw values (short / medium) both display as 短: the raw
+    // combos stay unique (budget_compliance silent) while the rendered
+    // labels collide (verbal_distinguishability fires) — the layers are
+    // complementary, not redundant.
+    const badGameType = cloneGameType()
+    const contentLength = badGameType.element_archetypes[0].attributes.find(
+      (attr) => attr.name === 'content_length'
+    )
+    if (!contentLength) throw new Error('fixture attribute missing')
+    contentLength.display_labels = { short: '短', medium: '短', long: '长' }
+    const report = validateLevel(badGameType, level)
+    const verbal = checkOf(report, 'verbal_distinguishability')
+    expect(verbal.verdict).toBe('fail')
+    const rendered = verbal.violations.find((v) => v.constraint === 'rendered_label_unique')
+    expect(rendered?.actual).toContain('短密文段')
+    expect(rendered?.related_elements).toEqual(['seg-1', 'seg-2'])
+    const budget = checkOf(report, 'budget_compliance')
+    expect(budget.violations.find((v) => v.constraint === 'instance_label_unique')).toBeUndefined()
+    expect(budget.verdict).toBe('pass')
+  })
+})
+
+describe('violation contract', () => {
+  it('every emitted violation carries field_path and suggestion (spec invariant)', () => {
+    const bad = cloneLevel()
+    bad.elements[0].params.content_length = 'gigantic'
+    bad.metadata.game_type_version = '9.9.9'
+    bad.difficulty.element_count = 7
+    const reverseRule = bad.rules.find((r) => r.id === 'rule-reverse-2')
+    if (!reverseRule) throw new Error('fixture rule missing')
+    reverseRule.target_elements = ['seg-1']
+    const report = validateLevel(gameType, bad)
+    const allViolations = report.checks.flatMap((check) => check.violations)
+    expect(allViolations.length).toBeGreaterThan(0)
+    for (const violation of allViolations) {
+      expect(violation.field_path.length).toBeGreaterThan(0)
+      expect(violation.suggestion.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/creation/src/validate/validate.ts
+++ b/packages/creation/src/validate/validate.ts
@@ -11,6 +11,10 @@
  * 'warn' (never 'pass'), and publish_ready is true only when every check —
  * universal and activated floor alike — is a literal 'pass'.
  *
+ * A structural shape gate runs before everything: malformed top-level
+ * collections short-circuit into a schema_conformance failure (report
+ * contract), never an exception (see levelShapeViolations).
+ *
  * The validator is strictly read-only over both inputs (spec invariant:
  * validators never modify the Level).
  */
@@ -29,8 +33,9 @@ import { checkCommunicationCompleteness } from './communication-completeness'
 import { checkConstructionVisibility } from './construction-visibility'
 import { checkFairness } from './fairness'
 import { checkGoalReachability } from './goal-reachability'
+import { buildCheckResult, isMappingValue } from './helpers'
 import { checkProgressMeasurability } from './progress-measurability'
-import { checkSchemaConformance } from './schema-conformance'
+import { checkSchemaConformance, levelShapeViolations } from './schema-conformance'
 import { checkSolvability } from './solvability'
 import { checkVerbalDistinguishability } from './verbal-distinguishability'
 
@@ -55,6 +60,25 @@ export function validateLevel(
   level: Level,
   catalog: CoPlayFormCatalog = SEED_CO_PLAY_FORM_CATALOG
 ): ValidationReport {
+  // Structural shape gate FIRST: malformed collections (elements: {}, …)
+  // would make the semantic checks throw. Surface them as a
+  // schema_conformance failure — the report contract, never an exception —
+  // and short-circuit (nothing downstream can interpret the shapes).
+  const shapeViolations = levelShapeViolations(level)
+  if (shapeViolations.length > 0) {
+    const metadata: Partial<Level['metadata']> = isMappingValue(level.metadata)
+      ? level.metadata
+      : {}
+    return {
+      level_id: String(metadata.id ?? ''),
+      game_type: String(metadata.game_type ?? ''),
+      game_type_version: String(metadata.game_type_version ?? ''),
+      overall_verdict: 'fail',
+      publish_ready: false,
+      checks: [buildCheckResult('schema_conformance', shapeViolations)],
+    }
+  }
+
   const checks: CheckResult[] = [
     checkSchemaConformance(gameType, level, catalog),
     checkSolvability(gameType, level),

--- a/packages/creation/src/validate/validate.ts
+++ b/packages/creation/src/validate/validate.ts
@@ -1,0 +1,96 @@
+/**
+ * Level validation entry (spec Mechanism 3 validator contract).
+ *
+ * Runs the four universal checks and enumerates the GameType's co-play-form
+ * floor checks from the catalog registry — never a hardcoded form→checks
+ * mapping. Enumerated floor ids execute through the implemented-checks
+ * registry (both the hidden_info_coop pair and the co_build pair are
+ * implemented); ids for later forms without an implementation are emitted
+ * with verdict 'skipped': explicitly present in the report, never silently
+ * absent, never a fake pass. Any skipped check caps overall_verdict at
+ * 'warn' (never 'pass'), and publish_ready is true only when every check —
+ * universal and activated floor alike — is a literal 'pass'.
+ *
+ * The validator is strictly read-only over both inputs (spec invariant:
+ * validators never modify the Level).
+ */
+
+import type {
+  CheckResult,
+  CoPlayFormCatalog,
+  GameType,
+  Level,
+  ValidationReport,
+  Verdict,
+} from '../schema/types'
+import { SEED_CO_PLAY_FORM_CATALOG } from '../schema/types'
+import { checkBudgetCompliance } from './budget-compliance'
+import { checkCommunicationCompleteness } from './communication-completeness'
+import { checkConstructionVisibility } from './construction-visibility'
+import { checkFairness } from './fairness'
+import { checkGoalReachability } from './goal-reachability'
+import { checkProgressMeasurability } from './progress-measurability'
+import { checkSchemaConformance } from './schema-conformance'
+import { checkSolvability } from './solvability'
+import { checkVerbalDistinguishability } from './verbal-distinguishability'
+
+export { validateGameType } from './gametype-consistency'
+
+/**
+ * Implemented floor checks (hidden_info_coop pair + co_build trio). The
+ * CoPlayFormCatalog stays the single enumeration source — this registry
+ * only decides whether an enumerated id executes or surfaces as 'skipped'.
+ */
+const IMPLEMENTED_FLOOR_CHECKS: Record<string, (gameType: GameType, level: Level) => CheckResult> =
+  {
+    communication_completeness: checkCommunicationCompleteness,
+    verbal_distinguishability: checkVerbalDistinguishability,
+    goal_reachability: checkGoalReachability,
+    progress_measurability: checkProgressMeasurability,
+    construction_visibility: checkConstructionVisibility,
+  }
+
+export function validateLevel(
+  gameType: GameType,
+  level: Level,
+  catalog: CoPlayFormCatalog = SEED_CO_PLAY_FORM_CATALOG
+): ValidationReport {
+  const checks: CheckResult[] = [
+    checkSchemaConformance(gameType, level, catalog),
+    checkSolvability(gameType, level),
+    checkFairness(gameType, level),
+    checkBudgetCompliance(gameType, level),
+  ]
+
+  const form = catalog.find((entry) => entry.id === gameType.co_play_form)
+  for (const floorCheckId of form?.floor_checks ?? []) {
+    const implementation = IMPLEMENTED_FLOOR_CHECKS[floorCheckId]
+    checks.push(
+      implementation
+        ? implementation(gameType, level)
+        : { check_type: floorCheckId, verdict: 'skipped', violations: [] }
+    )
+  }
+
+  return {
+    level_id: level.metadata.id,
+    game_type: level.metadata.game_type,
+    game_type_version: level.metadata.game_type_version,
+    overall_verdict: aggregateVerdict(checks),
+    publish_ready: checks.every((check) => check.verdict === 'pass'),
+    checks,
+  }
+}
+
+/**
+ * A skipped check is "not evaluated", never "pass": it caps the overall
+ * verdict at 'warn' so a spec-literal pass gate can never ship a level
+ * whose activated floor checks did not run.
+ */
+function aggregateVerdict(checks: CheckResult[]): Verdict {
+  const evaluated = checks.filter((check) => check.verdict !== 'skipped')
+  if (evaluated.some((check) => check.verdict === 'fail')) return 'fail'
+  const anySkipped = evaluated.length !== checks.length
+  if (anySkipped || evaluated.some((check) => check.verdict === 'warn')) return 'warn'
+  return 'pass'
+}

--- a/packages/creation/src/validate/verbal-distinguishability.ts
+++ b/packages/creation/src/validate/verbal-distinguishability.ts
@@ -1,0 +1,206 @@
+/**
+ * verbal_distinguishability — hidden_info_coop floor check (spec Mechanism 3).
+ *
+ * Archetype layer: pairwise pinyin syllable+tone edit distance between the
+ * GameType's canonical verbal labels (phonetic_pinyin is the metric's sole,
+ * unambiguous input — it records the platform's chosen colloquial reading).
+ * Distance below threshold → WARNING per spec.
+ *
+ * Instance layer: rendered instance labels — shared_label_attributes values
+ * rendered through display_labels + verbal_template — must be unique among
+ * same-archetype instances in the level. A rendered collision → ERROR (it
+ * blocks voice co-reference outright). This is the rendered-level
+ * counterpart of budget_compliance's raw-value uniqueness check, and it
+ * catches two distinct raw values whose display labels collide. Phonetic
+ * distance at the instance layer needs pinyin for display labels, which the
+ * schema does not declare — the spec's Open Questions propose an optional
+ * display_label_pinyin map as the unblock; until it settles, v1 implements
+ * the exact rendered-collision half only.
+ *
+ * Metric: syllable is the edit unit (Levenshtein over syllable sequences,
+ * insertion/deletion cost 1); a same-base tone-only difference costs 0.4 —
+ * tones are extra-weighted as smaller-than-syllable distances, so
+ * near-homophones (mì yào / mì yáo → 0.4) land far below a full-syllable
+ * change. PROVISIONAL threshold 1.0: two labels must differ by at least one
+ * full syllable (a tone-only or zero difference flags). Justified against
+ * the radio-cipher vocabulary: its label pairs sit at distance ≥ 2.0.
+ * Experimental calibration remains declared design debt (spec Open
+ * Questions).
+ */
+
+import type { CheckResult, ElementArchetype, GameType, Level, Violation } from '../schema/types'
+import { buildCheckResult } from './helpers'
+
+const DISTANCE_THRESHOLD = 1.0
+const TONE_SUBSTITUTION_COST = 0.4
+
+const TONE_MARKS: Record<string, [string, number]> = {
+  ā: ['a', 1],
+  á: ['a', 2],
+  ǎ: ['a', 3],
+  à: ['a', 4],
+  ē: ['e', 1],
+  é: ['e', 2],
+  ě: ['e', 3],
+  è: ['e', 4],
+  ī: ['i', 1],
+  í: ['i', 2],
+  ǐ: ['i', 3],
+  ì: ['i', 4],
+  ō: ['o', 1],
+  ó: ['o', 2],
+  ǒ: ['o', 3],
+  ò: ['o', 4],
+  ū: ['u', 1],
+  ú: ['u', 2],
+  ǔ: ['u', 3],
+  ù: ['u', 4],
+  ǖ: ['ü', 1],
+  ǘ: ['ü', 2],
+  ǚ: ['ü', 3],
+  ǜ: ['ü', 4],
+}
+
+interface Syllable {
+  base: string
+  tone: number
+}
+
+function parseSyllables(pinyin: string): Syllable[] {
+  return pinyin
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((s) => s.length > 0)
+    .map(parseSyllable)
+}
+
+/**
+ * Accepts both tone-marked ("mì") and numeric-tone ("mi4") pinyin forms,
+ * normalized to one representation so mixed inputs never silently
+ * mis-score (numeric tone 5 means neutral, like 0; "v" normalizes to "ü").
+ */
+function parseSyllable(raw: string): Syllable {
+  let base = ''
+  let tone = 0
+  for (const char of raw) {
+    const marked = TONE_MARKS[char]
+    if (marked) {
+      base += marked[0]
+      tone = marked[1]
+    } else {
+      base += char
+    }
+  }
+  const numeric = base.match(/^([a-zü]+)([0-5])$/)
+  if (numeric) {
+    base = numeric[1]
+    const digit = Number(numeric[2])
+    tone = digit === 5 ? 0 : digit
+  }
+  return { base: base.replace(/v/g, 'ü'), tone }
+}
+
+/**
+ * Syllable+tone edit distance between two phonetic_pinyin strings:
+ * Levenshtein over syllables; substitution costs 0 (identical), 0.4
+ * (same base, different tone), or 1 (different base); ins/del cost 1.
+ */
+export function pinyinDistance(a: string, b: string): number {
+  const sa = parseSyllables(a)
+  const sb = parseSyllables(b)
+  const rows = sa.length + 1
+  const cols = sb.length + 1
+  const dp: number[][] = Array.from({ length: rows }, () => new Array<number>(cols).fill(0))
+  for (let i = 1; i < rows; i++) dp[i][0] = i
+  for (let j = 1; j < cols; j++) dp[0][j] = j
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const x = sa[i - 1]
+      const y = sb[j - 1]
+      const substitution = x.base === y.base ? (x.tone === y.tone ? 0 : TONE_SUBSTITUTION_COST) : 1
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + substitution)
+    }
+  }
+  return dp[rows - 1][cols - 1]
+}
+
+export function checkVerbalDistinguishability(gameType: GameType, level: Level): CheckResult {
+  const violations: Violation[] = []
+
+  // Archetype layer: pairwise canonical-label distance over the vocabulary.
+  const archetypes = gameType.element_archetypes
+  for (let i = 0; i < archetypes.length; i++) {
+    for (let j = i + 1; j < archetypes.length; j++) {
+      const a = archetypes[i].verbal_label
+      const b = archetypes[j].verbal_label
+      const distance = pinyinDistance(a.phonetic_pinyin, b.phonetic_pinyin)
+      if (distance < DISTANCE_THRESHOLD) {
+        violations.push({
+          severity: 'warning',
+          field_path: `game_type.element_archetypes[${j}].verbal_label.phonetic_pinyin`,
+          constraint: 'verbal_distance_threshold',
+          expected: `syllable+tone edit distance >= ${DISTANCE_THRESHOLD} from "${a.canonical}" (${a.phonetic_pinyin})`,
+          actual: `"${b.canonical}" (${b.phonetic_pinyin}) at distance ${distance}`,
+          suggestion:
+            'Rename one archetype verbal label so the two differ by at least one full syllable',
+        })
+      }
+    }
+  }
+
+  // Instance layer: rendered instance labels unique per archetype.
+  const archetypeById = new Map(archetypes.map((a) => [a.id, a]))
+  const entries = gameType.information_partition_template?.shared_label_attributes ?? []
+  for (const entry of entries) {
+    const archetype = archetypeById.get(entry.element_archetype)
+    if (!archetype) continue // gametype_consistency reports the broken reference
+    const seen = new Map<string, string>()
+    level.elements.forEach((element, k) => {
+      if (element.archetype !== entry.element_archetype) return
+      const label = renderInstanceLabel(archetype, entry.attributes, element.params)
+      const firstId = seen.get(label)
+      if (firstId !== undefined) {
+        violations.push({
+          severity: 'error',
+          field_path: `elements[${k}]`,
+          constraint: 'rendered_label_unique',
+          expected: `unique rendered instance labels across "${entry.element_archetype}" instances`,
+          actual: `"${firstId}" and "${element.id}" both render as "${label}"`,
+          suggestion:
+            'Choose attribute values whose display labels render distinct instance labels, or add a mutually visible disambiguating attribute',
+          related_elements: [firstId, element.id],
+        })
+      } else {
+        seen.set(label, element.id)
+      }
+    })
+  }
+
+  return buildCheckResult('verbal_distinguishability', violations)
+}
+
+/**
+ * Render an instance label from the shared label attributes: each attribute
+ * value maps through display_labels, then through the attribute's
+ * verbal_template ("{content_length}密文段" → 短密文段); attributes without a
+ * template fall back to display value + canonical label. Multiple attributes
+ * concatenate.
+ */
+function renderInstanceLabel(
+  archetype: ElementArchetype,
+  attributes: string[],
+  params: Record<string, unknown>
+): string {
+  const pieces = attributes.map((attrName) => {
+    const definition = archetype.attributes.find((a) => a.name === attrName)
+    const raw = String(params[attrName])
+    const display = definition?.display_labels?.[raw] ?? raw
+    const template = definition?.verbal_template
+    if (template && template.includes(`{${attrName}}`)) {
+      return template.replace(`{${attrName}}`, display)
+    }
+    return `${display}${archetype.verbal_label.canonical}`
+  })
+  return pieces.join('')
+}

--- a/packages/creation/tsconfig.json
+++ b/packages/creation/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "dev"]
+}

--- a/packages/creation/vitest.config.ts
+++ b/packages/creation/vitest.config.ts
@@ -1,0 +1,16 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config'
+
+// Standalone vitest config mirroring the companion-memory package: this
+// package is pure, game-agnostic domain data + types, so tests default to
+// the Node environment (fixtures are read from disk with node:fs). The dev
+// shell's component test opts into jsdom per-file via a
+// `@vitest-environment jsdom` docblock, matching the platform package's
+// testing-library convention.
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,49 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/creation:
+    dependencies:
+      js-yaml:
+        specifier: ^4.2.0
+        version: 4.2.0
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: ^26.0.1
+        version: 26.0.1
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/game-bombsquad:
     dependencies:
       '@amiclaw/arcade-profile':


### PR DESCRIPTION
## Summary

- First implementation of the game-agnostic **element+rule creation schema** (design: `docs/architecture/arch-component-creation-schema.md`), landed as a new `packages/creation` workspace package. This is the first spec→code proof of the creation engine on the path toward the Roblox-style "players + their AI create levels" vision.
- Ships an executable **validator** (universal checks: schema_conformance / solvability / fairness / budget_compliance + a per-co-play-form **floor-check registry** — hidden_info_coop: communication_completeness + verbal_distinguishability; co_build: goal_reachability + progress_measurability + construction_visibility), a **declarative rule engine** (shared rule-execution core with action-gated rule triggering, role-filtered leak-guarded views, bounded-search solver: exhaustive_path_search + csp, calibrated), three worked **case-game fixtures** (radio-cipher, sound-garden, botanical-garden) that each pass validation (overall pass + publish_ready) and play to a win through the engine, and a developer-only **dev shell**.
- Game-agnostic (no per-game logic in control flow); **not wired into any player-facing surface — no product behavior changes.**

## Type of change

- [x] New feature (internal foundation; developer-only)

## Testing

- [x] Existing tests pass (full monorepo suite green via pre-commit hook)
- [x] New tests added (142 tests in `packages/creation`, incl. adversarial coop-integrity + floor-check + solver-vs-engine lockstep regressions)
- [x] Tested manually — drove all three games to a win in the dev shell (`pnpm --filter @amiclaw/creation dev`); independent spec-free behavioral audit confirmed exploit closure and playability

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated (design spec `arch-component-creation-schema.md` moved to `stage: current`; CHANGELOG internal-change entry)
- [x] Breaking changes documented if any — none (isolated package, no product surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)