### PR TITLE
fix(platform): honest leaderboard label and per-player daily dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ real 15-minute single-use validity, hints at the spam folder, and offers a
 cooldown-gated resend button plus an honest note of the 5-per-hour send cap. A
 换一个邮箱 link returns to the form to fix a typo.
 
+**One leaderboard row per player per day** - Fix. Replaying the daily challenge
+no longer stacks duplicate rows on the leaderboard: each player keeps a single
+row showing their best time of the day, and slower retries never displace it.
+Older duplicate rows are also collapsed when the board is read. The attempt
+counter now accumulates across tabs and browser restarts within the same day,
+so a retry can no longer present itself as a first attempt.
+
+**Honest attempt column on the daily leaderboard** - Fix. The daily leaderboard
+column previously labeled 失误 (mistakes) actually shows which attempt of the
+day set the time — a flawless first-try win read as "1 mistake". The column is
+now labeled 用时 · 尝试 and each row reads 第 N 次.
+
 **Daily Arcade loop and streaks** - New. The homepage now shows a real daily
 checklist for BombSquad and Oracle, result pages show profile-save and share
 feedback, and the leaderboard now includes a public streak board for claimed

--- a/e2e/regression/verify-mobile-beta-flow.gherkin
+++ b/e2e/regression/verify-mobile-beta-flow.gherkin
@@ -37,7 +37,7 @@ Feature: Mobile internal-beta layout regression guards
     When I open /leaderboard
     Then the nickname wraps onto multiple lines inside the "玩家" column
     And the rendered table width does not exceed the 320px viewport
-    And the "用时 · 失误" column header and every time and attempt value stay fully visible
+    And the "用时 · 尝试" column header and every time and attempt value stay fully visible
     And no horizontal scrolling and no silently clipped column occurs
 
   # bug: L3-1 — WireModule's transparent .wire-hit-target click proxy had

--- a/e2e/steps/result.steps.ts
+++ b/e2e/steps/result.steps.ts
@@ -287,13 +287,14 @@ Then('the rendered table width does not exceed the 320px viewport', async ({ pag
 })
 
 Then(
-  'the "用时 · 失误" column header and every time and attempt value stay fully visible',
+  'the "用时 · 尝试" column header and every time and attempt value stay fully visible',
   async ({ page }) => {
     const table = page.getByRole('table')
     await expect(table).toBeVisible()
-    // The Atlas rebuild merged time + 失误/attempt into one composite column;
-    // assert that header is present by its real text.
-    await expect(table.getByRole('columnheader', { name: '用时 · 失误' })).toBeVisible()
+    // The Atlas rebuild merged time + attempt into one composite column;
+    // assert that header is present by its real text (relabeled from the
+    // misleading 失误 — the value is the daily attempt number, not mistakes).
+    await expect(table.getByRole('columnheader', { name: '用时 · 尝试' })).toBeVisible()
     // The genuine L5-1 invariant: nothing is clipped at the 320px viewport.
     const overflow = await page.evaluate(
       () => document.documentElement.scrollWidth - document.documentElement.clientWidth

--- a/packages/api/src/handlers/get-leaderboard.test.ts
+++ b/packages/api/src/handlers/get-leaderboard.test.ts
@@ -20,16 +20,24 @@ function request(date: string): Request {
   return new Request(`https://claw.amio.fans/api/leaderboard?date=${date}`, { method: 'GET' })
 }
 
-describe('handleGetLeaderboard — run_id privacy', () => {
-  // run_id is an internal backend dedup key. It must never reach the public
-  // leaderboard response, or it would leak a stable per-run identifier.
-  it('strips the internal run_id from every entry in the public response', async () => {
+describe('handleGetLeaderboard — internal key privacy', () => {
+  // run_id (per-run idempotency) and device_id (per-player dedup) are internal
+  // backend keys. They must never reach the public leaderboard response, or
+  // they would leak stable per-run / per-device identifiers.
+  it('strips the internal run_id and device_id from every entry in the public response', async () => {
     const kv = new FakeKV()
     const date = '2026-06-30'
     await kv.put(
       `leaderboard:${date}`,
       JSON.stringify([
-        { rank: 1, nickname: '小明', time_ms: 130_000, attempt_number: 1, run_id: 'run-x' },
+        {
+          rank: 1,
+          nickname: '小明',
+          time_ms: 130_000,
+          attempt_number: 1,
+          run_id: 'run-x',
+          device_id: 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee',
+        },
         { rank: 2, nickname: '小红', time_ms: 140_000, attempt_number: 1, run_id: 'run-y' },
       ])
     )
@@ -40,8 +48,35 @@ describe('handleGetLeaderboard — run_id privacy', () => {
     expect(body.entries).toHaveLength(2)
     for (const entry of body.entries) {
       expect(entry).not.toHaveProperty('run_id')
+      expect(entry).not.toHaveProperty('device_id')
     }
     // The public fields survive intact.
     expect(body.entries[0]).toMatchObject({ rank: 1, nickname: '小明', time_ms: 130_000 })
+  })
+})
+
+describe('handleGetLeaderboard — read-time dedup of historical rows', () => {
+  // Rows written before write-time per-player dedup shipped can contain the
+  // same player several times. The GET collapses them (best time wins) so
+  // historical boards stay honest until the 48h KV TTL ages them out.
+  it('collapses duplicate legacy rows sharing a nickname and re-ranks', async () => {
+    const kv = new FakeKV()
+    const date = '2026-06-30'
+    await kv.put(
+      `leaderboard:${date}`,
+      JSON.stringify([
+        { rank: 1, nickname: '审计员07', time_ms: 130_000, attempt_number: 1 },
+        { rank: 2, nickname: '审计员07', time_ms: 140_000, attempt_number: 1 },
+        { rank: 3, nickname: '小红', time_ms: 150_000, attempt_number: 2 },
+      ])
+    )
+
+    const response = await handleGetLeaderboard(request(date), kv as unknown as KVNamespace)
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as LeaderboardResponse
+    expect(body.entries).toEqual([
+      { rank: 1, nickname: '审计员07', time_ms: 130_000, attempt_number: 1 },
+      { rank: 2, nickname: '小红', time_ms: 150_000, attempt_number: 2 },
+    ])
   })
 })

--- a/packages/api/src/handlers/get-leaderboard.ts
+++ b/packages/api/src/handlers/get-leaderboard.ts
@@ -1,8 +1,5 @@
 import type { LeaderboardEntry, LeaderboardResponse } from '../../../../shared/leaderboard-types'
-
-// Internal KV shape includes the dedup key; it must be stripped before the
-// public GET response so run_id is never exposed to leaderboard readers.
-type StoredEntry = LeaderboardEntry & { run_id?: string }
+import { dedupeStoredEntries, type StoredEntry } from '../leaderboard-entries'
 
 export async function handleGetLeaderboard(request: Request, kv: KVNamespace): Promise<Response> {
   const url = new URL(request.url)
@@ -16,11 +13,15 @@ export async function handleGetLeaderboard(request: Request, kv: KVNamespace): P
   }
 
   const raw = ((await kv.get(`leaderboard:${date}`, 'json')) as StoredEntry[] | null) ?? []
-  // Strip the internal run_id from every entry — it is a backend dedup key,
-  // not part of the public leaderboard contract.
-  const entries: LeaderboardEntry[] = raw.map((e) => {
+  // Read-time dedup: rows written before write-time per-player dedup shipped
+  // can still contain duplicates (same player, multiple runs). Collapsing at
+  // read keeps historical boards honest until they age out of the 48h KV TTL.
+  // Then strip the internal keys — run_id (per-run idempotency) and device_id
+  // (per-player dedup) are backend keys, not part of the public contract.
+  const entries: LeaderboardEntry[] = dedupeStoredEntries(raw).map((e) => {
     const entry = { ...e } as Partial<StoredEntry>
     delete entry.run_id
+    delete entry.device_id
     return entry as LeaderboardEntry
   })
 

--- a/packages/api/src/handlers/post-score.test.ts
+++ b/packages/api/src/handlers/post-score.test.ts
@@ -215,7 +215,7 @@ describe('handlePostScore — run_id idempotency', () => {
     expect(entries?.[0]).toMatchObject({ rank: 1, time_ms: 130_000, run_id: 'run-x' })
   })
 
-  it('appends runs that carry distinct run_ids', async () => {
+  it('appends runs that carry distinct run_ids from different devices', async () => {
     const kv = new FakeKV()
     const date = new Date().toISOString().slice(0, 10)
     await kv.put(
@@ -233,5 +233,143 @@ describe('handlePostScore — run_id idempotency', () => {
     expect(response.status).toBe(200)
     const entries = (await kv.get(`leaderboard:${date}`, 'json')) as LeaderboardEntry[] | null
     expect(entries).toHaveLength(2)
+  })
+})
+
+describe('handlePostScore — one row per player per day', () => {
+  type StoredRow = LeaderboardEntry & { run_id?: string; device_id?: string }
+  const date = new Date().toISOString().slice(0, 10)
+
+  it('replaces the player row when a new run beats their existing best', async () => {
+    const kv = new FakeKV()
+    await kv.put(
+      `leaderboard:${date}`,
+      JSON.stringify([
+        {
+          rank: 1,
+          nickname: '小明',
+          time_ms: 150_000,
+          attempt_number: 1,
+          device_id: VALID_DEVICE_ID,
+          run_id: 'run-1',
+        },
+      ])
+    )
+
+    const response = await handlePostScore(
+      request(submission({ time_ms: 130_000, attempt_number: 2, run_id: 'run-2' })),
+      kv as unknown as KVNamespace
+    )
+
+    expect(response.status).toBe(200)
+    const entries = (await kv.get(`leaderboard:${date}`, 'json')) as StoredRow[] | null
+    expect(entries).toHaveLength(1)
+    expect(entries?.[0]).toMatchObject({ rank: 1, time_ms: 130_000, attempt_number: 2 })
+  })
+
+  it('keeps the existing best and ranks it when a new run is slower', async () => {
+    const kv = new FakeKV()
+    await kv.put(
+      `leaderboard:${date}`,
+      JSON.stringify([
+        {
+          rank: 1,
+          nickname: '小红',
+          time_ms: 100_000,
+          attempt_number: 1,
+          device_id: 'cccccccc-dddd-4eee-9fff-000000000000',
+          run_id: 'run-other',
+        },
+        {
+          rank: 2,
+          nickname: '小明',
+          time_ms: 120_000,
+          attempt_number: 1,
+          device_id: VALID_DEVICE_ID,
+          run_id: 'run-1',
+        },
+      ])
+    )
+
+    const response = await handlePostScore(
+      request(
+        submission({
+          time_ms: 150_000,
+          module_times: [45_000, 40_000, 35_000, 29_000],
+          attempt_number: 2,
+          run_id: 'run-2',
+        })
+      ),
+      kv as unknown as KVNamespace
+    )
+
+    expect(response.status).toBe(200)
+    const entries = (await kv.get(`leaderboard:${date}`, 'json')) as StoredRow[] | null
+    // The slower retry did not create a second row for the player.
+    expect(entries).toHaveLength(2)
+    expect(entries?.[1]).toMatchObject({ rank: 2, time_ms: 120_000, attempt_number: 1 })
+    // The response rank points at the player's kept (best) row.
+    const body = (await response.json()) as { rank: number; total_players: number }
+    expect(body.rank).toBe(2)
+    expect(body.total_players).toBe(2)
+  })
+
+  it('keeps same-nickname submissions from different devices as separate rows', async () => {
+    const kv = new FakeKV()
+    await kv.put(
+      `leaderboard:${date}`,
+      JSON.stringify([
+        {
+          rank: 1,
+          nickname: '小明',
+          time_ms: 120_000,
+          attempt_number: 1,
+          device_id: 'cccccccc-dddd-4eee-9fff-000000000000',
+          run_id: 'run-other',
+        },
+      ])
+    )
+
+    const response = await handlePostScore(
+      request(submission({ time_ms: 130_000, run_id: 'run-mine' })),
+      kv as unknown as KVNamespace
+    )
+
+    expect(response.status).toBe(200)
+    const entries = (await kv.get(`leaderboard:${date}`, 'json')) as StoredRow[] | null
+    expect(entries).toHaveLength(2)
+  })
+
+  it('keeps per-day boards independent — a submission never touches another day', async () => {
+    const kv = new FakeKV()
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10)
+    await kv.put(
+      `leaderboard:${yesterday}`,
+      JSON.stringify([
+        {
+          rank: 1,
+          nickname: '小明',
+          time_ms: 150_000,
+          attempt_number: 1,
+          device_id: VALID_DEVICE_ID,
+          run_id: 'run-old',
+        },
+      ])
+    )
+
+    const response = await handlePostScore(
+      request(submission({ time_ms: 130_000, run_id: 'run-new' })),
+      kv as unknown as KVNamespace
+    )
+
+    expect(response.status).toBe(200)
+    const todayEntries = (await kv.get(`leaderboard:${date}`, 'json')) as StoredRow[] | null
+    const yesterdayEntries = (await kv.get(`leaderboard:${yesterday}`, 'json')) as
+      | StoredRow[]
+      | null
+    expect(todayEntries).toHaveLength(1)
+    expect(todayEntries?.[0]).toMatchObject({ time_ms: 130_000 })
+    expect(yesterdayEntries).toHaveLength(1)
+    expect(yesterdayEntries?.[0]).toMatchObject({ time_ms: 150_000 })
   })
 })

--- a/packages/api/src/handlers/post-score.ts
+++ b/packages/api/src/handlers/post-score.ts
@@ -1,12 +1,9 @@
-import type {
-  ScoreSubmission,
-  LeaderboardEntry,
-  ScoreSubmissionResponse,
-} from '../../../../shared/leaderboard-types'
+import type { ScoreSubmission, ScoreSubmissionResponse } from '../../../../shared/leaderboard-types'
 import { computeBestRecord, type BestRecord } from '../../../../shared/personal-best'
 import { captureSettlementEvent } from '../../../companion-memory/src/capture'
 import type { CompanionDb } from '../../../companion-memory/src/db'
 import { readSessionFromRequest } from '../auth/session'
+import { dedupeStoredEntries, type StoredEntry } from '../leaderboard-entries'
 import {
   MAX_AI_MODEL_LEN,
   MAX_AI_TOOL_LEN,
@@ -14,10 +11,6 @@ import {
   sanitizeNickname,
   validateSubmission,
 } from '../validation'
-
-// Internal KV shape: LeaderboardEntry plus the dedup key, which is never
-// exposed through the public GET response (stripped in get-leaderboard.ts).
-type StoredEntry = LeaderboardEntry & { run_id?: string }
 
 const RATE_LIMIT_MS = 10_000
 const MAX_ENTRIES = 100
@@ -77,6 +70,7 @@ export async function handlePostScore(
     time_ms: body.time_ms,
     attempt_number: body.attempt_number,
     ai_tool: sanitizeLeaderboardText(body.ai_tool, MAX_AI_TOOL_LEN),
+    device_id: body.device_id,
     ...(body.run_id ? { run_id: body.run_id } : {}),
   }
   const aiModel = body.ai_model
@@ -89,17 +83,25 @@ export async function handlePostScore(
   // the same run (e.g. page refresh or KV race) produce exactly one row.
   const base = body.run_id ? existing.filter((e) => e.run_id !== body.run_id) : existing
 
-  const updated = [...base, newEntry]
-    .sort((a, b) => a.time_ms - b.time_ms)
-    .slice(0, MAX_ENTRIES)
-    .map((entry, idx) => ({ ...entry, rank: idx + 1 }))
+  // One row per player per day: dedupeStoredEntries keeps each player's best
+  // time (keyed on device_id, nickname fallback for legacy rows), sorts, and
+  // reassigns ranks. A resubmission slower than the player's existing best is
+  // therefore dropped here — the board always shows the day's best run.
+  const updated = dedupeStoredEntries([...base, newEntry]).slice(0, MAX_ENTRIES)
 
   await kv.put(leaderboardKey, JSON.stringify(updated), {
     expirationTtl: KV_TTL_SECONDS,
   })
 
-  const rank =
-    updated.findIndex((e) => e.nickname === newEntry.nickname && e.time_ms === newEntry.time_ms) + 1
+  // The player's board rank is their kept (best) row — not necessarily the
+  // run just submitted. Fall back to the legacy nickname+time match for rows
+  // that predate device_id storage.
+  let rank = updated.findIndex((e) => e.device_id === body.device_id) + 1
+  if (rank === 0) {
+    rank =
+      updated.findIndex((e) => e.nickname === newEntry.nickname && e.time_ms === newEntry.time_ms) +
+      1
+  }
 
   const response: ScoreSubmissionResponse = {
     rank: rank > 0 ? rank : updated.length + 1,

--- a/packages/api/src/leaderboard-entries.test.ts
+++ b/packages/api/src/leaderboard-entries.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { dedupeStoredEntries, type StoredEntry } from './leaderboard-entries'
+
+const DEVICE_A = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee'
+const DEVICE_B = 'bbbbbbbb-cccc-4ddd-9eee-ffffffffffff'
+
+function entry(overrides: Partial<StoredEntry> = {}): StoredEntry {
+  return {
+    rank: 0,
+    nickname: '小明',
+    time_ms: 130_000,
+    attempt_number: 1,
+    ai_tool: 'claude',
+    ...overrides,
+  }
+}
+
+describe('dedupeStoredEntries — one row per player, best time wins', () => {
+  it('keeps only the faster run when the same device submits twice', () => {
+    const result = dedupeStoredEntries([
+      entry({ device_id: DEVICE_A, time_ms: 150_000, attempt_number: 1 }),
+      entry({ device_id: DEVICE_A, time_ms: 130_000, attempt_number: 3 }),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ rank: 1, time_ms: 130_000, attempt_number: 3 })
+  })
+
+  it('keeps the existing best when the same device submits a slower run', () => {
+    const result = dedupeStoredEntries([
+      entry({ device_id: DEVICE_A, time_ms: 130_000, attempt_number: 1 }),
+      entry({ device_id: DEVICE_A, time_ms: 150_000, attempt_number: 2 }),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ rank: 1, time_ms: 130_000, attempt_number: 1 })
+  })
+
+  it('keeps the incumbent on an exact tie (mirrors personal-best strict <)', () => {
+    const result = dedupeStoredEntries([
+      entry({ device_id: DEVICE_A, time_ms: 130_000, attempt_number: 1 }),
+      entry({ device_id: DEVICE_A, time_ms: 130_000, attempt_number: 2 }),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ attempt_number: 1 })
+  })
+
+  it('keeps different devices as separate rows even with the same nickname', () => {
+    const result = dedupeStoredEntries([
+      entry({ device_id: DEVICE_A, time_ms: 150_000 }),
+      entry({ device_id: DEVICE_B, time_ms: 130_000 }),
+    ])
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({ rank: 1, time_ms: 130_000, device_id: DEVICE_B })
+    expect(result[1]).toMatchObject({ rank: 2, time_ms: 150_000, device_id: DEVICE_A })
+  })
+
+  it('collapses legacy rows (no device_id) sharing a nickname, keeping the best', () => {
+    const result = dedupeStoredEntries([
+      entry({ nickname: '审计员07', time_ms: 150_000, attempt_number: 1 }),
+      entry({ nickname: '审计员07', time_ms: 130_000, attempt_number: 1 }),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ rank: 1, nickname: '审计员07', time_ms: 130_000 })
+  })
+
+  it('keeps legacy rows with distinct nicknames as separate rows', () => {
+    const result = dedupeStoredEntries([
+      entry({ nickname: '小明', time_ms: 150_000 }),
+      entry({ nickname: '小红', time_ms: 130_000 }),
+    ])
+    expect(result).toHaveLength(2)
+  })
+
+  it('merges a legacy row into a same-nickname device row, keeping the faster device run', () => {
+    const result = dedupeStoredEntries([
+      entry({ nickname: '小明', time_ms: 150_000 }),
+      entry({ nickname: '小明', device_id: DEVICE_A, time_ms: 130_000 }),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ time_ms: 130_000, device_id: DEVICE_A })
+  })
+
+  it('merges a faster legacy row into a same-nickname device row, adopting the device_id', () => {
+    const result = dedupeStoredEntries([
+      entry({ nickname: '小明', time_ms: 120_000, attempt_number: 2 }),
+      entry({ nickname: '小明', device_id: DEVICE_A, time_ms: 130_000, attempt_number: 4 }),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      time_ms: 120_000,
+      attempt_number: 2,
+      device_id: DEVICE_A,
+    })
+  })
+
+  it('re-sorts ascending by time and reassigns contiguous ranks after collapsing', () => {
+    const result = dedupeStoredEntries([
+      entry({ rank: 1, device_id: DEVICE_A, time_ms: 100_000 }),
+      entry({ rank: 2, device_id: DEVICE_A, time_ms: 140_000 }),
+      entry({ rank: 3, nickname: '小红', device_id: DEVICE_B, time_ms: 120_000 }),
+      entry({ rank: 4, nickname: 'Legacy', time_ms: 110_000 }),
+    ])
+    expect(result.map((e) => [e.rank, e.time_ms])).toEqual([
+      [1, 100_000],
+      [2, 110_000],
+      [3, 120_000],
+    ])
+  })
+})

--- a/packages/api/src/leaderboard-entries.ts
+++ b/packages/api/src/leaderboard-entries.ts
@@ -1,0 +1,65 @@
+import type { LeaderboardEntry } from '../../../shared/leaderboard-types'
+
+/**
+ * Internal KV row shape: the public LeaderboardEntry plus two backend-only
+ * keys. Both are stripped in get-leaderboard.ts before the public response.
+ *
+ *  - `run_id`    — per-run idempotency key (double-POST of the same run).
+ *  - `device_id` — per-player dedup key (one row per player per day). The
+ *    localStorage device UUID is the strongest player identity the anonymous
+ *    leaderboard has; clearing localStorage rotates it, which also resets the
+ *    nickname and attempt counter, so a "new" device is a new player.
+ */
+export type StoredEntry = LeaderboardEntry & { run_id?: string; device_id?: string }
+
+/**
+ * Collapse a day's rows to one entry per player (best time wins), then
+ * re-sort ascending by time and reassign ranks.
+ *
+ * Dedup keys, in order of strength:
+ *  1. `device_id` — rows sharing a device keep only the fastest (ties keep
+ *     the incumbent, mirroring personal-best's strict-`<` rule).
+ *  2. Legacy rows (written before device_id was stored) fall back to
+ *     `nickname`. Two distinct players sharing a nickname in legacy data
+ *     would wrongly collapse; accepted — legacy rows age out with the 48h
+ *     KV TTL.
+ *  3. Transition bridge: a legacy row sharing a nickname with a device-keyed
+ *     row is treated as the same player. The better time survives and adopts
+ *     the device_id so future write-time dedup stays keyed on the device.
+ */
+export function dedupeStoredEntries(entries: StoredEntry[]): StoredEntry[] {
+  const byDevice = new Map<string, StoredEntry>()
+  const legacyByNickname = new Map<string, StoredEntry>()
+
+  const better = (incumbent: StoredEntry | undefined, candidate: StoredEntry): StoredEntry =>
+    incumbent === undefined || candidate.time_ms < incumbent.time_ms ? candidate : incumbent
+
+  for (const entry of entries) {
+    if (entry.device_id) {
+      byDevice.set(entry.device_id, better(byDevice.get(entry.device_id), entry))
+    } else {
+      legacyByNickname.set(entry.nickname, better(legacyByNickname.get(entry.nickname), entry))
+    }
+  }
+
+  for (const [nickname, legacy] of legacyByNickname) {
+    let bestDeviceId: string | null = null
+    let bestRow: StoredEntry | null = null
+    for (const [deviceId, row] of byDevice) {
+      if (row.nickname !== nickname) continue
+      if (bestRow === null || row.time_ms < bestRow.time_ms) {
+        bestRow = row
+        bestDeviceId = deviceId
+      }
+    }
+    if (bestRow === null || bestDeviceId === null) continue
+    legacyByNickname.delete(nickname)
+    if (legacy.time_ms < bestRow.time_ms) {
+      byDevice.set(bestDeviceId, { ...legacy, device_id: bestDeviceId })
+    }
+  }
+
+  return [...byDevice.values(), ...legacyByNickname.values()]
+    .sort((a, b) => a.time_ms - b.time_ms)
+    .map((entry, idx) => ({ ...entry, rank: idx + 1 }))
+}

--- a/packages/game-bombsquad/src/hooks/useDailyChallenge.ts
+++ b/packages/game-bombsquad/src/hooks/useDailyChallenge.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import { getTodayString } from '@shared/date'
-import { readDailyAttemptCount, reserveDailyAttempt } from '@/utils/session'
+import { getDailyAttemptStorage, readDailyAttemptCount, reserveDailyAttempt } from '@/utils/session'
 
 /**
  * Pick the origin that the AI partner should fetch the manual from.
@@ -27,7 +27,8 @@ function getOrigin(): string {
 
 /**
  * Returns manual URLs for today's daily challenge and the practice mode.
- * Tracks attempt number per day in sessionStorage.
+ * Tracks attempt number per day in localStorage (via getDailyAttemptStorage)
+ * so the count is cumulative across tabs and browser restarts within a day.
  */
 export function useDailyChallenge(): {
   practiceUrl: string
@@ -41,11 +42,11 @@ export function useDailyChallenge(): {
   const practiceUrl = `${origin}/manual/practice`
 
   const [attemptNumber, setAttemptNumber] = useState(() =>
-    readDailyAttemptCount(sessionStorage, today)
+    readDailyAttemptCount(getDailyAttemptStorage(), today)
   )
 
   const incrementAttempt = useCallback(() => {
-    setAttemptNumber(reserveDailyAttempt(sessionStorage, today))
+    setAttemptNumber(reserveDailyAttempt(getDailyAttemptStorage(), today))
   }, [today])
 
   return { practiceUrl, dailyUrl, attemptNumber, incrementAttempt }

--- a/packages/game-bombsquad/src/pages/GamePage.attempt.test.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.attempt.test.tsx
@@ -49,7 +49,7 @@ vi.mock('@/modules/keypad/KeypadModule', () => ({
 
 import GamePage from './GamePage'
 import { GameProvider } from '@/store/game-context'
-import { getDailyAttemptKey } from '@/utils/session'
+import { getDailyAttemptKey, getDailyAttemptStorage } from '@/utils/session'
 
 const MINIMAL_MANUAL = {
   modules: {
@@ -71,8 +71,11 @@ function renderDailyRun() {
 }
 
 describe('GamePage daily attempt persistence', () => {
+  // Attempt counts live in the daily-attempt storage (localStorage in real
+  // browsers, in-memory fallback in this jsdom env) — reset it between tests.
   beforeEach(() => {
     sessionStorage.clear()
+    getDailyAttemptStorage().removeItem(getDailyAttemptKey())
     loadManualMock.mockReset()
     generateWireMock.mockClear()
     generateDialMock.mockClear()
@@ -82,6 +85,7 @@ describe('GamePage daily attempt persistence', () => {
 
   afterEach(() => {
     sessionStorage.clear()
+    getDailyAttemptStorage().removeItem(getDailyAttemptKey())
   })
 
   it('does not persist a daily attempt when manual loading fails before the first module', async () => {
@@ -93,7 +97,7 @@ describe('GamePage daily attempt persistence', () => {
       expect(screen.getByText(/加载失败/)).toBeInTheDocument()
     })
 
-    expect(sessionStorage.getItem(getDailyAttemptKey())).toBeNull()
+    expect(getDailyAttemptStorage().getItem(getDailyAttemptKey())).toBeNull()
   })
 
   it('persists the previewed daily attempt only once the run reaches the first module', async () => {
@@ -105,6 +109,6 @@ describe('GamePage daily attempt persistence', () => {
       expect(screen.getByTestId('wire-module')).toBeInTheDocument()
     })
 
-    expect(sessionStorage.getItem(getDailyAttemptKey())).toBe('1')
+    expect(getDailyAttemptStorage().getItem(getDailyAttemptKey())).toBe('1')
   })
 })

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -302,7 +302,16 @@ export default function ResultPage() {
         setSubmitFailKind(null)
         setSubmitFailMessage(null)
         setRankResult(result.data)
-        recordOptimistic(submission, result.data)
+        // The board keeps one row per player — the day's best. Only seed an
+        // optimistic entry when this run IS the personal best; a slower retry
+        // never appears on the board, so an optimistic copy of it would show
+        // the player a phantom second row next to their real best.
+        if (
+          result.data.personal_best_ms === undefined ||
+          submission.time_ms <= result.data.personal_best_ms
+        ) {
+          recordOptimistic(submission, result.data)
+        }
         try {
           sessionStorage.removeItem(`pending-score:${submission.date}`)
         } catch {

--- a/packages/game-bombsquad/src/utils/session.test.ts
+++ b/packages/game-bombsquad/src/utils/session.test.ts
@@ -5,6 +5,7 @@ import {
   commitDailyAttemptNumber,
   createGameRunId,
   getAttemptNumberForMode,
+  getDailyAttemptStorage,
   getRunSeed,
   readEntryRecoveryState,
   readDailyAttemptCount,
@@ -40,6 +41,19 @@ describe('session utilities', () => {
     expect(reserveDailyAttempt(storage, '2026-03-27')).toBe(1)
     expect(reserveDailyAttempt(storage, '2026-03-27')).toBe(2)
     expect(readDailyAttemptCount(storage, '2026-03-27')).toBe(2)
+  })
+
+  it('provides a working daily-attempt storage even without localStorage', () => {
+    // This jsdom env has no localStorage, so the accessor must hand back the
+    // in-memory fallback — and it must round-trip like real storage so the
+    // per-day cumulative attempt count survives within the app lifetime.
+    const storage = getDailyAttemptStorage()
+    storage.removeItem('attempt-2026-03-27')
+    expect(readDailyAttemptCount(storage, '2026-03-27')).toBe(0)
+    expect(reserveDailyAttempt(storage, '2026-03-27')).toBe(1)
+    expect(readDailyAttemptCount(storage, '2026-03-27')).toBe(1)
+    storage.removeItem('attempt-2026-03-27')
+    expect(readDailyAttemptCount(storage, '2026-03-27')).toBe(0)
   })
 
   it('returns mode-specific preview attempt numbers without reserving daily storage', () => {

--- a/packages/game-bombsquad/src/utils/session.ts
+++ b/packages/game-bombsquad/src/utils/session.ts
@@ -26,8 +26,40 @@ export function getDailyAttemptKey(date = getTodayString()): string {
   return `attempt-${date}`
 }
 
+export type DailyAttemptStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+const memoryAttemptStore = new Map<string, string>()
+const memoryAttemptStorage: DailyAttemptStorage = {
+  getItem: (key) => memoryAttemptStore.get(key) ?? null,
+  setItem: (key, value) => {
+    memoryAttemptStore.set(key, value)
+  },
+  removeItem: (key) => {
+    memoryAttemptStore.delete(key)
+  },
+}
+
+/**
+ * Daily attempt counts live in localStorage so the count is cumulative for
+ * the whole day: sessionStorage reset the counter on every new tab/session,
+ * letting any run present itself as "attempt 1". localStorage also keeps the
+ * counter aligned with the player identity — the device UUID and nickname
+ * live there too, so clearing it resets all three together. Falls back to an
+ * in-memory store when localStorage is unavailable (private browsing,
+ * restricted embeds, jsdom).
+ */
+export function getDailyAttemptStorage(): DailyAttemptStorage {
+  try {
+    const storage = globalThis.localStorage
+    if (storage) return storage
+  } catch {
+    // SecurityError in restricted contexts — fall through to memory.
+  }
+  return memoryAttemptStorage
+}
+
 export function readDailyAttemptCount(
-  storage: Pick<Storage, 'getItem'> = sessionStorage,
+  storage: Pick<Storage, 'getItem'> = getDailyAttemptStorage(),
   date = getTodayString()
 ): number {
   const rawValue = storage.getItem(getDailyAttemptKey(date))
@@ -36,7 +68,7 @@ export function readDailyAttemptCount(
 }
 
 export function reserveDailyAttempt(
-  storage: Pick<Storage, 'getItem' | 'setItem'> = sessionStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem'> = getDailyAttemptStorage(),
   date = getTodayString()
 ): number {
   const nextAttempt = readDailyAttemptCount(storage, date) + 1
@@ -45,7 +77,7 @@ export function reserveDailyAttempt(
 }
 
 export function previewDailyAttemptNumber(
-  storage: Pick<Storage, 'getItem'> = sessionStorage,
+  storage: Pick<Storage, 'getItem'> = getDailyAttemptStorage(),
   date = getTodayString()
 ): number {
   return readDailyAttemptCount(storage, date) + 1
@@ -53,7 +85,7 @@ export function previewDailyAttemptNumber(
 
 export function commitDailyAttemptNumber(
   attemptNumber: number,
-  storage: Pick<Storage, 'getItem' | 'setItem'> = sessionStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem'> = getDailyAttemptStorage(),
   date = getTodayString()
 ): number {
   const safeAttemptNumber = Number.isFinite(attemptNumber) && attemptNumber > 0 ? attemptNumber : 1
@@ -65,7 +97,7 @@ export function commitDailyAttemptNumber(
 
 export function getAttemptNumberForMode(
   mode: SessionMode,
-  storage: Pick<Storage, 'getItem'> = sessionStorage,
+  storage: Pick<Storage, 'getItem'> = getDailyAttemptStorage(),
   date = getTodayString()
 ): number {
   return mode === 'daily' ? previewDailyAttemptNumber(storage, date) : 1
@@ -74,7 +106,7 @@ export function getAttemptNumberForMode(
 export function commitAttemptNumberForMode(
   mode: SessionMode,
   attemptNumber: number,
-  storage: Pick<Storage, 'getItem' | 'setItem'> = sessionStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem'> = getDailyAttemptStorage(),
   date = getTodayString()
 ): number {
   return mode === 'daily' ? commitDailyAttemptNumber(attemptNumber, storage, date) : 1

--- a/packages/platform/src/components/leaderboard/DailyLeaderboardList.module.css
+++ b/packages/platform/src/components/leaderboard/DailyLeaderboardList.module.css
@@ -14,7 +14,7 @@
 /* Column grid is shared by the header and every row. Fixed track widths
    (not the prototype's 36px / 70px) keep the header and rows aligned: each
    row is its own grid container, so the rank track must fit a #1402-scale
-   rank and the score track the widest「用时 · 失误」value. */
+   rank and the score track the widest「用时 · 尝试」value. */
 .headRow,
 .row {
   display: grid;

--- a/packages/platform/src/components/leaderboard/DailyLeaderboardList.test.tsx
+++ b/packages/platform/src/components/leaderboard/DailyLeaderboardList.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * LeaderboardRows column-semantics test.
+ *
+ * The composite score column renders `attempt_number` — which daily attempt
+ * set the shown time. A previous header labeled it 失误 (mistakes), so a
+ * flawless first-try win read as "1 mistake". Guard the honest labeling:
+ * header says 尝试 and each cell renders 第 N 次.
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { LeaderboardEntry } from '@shared/leaderboard-types'
+import { LeaderboardRows } from './DailyLeaderboardList'
+
+const ENTRIES: LeaderboardEntry[] = [
+  { rank: 1, nickname: '小明', time_ms: 130_000, attempt_number: 1, ai_tool: 'claude' },
+  { rank: 2, nickname: '小红', time_ms: 145_000, attempt_number: 3 },
+]
+
+describe('LeaderboardRows — attempt column semantics', () => {
+  it('labels the composite column 用时 · 尝试, not 失误', () => {
+    render(<LeaderboardRows entries={ENTRIES} />)
+    expect(screen.getByRole('columnheader', { name: '用时 · 尝试' })).toBeInTheDocument()
+    expect(screen.queryByText(/失误/)).not.toBeInTheDocument()
+  })
+
+  it('renders each attempt value as 第 N 次', () => {
+    render(<LeaderboardRows entries={ENTRIES} />)
+    expect(screen.getByText(/02:10 · 第 1 次/)).toBeInTheDocument()
+    expect(screen.getByText(/02:25 · 第 3 次/)).toBeInTheDocument()
+  })
+})

--- a/packages/platform/src/components/leaderboard/DailyLeaderboardList.tsx
+++ b/packages/platform/src/components/leaderboard/DailyLeaderboardList.tsx
@@ -39,8 +39,10 @@ export function LeaderboardRows({ entries }: { entries: LeaderboardEntry[] }) {
       <div className={styles.headRow} role="row">
         <span role="columnheader">名次</span>
         <span role="columnheader">玩家</span>
+        {/* attempt_number is which daily attempt set this time — it is NOT a
+            mistake count, so the header must not say 失误. */}
         <span className={styles.headScore} role="columnheader">
-          用时 · 失误
+          用时 · 尝试
         </span>
       </div>
       {entries.map((row) => {
@@ -68,7 +70,7 @@ export function LeaderboardRows({ entries }: { entries: LeaderboardEntry[] }) {
               {aiMetadata && <span className={styles.aiMeta}>{aiMetadata}</span>}
             </span>
             <span className={styles.score} role="cell">
-              {formatMs(row.time_ms)} · {row.attempt_number} 次
+              {formatMs(row.time_ms)} · 第 {row.attempt_number} 次
             </span>
           </div>
         )


### PR DESCRIPTION
## Summary
- A5 (audit F12): 「失误」column relabeled — the wire carries `attempt_number`; no mistake count exists. Now 用时 · 尝试 / 第 N 次
- A6 (audit F23): one leaderboard row per player per day (device_id key, keep best); read-time dedup for legacy duplicates; attempts accumulate per day; device_id stripped from GET responses

Phase A batch 2 of the arcade product-closure plan. Independently verified (3-axis approve); C4 leaderboard doc synced.

## Test plan
- [x] api + dedup/session/platform suites green locally (full workspace suite re-ran green in commit hook)
- [x] typecheck / lint / format green
- [ ] CI full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w79dZWZzh7A7W6A7deN31