### PR TITLE
feat(platform): day-boundary transparency and unified product day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ cast a「真实卦签」— the per-day check-in act stays real, the sign conten
 declared demo. Real random casting stays off until the manual carries all 64
 hexagram texts; the current data covers 3 of 64.
 
+**The daily reset rule is now stated where "today" appears** - Change. Daily
+content follows the UTC date, so for Beijing players "today" rolls over at
+08:00 local time — but the site never said so. The homepage checklist, the
+BombSquad overview and landing daily card, the leaderboard, and the Oracle
+home now carry a compact hint stating the rule, with the rollover moment
+rendered in the viewer's own timezone.
+
+**Oracle and the arcade now agree on what day it is** - Fix. The Oracle home
+and sign card used the device's local calendar date while the 干支 seal and
+every other daily surface followed the UTC product day, so a sign cast before
+the daily reset could show one day's date with another day's 干支. Both the
+Gregorian date and the 干支 now derive from the same shared product day as the
+rest of the arcade, and the sign card dates itself from the cast timestamp.
+
 **Daily Arcade loop and streaks** - New. The homepage now shows a real daily
 checklist for BombSquad and Oracle, result pages show profile-save and share
 feedback, and the leaderboard now includes a public streak board for claimed

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -176,8 +176,10 @@ flows:
     name: Daily countdown display
     description: >-
       The homepage featured BombSquad overview shows a live 时 / 分 / 秒
-      countdown ticking toward the next daily reset.
-    steps: [landing, featured-bombsquad-overview, countdown-tick]
+      countdown ticking toward the next daily reset, plus a day-boundary hint
+      stating that daily content follows the UTC date and rolls over at the
+      viewer's localized wall-clock time (08:00 for Beijing users).
+    steps: [landing, featured-bombsquad-overview, countdown-tick, reset-rule-hint]
     status: active
 
   - id: bombsquad-zone-styling

--- a/e2e/homepage.gherkin
+++ b/e2e/homepage.gherkin
@@ -61,6 +61,7 @@ Feature: AMIO Arcade platform homepage
     Given I am on the homepage
     Then the BombSquad overview shows a countdown in 时 / 分 / 秒
     And the countdown counts down toward the next UTC 00:00 reset
+    And the overview states the daily reset rule with a localized rollover time
 
   # Source: home-signed-in-welcome
   @playwright

--- a/e2e/steps/homepage.steps.ts
+++ b/e2e/steps/homepage.steps.ts
@@ -209,6 +209,19 @@ Then('the countdown counts down toward the next UTC 00:00 reset', async ({ world
   expect(after).toBeLessThan(before)
 })
 
+Then(
+  'the overview states the daily reset rule with a localized rollover time',
+  async ({ page }) => {
+    // The hint states the honest day-boundary rule (product day = UTC date)
+    // and renders the rollover moment in the viewer's local wall-clock time,
+    // so the exact HH:MM depends on the browser timezone — assert the shape.
+    const featured = page.locator('#featured')
+    await expect(
+      featured.getByText(/每日内容按 UTC 日期刷新 · 本地时间每天 \d{2}:\d{2}/)
+    ).toBeVisible()
+  }
+)
+
 Then('I see the welcome strip greeting me by name', async ({ page }) => {
   await expect(page.getByText('你好，', { exact: false })).toBeVisible()
   // The display name is the session email local-part (nova@... -> nova).

--- a/packages/game-bombsquad/src/pages/BombSquadLandingPage.module.css
+++ b/packages/game-bombsquad/src/pages/BombSquadLandingPage.module.css
@@ -225,6 +225,12 @@
   margin-top: 4px;
 }
 
+.dailyHint {
+  margin-top: 6px;
+  font: 400 10px / 1.4 var(--font-body);
+  color: rgba(255, 255, 255, 0.45);
+}
+
 .dailyRight {
   display: flex;
   flex-direction: column;

--- a/packages/game-bombsquad/src/pages/BombSquadLandingPage.tsx
+++ b/packages/game-bombsquad/src/pages/BombSquadLandingPage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { AiToolList, BombSquadWordmark, DailyCountdown, Scenery } from '@amiclaw/ui'
+import { getDailyResetHint } from '@shared/date'
 import { formatMs } from '@shared/format-time'
 import Eyebrow from '@/components/bombsquad/Eyebrow'
 import Button from '@/components/bombsquad/Button'
@@ -90,6 +91,7 @@ export default function BombSquadLandingPage() {
               <div>
                 <div className={styles.dailyLabel}>今日挑战 · 重置</div>
                 <DailyCountdown size="sm" className={styles.countdown} />
+                <div className={styles.dailyHint}>{getDailyResetHint()}</div>
               </div>
               <div className={styles.dailyRight}>
                 <div className={styles.dailyRank}>

--- a/packages/game-bombsquad/src/pages/ResultPage.module.css
+++ b/packages/game-bombsquad/src/pages/ResultPage.module.css
@@ -293,6 +293,13 @@
   color: var(--y);
 }
 
+/* Day-boundary hint under the daily-loop status text. */
+.loopHint {
+  margin: 8px 0 0;
+  font: 400 11px / 1.4 var(--font-body);
+  color: rgba(255, 255, 255, 0.4);
+}
+
 .loopActions {
   display: flex;
   flex: 0 0 132px;

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -13,7 +13,7 @@ import { submitArcadeProfileEvent } from '@amiclaw/arcade-profile/api-client'
 import Button from '@/components/bombsquad/Button'
 import Glyph, { type GlyphKey } from '@/components/bombsquad/Glyph'
 import { useGame, MAX_STRIKES, type GameOutcome } from '@/store/game-context'
-import { getTodayString } from '@shared/date'
+import { getDailyResetHint, getTodayString } from '@shared/date'
 import { getDeviceId } from '@/utils/device-fingerprint'
 import { logEvent } from '@/utils/event-log'
 import { formatMs } from '@shared/format-time'
@@ -696,6 +696,7 @@ export default function ResultPage() {
                 {shareState !== 'idle' && (
                   <p className={styles.shareStatus}>{shareStatusText(shareState)}</p>
                 )}
+                <p className={styles.loopHint}>{getDailyResetHint()}</p>
               </div>
               <div className={styles.loopActions}>
                 <button type="button" className={styles.loopAction} onClick={handleShareResult}>

--- a/packages/game-yijing/src/glyphs/utils.test.ts
+++ b/packages/game-yijing/src/glyphs/utils.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest'
+import { getTodayString } from '@shared/date'
 import {
   coinsToYao,
   binaryKey,
   hexagramFromBinary,
   changedValues,
   changingLines,
+  ganzhi,
   yaoLabel,
   yaoShort,
   type YaoValue,
@@ -134,5 +136,38 @@ describe('KW_LOOKUP completeness', () => {
     expect(numbers.size).toBe(64)
     expect(Math.min(...numbers)).toBe(1)
     expect(Math.max(...numbers)).toBe(64)
+  })
+})
+
+describe('ganzhi — derives from the UTC product day', () => {
+  it('returns 甲子 for the 1984-02-02 epoch day', () => {
+    expect(ganzhi('1984-02-02')).toBe('甲子')
+  })
+
+  it('advances one cycle position per product day', () => {
+    expect(ganzhi('1984-02-03')).toBe('乙丑')
+  })
+
+  it('returns the previous position for the day before the epoch', () => {
+    expect(ganzhi('1984-02-01')).toBe('癸亥')
+  })
+
+  it('wraps the 60-day cycle (甲子 again 60 days after the epoch)', () => {
+    expect(ganzhi('1984-04-02')).toBe('甲子')
+  })
+
+  it('agrees for every instant of the same product day', () => {
+    // Start and end of the same UTC day must map to the same 干支.
+    const early = ganzhi(getTodayString(new Date('2026-07-07T00:01:00Z')))
+    const late = ganzhi(getTodayString(new Date('2026-07-07T23:59:00Z')))
+    expect(early).toBe(late)
+  })
+
+  it('differs across a UTC-midnight boundary even when the Beijing calendar date is unchanged', () => {
+    // 2026-07-07 07:59 Beijing == 2026-07-06T23:59Z (previous product day);
+    // 2026-07-07 08:01 Beijing == 2026-07-07T00:01Z (new product day).
+    const beforeRollover = ganzhi(getTodayString(new Date('2026-07-06T23:59:00Z')))
+    const afterRollover = ganzhi(getTodayString(new Date('2026-07-07T00:01:00Z')))
+    expect(beforeRollover).not.toBe(afterRollover)
   })
 })

--- a/packages/game-yijing/src/glyphs/utils.ts
+++ b/packages/game-yijing/src/glyphs/utils.ts
@@ -4,6 +4,7 @@
 // / window.yaoShort). `ganzhi` is a Phase-1 placeholder per handoff §9 — the
 // production build should swap in a real lunar / 甲子 library.
 
+import { getTodayString } from '@shared/date'
 import { KW_LOOKUP, type HexEntry } from './kw-lookup'
 
 /** Yao 爻 value space: 6 老阴, 7 少阳, 8 少阴, 9 老阳. */
@@ -64,15 +65,19 @@ const TIANGAN = ['甲', '乙', '丙', '丁', '戊', '己', '庚', '辛', '壬', 
 const DIZHI = ['子', '丑', '寅', '卯', '辰', '巳', '午', '未', '申', '酉', '戌', '亥'] as const
 
 /**
- * Placeholder 干支 (sexagenary cycle) for a given date.
+ * Placeholder 干支 (sexagenary cycle) label for a product day.
  *
- * Per handoff §9: "production should swap in a real lunar / 甲子 library."
- * This naive offset against the 1984-02-02 甲子 epoch is accurate enough for
- * scaffold display but must not be used for actual divination logic.
+ * Takes the shared `YYYY-MM-DD` product-day string (the UTC date — see
+ * `@shared/date`), so the label always agrees with the arcade shell's daily
+ * reset and with the Gregorian date shown next to it. Per handoff §9:
+ * "production should swap in a real lunar / 甲子 library" — this naive offset
+ * against the 1984-02-02 甲子 epoch is accurate enough for scaffold display
+ * but must not be used for actual divination logic.
  */
-export function ganzhi(date: Date = new Date()): string {
+export function ganzhi(isoDate: string = getTodayString()): string {
+  const [y, m, d] = isoDate.split('-').map(Number)
   const epoch = Date.UTC(1984, 1, 2) // 1984-02-02 = 甲子
-  const day = Math.floor((date.getTime() - epoch) / 86_400_000)
+  const day = Math.round((Date.UTC(y, m - 1, d) - epoch) / 86_400_000)
   const idx = ((day % 60) + 60) % 60
   return `${TIANGAN[idx % 10]}${DIZHI[idx % 12]}`
 }

--- a/packages/game-yijing/src/pages/PageHome.module.css
+++ b/packages/game-yijing/src/pages/PageHome.module.css
@@ -112,6 +112,11 @@
   color: #fff;
   margin-top: 4px;
 }
+.todayHint {
+  margin-top: 4px;
+  font: 400 10px / 1.4 var(--font-body);
+  color: rgba(255, 255, 255, 0.45);
+}
 
 /* ───── draw-of-the-day card ───── */
 .drawCard {

--- a/packages/game-yijing/src/pages/PageHome.tsx
+++ b/packages/game-yijing/src/pages/PageHome.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { Button, EyebrowTag, Scenery } from '@amiclaw/ui'
+import { getDailyResetHint, getTodayString, toChineseDateString } from '@shared/date'
 import { Hexagram, TaijiFrame } from '../glyphs'
 import { ganzhi, type YaoSextet } from '../glyphs/utils'
 import styles from './PageHome.module.css'
@@ -12,14 +13,12 @@ import styles from './PageHome.module.css'
 /* Mini icon on the draw-card — 6-yao mix used by the handoff prototype. */
 const DRAW_PREVIEW: YaoSextet = [7, 8, 7, 6, 7, 8]
 
-function todayCN(): string {
-  const d = new Date()
-  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`
-}
-
 export function PageHome() {
   const navigate = useNavigate()
-  const gz = ganzhi()
+  /* Today = the shared UTC product day, so the date, the 干支 stamp and the
+     daily checklist all roll over together at the shell's daily reset. */
+  const today = getTodayString()
+  const gz = ganzhi(today)
 
   return (
     <main className={styles.page}>
@@ -44,7 +43,8 @@ export function PageHome() {
             <div className={styles.todayStamp}>{gz}</div>
             <div className={styles.todayL}>
               <div className={styles.todayLbl}>今日 · {gz}日</div>
-              <div className={styles.todayCd}>{todayCN()}</div>
+              <div className={styles.todayCd}>{toChineseDateString(today)}</div>
+              <div className={styles.todayHint}>{getDailyResetHint()}</div>
             </div>
             {/* No ask-count stats here: Yijing has no counter backend, so any
                 「已问卦 / 你 第 N 次」number would be fabricated. */}

--- a/packages/game-yijing/src/pages/PageSign.tsx
+++ b/packages/game-yijing/src/pages/PageSign.tsx
@@ -7,6 +7,7 @@ import {
   recordOracleLocalSign,
 } from '@amiclaw/arcade-profile/local'
 import { submitArcadeProfileEvent } from '@amiclaw/arcade-profile/api-client'
+import { getTodayString, toChineseDateString } from '@shared/date'
 import { Hexagram } from '../glyphs'
 import {
   changedValues,
@@ -28,11 +29,6 @@ import styles from './PageSign.module.css'
 type SaveState = 'saving' | 'saved-local' | 'synced' | 'account-error' | 'unavailable'
 type ShareState = 'idle' | 'shared' | 'copied' | 'error'
 
-function todayCN(): string {
-  const d = new Date()
-  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`
-}
-
 export function PageSign() {
   const { yaoValues } = useSession()
   if (yaoValues === null) return <Navigate to="/home" replace />
@@ -45,6 +41,11 @@ function SignCard({ values }: { values: YaoSextet }) {
   const [saveState, setSaveState] = useState<SaveState>('saving')
   const [shareState, setShareState] = useState<ShareState>('idle')
 
+  /* The sign's product day (UTC date, shared with the arcade shell): the
+     cast timestamp when present. Both the Gregorian date and the 干支 seal
+     derive from it, so the card can never show one day's date with another
+     day's 干支. */
+  const signDate = castCreatedAt?.slice(0, 10) ?? getTodayString()
   const changed = changedValues(values) as unknown as YaoSextet
   const [benNumber, benCn] = hexagramFromBinary(values)
   const [, bianCn] = hexagramFromBinary(changed)
@@ -174,7 +175,7 @@ function SignCard({ values }: { values: YaoSextet }) {
         <div className={styles.card}>
           <div className={styles.cardHead}>
             <span className={styles.cardLbl}>AMIO 游乐场 · 卦签</span>
-            <span className={styles.cardDate}>{todayCN()}</span>
+            <span className={styles.cardDate}>{toChineseDateString(signDate)}</span>
           </div>
 
           <div className={styles.hexRow}>
@@ -201,7 +202,7 @@ function SignCard({ values }: { values: YaoSextet }) {
             <div className={styles.footUrl}>claw.amio.fans/oracle</div>
             <div className={styles.seal}>
               <span className={styles.sealL1}>{benCn}</span>
-              <span className={styles.sealL2}>{ganzhi()}</span>
+              <span className={styles.sealL2}>{ganzhi(signDate)}</span>
             </div>
           </div>
         </div>

--- a/packages/platform/src/components/home/DailyChecklist.module.css
+++ b/packages/platform/src/components/home/DailyChecklist.module.css
@@ -137,6 +137,12 @@
   font: 400 12px var(--font-body);
 }
 
+.hint {
+  margin: 6px 0 0;
+  color: rgba(255, 255, 255, 0.38);
+  font: 400 12px var(--font-body);
+}
+
 @media (max-width: 768px) {
   .section {
     padding: 22px;

--- a/packages/platform/src/components/home/DailyChecklist.tsx
+++ b/packages/platform/src/components/home/DailyChecklist.tsx
@@ -1,5 +1,5 @@
 import type { ArcadeProfileSummary } from '@amiclaw/arcade-profile/types'
-import { toChineseDateString } from '@shared/date'
+import { getDailyResetHint, toChineseDateString } from '@shared/date'
 import styles from './DailyChecklist.module.css'
 
 interface DailyChecklistProps {
@@ -72,6 +72,7 @@ export default function DailyChecklist({ profile, scope, loading = false }: Dail
           ? '正在读取账号记录；暂时显示这台设备上的状态。'
           : `最长连续 ${loop.streak.longest_days} 天。匿名状态只代表这台设备。`}
       </p>
+      <p className={styles.hint}>{getDailyResetHint()}</p>
     </section>
   )
 }

--- a/packages/platform/src/components/home/FeaturedBombSquad.module.css
+++ b/packages/platform/src/components/home/FeaturedBombSquad.module.css
@@ -110,6 +110,12 @@
   align-self: center;
 }
 
+.resetHint {
+  margin: 0;
+  font: 400 12px var(--font-body);
+  color: rgba(255, 255, 255, 0.45);
+}
+
 /* ----------  responsive: medium  ---------- */
 @media (max-width: 1080px) {
   .card {

--- a/packages/platform/src/components/home/FeaturedBombSquad.tsx
+++ b/packages/platform/src/components/home/FeaturedBombSquad.tsx
@@ -1,4 +1,5 @@
 import { AiToolList, BombSquadWordmark, DailyCountdown } from '@amiclaw/ui'
+import { getDailyResetHint } from '@shared/date'
 import styles from './FeaturedBombSquad.module.css'
 
 /* Featured BombSquad section — handoff §6.4. The left art panel is the
@@ -26,6 +27,7 @@ export default function FeaturedBombSquad() {
           <div className={styles.dailyPanel}>
             <h3 className={styles.sideTitle}>今日挑战</h3>
             <DailyCountdown size="lg" className={styles.countdown} />
+            <p className={styles.resetHint}>{getDailyResetHint()}</p>
           </div>
         </div>
       </div>

--- a/packages/platform/src/lib/shared-date.test.ts
+++ b/packages/platform/src/lib/shared-date.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Product-day helper tests (`@shared/date`).
+ *
+ * The product day is the UTC date: all daily surfaces (daily challenge,
+ * leaderboard, checklist, Oracle sign) roll over together at UTC midnight,
+ * which is 08:00 in Beijing. These tests pin the boundary behavior and the
+ * localized rollover-time rendering behind the user-facing reset hint.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  getDailyResetHint,
+  getLocalRolloverTime,
+  getTodayString,
+  toChineseDateString,
+} from '@shared/date'
+
+describe('getTodayString — UTC product day', () => {
+  it('07:59 Beijing still belongs to the previous product day (23:59 UTC)', () => {
+    // 2026-07-07 07:59 Asia/Shanghai == 2026-07-06T23:59Z
+    expect(getTodayString(new Date('2026-07-06T23:59:00Z'))).toBe('2026-07-06')
+  })
+
+  it('08:01 Beijing belongs to the new product day (00:01 UTC)', () => {
+    // 2026-07-07 08:01 Asia/Shanghai == 2026-07-07T00:01Z
+    expect(getTodayString(new Date('2026-07-07T00:01:00Z'))).toBe('2026-07-07')
+  })
+
+  it('rolls over exactly at UTC midnight', () => {
+    expect(getTodayString(new Date('2026-07-06T23:59:59.999Z'))).toBe('2026-07-06')
+    expect(getTodayString(new Date('2026-07-07T00:00:00.000Z'))).toBe('2026-07-07')
+  })
+})
+
+describe('getLocalRolloverTime', () => {
+  const now = new Date('2026-07-06T12:00:00Z')
+
+  it('renders the UTC-midnight rollover as 08:00 in Asia/Shanghai', () => {
+    expect(getLocalRolloverTime(now, 'Asia/Shanghai')).toBe('08:00')
+  })
+
+  it('renders 00:00 in UTC itself', () => {
+    expect(getLocalRolloverTime(now, 'UTC')).toBe('00:00')
+  })
+
+  it('handles non-hour offsets (Asia/Kathmandu, UTC+05:45)', () => {
+    expect(getLocalRolloverTime(now, 'Asia/Kathmandu')).toBe('05:45')
+  })
+})
+
+describe('getDailyResetHint', () => {
+  it('states the UTC rule with the localized rollover time', () => {
+    expect(getDailyResetHint(new Date('2026-07-06T12:00:00Z'), 'Asia/Shanghai')).toBe(
+      '每日内容按 UTC 日期刷新 · 本地时间每天 08:00'
+    )
+  })
+})
+
+describe('toChineseDateString', () => {
+  it('renders a product-day string in the Chinese date form', () => {
+    expect(toChineseDateString('2026-07-06')).toBe('2026 年 7 月 6 日')
+  })
+})

--- a/packages/platform/src/pages/AccountPage.module.css
+++ b/packages/platform/src/pages/AccountPage.module.css
@@ -147,6 +147,13 @@
   width: 100%;
 }
 
+/* Day-boundary hint under the 今日/连续 stat grid. */
+.statsHint {
+  margin: 0;
+  font: 400 12px var(--font-body);
+  color: rgba(255, 255, 255, 0.38);
+}
+
 .statBlock {
   min-width: 0;
   padding: 18px;

--- a/packages/platform/src/pages/AccountPage.tsx
+++ b/packages/platform/src/pages/AccountPage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@amiclaw/arcade-profile/local'
 import { claimArcadeProfile, fetchArcadeProfile } from '@amiclaw/arcade-profile/api-client'
 import { formatMs } from '@shared/format-time'
-import { toChineseDateString } from '@shared/date'
+import { getDailyResetHint, toChineseDateString } from '@shared/date'
 import { useAuth, type DisplayUser } from '@/hooks/useAuth'
 import CompanionCard from '@/components/companion/CompanionCard'
 import { companionSeedEnabled } from '@/lib/companion-seed'
@@ -330,6 +330,7 @@ function ArcadeStatsCard({
           }
         />
       </div>
+      <p className={styles.statsHint}>{getDailyResetHint()}</p>
       {!hasAnyRecord && (
         <a className={styles.emptyCta} href={emptyCtaHref}>
           开始玩

--- a/packages/platform/src/pages/LeaderboardPage.tsx
+++ b/packages/platform/src/pages/LeaderboardPage.tsx
@@ -1,7 +1,7 @@
 import { EyebrowTag } from '@amiclaw/ui'
 import DailyLeaderboardList from '@/components/leaderboard/DailyLeaderboardList'
 import StreakLeaderboardList from '@/components/leaderboard/StreakLeaderboardList'
-import { toChineseDateString } from '@shared/date'
+import { getDailyResetHint, toChineseDateString } from '@shared/date'
 import styles from './LeaderboardPage.module.css'
 
 /* Leaderboard page — BombSquad's daily time board remains the KV-backed daily
@@ -14,7 +14,9 @@ export default function LeaderboardPage() {
       <h2 className={styles.title}>
         Arcade · <span className={styles.accent}>每日</span>
       </h2>
-      <p className={styles.lead}>{toChineseDateString()} · 每日 UTC 0 点重置。</p>
+      <p className={styles.lead}>
+        {toChineseDateString()} · {getDailyResetHint()}
+      </p>
 
       <div className={styles.boardGrid}>
         <section className={styles.boardSection}>

--- a/shared/date.ts
+++ b/shared/date.ts
@@ -1,5 +1,8 @@
-export function getTodayString(): string {
-  return new Date().toISOString().slice(0, 10) // YYYY-MM-DD
+/* The product day is the UTC date: every daily surface (daily challenge,
+   leaderboard, checklist, Oracle sign) keys "today" off this string, and all
+   of them roll over together at UTC midnight (08:00 Beijing time). */
+export function getTodayString(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10) // YYYY-MM-DD (UTC product day)
 }
 
 /* Render a `YYYY-MM-DD` string as the Chinese date form
@@ -8,4 +11,25 @@ export function getTodayString(): string {
 export function toChineseDateString(iso?: string): string {
   const [y, m, d] = (iso ?? getTodayString()).split('-')
   return `${y} 年 ${Number(m)} 月 ${Number(d)} 日`
+}
+
+/* Local wall-clock time (`HH:MM`) at which the product day rolls over —
+   the next UTC midnight rendered in the viewer's timezone (or an explicit
+   `timeZone`, used by tests). Handles non-hour offsets (e.g. UTC+05:45). */
+export function getLocalRolloverTime(now: Date = new Date(), timeZone?: string): string {
+  const nextRollover = new Date(now)
+  nextRollover.setUTCHours(24, 0, 0, 0)
+  return new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+    ...(timeZone ? { timeZone } : {}),
+  }).format(nextRollover)
+}
+
+/* Compact user-facing hint stating the daily-reset rule. Shown wherever
+   今日/每日 content or the reset countdown appears, so players returning
+   before the local rollover time understand why "today" hasn't changed. */
+export function getDailyResetHint(now: Date = new Date(), timeZone?: string): string {
+  return `每日内容按 UTC 日期刷新 · 本地时间每天 ${getLocalRolloverTime(now, timeZone)}`
 }


### PR DESCRIPTION
## Summary
- A7 (audit F21): localized daily-reset hint on every surface presenting today/daily state (home checklist, daily entry, leaderboard, result page, account page) — the UTC product day is no longer a secret
- A8 (audit F22): Oracle date + 干支 unified onto the shared UTC product-day utility used by the shell; stored signs verified already UTC-keyed (no migration)

Phase A batch 3 of the arcade product-closure plan. Independent verify: soundness/coherence approve; one conformance fix round (two missed surfaces) applied and spot-checked.

## Test plan
- [x] shared-date 8/8 boundary tests (07:59/08:01 Beijing, UTC midnight), ganzhi 27/27
- [x] game-bombsquad 430 + platform 90 unit tests green; affected e2e 9/9
- [ ] CI full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w79dZWZzh7A7W6A7deN31