### PR TITLE
feat(game-yijing): honest oracle - remove AI claims and fake dialogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ column previously labeled 失误 (mistakes) actually shows which attempt of the
 day set the time — a flawless first-try win read as "1 mistake". The column is
 now labeled 用时 · 尝试 and each row reads 第 N 次.
 
+**The Oracle now tells the truth about itself** - Change. The Yijing Oracle
+flow made zero AI or voice calls while labeling its reading「Claude · 中文」and
+showing「AI 读心 / 语音对话中 / 正在说话」, and its「不太对」branch fabricated a
+player quote that was never spoken. All AI, voice, and mind-reading claims are
+removed: the reading screen is now a paced reveal of the classical texts
+themselves (本卦 卦辞 → 变爻 爻辞 → 变卦 卦辞), the sign card's「AI 洞见」became
+今日提点 sourced from the classical gloss, and the fixed demo cast is declared
+as 卦例演示 on every screen that shows it — including the coin screen's replay
+button and the homepage sample signs, which no longer masquerade as play
+history. The daily checklist and sign-save feedback no longer call the demo
+cast a「真实卦签」— the per-day check-in act stays real, the sign content is a
+declared demo. Real random casting stays off until the manual carries all 64
+hexagram texts; the current data covers 3 of 64.
+
 **Daily Arcade loop and streaks** - New. The homepage now shows a real daily
 checklist for BombSquad and Oracle, result pages show profile-save and share
 feedback, and the leaderboard now includes a public streak board for claimed

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -21,9 +21,9 @@
 #
 # --- Regression size budget --------------------------------------------------
 # Per the governance model (rule 3): the e2e regression suite is capped at
-# 2 x the journey-scenario count. With 24 active flows <-> 24 journey
-# scenarios, the regression size budget is 48 (2026-06-28, after the mode②
-# in-game voice-panel flow was added as a @playwright journey).
+# 2 x the journey-scenario count. With 25 active flows <-> 25 journey
+# scenarios, the regression size budget is 50 (2026-07-07, after the Yijing
+# Oracle honest-ritual flow was added as a @playwright journey).
 # Crossing it triggers a forced prune audit. Current regression count: 2.
 #
 # --- Retired scenario --------------------------------------------------------
@@ -326,4 +326,22 @@ flows:
         settle-listening,
         session-teardown,
       ]
+    status: active
+
+  # === Yijing Oracle flows ====================================================
+  # The /oracle/ hash-routed SPA. The flow is an honest ritual: the cast is a
+  # FIXED demo example declared to the player as 卦例演示 (real randomness is
+  # blocked on the full 64-hexagram judgment dataset), every reading text is
+  # classical manual data, and no screen claims AI, voice, or mind-reading
+  # involvement (audit F24/F25 rework).
+
+  - id: oracle-honest-session
+    name: Yijing Oracle honest demo ritual
+    description: >-
+      A visitor walks the full oracle session — home → 2-pick projection →
+      six coin throws (fixed demo cast, labeled 卦例演示) → staged classical
+      reading (本卦 卦辞 → 变爻 爻辞 → 变卦 卦辞, no fabricated dialogue) →
+      sign card with 今日提点 — and no screen in the flow renders an AI /
+      voice / mind-reading claim.
+    steps: [oracle-home, projection-picks, demo-cast, classical-reading, sign-card]
     status: active

--- a/e2e/steps/oracle.steps.ts
+++ b/e2e/steps/oracle.steps.ts
@@ -1,0 +1,52 @@
+/** Yijing Oracle steps — the /oracle/ hash-routed SPA (honest demo ritual). */
+import { expect } from '@playwright/test'
+import { Then, When } from './fixtures'
+
+/** Strings the F24/F25 honesty rework removed from the oracle flow. None of
+ *  them may render anywhere on any oracle screen while the flow stays a pure
+ *  frontend ritual (zero model / voice API calls). 「真实卦签」 additionally
+ *  guards the demo cast from being re-declared as a real sign (fix-round F1). */
+const BANNED_CLAIMS = [
+  'AI',
+  'Claude',
+  '语音',
+  '读心',
+  '正在说话',
+  '听你说',
+  '随时打断',
+  '真实卦签',
+] as const
+
+Then('the oracle route is {string}', async ({ page }, route: string) => {
+  await expect.poll(() => new URL(page.url()).hash).toBe(`#${route}`)
+})
+
+Then('the oracle page makes no AI, voice, or mind-reading claim', async ({ page }) => {
+  const text = (await page.locator('body').textContent()) ?? ''
+  for (const banned of BANNED_CLAIMS) {
+    expect(text, `oracle page must not claim "${banned}"`).not.toContain(banned)
+  }
+})
+
+When('I pick 2 projection images', async ({ page }) => {
+  // ProjArt tiles are unnamed icon buttons inside the projection grid; the
+  // named controls on the page (返回 / 清空 / 确认) all carry accessible names,
+  // so the tiles are addressed by their CSS-module class.
+  const tiles = page.locator('button[class*="tile"]')
+  await expect(tiles).toHaveCount(6)
+  await tiles.nth(0).click()
+  await tiles.nth(1).click()
+  await expect(page.getByText('已选 2 / 2')).toBeVisible()
+})
+
+When('I complete the six coin throws', async ({ page, world }) => {
+  // Each throw runs a 850ms coin-flip timer before the yao value lands; the
+  // harness clock is paused (fixtures pin it for run-seed determinism), so
+  // every tap is followed by an explicit clock advance to fire that timer.
+  for (let throwIdx = 0; throwIdx < 6; throwIdx++) {
+    const label = throwIdx === 0 ? '投币 →' : `投第 ${throwIdx + 1} 爻 →`
+    await page.getByRole('button', { name: label }).click()
+    await world.advance(900)
+  }
+  await expect(page.getByRole('button', { name: '继续 · 读卦辞 →' })).toBeVisible()
+})

--- a/e2e/yijing-oracle.gherkin
+++ b/e2e/yijing-oracle.gherkin
@@ -1,0 +1,48 @@
+# Yijing Oracle — the /oracle/ hash-routed SPA (home → projection → casting →
+# reading → sign). The flow is an honest ritual after the F24/F25 rework: the
+# cast is a FIXED demo example declared to the player as 卦例演示, every
+# reading text is classical manual data, and no screen claims AI, voice, or
+# mind-reading involvement. The coin-flip animation runs on a 850ms timer, so
+# the throw step drives the harness's controlled clock between taps.
+
+Feature: Yijing Oracle honest demo ritual
+  As a visitor to claw.amio.fans/oracle
+  I want to walk the full oracle session under honest labeling
+  So that I experience the divination ritual without being told an AI is reading my mind
+
+  # Source: oracle-honest-session
+  @playwright
+  Scenario: A visitor completes the oracle ritual and gets an honestly labeled sign card
+    Given I open /oracle/
+    Then the oracle route is "/home"
+    And the oracle page makes no AI, voice, or mind-reading claim
+    And I see the tip "卦例演示"
+
+    When I tap "开始问卦 →"
+    Then the oracle route is "/projection"
+    And the oracle page makes no AI, voice, or mind-reading claim
+
+    When I pick 2 projection images
+    And I tap "确认 · 开始投币 →"
+    Then the oracle route is "/casting"
+
+    When I complete the six coin throws
+    Then I see the tip "卦例演示 · 本卦 #13 · 变卦 #25 · 变爻在九三"
+    And the oracle page makes no AI, voice, or mind-reading claim
+
+    When I tap "继续 · 读卦辞 →"
+    Then the oracle route is "/reading"
+    And I see the tip "同人于野，亨。利涉大川，利君子贞。"
+    And the oracle page makes no AI, voice, or mind-reading claim
+
+    When I tap "继续 · 往下读 →"
+    Then I see the tip "伏戎于莽，升其高陵，三岁不兴。"
+
+    When I tap "继续 · 往下读 →"
+    Then I see the tip "无妄，元亨，利贞。其匪正有眚，不利有攸往。"
+
+    When I tap "生成今日卦签 →"
+    Then the oracle route is "/sign"
+    And I see the tip "今日提点"
+    And I see the tip "已保存到本设备"
+    And the oracle page makes no AI, voice, or mind-reading claim

--- a/packages/game-yijing/src/glyphs/utils.test.ts
+++ b/packages/game-yijing/src/glyphs/utils.test.ts
@@ -10,6 +10,7 @@ import {
   type YaoValue,
   type CoinSide,
 } from './utils'
+import { KW_LOOKUP } from './kw-lookup'
 
 describe('coinsToYao', () => {
   it('three heads sum to 9 (老阳)', () => {
@@ -113,5 +114,25 @@ describe('yaoShort', () => {
 
   it('returns the static-yang glyph for 7', () => {
     expect(yaoShort(7)).toBe('⚊')
+  })
+})
+
+/* All-64 lookup safety: a genuinely random three-coin cast can produce any of
+   the 2^6 = 64 binary keys, so the King Wen table must resolve every one of
+   them — no cast outcome may fall through to the `[0, '?', 'Unknown']`
+   fallback. */
+describe('KW_LOOKUP completeness', () => {
+  it('covers every possible 6-line cast outcome (all 64 binary keys)', () => {
+    for (let i = 0; i < 64; i++) {
+      const key = i.toString(2).padStart(6, '0')
+      expect(KW_LOOKUP[key]).toBeDefined()
+    }
+  })
+
+  it('maps the 64 keys onto the 64 distinct King Wen numbers', () => {
+    const numbers = new Set(Object.values(KW_LOOKUP).map(([n]) => n))
+    expect(numbers.size).toBe(64)
+    expect(Math.min(...numbers)).toBe(1)
+    expect(Math.max(...numbers)).toBe(64)
   })
 })

--- a/packages/game-yijing/src/manual/index.ts
+++ b/packages/game-yijing/src/manual/index.ts
@@ -1,2 +1,13 @@
+import type { HexagramEntry } from './schema'
+import { demoManual } from './demo-data'
+
 export type * from './schema'
 export { demoManual, demoHexagram } from './demo-data'
+
+/** Look up a hexagram's manual entry by its King Wen number.
+ *  Returns undefined when the manual does not carry that hexagram — the
+ *  current demo manual covers only 乾 #1 / 同人 #13 / 无妄 #25, so callers
+ *  MUST handle the miss instead of assuming full 64-hexagram coverage. */
+export function hexagramByNumber(kingWenNumber: number): HexagramEntry | undefined {
+  return demoManual.hexagrams.find((entry) => entry.number === kingWenNumber)
+}

--- a/packages/game-yijing/src/manual/schema.ts
+++ b/packages/game-yijing/src/manual/schema.ts
@@ -102,12 +102,15 @@ export interface CastingGuideValues {
 export interface CastingGuide {
   method: 'three-coin'
   values: CastingGuideValues
-  /** Ordered prose steps the AI follows when interpreting a cast. */
+  /** Ordered prose interpretation steps — Phase-2 oracle-ai-engine contract.
+   *  Unconsumed by the current no-AI flow: PageReading hardcodes its own
+   *  stage order (卦辞+卦象 → 变爻 → 变卦), which happens to match. */
   interpretation_order: string[]
 }
 
 export interface ProjectionGuide {
-  /** Multi-paragraph instruction the AI reads when fusing image signals. */
+  /** Multi-paragraph image-signal fusion instruction — Phase-2
+   *  oracle-ai-engine contract; unconsumed while the flow makes no AI calls. */
   instruction: string
   dimension_labels: {
     relationship: string

--- a/packages/game-yijing/src/pages/PageCasting.module.css
+++ b/packages/game-yijing/src/pages/PageCasting.module.css
@@ -4,7 +4,7 @@
    on the right.
 
    Ports prototype/yijing/styles.css `.yj-cast*` sections verbatim. The
-   `coinFlip` / `barPulse` / `drawn-grow` @keyframes live in
+   `coinFlip` / `drawn-grow` @keyframes live in
    packages/game-yijing/src/styles/animations.css (yijing-wide).
 
    Local CSS variables avoid touching the global tokens.css. */

--- a/packages/game-yijing/src/pages/PageCasting.tsx
+++ b/packages/game-yijing/src/pages/PageCasting.tsx
@@ -10,6 +10,7 @@ import {
   type YaoSextet,
   type YaoValue,
 } from '../glyphs/utils'
+import { hexagramByNumber } from '../manual'
 import { useSession } from '../session'
 import styles from './PageCasting.module.css'
 
@@ -17,9 +18,13 @@ import styles from './PageCasting.module.css'
 
    Six coin throws deterministically resolve to DEMO_VALUES = [7, 8, 9, 7, 7, 7]
    (bottom-up), producing 天火同人 #13 with one changing line at 九三 → 天雷无妄
-   #25. Deterministic so the visual reveal is identical run-over-run during
-   Phase 1 sibling-2 stub work. TODO sibling-3 or Phase 2: swap to real random
-   three-coin sums + computed variant. */
+   #25. The fixed cast is DECLARED to the player as a 卦例演示 (demo example) —
+   the UI must never present it as a random cast. Real randomness
+   (crypto.getRandomValues per three-coin throw) is blocked on content: the
+   manual carries judgment/line texts for only 3 of 64 hexagrams, and shipping
+   a random cast whose reading text exists for 3/64 outcomes would be a worse
+   lie than the labeled demo. Swap in real randomness only together with the
+   full 64-hexagram manual dataset. */
 
 const DEMO_VALUES: YaoSextet = [7, 8, 9, 7, 7, 7]
 const FLIP_MS = 850
@@ -86,6 +91,7 @@ export function PageCasting() {
   const [benNumber, benName] = hexagramFromBinary(DEMO_VALUES)
   const variantValues = changedValues(DEMO_VALUES) as unknown as YaoSextet
   const [bianNumber, bianName] = hexagramFromBinary(variantValues)
+  const benJudgment = hexagramByNumber(benNumber)?.judgment.classical
 
   // Progress index for the run-header step pill — current throw is N+1
   // until done.
@@ -112,7 +118,7 @@ export function PageCasting() {
   })()
 
   const primaryLabel = done
-    ? '继续 · 让 AI 解读 →'
+    ? '继续 · 读卦辞 →'
     : flipping
       ? '投掷中…'
       : throwIdx === 0
@@ -138,7 +144,7 @@ export function PageCasting() {
         <div className={styles.title}>起卦</div>
         <div className={styles.meta}>
           <div className={styles.metaLead}>{done ? '完成' : `第 ${stepIndex} / 6 次`}</div>
-          <div className={styles.metaSub}>投币 · 第 2 步</div>
+          <div className={styles.metaSub}>投币 · 第 2 步 · 卦例演示</div>
         </div>
       </header>
 
@@ -178,9 +184,9 @@ export function PageCasting() {
               <span className={styles.revealNameBian}>{bianName}</span>
             </div>
             <div className={styles.revealMeta}>
-              本卦 #{benNumber} · 变卦 #{bianNumber} · 变爻在九三
+              卦例演示 · 本卦 #{benNumber} · 变卦 #{bianNumber} · 变爻在九三
             </div>
-            <div className={styles.revealJudgment}>「同人于野，亨。利涉大川，利君子贞。」</div>
+            {benJudgment && <div className={styles.revealJudgment}>「{benJudgment}」</div>}
           </div>
         )}
 
@@ -225,10 +231,11 @@ export function PageCasting() {
           </div>
         )}
 
-        {/* CTA row */}
+        {/* CTA row — the ghost button replays the SAME fixed demo cast, so it
+            is labeled as a replay, never as a re-randomization. */}
         <div className={styles.cta}>
           <Button variant="ghost" onClick={reset} className={styles.ctaFull}>
-            重新投
+            重看演示
           </Button>
           <Button
             variant="primary"

--- a/packages/game-yijing/src/pages/PageHome.module.css
+++ b/packages/game-yijing/src/pages/PageHome.module.css
@@ -170,6 +170,7 @@
   gap: 10px;
   align-items: stretch;
 }
+/* Display-only sample tile — deliberately no cursor/hover affordance. */
 .pastCard {
   flex: 1;
   padding: 12px 14px;
@@ -179,14 +180,6 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  cursor: pointer;
-  transition: all 0.15s;
-  text-decoration: none;
-  color: inherit;
-}
-.pastCard:hover {
-  background: rgba(255, 255, 255, 0.07);
-  border-color: rgba(255, 255, 255, 0.15);
 }
 .pastD {
   font: 500 10px var(--amio-font-mono);

--- a/packages/game-yijing/src/pages/PageHome.tsx
+++ b/packages/game-yijing/src/pages/PageHome.tsx
@@ -1,26 +1,26 @@
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { Button, EyebrowTag, Scenery } from '@amiclaw/ui'
 import { Hexagram, TaijiFrame } from '../glyphs'
 import { ganzhi, type YaoSextet } from '../glyphs/utils'
 import styles from './PageHome.module.css'
 
 /* Home — handoff §6.1. Cosmic stage + Scenery backdrop, taiji hero, today
-   strip, draw-card CTA, past-row preview, BombSquad cross-link.
-   Past-row hexagram values are stub data (Phase-1 placeholder per task IA
-   Boundary §Out — historical persistence is Phase-2 work). */
+   strip, draw-card CTA, sample-sign row, BombSquad cross-link.
+   The sample row shows OTHER hexagrams as visual examples and is labeled
+   样例 — it must never masquerade as the visitor's own play history
+   (historical persistence is Phase-2 work). */
 
-interface PastEntry {
-  date: string
+interface SampleEntry {
   name: string
   values: YaoSextet
   hex: number
 }
 
-/* Three stub previous casts so the past-row reads as real on first visit. */
-const PAST_ENTRIES: PastEntry[] = [
-  { date: '5 · 26', name: '水风井', values: [8, 7, 7, 8, 7, 8], hex: 48 },
-  { date: '5 · 25', name: '山泽损', values: [7, 7, 8, 7, 7, 8], hex: 41 },
-  { date: '5 · 24', name: '火天大有', values: [7, 7, 7, 7, 8, 7], hex: 14 },
+/* Three sample hexagrams so first-time visitors see what a sign looks like. */
+const SAMPLE_ENTRIES: SampleEntry[] = [
+  { name: '水风井', values: [8, 7, 7, 8, 7, 8], hex: 48 },
+  { name: '山泽损', values: [7, 7, 8, 7, 7, 8], hex: 41 },
+  { name: '火天大有', values: [7, 7, 7, 7, 8, 7], hex: 14 },
 ]
 
 /* Mini icon on the draw-card — 6-yao mix used by the handoff prototype. */
@@ -41,7 +41,7 @@ export function PageHome() {
 
       <div className={styles.content}>
         <div className={styles.top}>
-          <EyebrowTag variant="hero-pill">语音 oracle · 已就位</EyebrowTag>
+          <EyebrowTag variant="hero-pill">投币起卦 · 经典卦辞</EyebrowTag>
         </div>
 
         <div className={styles.hero}>
@@ -50,7 +50,7 @@ export function PageHome() {
             易<span className={styles.titleAccent}>经</span>
           </h1>
           <div className={styles.titleCn}>签 · 卜 · 卦</div>
-          <p className={styles.titleSub}>不说出口，AI 读心 · 卦象解读 · 每日一卦</p>
+          <p className={styles.titleSub}>心中默念一事 · 投币起卦 · 读一段经典卦辞</p>
         </div>
 
         <div className={styles.rightCol}>
@@ -66,9 +66,9 @@ export function PageHome() {
 
           <div className={styles.drawCard}>
             <div className={styles.drawL}>
-              <div className={styles.drawLbl}>今日一卦</div>
-              <div className={styles.drawTtl}>投一次硬币，听一卦</div>
-              <div className={styles.drawSub}>5–8 分钟 · 语音引导 · 生成一张今日卦签</div>
+              <div className={styles.drawLbl}>卦例演示</div>
+              <div className={styles.drawTtl}>投一次硬币，读一卦</div>
+              <div className={styles.drawSub}>2–3 分钟 · 当前为固定卦例 · 生成一张卦签</div>
             </div>
             <div className={styles.drawR}>
               <Hexagram values={DRAW_PREVIEW} size={36} lineH={5} gap={3} />
@@ -80,13 +80,15 @@ export function PageHome() {
             </div>
           </div>
 
+          {/* Display-only samples — not links: tapping one used to open the
+              /sign demo card showing a DIFFERENT hexagram than the tile. */}
           <div className={styles.pastRow}>
-            {PAST_ENTRIES.map((p) => (
-              <Link key={p.date} to="/sign" className={styles.pastCard}>
-                <div className={styles.pastD}>{p.date}</div>
+            {SAMPLE_ENTRIES.map((p) => (
+              <div key={p.hex} className={styles.pastCard}>
+                <div className={styles.pastD}>样例</div>
                 <div className={styles.pastN}>{p.name}</div>
                 <Hexagram values={p.values} size={28} lineH={4} gap={2} />
-              </Link>
+              </div>
             ))}
           </div>
 

--- a/packages/game-yijing/src/pages/PageProjection.tsx
+++ b/packages/game-yijing/src/pages/PageProjection.tsx
@@ -52,7 +52,9 @@ export function PageProjection() {
               不用说出口，选两张此刻最有感觉的图。
             </p>
           </div>
-          <p className={styles.hint}>没有对错。它们是你的影子，AI 稍后会从中读你的心。</p>
+          <p className={styles.hint}>
+            没有对错。选图只是仪式的一部分，帮你把心里那件事想得更清楚。
+          </p>
         </div>
 
         <div className={styles.grid}>

--- a/packages/game-yijing/src/pages/PageReading.module.css
+++ b/packages/game-yijing/src/pages/PageReading.module.css
@@ -1,10 +1,9 @@
-/* PageReading — handoff §6.4 读心·解读.
+/* PageReading — 解卦: staged classical-text reveal.
    Mobile (default): single-column flow. Desktop (≥ 900px): 2-col grid
-   with hexagrams + voice + confirm on the left and the conversation
-   stream on the right (max-height 540px, scrollable).
+   with the hexagram pair on the left and the reading stream on the
+   right (max-height 540px, scrollable).
 
-   Ports prototype/yijing/styles.css `.yj-read*` sections. The
-   `barPulse` keyframe is global (src/styles/animations.css). */
+   Ports prototype/yijing/styles.css `.yj-read*` sections. */
 .page {
   min-height: 100vh;
   display: flex;
@@ -131,138 +130,6 @@
   color: rgba(255, 255, 255, 0.35);
 }
 
-/* ---------- voice indicator ---------- */
-.voice {
-  display: grid;
-  grid-template-columns: 56px 1fr auto;
-  gap: 14px;
-  align-items: center;
-  padding: 14px 18px;
-  border-radius: 18px;
-  background: var(--glass);
-  backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 229, 62, 0.25);
-  position: relative;
-}
-
-.voice::before {
-  content: '';
-  position: absolute;
-  inset: -1px;
-  border-radius: 18px;
-  background: linear-gradient(135deg, rgba(255, 229, 62, 0.3), transparent 60%);
-  z-index: -1;
-  opacity: 0.5;
-}
-
-.voiceAvatar {
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  padding: 3px;
-  background: conic-gradient(
-    from 0deg,
-    rgba(255, 229, 62, 0.7),
-    rgba(180, 120, 255, 0.55),
-    rgba(100, 200, 255, 0.55),
-    rgba(255, 229, 62, 0.7)
-  );
-  /* Voice-avatar spin is 16s per handoff §6.4 — distinct from @amiclaw/ui
-     ConicAvatar's default 20s; inlined here to avoid touching the shared
-     primitive for one bespoke pace. */
-  animation: spin 16s linear infinite;
-}
-
-.voiceAvatarInner {
-  width: 100%;
-  height: 100%;
-  border-radius: 50%;
-  background: #050511;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font: 700 12px var(--font-display);
-  color: var(--y);
-}
-
-.voiceBars {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-  height: 36px;
-}
-
-.voiceBar {
-  width: 3px;
-  background: var(--y);
-  border-radius: 2px;
-  box-shadow: 0 0 4px var(--y-glow-50);
-  /* `barPulse` keyframe is global from src/styles/animations.css */
-  animation: barPulse 1.1s ease-in-out infinite;
-}
-
-.voiceBarPaused {
-  animation-play-state: paused;
-  height: 24% !important;
-  opacity: 0.35 !important;
-}
-
-.voiceState {
-  font: 500 11px var(--amio-font-mono);
-  color: var(--y);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-}
-
-.voiceSub {
-  font: 400 11px var(--font-body);
-  color: rgba(255, 255, 255, 0.5);
-  margin-top: 4px;
-  letter-spacing: 0;
-  text-transform: none;
-}
-
-/* ---------- confirm row ---------- */
-.confirm {
-  display: flex;
-  gap: 10px;
-  padding: 4px 0 8px;
-}
-
-.confirm button {
-  flex: 1;
-  padding: 14px 18px;
-  border-radius: 14px;
-  cursor: pointer;
-  font: 600 14px var(--font-body);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  transition: all 0.2s;
-}
-
-.confirmYes {
-  background: rgba(75, 210, 102, 0.12);
-  color: var(--green);
-  border: 1px solid rgba(75, 210, 102, 0.35);
-}
-
-.confirmYes:hover {
-  background: rgba(75, 210, 102, 0.2);
-  box-shadow: 0 0 18px rgba(75, 210, 102, 0.25);
-}
-
-.confirmNo {
-  background: rgba(255, 107, 157, 0.08);
-  color: var(--rose);
-  border: 1px solid rgba(255, 107, 157, 0.3);
-}
-
-.confirmNo:hover {
-  background: rgba(255, 107, 157, 0.15);
-}
-
 /* ---------- reading stream ---------- */
 .stream {
   display: flex;
@@ -278,16 +145,6 @@
   border: 1px solid var(--hairline);
 }
 
-.blockGuess {
-  background: linear-gradient(135deg, rgba(255, 229, 62, 0.08), rgba(180, 120, 255, 0.04));
-  border-color: rgba(255, 229, 62, 0.3);
-}
-
-.blockUser {
-  background: rgba(74, 158, 255, 0.06);
-  border-color: rgba(74, 158, 255, 0.25);
-}
-
 .blockQuote {
   background: rgba(180, 120, 255, 0.06);
   border-color: rgba(180, 120, 255, 0.25);
@@ -301,18 +158,6 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-}
-
-.labelAi {
-  color: var(--y);
-}
-
-.labelGuess {
-  color: var(--y);
-}
-
-.labelUser {
-  color: var(--blue);
 }
 
 .labelQuote {
@@ -338,11 +183,6 @@
   color: rgba(255, 255, 255, 0.7);
 }
 
-.accent {
-  color: var(--y);
-  font-weight: 600;
-}
-
 /* ---------- CTA ---------- */
 .cta {
   margin-top: auto;
@@ -350,15 +190,6 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-}
-
-.textLink {
-  text-align: left;
-  color: rgba(255, 255, 255, 0.55);
-  font: 400 13px var(--font-body);
-  background: none;
-  border: none;
-  padding: 8px 4px;
 }
 
 .ctaFull {
@@ -374,8 +205,6 @@
     grid-template-columns: minmax(280px, 0.9fr) minmax(0, 1.1fr);
     grid-template-areas:
       'hex    stream'
-      'voice  stream'
-      'btns   stream'
       'cta    cta';
     gap: 18px 36px;
     padding: 24px 48px 60px;
@@ -383,12 +212,6 @@
   }
   .hexes {
     grid-area: hex;
-  }
-  .voice {
-    grid-area: voice;
-  }
-  .confirm {
-    grid-area: btns;
   }
   .stream {
     grid-area: stream;

--- a/packages/game-yijing/src/pages/PageReading.test.tsx
+++ b/packages/game-yijing/src/pages/PageReading.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { SessionProvider } from '../session'
+import { PageReading } from './PageReading'
+
+/* PageReading 解卦 — staged classical-text reveal.
+
+   The former cold-reading screen fabricated an AI guess and, after the player
+   tapped「不太对」, a user-voice line the player never spoke. The rework
+   replaced that with a paced reveal of manual data only:
+     stage 0 — 本卦 卦辞 + 卦象
+     stage 1 — + 变爻 爻辞 (demo cast: 九三)
+     stage 2 — + 变卦 卦辞 + sign CTA
+   The demo fallback cast is 同人 #13 → 无妄 #25 with 九三 changing. */
+
+// The fabricated user-voice line that the ✗ branch used to inject — must
+// never render anywhere in the flow again.
+const FABRICATED_USER_LINE = '「不是关系本身，而是『要不要继续往前走』。」'
+
+function renderPage() {
+  return render(
+    <SessionProvider>
+      <MemoryRouter>
+        <PageReading />
+      </MemoryRouter>
+    </SessionProvider>
+  )
+}
+
+const advance = () => fireEvent.click(screen.getByRole('button', { name: '继续 · 往下读 →' }))
+
+describe('PageReading staged reveal', () => {
+  beforeEach(() => sessionStorage.clear())
+  afterEach(cleanup)
+
+  it('stage 0 shows the 本卦 judgment and image, nothing beyond', () => {
+    renderPage()
+
+    expect(screen.getByText('同人于野，亨。利涉大川，利君子贞。')).toBeTruthy()
+    expect(screen.getByText('天与火，同人；君子以类族辨物。')).toBeTruthy()
+    expect(screen.queryByText(/伏戎于莽/)).toBeNull()
+    expect(screen.queryByText(/无妄，元亨/)).toBeNull()
+    expect(screen.queryByRole('button', { name: '生成今日卦签 →' })).toBeNull()
+  })
+
+  it('offers no fake-dialogue confirm buttons and never renders a fabricated user line', () => {
+    renderPage()
+
+    expect(screen.queryByRole('button', { name: /不太对/ })).toBeNull()
+    expect(screen.queryByRole('button', { name: /差不多/ })).toBeNull()
+    expect(screen.queryByText(FABRICATED_USER_LINE)).toBeNull()
+
+    advance()
+    advance()
+
+    expect(screen.queryByText(FABRICATED_USER_LINE)).toBeNull()
+  })
+
+  it('reveals the changing-line text on the first 继续', () => {
+    renderPage()
+    advance()
+
+    expect(screen.getByText('变爻 · 九三')).toBeTruthy()
+    expect(screen.getByText('伏戎于莽，升其高陵，三岁不兴。')).toBeTruthy()
+    expect(screen.queryByText(/无妄，元亨/)).toBeNull()
+  })
+
+  it('reveals the 变卦 judgment on the second 继续 and offers the sign CTA', () => {
+    renderPage()
+    advance()
+    advance()
+
+    expect(screen.getByText('无妄，元亨，利贞。其匪正有眚，不利有攸往。')).toBeTruthy()
+    expect(screen.getByRole('button', { name: '生成今日卦签 →' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: '继续 · 往下读 →' })).toBeNull()
+  })
+})

--- a/packages/game-yijing/src/pages/PageReading.tsx
+++ b/packages/game-yijing/src/pages/PageReading.tsx
@@ -1,71 +1,51 @@
-import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { Button } from '@amiclaw/ui'
 import { Hexagram } from '../glyphs'
-import { changedValues, hexagramFromBinary, type YaoSextet } from '../glyphs/utils'
+import { changedValues, changingLines, hexagramFromBinary, type YaoSextet } from '../glyphs/utils'
+import { hexagramByNumber, type HexagramLine } from '../manual'
 import { useSession } from '../session'
 import styles from './PageReading.module.css'
 
-/* PageReading — handoff §6.4 读心·解读.
+/* PageReading — 解卦: staged reveal of the classical reading.
 
-   Cold-reading three-phase state machine:
-     phase 0  — AI 念卦辞 + 初次推测              (confirm-row visible)
-     phase 1  — 玩家选「✗ 不太对」，补充语音回应  (confirm-row visible)
-     phase 2  — AI 调整 + 念变爻 + 综合洞见        (confirm-row hidden,
-                  CTA → 生成今日卦签)
+   Honest by construction: every text on this screen is manual data for the
+   cast hexagrams (classical originals + their modern glosses). There is no
+   AI, no voice, no guessed "mind reading" and no fabricated dialogue — the
+   former cold-reading phase machine is repurposed as a paced reveal:
 
-   Edge case (happy path): clicking ✓ 差不多 at phase 0 jumps to phase 2
-   directly — the user-block is NOT appended because there was no
-   correction. A local `corrected` flag captures whether the user passed
-   through phase 1 (the only situation that surfaces the user-block). */
+     stage 0  — 本卦 卦辞 + 卦象               (继续 → reveals more)
+     stage 1  — + 变爻 爻辞                     (继续 → reveals more)
+     stage 2  — + 变卦 卦辞, CTA → 生成今日卦签
 
-const VOICE_TOGGLE_MS = 3500
+   Casts without changing lines skip stage 1 (no 变爻 to read). */
 
 // Fallback sextet for direct /reading navigation when the session has no
 // cast result yet. Matches PageCasting's DEMO_VALUES (天火同人 → 天雷无妄).
 const DEMO_FALLBACK: YaoSextet = [7, 8, 9, 7, 7, 7]
 
-const BAR_COUNT = 14
-const BAR_STAGGER_S = 0.07
-
 export function PageReading() {
-  const { phase, setPhase, voiceState, setVoiceState, yaoValues } = useSession()
+  const { stage, setStage, yaoValues } = useSession()
   const navigate = useNavigate()
-  const [corrected, setCorrected] = useState(false)
-
-  // Voice toggle every 3.5s for visual life. `setVoiceState` is referentially
-  // stable via SessionProvider's useCallback, so it does not retrigger.
-  useEffect(() => {
-    // Kick off in `speaking` so phase-0 stream looks active even on direct nav.
-    if (voiceState === 'idle') setVoiceState('speaking')
-    const timer = window.setInterval(() => {
-      setVoiceState(voiceState === 'speaking' ? 'listening' : 'speaking')
-    }, VOICE_TOGGLE_MS)
-    return () => window.clearInterval(timer)
-  }, [voiceState, setVoiceState])
 
   const benValues: YaoSextet = yaoValues ?? DEMO_FALLBACK
   const bianValues = changedValues(benValues) as unknown as YaoSextet
-  const [, benName] = hexagramFromBinary(benValues)
-  const [, bianName] = hexagramFromBinary(bianValues)
+  const [benNumber, benName] = hexagramFromBinary(benValues)
+  const [bianNumber, bianName] = hexagramFromBinary(bianValues)
 
-  const speaking = voiceState === 'speaking'
+  const benEntry = hexagramByNumber(benNumber)
+  const bianEntry = hexagramByNumber(bianNumber)
+  const changing = changingLines(benValues)
+  const changingEntries: HexagramLine[] = benEntry
+    ? changing
+        .map((idx) => benEntry.lines.find((line) => line.position === idx + 1))
+        .filter((line): line is HexagramLine => line !== undefined)
+    : []
 
-  // Happy-path: ✓ at phase 0 jumps straight to phase 2 with no user-block.
-  // Correction path: ✗ at phase 0 → phase 1 (records correction); ✓ at
-  // phase 1 → phase 2 (user-block stays in the stream).
-  const onYes = () => {
-    if (phase === 0) {
-      setPhase(2)
-    } else if (phase === 1) {
-      setPhase(2)
-    }
-  }
-  const onNo = () => {
-    if (phase < 2) {
-      setCorrected(true)
-      setPhase(1)
-    }
+  const done = stage >= 2
+  const advance = () => {
+    // Skip the 变爻 stage when the cast has no changing lines to read.
+    if (stage === 0) setStage(changingEntries.length > 0 ? 1 : 2)
+    else if (stage === 1) setStage(2)
   }
 
   return (
@@ -84,10 +64,10 @@ export function PageReading() {
             <path d="M15 4 L7 12 L15 20" />
           </svg>
         </Link>
-        <div className={styles.title}>读心</div>
+        <div className={styles.title}>解卦</div>
         <div className={styles.meta}>
           <div className={styles.metaLead}>第 3 步 / 3</div>
-          <div className={styles.metaSub}>语音对话中</div>
+          <div className={styles.metaSub}>经典卦辞 · 卦例演示</div>
         </div>
       </header>
 
@@ -107,118 +87,89 @@ export function PageReading() {
           </div>
         </div>
 
-        {/* voice indicator */}
-        <div className={styles.voice}>
-          <div className={styles.voiceAvatar}>
-            <div className={styles.voiceAvatarInner}>AI</div>
-          </div>
-          <div>
-            <div className={styles.voiceBars}>
-              {Array.from({ length: BAR_COUNT }).map((_, i) => {
-                const barCls = [styles.voiceBar, !speaking && styles.voiceBarPaused]
-                  .filter(Boolean)
-                  .join(' ')
-                return (
-                  <span
-                    key={i}
-                    className={barCls}
-                    style={{ animationDelay: `${i * BAR_STAGGER_S}s` }}
-                  />
-                )
-              })}
-            </div>
-          </div>
-          <div className={styles.voiceState}>
-            {speaking ? '正在说话' : '听你说'}
-            <div className={styles.voiceSub}>{speaking ? 'Claude · 中文' : '随时打断'}</div>
-          </div>
-        </div>
-
-        {/* confirm row — visible only while still in cold-reading */}
-        {phase < 2 && (
-          <div className={styles.confirm}>
-            <button type="button" className={styles.confirmNo} onClick={onNo}>
-              <span style={{ fontSize: 14 }}>✗</span> 不太对
-            </button>
-            <button type="button" className={styles.confirmYes} onClick={onYes}>
-              <span style={{ fontSize: 14 }}>✓</span> 差不多
-            </button>
-          </div>
-        )}
-
-        {/* reading stream */}
+        {/* reading stream — classical originals + modern glosses, staged */}
         <div className={styles.stream}>
-          {/* phase ≥ 0 — always */}
-          <div className={`${styles.block} ${styles.blockQuote}`}>
-            <div className={`${styles.blockLabel} ${styles.labelQuote}`}>本卦 · 卦辞</div>
-            <div className={`${styles.blockBody} ${styles.bodyClassical}`}>
-              同人于野，亨。利涉大川，利君子贞。
-            </div>
-          </div>
-
-          <div className={`${styles.block} ${styles.blockGuess}`}>
-            <div className={`${styles.blockLabel} ${styles.labelGuess}`}>AI · 推测</div>
-            <div className={styles.blockBody}>
-              根据你的卦象和你刚才的选择，我有一个感觉……你最近在思考一段
-              <span className={styles.accent}>合作关系</span>里的某个
-              <span className={styles.accent}>转折</span>。可能是一个你曾经觉得
-              「该一起努力」的人，你们之间正在悄悄发生变化。
-            </div>
-          </div>
-
-          {/* phase ≥ 1 AND corrected — user-block from the ✗ path only */}
-          {phase >= 1 && corrected && (
-            <div className={`${styles.block} ${styles.blockUser}`}>
-              <div className={`${styles.blockLabel} ${styles.labelUser}`}>你 · 语音</div>
-              <div className={styles.blockBody}>「不是关系本身，而是『要不要继续往前走』。」</div>
-            </div>
-          )}
-
-          {/* phase ≥ 2 — adjusted guess + 变爻 quote + 综合洞见 */}
-          {phase >= 2 && (
+          {benEntry ? (
             <>
-              <div className={`${styles.block} ${styles.blockGuess}`}>
-                <div className={`${styles.blockLabel} ${styles.labelGuess}`}>AI · 调整后</div>
-                <div className={styles.blockBody}>
-                  原来如此，那换个角度看这一卦——你抽到的
-                  <span className={styles.accent}>同人</span>
-                  ，下卦是离（火），上卦是乾（天），火往上烧、天在更高处。
-                  这是一卦讲「同行人能走多远」的卦。
+              <div className={`${styles.block} ${styles.blockQuote}`}>
+                <div className={`${styles.blockLabel} ${styles.labelQuote}`}>本卦 · 卦辞</div>
+                <div className={`${styles.blockBody} ${styles.bodyClassical}`}>
+                  {benEntry.judgment.classical}
+                </div>
+                <div className={`${styles.blockBody} ${styles.bodyGloss}`}>
+                  {benEntry.judgment.modern_interpretation}
                 </div>
               </div>
 
               <div className={`${styles.block} ${styles.blockQuote}`}>
-                <div className={`${styles.blockLabel} ${styles.labelQuote}`}>变爻 · 九三</div>
+                <div className={`${styles.blockLabel} ${styles.labelQuote}`}>本卦 · 卦象</div>
                 <div className={`${styles.blockBody} ${styles.bodyClassical}`}>
-                  伏戎于莽，升其高陵，三岁不兴。
+                  {benEntry.image.classical}
                 </div>
                 <div className={`${styles.blockBody} ${styles.bodyGloss}`}>
-                  ——把兵藏进草丛，登上高陵远望。三年都不轻举妄动。
-                </div>
-              </div>
-
-              <div className={styles.block}>
-                <div className={`${styles.blockLabel} ${styles.labelAi}`}>AI · 综合洞见</div>
-                <div className={styles.blockBody}>
-                  同人之道在野不在朋党。九三的潜伏与不兴，是要你把脚步先停下来，
-                  听清自己更想要什么——
-                  <span className={styles.accent}>主动停一停</span>
-                  不是放弃，是让真正的同行人显形。
+                  {benEntry.image.modern_interpretation}
                 </div>
               </div>
             </>
+          ) : (
+            <div className={styles.block}>
+              <div className={`${styles.blockLabel} ${styles.labelQuote}`}>本卦 · 卦辞</div>
+              <div className={styles.blockBody}>
+                本卦 {benName}（第 {benNumber} 卦）的卦辞文本暂未收录。
+              </div>
+            </div>
           )}
+
+          {/* stage ≥ 1 — changing-line texts */}
+          {stage >= 1 &&
+            changingEntries.map((line) => (
+              <div key={line.position} className={`${styles.block} ${styles.blockQuote}`}>
+                <div className={`${styles.blockLabel} ${styles.labelQuote}`}>
+                  变爻 · {line.name}
+                </div>
+                <div className={`${styles.blockBody} ${styles.bodyClassical}`}>
+                  {line.classical}
+                </div>
+                <div className={`${styles.blockBody} ${styles.bodyGloss}`}>
+                  {line.modern_interpretation}
+                </div>
+                <div className={`${styles.blockBody} ${styles.bodyGloss}`}>
+                  {line.changing_guidance}
+                </div>
+              </div>
+            ))}
+
+          {/* stage ≥ 2 — 变卦 judgment closes the reading */}
+          {stage >= 2 &&
+            (bianEntry ? (
+              <div className={`${styles.block} ${styles.blockQuote}`}>
+                <div className={`${styles.blockLabel} ${styles.labelQuote}`}>变卦 · 卦辞</div>
+                <div className={`${styles.blockBody} ${styles.bodyClassical}`}>
+                  {bianEntry.judgment.classical}
+                </div>
+                <div className={`${styles.blockBody} ${styles.bodyGloss}`}>
+                  {bianEntry.judgment.modern_interpretation}
+                </div>
+              </div>
+            ) : (
+              <div className={styles.block}>
+                <div className={`${styles.blockLabel} ${styles.labelQuote}`}>变卦 · 卦辞</div>
+                <div className={styles.blockBody}>
+                  变卦 {bianName}（第 {bianNumber} 卦）的卦辞文本暂未收录。
+                </div>
+              </div>
+            ))}
         </div>
 
         <div className={styles.cta}>
-          {phase >= 2 ? (
+          {done ? (
             <Button variant="primary" onClick={() => navigate('/sign')} className={styles.ctaFull}>
               生成今日卦签 →
             </Button>
           ) : (
-            <button type="button" className={styles.textLink}>
-              ⓘ AI 还在和你对话 —— 听完再确认
-            </button>
+            <Button variant="primary" onClick={advance} className={styles.ctaFull}>
+              继续 · 往下读 →
+            </Button>
           )}
           <Button variant="ghost" onClick={() => navigate('/home')} className={styles.ctaFull}>
             退出

--- a/packages/game-yijing/src/pages/PageSign.profile.test.tsx
+++ b/packages/game-yijing/src/pages/PageSign.profile.test.tsx
@@ -59,7 +59,7 @@ describe('PageSign arcade profile write', () => {
 
     expect(mocks.recordOracleLocalSign).not.toHaveBeenCalled()
     expect(mocks.submitArcadeProfileEvent).not.toHaveBeenCalled()
-    expect(screen.getByText('等待真实卦签')).toBeTruthy()
+    expect(screen.getByText('尚未起卦')).toBeTruthy()
   })
 
   it('saves a real cast sign locally and submits it for logged-in accounts', async () => {

--- a/packages/game-yijing/src/pages/PageSign.tsx
+++ b/packages/game-yijing/src/pages/PageSign.tsx
@@ -8,21 +8,27 @@ import {
 } from '@amiclaw/arcade-profile/local'
 import { submitArcadeProfileEvent } from '@amiclaw/arcade-profile/api-client'
 import { Hexagram } from '../glyphs'
-import { changedValues, ganzhi, hexagramFromBinary, type YaoSextet } from '../glyphs/utils'
+import {
+  changedValues,
+  changingLines,
+  ganzhi,
+  hexagramFromBinary,
+  type YaoSextet,
+} from '../glyphs/utils'
+import { hexagramByNumber } from '../manual'
 import { useSession } from '../session'
 import styles from './PageSign.module.css'
 
 /* Sign — handoff §6.5. Shareable oracle card with header / hex row /
-   judgment / divider / insight / vermilion seal foot. Demo data falls back
-   to 同人 #13 → 无妄 #25 when the session hasn't cast yet (e.g. direct
+   judgment / divider / takeaway / vermilion seal foot. Every text on the
+   card is manual data for the cast hexagrams (classical judgment + its
+   modern gloss) — no AI-attributed content. Demo data falls back to
+   同人 #13 → 无妄 #25 when the session hasn't cast yet (e.g. direct
    navigation, Phase-1 persistence is sessionStorage-only). */
 
 /* Fallback to the canonical demo cast result (handoff prototype). */
 const DEMO_YAO: YaoSextet = [7, 8, 9, 7, 7, 7]
 
-const JUDGMENT = '同人于野，亨。利涉大川，利君子贞。'
-const INSIGHT =
-  '在协同与方向之间，你正寻求一致。占据更高视角，便能看见同心而异轨者亦可同人——主动停一停，不是放弃，是让真正的同行人显形。'
 type SaveState = 'demo' | 'saving' | 'saved-local' | 'synced' | 'account-error' | 'unavailable'
 type ShareState = 'idle' | 'shared' | 'copied' | 'error'
 
@@ -39,8 +45,22 @@ export function PageSign() {
 
   const values: YaoSextet = yaoValues ?? DEMO_YAO
   const changed = changedValues(values) as unknown as YaoSextet
-  const [, benCn] = hexagramFromBinary(values)
+  const [benNumber, benCn] = hexagramFromBinary(values)
   const [, bianCn] = hexagramFromBinary(changed)
+
+  // Card texts are manual data for the cast hexagram: the classical judgment,
+  // plus the first changing line's modern gloss as the takeaway (falling back
+  // to the judgment gloss when the cast has no changing lines).
+  const benEntry = hexagramByNumber(benNumber)
+  const judgment = benEntry?.judgment.classical ?? ''
+  const firstChangingLine = (() => {
+    if (!benEntry) return undefined
+    const position = changingLines(values)[0]
+    if (position === undefined) return undefined
+    return benEntry.lines.find((line) => line.position === position + 1)
+  })()
+  const takeaway =
+    firstChangingLine?.modern_interpretation ?? benEntry?.judgment.modern_interpretation ?? ''
 
   useEffect(() => {
     if (yaoValues === null) {
@@ -81,8 +101,9 @@ export function PageSign() {
   }, [bianCn, benCn, castCreatedAt, sessionId, yaoValues])
 
   const shareText = useCallback(
-    () => `AMIO 游乐场今日卦签：${benCn} → ${bianCn}。${INSIGHT} ${window.location.origin}/oracle/`,
-    [benCn, bianCn]
+    () =>
+      `AMIO 游乐场今日卦签：${benCn} → ${bianCn}。${takeaway} ${window.location.origin}/oracle/`,
+    [benCn, bianCn, takeaway]
   )
 
   const handleShare = useCallback(async () => {
@@ -167,11 +188,11 @@ export function PageSign() {
             </div>
           </div>
 
-          <div className={styles.judgment}>{JUDGMENT}</div>
+          <div className={styles.judgment}>{judgment}</div>
 
-          <div className={styles.divider}>AI 洞见</div>
+          <div className={styles.divider}>今日提点</div>
 
-          <div className={styles.insight}>{INSIGHT}</div>
+          <div className={styles.insight}>{takeaway}</div>
 
           <div className={styles.foot}>
             <div className={styles.footUrl}>claw.amio.fans/oracle</div>
@@ -191,7 +212,7 @@ export function PageSign() {
                 ? '本次卦签没有写入档案；请重新问卦后再试。'
                 : yaoValues === null
                   ? 'Demo 卦签不会写入档案。'
-                  : '真实卦签已计入今日清单。'}
+                  : '本次卦签已计入今日清单。'}
             </span>
             {shareState !== 'idle' && (
               <span className={styles.feedbackMeta}>{shareStatusText(shareState)}</span>
@@ -258,7 +279,7 @@ function saveStatusText(state: SaveState): string {
     case 'saving':
       return '保存中…'
     default:
-      return '等待真实卦签'
+      return '尚未起卦'
   }
 }
 

--- a/packages/game-yijing/src/pages/honest-copy.test.tsx
+++ b/packages/game-yijing/src/pages/honest-copy.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SessionProvider } from '../session'
+import { PageHome } from './PageHome'
+import { PageProjection } from './PageProjection'
+import { PageCasting } from './PageCasting'
+import { PageReading } from './PageReading'
+import { PageSign } from './PageSign'
+
+// The cast-completed PageSign scan below submits the sign to the profile API;
+// stub the network boundary so the scan stays offline (anon = local-only save).
+vi.mock('@amiclaw/arcade-profile/api-client', () => ({
+  submitArcadeProfileEvent: vi.fn(() => Promise.resolve({ kind: 'anon' })),
+}))
+
+/** In-memory Storage stand-in — this vitest jsdom setup exposes no global
+ *  `localStorage` (Node's experimental one is disabled), and the arcade-profile
+ *  local store checks `typeof localStorage` at the global scope. */
+function memoryStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    key: (i: number) => [...map.keys()][i] ?? null,
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, String(v)),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+  }
+}
+
+/* Honesty regression — the oracle flow makes zero model / voice API calls, so
+   no screen may claim AI, voice, or mind-reading involvement. These strings
+   were removed by the 诚实仪式 rework (audit F24/F25) and must never render
+   again while the flow stays a pure frontend ritual. */
+
+const BANNED_STRINGS = [
+  'AI',
+  'Claude',
+  '语音',
+  '读心',
+  '正在说话',
+  '听你说',
+  '随时打断',
+  // The cold-reading confirm row fabricated a dialogue; its buttons are the
+  // regression canary for the fake-conversation mechanic as a whole.
+  '不太对',
+  '差不多',
+  // The fixed demo cast must never be re-declared as a「真实」sign anywhere
+  // in the flow (verify finding F1) — the check-in ACT is real, the sign
+  // CONTENT is a demo until the full 64-hexagram dataset lands.
+  '真实卦签',
+] as const
+
+const PAGES = [
+  ['PageHome', PageHome],
+  ['PageProjection', PageProjection],
+  ['PageCasting', PageCasting],
+  ['PageReading', PageReading],
+  ['PageSign', PageSign],
+] as const
+
+// Matches SessionProvider's StoredSession shape — seeds a cast-completed
+// session so PageSign renders its save/check-in branch instead of the
+// empty-session demo branch.
+const CAST_COMPLETED_SESSION = {
+  picked: ['a', 'b'],
+  yaoValues: [7, 8, 9, 7, 7, 7],
+  castCreatedAt: '2026-07-07T08:00:00.000Z',
+  stage: 2,
+  sessionId: 'honesty-scan-session',
+}
+
+function renderPage(Page: (typeof PAGES)[number][1]) {
+  return render(
+    <SessionProvider>
+      <MemoryRouter>
+        <Page />
+      </MemoryRouter>
+    </SessionProvider>
+  )
+}
+
+function expectNoBannedStrings(container: HTMLElement) {
+  const text = container.textContent ?? ''
+  for (const banned of BANNED_STRINGS) {
+    expect(text).not.toContain(banned)
+  }
+}
+
+describe('oracle honesty — no AI / voice / mind-reading claims', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.stubGlobal('localStorage', memoryStorage())
+  })
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it.each(PAGES)('%s renders none of the banned claim strings', (_name, Page) => {
+    const { container } = renderPage(Page)
+    expectNoBannedStrings(container)
+  })
+
+  it('PageSign with a completed cast scans clean on the save/check-in branch too', async () => {
+    // The empty-session it.each render lands on the demo branch; this seeded
+    // render exercises the save path whose copy once claimed「真实卦签」.
+    sessionStorage.setItem('amiclaw-yijing-session-v1', JSON.stringify(CAST_COMPLETED_SESSION))
+    const { container } = renderPage(PageSign)
+
+    expect(await screen.findByText('已保存到本设备')).toBeTruthy()
+    expect(screen.getByText('本次卦签已计入今日清单。')).toBeTruthy()
+    expectNoBannedStrings(container)
+  })
+
+  it('PageHome declares the fixed demo cast instead of implying a daily draw', () => {
+    const { container } = renderPage(PageHome)
+    expect(container.textContent).toContain('卦例演示')
+    expect(container.textContent).toContain('固定卦例')
+  })
+
+  it('PageHome labels the sample signs as 样例, not as play history', () => {
+    const { getAllByText } = renderPage(PageHome)
+    expect(getAllByText('样例').length).toBe(3)
+  })
+})

--- a/packages/game-yijing/src/session/SessionProvider.tsx
+++ b/packages/game-yijing/src/session/SessionProvider.tsx
@@ -6,7 +6,7 @@
 
 import { createContext, useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { YaoSextet } from '../glyphs/utils'
-import type { ColdReadingPhase, ProjArtId, SessionContextValue, VoiceState } from './types'
+import type { ProjArtId, RevealStage, SessionContextValue } from './types'
 
 export const SessionContext = createContext<SessionContextValue | null>(null)
 
@@ -16,8 +16,7 @@ interface StoredSession {
   picked: ProjArtId[]
   yaoValues: YaoSextet | null
   castCreatedAt?: string | null
-  phase: ColdReadingPhase
-  voiceState: VoiceState
+  stage?: RevealStage
   sessionId: string
 }
 
@@ -49,10 +48,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
   const [castCreatedAt, setCastCreatedAt] = useState<string | null>(
     () => loadStored()?.castCreatedAt ?? null
   )
-  const [phase, setPhaseState] = useState<ColdReadingPhase>(() => loadStored()?.phase ?? 0)
-  const [voiceState, setVoiceStateState] = useState<VoiceState>(
-    () => loadStored()?.voiceState ?? 'idle'
-  )
+  const [stage, setStageState] = useState<RevealStage>(() => loadStored()?.stage ?? 0)
   const [sessionId, setSessionId] = useState<string>(
     () => loadStored()?.sessionId ?? crypto.randomUUID()
   )
@@ -68,12 +64,8 @@ export function SessionProvider({ children }: SessionProviderProps) {
     setCastCreatedAt(new Date().toISOString())
   }, [])
 
-  const setPhase = useCallback((next: ColdReadingPhase) => {
-    setPhaseState(next)
-  }, [])
-
-  const setVoiceState = useCallback((next: VoiceState) => {
-    setVoiceStateState(next)
+  const setStage = useCallback((next: RevealStage) => {
+    setStageState(next)
   }, [])
 
   const reset = useCallback(() => {
@@ -90,8 +82,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
     setPicked([])
     setYaoValuesState(null)
     setCastCreatedAt(null)
-    setPhaseState(0)
-    setVoiceStateState('idle')
+    setStageState(0)
     setSessionId(crypto.randomUUID())
   }, [])
 
@@ -103,43 +94,38 @@ export function SessionProvider({ children }: SessionProviderProps) {
         picked,
         yaoValues,
         castCreatedAt,
-        phase,
-        voiceState,
+        stage,
         sessionId,
       }
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot))
     } catch {
       // Swallow — full quota, disabled storage, serialization failure.
     }
-  }, [picked, yaoValues, castCreatedAt, phase, voiceState, sessionId])
+  }, [picked, yaoValues, castCreatedAt, stage, sessionId])
 
   const value = useMemo<SessionContextValue>(
     () => ({
       picked,
       yaoValues,
       castCreatedAt,
-      phase,
-      voiceState,
+      stage,
       sessionId,
       pickImage,
       clearPicks,
       setYaoValues,
-      setPhase,
-      setVoiceState,
+      setStage,
       reset,
     }),
     [
       picked,
       yaoValues,
       castCreatedAt,
-      phase,
-      voiceState,
+      stage,
       sessionId,
       pickImage,
       clearPicks,
       setYaoValues,
-      setPhase,
-      setVoiceState,
+      setStage,
       reset,
     ]
   )

--- a/packages/game-yijing/src/session/types.ts
+++ b/packages/game-yijing/src/session/types.ts
@@ -1,18 +1,15 @@
 // Session state shape for the yijing-oracle 5-screen flow.
-// Sibling 1 scaffold — sibling 2 wires real interactions into the actions.
-// Phase mapping per handoff §8 + design doc §AI 融合推测流程.
+// The reading screen is a staged classical-text reveal (no AI, no voice):
+// `stage` tracks how much of the reading has been revealed.
 
 import type { YaoSextet } from '../glyphs/utils'
 
 /** Stable identifiers for the 6 projection images (handoff §6.2). */
 export type ProjArtId = 'a' | 'b' | 'c' | 'd' | 'e' | 'f'
 
-/** Cold-reading sub-phase during the reading screen.
- *  0 = initial AI guess, 1 = after player correction, 2 = deep interpretation. */
-export type ColdReadingPhase = 0 | 1 | 2
-
-/** Voice I/O visual state used by the reading screen mic indicator. */
-export type VoiceState = 'speaking' | 'listening' | 'idle'
+/** Staged-reveal progress on the reading screen.
+ *  0 = 本卦 judgment, 1 = + changing-line texts, 2 = + 变卦 judgment (complete). */
+export type RevealStage = 0 | 1 | 2
 
 export interface SessionState {
   /** Player's projection choices — FIFO, max length 2 (handoff §8 / §6.2). */
@@ -24,11 +21,8 @@ export interface SessionState {
   /** ISO timestamp for the cast that produced `yaoValues`; null until cast completes. */
   castCreatedAt: string | null
 
-  /** Cold-reading sub-phase on the reading screen. */
-  phase: ColdReadingPhase
-
-  /** Voice indicator state. */
-  voiceState: VoiceState
+  /** Staged-reveal progress on the reading screen. */
+  stage: RevealStage
 
   /** Per-session identifier; new value each `reset()` (used by sign-generator). */
   sessionId: string
@@ -41,10 +35,8 @@ export interface SessionActions {
   clearPicks: () => void
   /** Record the cast result. */
   setYaoValues: (values: YaoSextet) => void
-  /** Advance / set the cold-reading sub-phase. */
-  setPhase: (phase: ColdReadingPhase) => void
-  /** Update the voice indicator state. */
-  setVoiceState: (state: VoiceState) => void
+  /** Advance / set the reading reveal stage. */
+  setStage: (stage: RevealStage) => void
   /** Wipe all session state and mint a fresh sessionId — used by "再问一次". */
   reset: () => void
 }

--- a/packages/game-yijing/src/styles/animations.css
+++ b/packages/game-yijing/src/styles/animations.css
@@ -9,7 +9,6 @@
    CoinTrio can resolve to the casting flip motion.
 
    - coinFlip    .85s cubic-bezier  — casting coin three-axis toss
-   - barPulse    1.1s ease-in-out   — reading voice waveform
    - drawn-grow  .5s ease-out       — hexagram line reveal; per-yao stagger via `--yao-idx`
    ============================================================ */
 
@@ -39,19 +38,6 @@
   animation: coinFlip 0.85s cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 
-/* Reading voice waveform — ports prototype/yijing/styles.css `.yj-voice-bars .b`. */
-@keyframes barPulse {
-  0%,
-  100% {
-    height: 18%;
-    opacity: 0.55;
-  }
-  50% {
-    height: 100%;
-    opacity: 1;
-  }
-}
-
 /* Hexagram line reveal — fade in + slide up 8px. Applied to a wrapper around
    the casting sidebar hexagram on each new throw via a re-keyed mount. */
 @keyframes drawn-grow {
@@ -71,13 +57,6 @@
     0%,
     100% {
       transform: none;
-    }
-  }
-  @keyframes barPulse {
-    0%,
-    100% {
-      height: 100%;
-      opacity: 1;
     }
   }
   @keyframes drawn-grow {

--- a/packages/platform/src/components/home/DailyChecklist.tsx
+++ b/packages/platform/src/components/home/DailyChecklist.tsx
@@ -23,7 +23,7 @@ export default function DailyChecklist({ profile, scope, loading = false }: Dail
     {
       id: 'oracle',
       title: 'Oracle 今日卦签',
-      detail: '完成真实卦签计入连续打卡',
+      detail: '走完起卦流程才计入连续打卡',
       href: '/oracle/#/home',
       completed: loop.checklist.oracle_sign.completed,
       completedAt: loop.checklist.oracle_sign.completed_at,


### PR DESCRIPTION
## Summary
- A4a (audit F25/F24): every AI/voice/mind-reading claim removed from the Oracle flow; fabricated user-voice dialogue deleted (staged classical-text reveal replaces the cold-reading theater); the fixed cast is now honestly declared a demo on every surface
- Real random casting is blocked on content (manual covers 3/64 hexagrams) — follow-up adds the full 64-hexagram manual and flips randomness

Phase A item A4a of the arcade product-closure plan. Independent verify: soundness approve; one fix round (demo-vs-real copy contradiction + 4 lows) applied and re-tested.

## Test plan
- [x] game-yijing 39/39 + platform 82/82 unit tests; honest-copy banned-string regression suites
- [x] e2e:audit 25↔25; full Playwright 29/29 incl. new oracle journey
- [ ] CI full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w79dZWZzh7A7W6A7deN31