### PR TITLE
fix(platform): honest auth feedback and first-win celebration flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**First daily win celebrates before it asks** - Change. Defusing the daily bomb
+now lands on the result celebration directly: the nickname / AI-partner modal no
+longer auto-opens over the screen. The rank card states honestly that the run is
+not on the board yet, and its 填写并上榜 button opens the gate on demand — the
+gate is now skippable (稍后再说, Esc, backdrop) and re-openable later from the
+same card. The endgame survey now waits until the rank outcome has settled, so
+it can never stack over the rank reveal; if the gate is skipped, the survey
+simply waits for a later session.
+
+**A failed login link now explains itself** - Fix. Opening an expired, used, or
+otherwise invalid magic link (or a failed Google sign-in) previously landed on a
+login page that looked untouched. The page now reads the error and shows a clear
+Chinese explanation — what happened and what to do — for every error the auth
+backend emits, with the sign-in form ready right below.
+
+**Sending a login link now gives real feedback** - Change. After requesting a
+magic link, the login page now echoes the address it was sent to, states the
+real 15-minute single-use validity, hints at the spam folder, and offers a
+cooldown-gated resend button plus an honest note of the 5-per-hour send cap. A
+换一个邮箱 link returns to the form to fix a typo.
+
 **Daily Arcade loop and streaks** - New. The homepage now shows a real daily
 checklist for BombSquad and Oracle, result pages show profile-save and share
 feedback, and the leaderboard now includes a public streak board for claimed

--- a/e2e/add-leaderboard-ai-metadata.gherkin
+++ b/e2e/add-leaderboard-ai-metadata.gherkin
@@ -17,10 +17,10 @@ Feature: Leaderboard AI metadata
     Given I have just defused the bomb in a daily run and the result page is open
     And no nickname is stored on this device
     And no leaderboard AI metadata is stored on this device
-    Then the NicknameModal is open and covers the screen
-    And the NicknameModal has no close button and cannot be dismissed by tapping the backdrop
+    Then the result page shows the honest not-on-board notice
 
-    When I type the Chinese nickname "小明" into the NicknameModal input
+    When I open the leaderboard submission modal
+    And I type the Chinese nickname "小明" into the NicknameModal input
     And I choose AI assistant "Claude"
     And I type AI model "Claude Sonnet 4.5"
     And I tap "确认"

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -57,19 +57,22 @@ flows:
   - id: daily-win-to-leaderboard
     name: Daily win to leaderboard
     description: >-
-      After defusing the daily bomb the result page collects a nickname on the
-      first submission, posts the score, and the player navigates to the
-      leaderboard to find their own row.
-    steps: [result-win, nickname-modal, score-submit, global-rank, leaderboard]
+      After defusing the daily bomb the result page celebrates first — no
+      auto-opened modal — and shows an honest not-on-board notice; the
+      rank-card CTA opens the deferrable nickname gate (skippable and
+      re-openable), posts the score on confirm, and the player navigates to
+      the leaderboard to find their own row.
+    steps: [result-win, rank-cta, nickname-modal, score-submit, global-rank, leaderboard]
     status: active
 
   - id: leaderboard-ai-metadata
     name: Leaderboard AI metadata
     description: >-
-      After a first daily win the result page collects the player nickname,
-      required AI assistant, and optional model, submits them with the score,
-      and the leaderboard row displays the Chinese nickname and AI metadata.
-    steps: [result-win, nickname-modal, ai-metadata, score-submit, leaderboard]
+      After a first daily win the rank-card CTA opens the deferrable gate that
+      collects the player nickname, required AI assistant, and optional model,
+      submits them with the score, and the leaderboard row displays the
+      Chinese nickname and AI metadata.
+    steps: [result-win, rank-cta, nickname-modal, ai-metadata, score-submit, leaderboard]
     status: active
 
   - id: daily-fail-strikeout
@@ -119,11 +122,13 @@ flows:
     name: Result-page endgame survey
     description: >-
       After any game outcome the result page shows a once-per-device endgame
-      survey — a dismissable survey-only modal on a practice run, or merged with
-      the nickname gate into one dialog on a first daily win. Submitting posts a
-      survey_submit event; submitting or skipping both retire the survey for the
-      device.
-    steps: [game-end, result, post-game-survey-modal, survey-submit-or-skip]
+      survey as a dismissable survey-only modal. The survey delay starts only
+      once the celebration beat has settled — on a first daily win that means
+      after the deferred leaderboard gate is filled and the rank outcome
+      arrives — so it never stacks over the rank reveal. Submitting posts a
+      survey_submit event; submitting or skipping both retire the survey for
+      the device.
+    steps: [game-end, result, celebration-settled, post-game-survey-modal, survey-submit-or-skip]
     status: active
 
   # The flow id is kept stable across the Atlas redesign (renaming it would

--- a/e2e/mobile-beta-flow.gherkin
+++ b/e2e/mobile-beta-flow.gherkin
@@ -1,8 +1,10 @@
 # Mobile internal-beta — the daily win-to-leaderboard path a friend follows on
-# their phone: a defused daily run -> /bombsquad/result recap -> PostGameModal
-# nickname + AI metadata gate -> score submission -> /leaderboard ranking.
-# Daily mode is used deliberately so the modal and the leaderboard segment are
-# exercised.
+# their phone: a defused daily run -> /bombsquad/result celebration (rank-
+# reveal-first, no auto-opened modal) -> honest not-on-board notice -> the
+# rank-card CTA opens the deferrable nickname + AI metadata gate -> score
+# submission -> /leaderboard ranking. Daily mode is used deliberately so the
+# gate and the leaderboard segment are exercised, including the skip-and-
+# reopen (deferred fill) beat.
 #
 # Restructured for the e2e harness: each scenario carries a per-scenario
 # flow-source comment tracing to e2e/flow-inventory.yaml plus a consumption-layer
@@ -30,14 +32,16 @@ Feature: Mobile internal-beta daily win to leaderboard
 
   # Source: daily-win-to-leaderboard
   @playwright
-  Scenario: A first daily win collects a nickname, posts the score, and shows my leaderboard row
+  Scenario: A first daily win celebrates first, then collects a nickname on demand and shows my leaderboard row
     Given I have just defused the bomb in a daily run and the result page is open
     And no nickname is stored on this device
     Then I see the heading "拆弹成功"
     And I see the total run time
     And the module breakdown lists all 4 modules without horizontal overflow
-    And the NicknameModal is open and covers the screen
-    And the NicknameModal has no close button and cannot be dismissed by tapping the backdrop
+    And the result page shows the honest not-on-board notice
+
+    When I open the leaderboard submission modal
+    Then the leaderboard modal can be deferred and reopened
 
     When I type a nickname into the NicknameModal input
     And I choose AI assistant "Claude"

--- a/e2e/result-page-survey.gherkin
+++ b/e2e/result-page-survey.gherkin
@@ -1,8 +1,9 @@
 # Result-page endgame survey — the once-per-device PostGameModal survey shown
-# after any game outcome. The survey waits until after the result feedback has
-# had time to land. On a first daily win, the leaderboard nickname / AI metadata
-# gate can still open immediately before score submission; the survey follows
-# later as a separate dialog. Submitting posts a `survey_submit` event to
+# after any game outcome. The survey delay starts only once the celebration
+# beat has settled: on a first daily win that means after the deferred
+# leaderboard gate (opened from the rank-card CTA) is filled and the rank
+# outcome arrives — the survey can never stack over the rank reveal. It then
+# follows as a separate dialog. Submitting posts a `survey_submit` event to
 # /api/events; submitting or skipping both retire the survey for the device.
 #
 # Gated by localStorage['bombsquad-survey-answered'] (packages/game-bombsquad/src/utils/

--- a/e2e/steps/result.steps.ts
+++ b/e2e/steps/result.steps.ts
@@ -72,22 +72,31 @@ Then('the module breakdown lists all 4 modules without horizontal overflow', asy
   expect(overflow).toBeLessThanOrEqual(1)
 })
 
-Then('the NicknameModal is open and covers the screen', async ({ page }) => {
+Then('the result page shows the honest not-on-board notice', async ({ page }) => {
+  // Rank-reveal-first (audit F1): no auto-opened modal over the celebration;
+  // the rank card states the run is not on the board and offers the fill CTA.
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+  await expect(page.getByText('这局成绩还没上榜')).toBeVisible()
+  await expect(page.getByRole('button', { name: '填写并上榜' })).toBeVisible()
+})
+
+When('I open the leaderboard submission modal', async ({ page }) => {
+  await page.getByRole('button', { name: '填写并上榜' }).click()
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()
   await expect(dialog.getByText('给自己起个名字')).toBeVisible()
 })
 
-Then(
-  'the NicknameModal has no close button and cannot be dismissed by tapping the backdrop',
-  async ({ page }) => {
-    const dialog = page.getByRole('dialog')
-    await expect(dialog.getByRole('button', { name: '关闭' })).toHaveCount(0)
-    // Tap the backdrop (top-left corner, outside the centered dialog panel).
-    await page.mouse.click(8, 8)
-    await expect(dialog).toBeVisible()
-  }
-)
+Then('the leaderboard modal can be deferred and reopened', async ({ page }) => {
+  // Skip path: 稍后再说 closes the gate, the run stays off the board with the
+  // CTA still offered; deferred-fill path: the CTA reopens the same gate.
+  const dialog = page.getByRole('dialog')
+  await dialog.getByRole('button', { name: '稍后再说', exact: true }).click()
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+  await expect(page.getByText('这局成绩还没上榜')).toBeVisible()
+  await page.getByRole('button', { name: '填写并上榜' }).click()
+  await expect(page.getByRole('dialog')).toBeVisible()
+})
 
 When('I type a nickname into the NicknameModal input', async ({ page }) => {
   await page.getByRole('dialog').getByRole('textbox', { name: '昵称' }).fill(E2E_NICKNAME)
@@ -142,12 +151,17 @@ Then(
 // --- Leaderboard submission assertion (shared by mobile-beta + game-modes) ----
 
 Then('the leaderboard submission carries a plausible time', async ({ world, page }) => {
-  // A daily-win submission only fires once the NicknameModal is confirmed.
-  // Scenarios that do not walk the modal explicitly (e.g. game-modes "defuse
-  // all four modules") still need the POST to have happened — confirm a
-  // pending modal here so the captured body can be asserted.
+  // A first daily-win submission only fires once the deferred leaderboard
+  // gate is filled. Scenarios that do not walk the gate explicitly (e.g.
+  // game-modes "defuse all four modules") still need the POST to have
+  // happened — open the gate from the rank-card CTA when it is not already
+  // open, then confirm it, so the captured body can be asserted.
   if (world.leaderboard.submissions.length === 0) {
     const dialog = page.getByRole('dialog')
+    if ((await dialog.count()) === 0) {
+      const cta = page.getByRole('button', { name: '填写并上榜' })
+      if ((await cta.count()) > 0) await cta.click()
+    }
     if ((await dialog.count()) > 0 && (await dialog.getByRole('textbox').count()) > 0) {
       await dialog.getByRole('textbox', { name: '昵称' }).fill(E2E_NICKNAME)
       const assistant = dialog.getByRole('button', { name: E2E_AI_ASSISTANT_LABEL, exact: true })

--- a/e2e/steps/survey.steps.ts
+++ b/e2e/steps/survey.steps.ts
@@ -31,6 +31,10 @@ Given(
 Given('any required leaderboard gate is completed before the survey', async ({ page, world }) => {
   if (world.runMode !== 'daily') return
 
+  // The gate no longer auto-opens (rank-reveal-first) — open it from the
+  // rank card's CTA, then fill and confirm. The survey delay only starts
+  // once the rank outcome has settled, i.e. after this submission lands.
+  await page.getByRole('button', { name: '填写并上榜' }).click()
   const dialog = page.getByRole('dialog')
   await expect(dialog).toHaveCount(1)
   await dialog.getByRole('textbox', { name: '昵称' }).fill(E2E_NICKNAME)

--- a/packages/api/src/auth/config.ts
+++ b/packages/api/src/auth/config.ts
@@ -11,6 +11,8 @@
  * with zero configuration; production overrides them via Pages env / secrets.
  */
 
+import { MAGIC_LINK_TTL_MINUTES, MAGIC_LINK_HOURLY_SEND_LIMIT } from '../../../../shared/auth-types'
+
 export interface AuthEnv {
   /** `AUTH` KV namespace — token hashes, sessions, audit, rate-limit counters. */
   AUTH: KVNamespace
@@ -34,8 +36,9 @@ export interface AuthEnv {
 
 // --- Tunables (invariant-bearing) -----------------------------------------
 
-/** Magic-link token TTL — invariant ①: ≤ 15 minutes. */
-export const MAGIC_LINK_TTL_SECONDS = 15 * 60
+/** Magic-link token TTL — invariant ①: ≤ 15 minutes. Minutes SSOT lives in
+ *  shared/auth-types.ts so the login-page copy can never drift from this TTL. */
+export const MAGIC_LINK_TTL_SECONDS = MAGIC_LINK_TTL_MINUTES * 60
 
 /** Opaque session lifetime. No sliding renewal in this round (Open Question). */
 export const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60 // 30 days
@@ -43,8 +46,9 @@ export const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60 // 30 days
 /** Audit-log retention. */
 export const AUDIT_TTL_SECONDS = 90 * 24 * 60 * 60 // 90 days
 
-/** Invariant ③ — per-email send cap within the window. */
-export const EMAIL_SEND_LIMIT = 5
+/** Invariant ③ — per-email send cap within the window. Cap SSOT lives in
+ *  shared/auth-types.ts so the login-page resend copy states the real limit. */
+export const EMAIL_SEND_LIMIT = MAGIC_LINK_HOURLY_SEND_LIMIT
 export const EMAIL_SEND_WINDOW_SECONDS = 60 * 60 // 1 hour
 
 /** Invariant ③ — global verify-endpoint cap within the window. */

--- a/packages/game-bombsquad/src/components/PostGameModal.test.tsx
+++ b/packages/game-bombsquad/src/components/PostGameModal.test.tsx
@@ -3,8 +3,10 @@
  *
  * Covers the unified post-game modal that composes an optional nickname
  * section and an optional 4-question survey section into a single dialog —
- * never two stacked. Three shapes are exercised: survey-only (dismissable),
- * nickname-only (non-dismissable), and the merged nickname+survey modal.
+ * never two stacked. Three shapes are exercised: survey-only, nickname-only,
+ * and the merged nickname+survey modal. Every shape is dismissable — skipping
+ * the leaderboard gate defers the submission (the caller re-offers it), while
+ * skipping the survey retires it for the device.
  *
  * Note on localStorage: jsdom's `localStorage` in this workspace is a
  * method-less stub (see `nickname.test.ts`). The modal's nickname section
@@ -252,7 +254,7 @@ describe('PostGameModal', () => {
   })
 
   describe('nickname-only modal', () => {
-    it('renders the nickname gate, no survey, and is non-dismissable', () => {
+    it('renders the nickname gate, no survey, and a defer affordance', () => {
       render(
         <PostGameModal open showNickname showSurvey={false} onConfirm={vi.fn()} onSkip={vi.fn()} />
       )
@@ -260,20 +262,30 @@ describe('PostGameModal', () => {
       expect(screen.getByRole('dialog', { name: /给自己起个名字/ })).toBeInTheDocument()
       expect(screen.getByLabelText(/昵称/)).toBeInTheDocument()
       expect(screen.queryByText('你这局用的是哪个 AI 工具？')).not.toBeInTheDocument()
-      // Non-dismissable: no skip / close affordance.
-      expect(screen.queryByRole('button', { name: '跳过' })).not.toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: '跳过问卷' })).not.toBeInTheDocument()
+      // Dismissable (audit F1): the gate defers instead of blocking — a skip
+      // button, a close affordance, and the honest not-on-board note.
+      expect(screen.getByRole('button', { name: '稍后再说' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: '关闭' })).toBeInTheDocument()
+      expect(screen.getByText(/成绩暂不上榜，稍后可在结果页补填/)).toBeInTheDocument()
     })
 
-    it('Escape and backdrop clicks do not dismiss the nickname gate', () => {
+    it('skip, Escape, and backdrop clicks all defer the nickname gate via onSkip', () => {
+      const onConfirm = vi.fn()
       const onSkip = vi.fn()
       render(
-        <PostGameModal open showNickname showSurvey={false} onConfirm={vi.fn()} onSkip={onSkip} />
+        <PostGameModal open showNickname showSurvey={false} onConfirm={onConfirm} onSkip={onSkip} />
       )
 
+      fireEvent.click(screen.getByRole('button', { name: '稍后再说' }))
+      expect(onSkip).toHaveBeenCalledTimes(1)
+
       fireEvent.keyDown(window, { key: 'Escape' })
+      expect(onSkip).toHaveBeenCalledTimes(2)
+
       fireEvent.click(screen.getByRole('dialog').parentElement as HTMLElement)
-      expect(onSkip).not.toHaveBeenCalled()
+      expect(onSkip).toHaveBeenCalledTimes(3)
+
+      expect(onConfirm).not.toHaveBeenCalled()
     })
 
     it('confirm emits only the nickname once a valid value is typed', () => {
@@ -310,7 +322,9 @@ describe('PostGameModal', () => {
       expect(screen.getAllByRole('dialog')).toHaveLength(1)
       expect(screen.getByLabelText(/昵称/)).toBeInTheDocument()
       expect(screen.getByText('你这局用的是哪个 AI 工具？')).toBeInTheDocument()
-      // No standalone skip control — but the survey optionality is made plain.
+      // The gate defers with 稍后再说 (not the survey's 跳过 wording), and the
+      // survey optionality is made plain.
+      expect(screen.getByRole('button', { name: '稍后再说' })).toBeInTheDocument()
       expect(screen.queryByRole('button', { name: '跳过' })).not.toBeInTheDocument()
       expect(screen.getByText(/问卷选填/)).toBeInTheDocument()
     })

--- a/packages/game-bombsquad/src/components/PostGameModal.tsx
+++ b/packages/game-bombsquad/src/components/PostGameModal.tsx
@@ -49,8 +49,9 @@ interface PostGameModalProps {
   open: boolean
   /**
    * Render the nickname section. When true the section is required and gates
-   * confirm — the modal also becomes non-dismissable (no Esc / backdrop / skip)
-   * because a daily score cannot post without a nickname.
+   * confirm — but the modal stays dismissable: skipping defers the leaderboard
+   * submission (the run is simply not on the board yet) rather than blocking
+   * the result screen.
    */
   showNickname: boolean
   /**
@@ -66,7 +67,7 @@ interface PostGameModalProps {
    * `survey_submit` event when `result.survey` is set.
    */
   onConfirm: (result: PostGameModalResult) => void
-  /** Fired when a survey-only modal is dismissed without submitting. */
+  /** Fired when the modal is dismissed without submitting (skip / Esc / backdrop). */
   onSkip: () => void
 }
 
@@ -74,13 +75,14 @@ interface PostGameModalProps {
  * Unified post-game modal — never two stacked dialogs.
  *
  * Composes two optional sections:
- *  - Nickname: required first-submission gate for the daily leaderboard.
+ *  - Nickname / AI metadata: the leaderboard submission gate for a first
+ *    daily win. Deferrable — skipping keeps the run off the board and the
+ *    caller re-offers the gate later (the result page's 上榜 CTA).
  *  - Survey: a 4-question endgame survey, shown once per device.
  *
- * The modal opens when EITHER section is needed. Dismissability is
- * conditional: with the nickname section present the modal is non-dismissable
- * (no close affordance, Esc / backdrop inert); when only the survey shows it
- * is dismissable via the skip button, Esc, or a backdrop click.
+ * Every shape is dismissable via the skip button, Esc, or a backdrop click;
+ * only the skip semantics differ (the caller retires a skipped survey but
+ * keeps a skipped leaderboard gate re-openable).
  *
  * Styled in the Atlas star-chart visual language — a glass-card dialog on a
  * dimmed cosmic backdrop with the AMIO-yellow accent (docs/DesignSystem.md).
@@ -115,19 +117,20 @@ export default function PostGameModal({
   const q3Id = `${baseId}-q3`
   const q4Id = `${baseId}-q4`
 
-  // Non-dismissable whenever a leaderboard submission gate is present.
-  const dismissable = showSurvey && !showNickname && !showLeaderboardMetadata
+  // The survey-only shape keeps its stricter submit gating and its 跳过
+  // wording; leaderboard shapes defer with 稍后再说 instead.
+  const surveyOnly = showSurvey && !showNickname && !showLeaderboardMetadata
 
-  // Esc closes a survey-only modal. Registered before the early return so the
+  // Esc dismisses every shape. Registered before the early return so the
   // hook order stays stable across renders.
   useEffect(() => {
-    if (!open || !dismissable) return
+    if (!open) return
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') onSkip()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [open, dismissable, onSkip])
+  }, [open, onSkip])
 
   if (!open) return null
 
@@ -148,7 +151,7 @@ export default function PostGameModal({
   // the survey-only modal — which always offers a separate skip affordance
   // anyway. Whenever the nickname section is present, confirm needs only a
   // valid nickname; a partially-filled survey is dropped silently on confirm.
-  const canConfirm = nicknameOk && leaderboardMetadataOk && (dismissable ? surveyComplete : true)
+  const canConfirm = nicknameOk && leaderboardMetadataOk && (surveyOnly ? surveyComplete : true)
 
   const handleConfirm = () => {
     if (!canConfirm) return
@@ -203,7 +206,7 @@ export default function PostGameModal({
   }
 
   return (
-    <div className={styles.overlay} role="presentation" onClick={dismissable ? onSkip : undefined}>
+    <div className={styles.overlay} role="presentation" onClick={onSkip}>
       <div
         className={styles.dialog}
         role="dialog"
@@ -212,11 +215,14 @@ export default function PostGameModal({
         aria-describedby={showNickname ? nicknameTipId : undefined}
         onClick={(event) => event.stopPropagation()}
       >
-        {dismissable && (
-          <button type="button" className={styles.closeBtn} onClick={onSkip} aria-label="跳过问卷">
-            ✕
-          </button>
-        )}
+        <button
+          type="button"
+          className={styles.closeBtn}
+          onClick={onSkip}
+          aria-label={surveyOnly ? '跳过问卷' : '关闭'}
+        >
+          ✕
+        </button>
 
         <h2 id={titleId} className={styles.title}>
           {showNickname
@@ -440,15 +446,19 @@ export default function PostGameModal({
             </section>
           )}
 
+          {!surveyOnly && (
+            // Honest deferral note for the leaderboard gate: skipping keeps
+            // the run off the board, and the result page re-offers the fill.
+            <p className={styles.tip}>现在跳过也可以 —— 成绩暂不上榜，稍后可在结果页补填。</p>
+          )}
+
           <div className={styles.actions}>
             <Button variant="primary" type="submit" full disabled={!canConfirm}>
               {showNickname ? '确认' : '提交'}
             </Button>
-            {dismissable && (
-              <Button variant="ghost" full onClick={onSkip}>
-                跳过
-              </Button>
-            )}
+            <Button variant="ghost" full onClick={onSkip}>
+              {surveyOnly ? '跳过' : '稍后再说'}
+            </Button>
           </div>
         </form>
       </div>

--- a/packages/game-bombsquad/src/pages/ResultPage.module.css
+++ b/packages/game-bombsquad/src/pages/ResultPage.module.css
@@ -206,8 +206,35 @@
 }
 
 .rankPending {
-  font: 400 13px var(--font-body);
+  font: 400 13px/1.6 var(--font-body);
   color: var(--soft);
+}
+
+/* The deferred leaderboard-gate CTA inside the rank card — the fill-and-rank
+   entry a first-win player uses after (or instead of) skipping the modal. */
+.boardCta {
+  display: block;
+  margin: 10px auto 0;
+  padding: 8px 16px;
+  border: 1px solid rgba(255, 229, 62, 0.4);
+  border-radius: 999px;
+  background: rgba(255, 229, 62, 0.1);
+  color: var(--y);
+  font: 500 13px var(--font-body);
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+.boardCta:hover {
+  background: rgba(255, 229, 62, 0.18);
+  border-color: var(--y);
+}
+
+.boardCta:focus-visible {
+  outline: 2px solid var(--y);
+  outline-offset: 2px;
 }
 
 .retryBtn {

--- a/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.nickname.test.tsx
@@ -1,14 +1,18 @@
 /**
  * ResultPage nickname-gate integration tests.
  *
- * Covers the three branches of the daily-mode submission flow:
- *   1. First-visit daily run, localStorage empty → PostGameModal renders the
- *      nickname section, the score is NOT submitted, and submission only fires
- *      after the player types a valid nickname, chooses an AI tool, and
- *      confirms.
- *   2. Returning daily run, localStorage already has nickname + AI metadata
+ * Covers the branches of the daily-mode submission flow:
+ *   1. First-visit daily run, localStorage empty → the celebration renders
+ *      FIRST with no auto-opened modal (rank-reveal-first ordering, audit F1);
+ *      the rank card states the honest not-on-board fact and its CTA opens the
+ *      deferrable gate; submission only fires after the player confirms.
+ *   2. Skip path → deferring the gate keeps the run off the board, with the
+ *      CTA still offered for a later fill.
+ *   3. Deferred-fill path → reopening the gate after a skip still submits and
+ *      reveals the rank.
+ *   4. Returning daily run, localStorage already has nickname + AI metadata
  *      → no modal, the score is submitted immediately with cached values.
- *   3. Practice mode → no modal, no submit (practice never posts a score).
+ *   5. Practice mode → no modal, no submit (practice never posts a score).
  *
  * Setup mirrors `ResultPage.test.tsx`: pre-seed sessionStorage with a finished
  * game state so `GameProvider`'s lazy initializer hydrates straight into a
@@ -147,14 +151,22 @@ describe('ResultPage nickname gate', () => {
     sessionStorage.clear()
   })
 
-  it('first-visit daily run: shows modal, blocks submit until the player confirms', async () => {
+  it('first-visit daily run: celebration first, gate opens via the rank-card CTA', async () => {
     sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedDailyState()))
 
     renderResultPage()
 
-    // Modal is visible and blocks submission.
-    expect(screen.getByRole('dialog', { name: /给自己起个名字/ })).toBeInTheDocument()
+    // Rank-reveal-first ordering (audit F1): the celebration renders
+    // unobstructed — no auto-opened modal — and the rank card states the
+    // honest not-on-board fact. No submission fires without the gate.
+    expect(screen.getByText('拆弹成功')).toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByText(/这局成绩还没上榜/)).toBeInTheDocument()
     expect(mockedSubmit).not.toHaveBeenCalled()
+
+    // The CTA opens the gate on demand.
+    fireEvent.click(screen.getByRole('button', { name: '填写并上榜' }))
+    expect(screen.getByRole('dialog', { name: /给自己起个名字/ })).toBeInTheDocument()
 
     // The confirm button is disabled until a valid nickname and AI tool are set.
     const confirmBtn = screen.getByRole('button', { name: /^确认$/ })
@@ -180,9 +192,51 @@ describe('ResultPage nickname gate', () => {
       run_id: 'run-daily-result',
     })
 
-    // localStorage persisted the nickname; modal is gone.
+    // localStorage persisted the nickname; modal is gone; the rank reveals in
+    // place of the not-on-board notice.
     expect(localStorage.getItem(NICKNAME_KEY)).toBe('小明')
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(await screen.findByText('全球排名')).toBeInTheDocument()
+  })
+
+  it('skip path: deferring the gate keeps the run off the board with the CTA still offered', async () => {
+    sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedDailyState()))
+
+    renderResultPage()
+
+    fireEvent.click(screen.getByRole('button', { name: '填写并上榜' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '稍后再说' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    // No submission fired; the honest notice + CTA remain for a later fill.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockedSubmit).not.toHaveBeenCalled()
+    expect(screen.getByText(/这局成绩还没上榜/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '填写并上榜' })).toBeInTheDocument()
+  })
+
+  it('deferred-fill path: reopening the gate after a skip still submits and reveals the rank', async () => {
+    sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedDailyState()))
+
+    renderResultPage()
+
+    fireEvent.click(screen.getByRole('button', { name: '填写并上榜' }))
+    fireEvent.click(screen.getByRole('button', { name: '稍后再说' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '填写并上榜' }))
+    fireEvent.change(screen.getByLabelText(/昵称/), { target: { value: '小明' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Claude' }))
+    fireEvent.click(screen.getByRole('button', { name: /^确认$/ }))
+
+    await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(1))
+    expect(mockedSubmit.mock.calls[0][0]).toMatchObject({
+      nickname: '小明',
+      ai_tool: 'claude',
+      run_id: 'run-daily-result',
+    })
+    expect(await screen.findByText('全球排名')).toBeInTheDocument()
   })
 
   it('returning daily run: cached nickname and AI metadata → submit fires immediately', async () => {

--- a/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
@@ -7,8 +7,10 @@
  *   2. A device that has already answered/skipped sees no modal.
  *   3. Submitting the survey emits `survey_submit` and marks the device.
  *   4. Skipping marks the device WITHOUT emitting `survey_submit`.
- *   5. First daily win opens the leaderboard gate first; the survey remains
- *      deferred until after that gate closes.
+ *   5. First daily win: nothing auto-opens over the celebration; the survey
+ *      delay only starts once the rank outcome has settled (audit F13), so
+ *      the questionnaire can never stack over the rank reveal.
+ *   6. Skipping the leaderboard gate defers the survey to a later session.
  *
  * Setup mirrors the sibling ResultPage tests: pre-seed sessionStorage with a
  * finished-game state so `GameProvider`'s lazy initializer hydrates straight
@@ -225,18 +227,27 @@ describe('ResultPage endgame survey', () => {
     expect(screen.getByRole('button', { name: '再来一局' })).toBeInTheDocument()
   })
 
-  it('first daily win opens the leaderboard gate before the deferred survey', async () => {
+  it('first daily win: the survey stays deferred until the rank reveal has settled', async () => {
     surveyMock.hasAnsweredSurvey.mockReturnValue(false)
     renderResult(finishedState({ mode: 'daily', outcome: 'defused' }))
 
-    // Exactly one dialog — the leaderboard gate opens first, without the
-    // survey-only fun / difficulty questions.
+    // Rank-reveal-first (audit F1): nothing auto-opens over the celebration.
+    expect(screen.getByText('拆弹成功')).toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(submitScore).not.toHaveBeenCalled()
+
+    // The survey delay has not even started while the run is off the board —
+    // advancing past it opens nothing (audit F13).
+    advancePastResultFeedback()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    // Open the deferred gate from the rank-card CTA and complete it. The gate
+    // dialog carries no survey-only fun / difficulty questions.
+    fireEvent.click(screen.getByRole('button', { name: '填写并上榜' }))
     expect(screen.getAllByRole('dialog')).toHaveLength(1)
     expect(screen.getByLabelText(/昵称/)).toBeInTheDocument()
     expect(screen.getByText('你这局用的是哪个 AI 工具？')).toBeInTheDocument()
     expect(screen.queryByText('整体好玩程度')).not.toBeInTheDocument()
-    // Score is gated behind the nickname and AI metadata while the modal is open.
-    expect(submitScore).not.toHaveBeenCalled()
 
     fireEvent.change(screen.getByLabelText(/昵称/), { target: { value: '小测' } })
     fireEvent.click(screen.getByRole('button', { name: 'Claude' }))
@@ -252,8 +263,14 @@ describe('ResultPage endgame survey', () => {
     expect(logEvent).not.toHaveBeenCalledWith('survey_submit', expect.anything())
     expect(surveyMock.markSurveyAnswered).not.toHaveBeenCalled()
 
-    advancePastResultFeedback()
+    // Flush the submit promise so the rank settles and reveals.
+    await act(async () => {})
+    expect(screen.getByText('全球排名')).toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
+    // Only now does the survey delay start; after it, the survey opens alone —
+    // after the celebration beat, never over the reveal itself.
+    advancePastResultFeedback()
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(screen.getByText('整体好玩程度')).toBeInTheDocument()
     answerRequiredSurvey()
@@ -272,15 +289,14 @@ describe('ResultPage endgame survey', () => {
     surveyMock.hasAnsweredSurvey.mockReturnValue(false)
     renderResult(finishedState({ mode: 'daily', outcome: 'defused' }))
 
+    // Fill only the leaderboard gate; leave the survey questions for later.
+    fireEvent.click(screen.getByRole('button', { name: '填写并上榜' }))
     expect(screen.getAllByRole('dialog')).toHaveLength(1)
-
-    // Fill only the leaderboard gate; leave the survey-only questions untouched.
     fireEvent.change(screen.getByLabelText(/昵称/), { target: { value: '小测' } })
     fireEvent.click(screen.getByRole('button', { name: 'Claude' }))
     fireEvent.click(screen.getByRole('button', { name: '确认' }))
 
-    // Score still submits, the device is marked answered, but a skipped
-    // survey fires no `survey_submit`.
+    // Score submits; the survey has not shown, so the device is not marked.
     expect(submitScore).toHaveBeenCalledTimes(1)
     expect(vi.mocked(submitScore).mock.calls[0][0]).toMatchObject({
       nickname: '小测',
@@ -290,10 +306,29 @@ describe('ResultPage endgame survey', () => {
     expect(surveyMock.markSurveyAnswered).not.toHaveBeenCalled()
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
+    // Rank settles, then the deferred survey opens and is skippable.
+    await act(async () => {})
     advancePastResultFeedback()
 
     fireEvent.click(screen.getByRole('button', { name: '跳过' }))
     expect(surveyMock.markSurveyAnswered).toHaveBeenCalledTimes(1)
+    expect(logEvent).not.toHaveBeenCalledWith('survey_submit', expect.anything())
+  })
+
+  it('skipping the leaderboard gate defers the survey to a later session', async () => {
+    surveyMock.hasAnsweredSurvey.mockReturnValue(false)
+    renderResult(finishedState({ mode: 'daily', outcome: 'defused' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '填写并上榜' }))
+    fireEvent.click(screen.getByRole('button', { name: '稍后再说' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    // The run never settled on the board this session — the survey never
+    // opens and the device is NOT marked answered, so a later session can
+    // still ask once.
+    advancePastResultFeedback()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(surveyMock.markSurveyAnswered).not.toHaveBeenCalled()
     expect(logEvent).not.toHaveBeenCalledWith('survey_submit', expect.anything())
   })
 })

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -199,18 +199,22 @@ export default function ResultPage() {
     () => getStoredLeaderboardPlayerMetadata()
   )
 
-  // The post-game modal has two separate purposes. The leaderboard gate can
-  // open immediately when a first daily defuse needs a nickname / AI metadata
-  // before score submission. The once-per-device survey waits until after the
-  // result feedback has had time to land, so a first win is not covered by a
-  // questionnaire before the player can read it.
+  // The post-game modal has two separate purposes. The leaderboard gate NEVER
+  // auto-opens (audit F1): the celebration and rank reveal own the first beat,
+  // and the rank card's 上榜 CTA opens the gate on demand — skippable, and
+  // re-openable later from the same card (deferred fill). The once-per-device
+  // survey waits until the celebration beat has settled, so it can never stack
+  // over the rank reveal.
   const [needNickname] = useState(() => hasFinishedDailyRun && nickname === null)
   const [needLeaderboardMetadata] = useState(
     () => hasFinishedDailyRun && leaderboardMetadata === null
   )
   const [needSurvey] = useState(() => !hasAnsweredSurvey())
-  const needsLeaderboardGate = needNickname || needLeaderboardMetadata
-  const [leaderboardGateOpen, setLeaderboardGateOpen] = useState(needsLeaderboardGate)
+  const [leaderboardGateOpen, setLeaderboardGateOpen] = useState(false)
+  // Live, not mount-frozen: flips false the moment a confirm stores both
+  // values, which swaps the rank card's CTA for the submitting → rank states.
+  const needsSubmissionInput =
+    hasFinishedDailyRun && (nickname === null || leaderboardMetadata === null)
   const [surveyReady, setSurveyReady] = useState(false)
   const [surveyRetired, setSurveyRetired] = useState(false)
   const surveyOpen = needSurvey && !surveyRetired && surveyReady && !leaderboardGateOpen
@@ -237,15 +241,17 @@ export default function ResultPage() {
   // second layer of protection.
   const submittedRef = useRef<'idle' | 'in-flight' | 'done'>('idle')
 
-  // The daily score is still gated while the modal is open with a leaderboard
-  // submission section present.
-  const leaderboardGatePending = modalPurpose === 'leaderboard'
-
+  // The survey delay counts from when the celebration beat settles, not from
+  // mount (audit F13): a daily defused run settles when its rank outcome
+  // arrives (rank revealed, or the submission failed); any other run settles
+  // on mount. A first win whose leaderboard gate stays unfilled never settles
+  // this session — the once-per-device survey simply waits for a later one.
+  const celebrationSettled = !hasFinishedDailyRun || rankResult !== null || submitFailed
   useEffect(() => {
-    if (!needSurvey || noRunData) return
+    if (!needSurvey || noRunData || !celebrationSettled) return
     const id = setTimeout(() => setSurveyReady(true), RESULT_FEEDBACK_SURVEY_DELAY_MS)
     return () => clearTimeout(id)
-  }, [needSurvey, noRunData])
+  }, [needSurvey, noRunData, celebrationSettled])
 
   const buildSubmission = useCallback(
     (nicknameValue: string, metadataValue: LeaderboardPlayerMetadata): ScoreSubmission | null => {
@@ -610,9 +616,23 @@ export default function ResultPage() {
               ) : (
                 <div className={styles.rankCell}>
                   <div className={styles.rankPending}>
-                    {leaderboardGatePending && '提交前请填写昵称和 AI 搭档'}
-                    {!leaderboardGatePending && submitting && '提交成绩中…'}
-                    {!leaderboardGatePending &&
+                    {needsSubmissionInput && (
+                      // Honest not-on-board state (audit F1): the run is NOT
+                      // on the leaderboard until the player fills the gate.
+                      // The CTA re-opens the modal at any time — the deferred
+                      // fill path after a skip.
+                      <>
+                        这局成绩还没上榜。填写昵称和 AI 搭档后，即可上榜并查看全球排名。
+                        <button
+                          className={styles.boardCta}
+                          onClick={() => setLeaderboardGateOpen(true)}
+                        >
+                          填写并上榜
+                        </button>
+                      </>
+                    )}
+                    {!needsSubmissionInput && submitting && '提交成绩中…'}
+                    {!needsSubmissionInput &&
                       !submitting &&
                       submitFailed &&
                       (submitFailKind === 'rejected' ? (

--- a/packages/platform/src/pages/LoginPage.module.css
+++ b/packages/platform/src/pages/LoginPage.module.css
@@ -86,6 +86,70 @@
   text-align: center;
 }
 
+/* ----------  post-send state (email echo, validity, resend)  ---------- */
+.sentPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  text-align: center;
+}
+
+/* Echo of the address the player typed — prominent so a typo is caught. */
+.sentEmail {
+  margin: 0;
+  font: 500 18px var(--font-body);
+  color: var(--amio-yellow);
+  word-break: break-all;
+}
+
+.sentHints {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font: 400 13px/1.6 var(--font-body);
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.sentRateNote {
+  margin: 0;
+  font: 400 12px var(--font-body);
+  color: rgba(255, 255, 255, 0.45);
+}
+
+/* Back to the form to fix a typoed address. Mirrors the escape-link style. */
+.switchEmail {
+  align-self: center;
+  padding: 0;
+  border: none;
+  background: none;
+  color: rgba(255, 255, 255, 0.6);
+  font: 400 13px var(--font-body);
+  cursor: pointer;
+  border-bottom: 1px solid var(--border-hairline);
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+}
+
+.switchEmail:hover {
+  color: var(--text-1);
+  border-bottom-color: rgba(255, 255, 255, 0.4);
+}
+
+/* ----------  ?error= banner (failed magic-link verify / OAuth)  ---------- */
+.errorBanner {
+  margin: 0 0 18px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 138, 138, 0.35);
+  background: rgba(255, 138, 138, 0.08);
+  font: 400 14px/1.6 var(--font-body);
+  color: #ff8a8a;
+}
+
 /* ----------  signed-in notice (an authenticated visitor on /login)  ---------- */
 .identityLabel {
   margin: 0;

--- a/packages/platform/src/pages/LoginPage.test.tsx
+++ b/packages/platform/src/pages/LoginPage.test.tsx
@@ -16,9 +16,15 @@
  *   4. an already-authenticated visitor sees their identity and the continue /
  *      sign-out actions instead of the bare form; signing out POSTs
  *      /api/auth/logout and returns the site to the anonymous state.
+ *   5. a failed verify / OAuth round-trip lands on /login?error=<value> and the
+ *      page renders a clear Chinese explanation for every backend error value
+ *      (plus an honest fallback), keeping the form ready below it.
+ *   6. the post-send state echoes the typed email, states the real 15-minute
+ *      validity and the spam-folder hint, and offers a cooldown-gated resend
+ *      that honestly states the backend's 5-per-hour cap.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { act, render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import type { SessionResponse } from '@shared/auth-types'
 import LoginPage from './LoginPage'
@@ -44,9 +50,9 @@ function stubSession(session: SessionResponse) {
   )
 }
 
-function renderLogin() {
+function renderLogin(entry = '/login') {
   return render(
-    <MemoryRouter initialEntries={['/login']}>
+    <MemoryRouter initialEntries={[entry]}>
       <LoginPage />
     </MemoryRouter>
   )
@@ -129,6 +135,106 @@ describe('LoginPage /login', () => {
     expect(magicCalls).toHaveLength(1)
     const [, init] = magicCalls[0] as unknown as [string, RequestInit]
     expect(JSON.parse(init.body as string)).toEqual({ email: 'nova@amio.fans' })
+  })
+
+  it('renders a clear error state for an expired or used magic link (?error=invalid)', () => {
+    renderLogin('/login?error=invalid')
+
+    // What happened + what to do, in one honest banner.
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toContain('登录链接已失效或已被使用')
+    expect(alert.textContent).toContain('15 分钟')
+    expect(alert.textContent).toContain('重新输入邮箱')
+    // The form stays ready right below the explanation.
+    expect(screen.getByLabelText('邮箱')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '发送登录链接' })).toBeInTheDocument()
+  })
+
+  it('renders a distinct message for every backend error value, with an honest fallback', () => {
+    // The full enum the auth backend 302s to /login with: magic-link verify
+    // (invalid / rate_limited), Google start (google_unavailable) and callback
+    // (google_denied / invalid_state / google_failed / email_unverified).
+    const cases: Array<[string, RegExp]> = [
+      ['rate_limited', /过于频繁/],
+      ['google_unavailable', /Google 登录暂未开放/],
+      ['google_denied', /Google 登录已取消/],
+      ['invalid_state', /会话已过期/],
+      ['google_failed', /Google 登录没有完成/],
+      ['email_unverified', /尚未通过 Google 验证/],
+      // Unknown future values still get an explanation, never a silent form.
+      ['some_future_error', /登录没有完成/],
+    ]
+    for (const [error, expected] of cases) {
+      const { unmount } = renderLogin(`/login?error=${error}`)
+      expect(screen.getByRole('alert').textContent).toMatch(expected)
+      unmount()
+    }
+  })
+
+  it('shows no error banner without the error param', () => {
+    renderLogin()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('after sending: echoes the email, states validity + spam hints, and gates resend on a cooldown', async () => {
+    vi.useFakeTimers()
+    try {
+      const fetchSpy = vi.fn((input: RequestInfo | URL) => {
+        if (urlOf(input).includes('/api/auth/session')) {
+          return Promise.resolve(new Response(JSON.stringify(ANON), { status: 200 }))
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ ok: true, message: 'x' }), { status: 200 })
+        )
+      })
+      vi.stubGlobal('fetch', fetchSpy)
+      renderLogin()
+
+      fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'nova@amio.fans' } })
+      fireEvent.click(screen.getByRole('button', { name: '发送登录链接' }))
+      await act(async () => {})
+
+      // Unified confirmation + the player's own typed address echoed back.
+      expect(screen.getByText('如果该邮箱可用，你会收到一封登录邮件。')).toBeInTheDocument()
+      expect(screen.getByText('nova@amio.fans')).toBeInTheDocument()
+      // Real validity period (shared/auth-types SSOT) + spam-folder hint.
+      expect(screen.getByText(/15 分钟内有效/)).toBeInTheDocument()
+      expect(screen.getByText(/垃圾邮件/)).toBeInTheDocument()
+      // Honest rate-limit note mirroring the backend's real per-hour cap.
+      expect(screen.getByText(/最多发送 5 封/)).toBeInTheDocument()
+
+      // Resend is cooldown-gated: disabled with a countdown, then enabled.
+      expect(screen.getByRole('button', { name: /重新发送（60 秒后可用）/ })).toBeDisabled()
+      for (let i = 0; i < 60; i++) {
+        await act(async () => {
+          vi.advanceTimersByTime(1000)
+        })
+      }
+      const resend = screen.getByRole('button', { name: '重新发送登录邮件' })
+      expect(resend).toBeEnabled()
+
+      // A resend fires a second POST and re-arms the cooldown in place — the
+      // sent panel never flips back to the form.
+      fireEvent.click(resend)
+      await act(async () => {})
+      const magicCalls = fetchSpy.mock.calls.filter(([input]) =>
+        urlOf(input as RequestInfo | URL).includes('/api/auth/magic-link/request')
+      )
+      expect(magicCalls).toHaveLength(2)
+      expect(screen.getByRole('button', { name: /重新发送（60 秒后可用）/ })).toBeDisabled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('offers a way back to the form to fix a typoed address', async () => {
+    renderLogin()
+
+    fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'nova@amio.fans' } })
+    fireEvent.click(screen.getByRole('button', { name: '发送登录链接' }))
+
+    fireEvent.click(await screen.findByRole('button', { name: '换一个邮箱' }))
+    expect(screen.getByLabelText('邮箱')).toBeInTheDocument()
   })
 
   it('surfaces a retry message on a network failure', async () => {

--- a/packages/platform/src/pages/LoginPage.tsx
+++ b/packages/platform/src/pages/LoginPage.tsx
@@ -1,7 +1,11 @@
-import { useState, type FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useEffect, useState, type FormEvent } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Button, EyebrowTag, GlassCard } from '@amiclaw/ui'
-import type { MagicLinkRequestBody } from '@shared/auth-types'
+import {
+  MAGIC_LINK_TTL_MINUTES,
+  MAGIC_LINK_HOURLY_SEND_LIMIT,
+  type MagicLinkRequestBody,
+} from '@shared/auth-types'
 import { API_BASE } from '@shared/api-base'
 import { useAuth, type DisplayUser } from '@/hooks/useAuth'
 import styles from './LoginPage.module.css'
@@ -14,6 +18,35 @@ const GOOGLE_START_URL = `${API_BASE}/api/auth/google/start`
    the same message is shown whether or not the email is known, so the page
    never reveals which addresses can sign in. */
 const UNIFIED_CONFIRMATION = '如果该邮箱可用，你会收到一封登录邮件。'
+
+/* Client-side resend cooldown. A UX pace-keeper only — the real abuse cap is
+   the backend's per-email hourly limit, which the copy below states honestly
+   (the unified response makes an over-cap send indistinguishable client-side). */
+const RESEND_COOLDOWN_SECONDS = 60
+
+/* Copy for every `?error=` value the auth backend 302s to /login with.
+   Sources: magic-link verify (invalid / rate_limited), Google OAuth start
+   (google_unavailable) and callback (google_denied / invalid_state / invalid /
+   google_failed / email_unverified). Each entry says what happened and what to
+   do next; the form below stays ready so the player can act immediately. */
+const LOGIN_ERROR_COPY: Record<string, string> = {
+  invalid: `登录链接已失效或已被使用。链接只能使用一次、${MAGIC_LINK_TTL_MINUTES} 分钟内有效 —— 在下方重新输入邮箱，获取一封新的登录邮件。`,
+  rate_limited: '登录验证请求过于频繁，系统暂时限流。请稍等几分钟，再重新获取登录链接。',
+  google_unavailable: 'Google 登录暂未开放。请先用下方邮箱获取登录链接。',
+  google_denied: 'Google 登录已取消。可以重新点击 Google 登录，或改用邮箱获取登录链接。',
+  invalid_state: 'Google 登录会话已过期，请重新发起一次 Google 登录。',
+  google_failed: 'Google 登录没有完成，请重试；也可以改用邮箱获取登录链接。',
+  email_unverified: '这个 Google 账号的邮箱尚未通过 Google 验证，请改用下方邮箱获取登录链接。',
+}
+
+/* Backends may add error values; an unknown value still deserves an honest
+   explanation instead of a silent dead end. */
+const LOGIN_ERROR_FALLBACK = '登录没有完成。请在下方重新输入邮箱，获取一封新的登录邮件。'
+
+function loginErrorText(error: string | null): string | null {
+  if (!error) return null
+  return LOGIN_ERROR_COPY[error] ?? LOGIN_ERROR_FALLBACK
+}
 
 type Phase = 'idle' | 'submitting' | 'sent' | 'error'
 
@@ -35,26 +68,64 @@ function startWithOwnAI() {
    Platform chrome — brand yellow, dark-only, CSS-only transitions. */
 export default function LoginPage() {
   const { status, user, logout } = useAuth()
+  const [searchParams] = useSearchParams()
   const [email, setEmail] = useState('')
   const [phase, setPhase] = useState<Phase>('idle')
+  const [resendCooldown, setResendCooldown] = useState(0)
+  const [resending, setResending] = useState(false)
 
-  async function onSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    if (phase === 'submitting') return
-    setPhase('submitting')
+  // The verify / OAuth endpoints land their failures here as ?error=<value>.
+  // Rendered until a send succeeds — the form stays ready right below it.
+  const errorParam = loginErrorText(searchParams.get('error'))
 
+  // Tick the resend cooldown down once per second while the sent panel shows.
+  // setState fires only inside the timeout callback, never synchronously in
+  // the effect body (react-hooks/set-state-in-effect).
+  useEffect(() => {
+    if (phase !== 'sent' || resendCooldown <= 0) return
+    const id = setTimeout(() => setResendCooldown((s) => s - 1), 1000)
+    return () => clearTimeout(id)
+  }, [phase, resendCooldown])
+
+  // POST the magic-link request. Any completed request — known, unknown,
+  // malformed, or rate-limited — resolves to the same unified confirmation
+  // (anti-enumeration). Only a true network failure returns false.
+  async function sendRequest(): Promise<boolean> {
     const body: MagicLinkRequestBody = { email }
     try {
-      // Any completed request — known, unknown, malformed, or rate-limited —
-      // resolves to the same unified confirmation (anti-enumeration). Only a
-      // true network failure surfaces a retry.
       await fetch(`${API_BASE}/api/auth/magic-link/request`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       })
-      setPhase('sent')
+      return true
     } catch {
+      return false
+    }
+  }
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (phase === 'submitting') return
+    setPhase('submitting')
+    if (await sendRequest()) {
+      setPhase('sent')
+      setResendCooldown(RESEND_COOLDOWN_SECONDS)
+    } else {
+      setPhase('error')
+    }
+  }
+
+  // Resend keeps the sent panel in place (no flip back to the form while in
+  // flight); a network failure drops back to the form with the retry line.
+  async function onResend() {
+    if (resending || resendCooldown > 0) return
+    setResending(true)
+    const ok = await sendRequest()
+    setResending(false)
+    if (ok) {
+      setResendCooldown(RESEND_COOLDOWN_SECONDS)
+    } else {
       setPhase('error')
     }
   }
@@ -77,11 +148,38 @@ export default function LoginPage() {
 
       <GlassCard radius="2xl" className={styles.card}>
         {phase === 'sent' ? (
-          <p className={styles.confirmation} role="status">
-            {UNIFIED_CONFIRMATION}
-          </p>
+          <div className={styles.sentPanel}>
+            <p className={styles.confirmation} role="status">
+              {UNIFIED_CONFIRMATION}
+            </p>
+            {/* Echo of the player's own typed address — leaks nothing the
+                player didn't already know, and catches typos early. */}
+            <p className={styles.sentEmail}>{email}</p>
+            <ul className={styles.sentHints}>
+              <li>登录链接 {MAGIC_LINK_TTL_MINUTES} 分钟内有效，且只能使用一次。</li>
+              <li>没收到？看看垃圾邮件或推广分类，也可能晚到一两分钟。</li>
+            </ul>
+            <Button variant="ghost" onClick={onResend} disabled={resending || resendCooldown > 0}>
+              {resending
+                ? '发送中…'
+                : resendCooldown > 0
+                  ? `重新发送（${resendCooldown} 秒后可用）`
+                  : '重新发送登录邮件'}
+            </Button>
+            <p className={styles.sentRateNote}>
+              同一邮箱一小时内最多发送 {MAGIC_LINK_HOURLY_SEND_LIMIT} 封登录邮件。
+            </p>
+            <button type="button" className={styles.switchEmail} onClick={() => setPhase('idle')}>
+              换一个邮箱
+            </button>
+          </div>
         ) : (
           <>
+            {errorParam && (
+              <p className={styles.errorBanner} role="alert">
+                {errorParam}
+              </p>
+            )}
             <form className={styles.form} onSubmit={onSubmit}>
               <label className={styles.label} htmlFor="login-email">
                 邮箱

--- a/shared/auth-types.ts
+++ b/shared/auth-types.ts
@@ -13,6 +13,22 @@
 /** Session cookie name carrying the opaque session id. */
 export const SESSION_COOKIE_NAME = 'amiclaw_session'
 
+/**
+ * Magic-link token TTL in minutes — invariant ①: ≤ 15 minutes. SSOT for both
+ * the KV expirationTtl (packages/api auth config) and the login-page validity
+ * copy, so the promise shown to the player can never drift from the backend.
+ */
+export const MAGIC_LINK_TTL_MINUTES = 15
+
+/**
+ * Per-email magic-link send cap within one hour — invariant ③. SSOT for both
+ * the KV rate-limit counter (packages/api auth config) and the login-page
+ * resend copy. The backend swallows over-cap sends behind the unified
+ * anti-enumeration response, so the frontend states the cap honestly instead
+ * of pretending it can detect a throttle.
+ */
+export const MAGIC_LINK_HOURLY_SEND_LIMIT = 5
+
 /** Body of `POST /api/auth/magic-link/request`. */
 export interface MagicLinkRequestBody {
   email: string


### PR DESCRIPTION
## Summary
- A2 (audit F15): render login error states for all backend auth error enum values — expired/invalid magic links no longer fail silently
- A3 (audit F14): magic-link post-send feedback — email echo, real TTL, resend honoring rate limit, spam-folder hint
- A9 (audit F1/F13): first-win flow reworked — rank reveal first, nickname gate skippable/deferrable with honest not-on-board messaging, survey never stacks over rank reveal

Phase A batch 1 of [arcade product-closure plan](https://github.com/amio-love/amiclaw). Independently verified (3-axis pass, zero fixes); full unit suite + e2e audit green locally.

## Test plan
- [x] pnpm -r test:run (1359 tests green)
- [x] e2e audit 24↔24, bddgen + Playwright specs green
- [ ] CI full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w79dZWZzh7A7W6A7deN31