### PR TITLE
feat(platform): companion dock - persistent presence layer (B1 slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Your companion now lives on the platform** - Feature. Signed-in players with
+a companion get a persistent companion dock above the tab bar on every platform
+page: the companion's name, a breathing status dot, its latest line, and a
+control menu. Coming back after half a day away lands a short text greeting
+built only from real play history (your latest memory and streak — nothing
+invented), capped per day; one tap mutes it and the choice is remembered on
+your account across devices. Entering the daily challenge now defaults
+companion owners into playing WITH their companion — the in-game voice partner
+connects in one tap, live subtitles ride the top of the game screen, and the
+result page carries a factual post-game line — while bring-your-own-AI stays
+one tap away. Voice on the platform pages themselves ships next: until then
+the dock is honestly text-only and never asks for the microphone outside a
+run.
+
 **Practice mode rotates its puzzle** - Change. Every practice run now draws a
 fresh random bomb within the unchanged practice manual's rules, so replaying
 practice is real practice instead of answer recall. The manual players hand

--- a/e2e/companion-dock.gherkin
+++ b/e2e/companion-dock.gherkin
@@ -1,0 +1,42 @@
+# Companion presence layer (伙伴坞) — the persistent companion dock on the
+# platform shell, and the companion co-play default entry into the daily
+# challenge (companion-presence-design.md minimal slice).
+#
+# Deterministic + hermetic: auth and the /api/companion* control plane are
+# route-mocked in fixtures.ts (world.signIn + world.companion + the settings
+# PUT capture); the memory album is an honest empty default, so the arrival
+# greeting renders its no-episode variant. While the lobby-voice capability
+# flag is off the lobby never touches mic / permission APIs — the mic button
+# surfaces the honest in-game-voice note instead (the full auto-voice
+# permission sequence is pinned flag-on by CompanionDock.lobby-voice.test.tsx);
+# the anonymous no-dock state is pinned by the CompanionDock unit tests (the
+# dock renders nothing without a session).
+
+Feature: Companion presence dock and co-play entry
+  As a signed-in player with a companion
+  I want my companion present on every platform page and one tap into
+  playing together
+  So that the companion is an ambient presence, not a buried feature
+
+  Background:
+    Given I am a signed-in player with a companion named "阿澈"
+
+  # Source: companion-dock-presence
+  @playwright
+  Scenario: The dock greets on arrival and remembers a mute across the menu
+    When I open /
+    Then the companion dock shows "阿澈" with the arrival greeting
+    And the dock offers a mic button
+
+    When I mute the companion from the dock control menu
+    Then the dock lands muted and quiet-remembered is persisted to the account
+
+  # Source: companion-coplay-entry
+  @playwright
+  Scenario: A companion user enters the daily challenge with co-play by default
+    Given I open /
+    When I enter the daily challenge from the BombSquad landing
+    Then the co-play entry is the default and the BYO handoff stays visible
+
+    When I start the run together with "阿澈"
+    Then the run starts in mode② with the platform voice partner connected

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -21,9 +21,9 @@
 #
 # --- Regression size budget --------------------------------------------------
 # Per the governance model (rule 3): the e2e regression suite is capped at
-# 2 x the journey-scenario count. With 26 active flows <-> 26 journey
-# scenarios, the regression size budget is 52 (2026-07-07, after the
-# leaderboard date-navigation flow was added as a @playwright journey).
+# 2 x the journey-scenario count. With 28 active flows <-> 28 journey
+# scenarios, the regression size budget is 56 (2026-07-08, after the companion
+# dock presence + co-play entry flows landed as @playwright journeys).
 # Crossing it triggers a forced prune audit. Current regression count: 2.
 #
 # --- Retired scenario --------------------------------------------------------
@@ -290,6 +290,57 @@ flows:
       existing companion instead of the setup form — no second-companion path
       exists anywhere on the platform (a second POST is rejected with 409).
     steps: [signed-in, companion-onboarding, companion-readback, one-companion-invariant]
+    status: active
+
+  - id: companion-dock-presence
+    name: Companion dock presence and posture memory
+    description: >-
+      A signed-in player with a companion sees the persistent 伙伴坞 (companion
+      dock) above the tab bar on the platform shell: name + breathing pulse dot
+      + text region + mic button. Opening the homepage fires the arrival
+      greeting beat (节拍 1 — template-filled from real data; the harness's
+      empty album renders the honest no-episode variant) as a text bubble that
+      collapses into the dock line. While the lobby-voice capability flag is
+      off, the lobby NEVER requests the mic — the mic button carries the
+      honest note pointing at the in-game voice channel. Muting from the dock's
+      control menu freezes proactive beats, lands the dock in its 静音 state,
+      and persists the quiet-remembered posture to the account
+      (PUT /api/companion/settings) — future visits land quiet. The anonymous
+      no-dock state is pinned by the CompanionDock unit tests.
+    steps:
+      [
+        signed-in-companion,
+        dock-visible,
+        arrival-greeting,
+        honest-voice-note,
+        dock-mute,
+        posture-persisted,
+      ]
+    status: active
+
+  - id: companion-coplay-entry
+    name: Companion co-play daily entry default
+    description: >-
+      A signed-in player WITH a companion entering the daily challenge gets the
+      companion co-play path (mode②, the platform voice partner) as the DEFAULT:
+      the connect page replaces the two-step manual handoff with a one-tap
+      「和 X 一起进入」 that navigates straight to the run carrying
+      ?partner=platform (the manual rides the voice session's create message),
+      while the BYO manual handoff stays visible as the explicit alternative.
+      Anonymous and companion-less players keep the original two-step BYO flow
+      unchanged (covered by landing-to-daily). The in-game voice panel connects
+      over the stubbed /ai-ws/* bridge and the AI greets first, proving the
+      co-play wire end to end.
+    steps:
+      [
+        signed-in-companion,
+        bombsquad-landing,
+        cta-daily,
+        coplay-default,
+        byo-alternative,
+        mode2-run,
+        voice-connected,
+      ]
     status: active
 
   - id: companion-memory-album

--- a/e2e/steps/companion.steps.ts
+++ b/e2e/steps/companion.steps.ts
@@ -1,11 +1,18 @@
-/** mode② companion onboarding steps — the /me/companion setup flow.
+/** mode② companion steps — the /me/companion setup flow, the persistent
+    companion dock (伙伴坞), and the daily co-play entry default.
     Auth + the /api/companion* control plane are route-mocked in fixtures.ts
-    (world.signIn + world.companion), so this journey runs against the static
-    build with no Workers runtime, exactly like the magic-link auth journey. */
-import { expect } from '@playwright/test'
+    (world.signIn + world.companion + the settings PUT capture), so these
+    journeys run against the static build with no Workers runtime, exactly
+    like the magic-link auth journey. */
+import { expect, type Locator, type Page } from '@playwright/test'
 import { Given, When, Then } from './fixtures'
 
 const TEST_EMAIL = 'nova@amio.fans'
+
+/** The dock — `<aside aria-label="伙伴坞">` renders as a complementary region. */
+function companionDock(page: Page): Locator {
+  return page.getByRole('complementary', { name: '伙伴坞' })
+}
 
 Given('I am a signed-in player without a companion', async ({ world }) => {
   // signIn() must precede navigation so the first session read is authenticated;
@@ -13,6 +20,116 @@ Given('I am a signed-in player without a companion', async ({ world }) => {
   world.signIn({ user_id: 'e2e-user', email: TEST_EMAIL })
   world.companion = null
 })
+
+Given(
+  'I am a signed-in player with a companion named {string}',
+  async ({ world }, name: string) => {
+    // signIn() + a pre-existing companion BEFORE the first navigation, so the
+    // dock renders from the first page load. voice-default = the auto-voice
+    // login sequence runs (the fake-media flags auto-grant the mic request).
+    world.signIn({ user_id: 'e2e-user', email: TEST_EMAIL })
+    world.companion = {
+      name,
+      address_style: '',
+      voice_id: 'companion-warm',
+      profile_enabled: true,
+      voice_posture: 'voice-default',
+      created_at: '2026-06-30T00:00:00.000Z',
+    }
+  }
+)
+
+// --- Companion dock (伙伴坞) ---------------------------------------------------
+
+Then(
+  'the companion dock shows {string} with the arrival greeting',
+  async ({ page }, name: string) => {
+    const dock = companionDock(page)
+    await expect(dock).toBeVisible()
+    await expect(dock.getByText(name).first()).toBeVisible()
+    // Fresh harness profile = never played → the greeting's no-episode variant
+    // (an honest template fill; no fabricated episode reference). It lands in
+    // the floating bubble AND collapses into the dock's one-line text region.
+    await expect(page.getByText('我在这。今天的每日挑战等你。').first()).toBeVisible()
+  }
+)
+
+Then('the dock offers a mic button', async ({ page }) => {
+  // While lobby voice is behind its capability flag the mic button carries
+  // the honest note affordance (语音陪伴说明) — tapping it surfaces where
+  // voice genuinely runs (the in-game co-play channel) and never triggers a
+  // permission prompt.
+  const micButton = companionDock(page).getByRole('button', { name: '语音陪伴说明' })
+  await expect(micButton).toBeVisible()
+  await micButton.click()
+  await expect(page.getByText('语音陪伴在拆弹局内可用，进入每日挑战开启。')).toBeVisible()
+})
+
+When('I mute the companion from the dock control menu', async ({ page, world }) => {
+  await companionDock(page)
+    .getByRole('button', { name: `${world.companion?.name} 控制菜单` })
+    .click()
+  await page.getByRole('menuitem', { name: '静音' }).click()
+})
+
+Then(
+  'the dock lands muted and quiet-remembered is persisted to the account',
+  async ({ page, world }) => {
+    const name = world.companion?.name ?? ''
+    await expect(companionDock(page).getByText(`${name}在这（静音中）`)).toBeVisible()
+    // The posture write reached the account control plane (PUT captured).
+    await expect
+      .poll(() => world.companionSettingsPuts.at(-1)?.voice_posture)
+      .toBe('quiet-remembered')
+  }
+)
+
+// --- Companion co-play entry (daily challenge default) --------------------------
+
+When('I enter the daily challenge from the BombSquad landing', async ({ page, world }) => {
+  // Signed-in homepage: the WelcomeStrip's 开始玩 CTA (no arrow — the anonymous
+  // hero's 开始玩 → belongs to the signed-out variant) crosses into the
+  // BombSquad SPA, then the landing's 每日挑战 CTA opens the connect flow.
+  await page.getByRole('button', { name: '开始玩', exact: true }).click()
+  await page.waitForURL((url) => new URL(url).pathname.replace(/\/$/, '') === '/bombsquad', {
+    timeout: 12_000,
+  })
+  await world.openConnect('daily')
+})
+
+Then(
+  'the co-play entry is the default and the BYO handoff stays visible',
+  async ({ page, world }) => {
+    const name = world.companion?.name ?? ''
+    // The co-play chooser is the default surface — no manual-copy step 1.
+    await expect(page.getByRole('button', { name: `和 ${name} 一起进入 →` })).toBeVisible()
+    await expect(page.getByText('第 1/2 步')).toHaveCount(0)
+    // The BYO manual handoff remains the visible alternative.
+    await expect(page.getByRole('button', { name: '自带 AI，手动对接' })).toBeVisible()
+  }
+)
+
+When('I start the run together with {string}', async ({ page, world }, name: string) => {
+  // Re-pin the clock to the seed instant before the run navigation, mirroring
+  // finishConnectFlow(): GamePage's getRunSeed reads Date.now() on mount.
+  await page.clock.setSystemTime(world.seedT)
+  await page.getByRole('button', { name: `和 ${name} 一起进入 →` }).click()
+  await page.waitForURL((url) => new URL(url).pathname === '/bombsquad/run', { timeout: 12_000 })
+})
+
+Then(
+  'the run starts in mode② with the platform voice partner connected',
+  async ({ page, world }) => {
+    // partner=platform rode the handoff URL — the mode② opt-in signal.
+    expect(new URL(page.url()).searchParams.get('partner')).toBe('platform')
+    await world.waitForRunStarted()
+    // The in-game voice panel mounted and its stubbed session produced the
+    // AI-first greeting — the proof the co-play wire is live end to end.
+    const panel = page.getByRole('region', { name: 'AI 语音伙伴' })
+    await expect(panel).toBeVisible()
+    await expect(panel.getByText(world.voice.reply)).toBeVisible()
+  }
+)
 
 When('I open the companion onboarding page', async ({ world }) => {
   await world.openPath('/me/companion')

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -185,14 +185,18 @@ export class World {
   /** Captured POST /api/auth/magic-link/request bodies for assertions. */
   readonly magicLinkRequests: Record<string, unknown>[] = []
   /** The route-mocked companion identity, or null for "not set up yet". POST
-   *  /api/companion/setup creates it; GET /api/companion reflects it. */
+   *  /api/companion/setup creates it; GET /api/companion reflects it; PUT
+   *  /api/companion/settings mutates `voice_posture` in place. */
   companion: {
     name: string
     address_style: string
     voice_id: string
     profile_enabled: boolean
+    voice_posture: string
     created_at: string
   } | null = null
+  /** Captured PUT /api/companion/settings bodies (voice-posture writes). */
+  readonly companionSettingsPuts: Record<string, unknown>[] = []
   /** Stub config + captured frames for the mode② voice WebSocket. */
   readonly voice: VoiceMockState = {
     reply: VOICE_REPLY_TEXT,
@@ -351,15 +355,15 @@ export class World {
   }
 
   /**
-   * Enter a mode② daily run with the platform voice partner. The voice panel
-   * mounts only on a daily run opted in via `?partner=platform` (there is no
-   * connect-flow affordance for it yet — it is a pure URL signal), so the run is
-   * reached by a direct deep-link goto. The seed-pinning clock installed by the
-   * preceding `I open /` step stays frozen across this navigation, so GamePage
-   * mounts under the pinned daily seed exactly as a connect-flow entry would,
-   * and the route-mocked manual loads the same fixture. PLAYING (the visible
-   * stopwatch) implies the manual loaded, so the VoicePanel is mounted and its
-   * `/ai-ws/*` socket — stubbed in the fixture wiring — is connecting.
+   * Enter a mode② daily run with the platform voice partner by a direct
+   * deep-link goto (the URL signal predates the connect-flow co-play entry and
+   * must keep working; the connect-flow default for companion users is covered
+   * by the companion-coplay-entry journey). The seed-pinning clock installed by
+   * the preceding `I open /` step stays frozen across this navigation, so
+   * GamePage mounts under the pinned daily seed exactly as a connect-flow entry
+   * would, and the route-mocked manual loads the same fixture. PLAYING (the
+   * visible stopwatch) implies the manual loaded, so the VoicePanel is mounted
+   * and its `/ai-ws/*` socket — stubbed in the fixture wiring — is connecting.
    */
   async startPlatformVoiceDailyRun(): Promise<void> {
     this.runMode = 'daily'
@@ -589,12 +593,55 @@ export const test = base.extend<{ world: World }>({
           address_style: body.address_style ?? '',
           voice_id: body.voice_id,
           profile_enabled: true,
+          voice_posture: 'voice-default',
           created_at: '2026-06-30T00:00:00.000Z',
         }
         await route.fulfill({
           status: 201,
           contentType: 'application/json',
           body: JSON.stringify({ companion: world.companion }),
+        })
+      })
+
+      // Companion presence settings (PUT /api/companion/settings) — the dock's
+      // voice-posture writes. Captures each body and mutates the mocked
+      // identity in place, mirroring the real handler's semantics.
+      await page.route('**/api/companion/settings', async (route) => {
+        const request = route.request()
+        if (request.method() !== 'PUT') {
+          await route.fulfill({ status: 405, body: 'Method Not Allowed' })
+          return
+        }
+        if (world.companion === null) {
+          await route.fulfill({
+            status: 404,
+            contentType: 'application/json',
+            body: JSON.stringify({ error: 'no companion set up' }),
+          })
+          return
+        }
+        const body = request.postDataJSON() as { voice_posture?: string }
+        world.companionSettingsPuts.push(body)
+        if (typeof body.voice_posture === 'string') {
+          world.companion.voice_posture = body.voice_posture
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ voice_posture: world.companion.voice_posture }),
+        })
+      })
+
+      // Companion memory album (GET /api/companion/memories) — the dock's
+      // arrival greeting reads the most recent episode. The static harness has
+      // no capture pipeline, so an honest empty album is the default; the
+      // greeting then renders its no-episode variant.
+      await page.route('**/api/companion/memories**', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          headers: { 'Cache-Control': 'no-store' },
+          body: JSON.stringify({ memories: [] }),
         })
       })
 

--- a/functions/api/companion/settings.ts
+++ b/functions/api/companion/settings.ts
@@ -1,0 +1,25 @@
+import { handlePutCompanionSettings } from '../../../packages/api/src/handlers/companion-settings'
+import type { CompanionApiEnv } from '../../../packages/api/src/handlers/companion-shared'
+import { applyCorsHeaders, buildCorsHeaders } from '../../../packages/api/src/cors'
+
+interface Context {
+  request: Request
+  env: CompanionApiEnv
+}
+
+const CORS_METHODS = 'PUT, OPTIONS'
+
+export async function onRequest(context: Context): Promise<Response> {
+  const { request, env } = context
+  const corsHeaders = buildCorsHeaders(request, CORS_METHODS)
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  if (request.method === 'PUT') {
+    return applyCorsHeaders(await handlePutCompanionSettings(request, env), corsHeaders)
+  }
+
+  return applyCorsHeaders(new Response('Method Not Allowed', { status: 405 }), corsHeaders)
+}

--- a/packages/api/src/handlers/companion-get.ts
+++ b/packages/api/src/handlers/companion-get.ts
@@ -16,7 +16,7 @@ import type { CompanionResponse } from '../../../companion-memory/src/types'
 import { getCompanion } from '../../../companion-memory/src/store'
 import { requireSession } from '../auth/require-session'
 import { jsonResponse } from '../auth/respond'
-import type { CompanionApiEnv } from './companion-shared'
+import { wireVoicePosture, type CompanionApiEnv } from './companion-shared'
 
 export async function handleGetCompanion(
   request: Request,
@@ -35,6 +35,7 @@ export async function handleGetCompanion(
     address_style: companion.address_style,
     voice_id: companion.voice_id,
     profile_enabled: companion.profile_enabled === 1,
+    voice_posture: wireVoicePosture(companion),
     created_at: companion.created_at,
   }
   return jsonResponse(body, 200, { 'Cache-Control': 'no-store' })

--- a/packages/api/src/handlers/companion-settings.ts
+++ b/packages/api/src/handlers/companion-settings.ts
@@ -1,0 +1,43 @@
+/**
+ * PUT /api/companion/settings — the presence-layer settings write
+ * (companion-presence-design §姿态记忆模型).
+ *
+ * Persists the remembered auto-voice posture (`voice_posture`) on the 1:1
+ * companion row so it syncs across devices; the client mirrors every write
+ * into its localStorage cache for the pre-API read at page load. Owner
+ * identity comes ONLY from the session (require-session guard) — never from
+ * the request. The endpoint is deliberately narrow: one scalar today, shaped
+ * so later presence preferences (勿扰时段, 主动性档位) land as additional
+ * optional body fields on this same route without a new endpoint.
+ */
+
+import type { CompanionSettingsResponse } from '../../../companion-memory/src/types'
+import { isVoicePosture } from '../../../companion-memory/src/types'
+import { setVoicePosture } from '../../../companion-memory/src/store'
+import { requireSession } from '../auth/require-session'
+import { jsonResponse } from '../auth/respond'
+import { parseJsonBody, type CompanionApiEnv } from './companion-shared'
+
+export async function handlePutCompanionSettings(
+  request: Request,
+  env: CompanionApiEnv
+): Promise<Response> {
+  const auth = await requireSession(env.AUTH, request)
+  if (!auth.ok) return auth.response
+
+  const body = await parseJsonBody(request)
+  const posture = (body as { voice_posture?: unknown } | null)?.voice_posture
+  if (!isVoicePosture(posture)) {
+    return jsonResponse(
+      { error: 'voice_posture must be voice-default | quiet-remembered | denied-remembered' },
+      422
+    )
+  }
+
+  const updated = await setVoicePosture(env.COMPANION_DB, auth.session.user_id, posture)
+  if (!updated) {
+    return jsonResponse({ error: 'no companion set up' }, 404)
+  }
+  const responseBody: CompanionSettingsResponse = { voice_posture: posture }
+  return jsonResponse(responseBody, 200)
+}

--- a/packages/api/src/handlers/companion-setup.ts
+++ b/packages/api/src/handlers/companion-setup.ts
@@ -13,7 +13,7 @@ import type { CompanionSetupResponse } from '../../../companion-memory/src/types
 import { createCompanion } from '../../../companion-memory/src/store'
 import { requireSession } from '../auth/require-session'
 import { jsonResponse } from '../auth/respond'
-import { parseJsonBody, type CompanionApiEnv } from './companion-shared'
+import { parseJsonBody, wireVoicePosture, type CompanionApiEnv } from './companion-shared'
 
 const NAME_MAX = 30
 const ADDRESS_STYLE_MAX = 30
@@ -67,6 +67,7 @@ export async function handleCompanionSetup(
       address_style: companion.address_style,
       voice_id: companion.voice_id,
       profile_enabled: companion.profile_enabled === 1,
+      voice_posture: wireVoicePosture(companion),
       created_at: companion.created_at,
     },
   }

--- a/packages/api/src/handlers/companion-shared.ts
+++ b/packages/api/src/handlers/companion-shared.ts
@@ -9,6 +9,11 @@
  */
 
 import type { CompanionDb } from '../../../companion-memory/src/db'
+import {
+  isVoicePosture,
+  type CompanionRecord,
+  type VoicePosture,
+} from '../../../companion-memory/src/types'
 
 /** Bindings the companion control plane needs (Pages dashboard-configured). */
 export interface CompanionApiEnv {
@@ -25,4 +30,13 @@ export async function parseJsonBody(request: Request): Promise<unknown | null> {
   } catch {
     return null
   }
+}
+
+/**
+ * Narrow a companion row's `voice_posture` to the wire enum. The column CHECK
+ * already enforces the enum in D1; this guards hand-edited rows and keeps the
+ * wire type honest, degrading to the design's initial posture.
+ */
+export function wireVoicePosture(companion: Pick<CompanionRecord, 'voice_posture'>): VoicePosture {
+  return isVoicePosture(companion.voice_posture) ? companion.voice_posture : 'voice-default'
 }

--- a/packages/api/src/handlers/companion.test.ts
+++ b/packages/api/src/handlers/companion.test.ts
@@ -21,6 +21,7 @@ import {
   handleGetProfile,
   handlePutProfileSettings,
 } from './companion-profile'
+import { handlePutCompanionSettings } from './companion-settings'
 import { handleClaimCorrection, handleClaimDelete } from './companion-profile-claim'
 import { handleGetMemories, handleMemoryDelete } from './companion-memories'
 import type { CompanionApiEnv } from './companion-shared'
@@ -117,6 +118,10 @@ describe('require-session gate (every endpoint, unauthenticated -> 401)', () => 
       handleGetMemories(anonRequest('/api/companion/memories'), env),
       handleMemoryDelete(anonRequest('/api/companion/memories/x', { method: 'DELETE' }), env, 'x'),
       handleGetCompanion(anonRequest('/api/companion'), env),
+      handlePutCompanionSettings(
+        anonRequest('/api/companion/settings', { method: 'PUT', body: '{}' }),
+        env
+      ),
     ])
     for (const response of responses) {
       expect(response.status).toBe(401)
@@ -148,6 +153,8 @@ describe('GET /api/companion (identity read)', () => {
       address_style: 'captain',
       voice_id: 'companion-warm',
       profile_enabled: true,
+      // Presence layer: every companion starts on auto-voice (migration 0004).
+      voice_posture: 'voice-default',
     })
     expect(typeof body.created_at).toBe('string')
   })
@@ -252,6 +259,50 @@ describe('PUT /api/companion/profile (the switch)', () => {
       env
     )
     expect(response.status).toBe(422)
+  })
+})
+
+describe('PUT /api/companion/settings (voice posture)', () => {
+  it('rejects a non-enum posture with 422 and a missing companion with 404', async () => {
+    const { env } = await makeEnv()
+    const invalid = await handlePutCompanionSettings(
+      authedRequest('/api/companion/settings', {
+        method: 'PUT',
+        body: JSON.stringify({ voice_posture: 'shouting' }),
+      }),
+      env
+    )
+    expect(invalid.status).toBe(422)
+
+    const noCompanion = await handlePutCompanionSettings(
+      authedRequest('/api/companion/settings', {
+        method: 'PUT',
+        body: JSON.stringify({ voice_posture: 'quiet-remembered' }),
+      }),
+      env
+    )
+    expect(noCompanion.status).toBe(404)
+  })
+
+  it('persists the posture for the session user and the identity read reflects it', async () => {
+    const { env } = await makeEnv()
+    await setupCompanion(env)
+
+    const response = await handlePutCompanionSettings(
+      authedRequest('/api/companion/settings', {
+        method: 'PUT',
+        // A smuggled owner id is ignored by construction — the session wins.
+        body: JSON.stringify({ voice_posture: 'denied-remembered', user_id: 'user-b' }),
+      }),
+      env
+    )
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ voice_posture: 'denied-remembered' })
+
+    const read = await handleGetCompanion(authedRequest('/api/companion'), env)
+    expect(((await read.json()) as { voice_posture: string }).voice_posture).toBe(
+      'denied-remembered'
+    )
   })
 })
 

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -14,6 +14,7 @@
   "include": ["src", "../../shared", "../companion-memory/src/test-support/node-sqlite.d.ts"],
   "exclude": [
     "../../shared/api-base.ts",
+    "../../shared/companion-presence.ts",
     "../../shared/leaderboard-api.ts",
     "../../shared/leaderboard-optimistic.ts"
   ]

--- a/packages/companion-memory/migrations/0004_companion_voice_posture.sql
+++ b/packages/companion-memory/migrations/0004_companion_voice_posture.sql
@@ -1,0 +1,18 @@
+-- Migration 0004 — companion voice posture (presence layer, additive only).
+--
+-- Account-level memory of the auto-voice posture ruled in
+-- companion-presence-design §姿态记忆模型:
+--
+--   voice-default      auto-voice on login (initial posture of every companion)
+--   quiet-remembered   the player muted / downgraded voice; future visits land quiet
+--   denied-remembered  the browser mic permission was denied; never auto-re-prompt
+--
+-- One column on the existing 1:1 companion row (not a settings side table):
+-- the posture is a single scalar per companion, read on every identity fetch
+-- (`GET /api/companion`) and written by `PUT /api/companion/settings`. The
+-- client keeps a localStorage cache (`amio_companion_voice_posture`) for the
+-- pre-API read at page load; this column is the cross-device SSOT.
+
+ALTER TABLE companion
+  ADD COLUMN voice_posture TEXT NOT NULL DEFAULT 'voice-default'
+    CHECK (voice_posture IN ('voice-default', 'quiet-remembered', 'denied-remembered'));

--- a/packages/companion-memory/src/store.test.ts
+++ b/packages/companion-memory/src/store.test.ts
@@ -16,6 +16,7 @@ import {
   listActiveClaimsWithEvidence,
   listMemories,
   setProfileEnabled,
+  setVoicePosture,
 } from './store'
 import { createTestDb } from './test-support/sqlite-db'
 import type { ProfileClaimRecord } from './types'
@@ -234,5 +235,41 @@ describe('setProfileEnabled', () => {
     expect(await setProfileEnabled(db, 'user-a', false)).toBe(true)
     expect((await getCompanion(db, 'user-a'))?.profile_enabled).toBe(0)
     expect(await setProfileEnabled(db, 'nobody', false)).toBe(false)
+  })
+})
+
+describe('setVoicePosture', () => {
+  it('defaults to voice-default and persists each remembered posture', async () => {
+    const db = createTestDb()
+    await createCompanion(
+      db,
+      { userId: 'user-a', name: 'Ami', voiceId: 'companion-warm' },
+      testDeps()
+    )
+    // Migration 0004 default: every companion starts on auto-voice.
+    expect((await getCompanion(db, 'user-a'))?.voice_posture).toBe('voice-default')
+
+    expect(await setVoicePosture(db, 'user-a', 'quiet-remembered')).toBe(true)
+    expect((await getCompanion(db, 'user-a'))?.voice_posture).toBe('quiet-remembered')
+
+    expect(await setVoicePosture(db, 'user-a', 'denied-remembered')).toBe(true)
+    expect((await getCompanion(db, 'user-a'))?.voice_posture).toBe('denied-remembered')
+
+    expect(await setVoicePosture(db, 'user-a', 'voice-default')).toBe(true)
+    expect((await getCompanion(db, 'user-a'))?.voice_posture).toBe('voice-default')
+  })
+
+  it('reports a missing companion and rejects a non-enum value at the schema', async () => {
+    const db = createTestDb()
+    expect(await setVoicePosture(db, 'nobody', 'quiet-remembered')).toBe(false)
+
+    await createCompanion(
+      db,
+      { userId: 'user-a', name: 'Ami', voiceId: 'companion-warm' },
+      testDeps()
+    )
+    // The column CHECK is the last line of defence below the handler's guard.
+    await expect(setVoicePosture(db, 'user-a', 'shouting')).rejects.toThrow()
+    expect((await getCompanion(db, 'user-a'))?.voice_posture).toBe('voice-default')
   })
 })

--- a/packages/companion-memory/src/store.ts
+++ b/packages/companion-memory/src/store.ts
@@ -64,6 +64,23 @@ export async function createCompanion(
   return getCompanion(db, input.userId)
 }
 
+/**
+ * Persist the remembered auto-voice posture (presence layer; the caller has
+ * already narrowed the value to the `VoicePosture` enum — the column CHECK is
+ * the last line of defence). Returns false when no companion.
+ */
+export async function setVoicePosture(
+  db: CompanionDb,
+  userId: string,
+  posture: string
+): Promise<boolean> {
+  const result = await db
+    .prepare('UPDATE companion SET voice_posture = ? WHERE user_id = ?')
+    .bind(posture, userId)
+    .run()
+  return result.meta.changes > 0
+}
+
 /** Flip the profile (understanding layer) switch. Returns false when no companion. */
 export async function setProfileEnabled(
   db: CompanionDb,

--- a/packages/companion-memory/src/types.ts
+++ b/packages/companion-memory/src/types.ts
@@ -34,6 +34,11 @@ export {
   PLATFORM_VOICE_IDS,
   isPlatformVoiceId,
   type PlatformVoiceId,
+  VOICE_POSTURES,
+  isVoicePosture,
+  type VoicePosture,
+  type CompanionSettingsBody,
+  type CompanionSettingsResponse,
   type CompanionIdentity,
   type CompanionResponse,
   type CompanionSetupBody,
@@ -60,6 +65,12 @@ export interface CompanionRecord {
   voice_id: string
   /** SQLite boolean: 0 | 1. */
   profile_enabled: number
+  /**
+   * Remembered auto-voice posture (presence layer; migration 0004). One of
+   * `voice-default` / `quiet-remembered` / `denied-remembered` — the CHECK
+   * constraint enforces the enum; wire readers still narrow via `isVoicePosture`.
+   */
+  voice_posture: string
   /**
    * Bulk profile-delete watermark (ISO 8601, `null` = never bulk-deleted).
    * Consolidation skips claim production for events captured at-or-before it.

--- a/packages/game-bombsquad/src/game-flow.test.tsx
+++ b/packages/game-bombsquad/src/game-flow.test.tsx
@@ -58,6 +58,13 @@ vi.mock('@shared/leaderboard-api', () => ({
   fetchLeaderboard: vi.fn().mockResolvedValue({ date: '2026-03-16', entries: [] }),
 }))
 
+// These flows cover the anonymous BYO path; pin the companion co-play gate to
+// `unavailable` so the daily connect page renders the classic two-step flow
+// (the co-play entry has its own tests in ConnectPage.companion.test.tsx).
+vi.mock('@/hooks/useCompanionPartner', () => ({
+  useCompanionPartner: () => ({ status: 'unavailable' }),
+}))
+
 vi.mock('./utils/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
 }))

--- a/packages/game-bombsquad/src/hooks/useCompanionPartner.test.ts
+++ b/packages/game-bombsquad/src/hooks/useCompanionPartner.test.ts
@@ -1,0 +1,98 @@
+/**
+ * useCompanionPartner — the connect page's companion co-play gate.
+ *
+ * Two same-origin reads decide the entry default: GET /api/auth/session
+ * (authenticated?) then GET /api/companion (identity or 404). Every failure
+ * shape must resolve `unavailable`, keeping the anonymous / companion-less
+ * entry flow untouched.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useCompanionPartner } from './useCompanionPartner'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useCompanionPartner', () => {
+  it('resolves available with the companion name for a signed-in companion user', async () => {
+    fetchMock.mockImplementation((input) => {
+      const url = String(input)
+      if (url.endsWith('/api/auth/session')) {
+        return Promise.resolve(
+          jsonResponse({ authenticated: true, identity: { user_id: 'u1', email: 'a@b.c' } })
+        )
+      }
+      return Promise.resolve(
+        jsonResponse({
+          name: '阿澈',
+          address_style: '',
+          voice_id: 'companion-warm',
+          profile_enabled: true,
+          voice_posture: 'voice-default',
+          created_at: '2026-06-30T00:00:00.000Z',
+        })
+      )
+    })
+
+    const { result } = renderHook(() => useCompanionPartner(true))
+    expect(result.current.status).toBe('checking')
+    await waitFor(() => {
+      expect(result.current).toEqual({ status: 'available', name: '阿澈' })
+    })
+  })
+
+  it('resolves unavailable for an anonymous visitor without touching /api/companion', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ authenticated: false, identity: null }))
+
+    const { result } = renderHook(() => useCompanionPartner(true))
+    await waitFor(() => {
+      expect(result.current.status).toBe('unavailable')
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves unavailable when the companion read 404s (no companion yet)', async () => {
+    fetchMock.mockImplementation((input) => {
+      const url = String(input)
+      if (url.endsWith('/api/auth/session')) {
+        return Promise.resolve(jsonResponse({ authenticated: true, identity: {} }))
+      }
+      return Promise.resolve(jsonResponse({ error: 'no companion set up' }, 404))
+    })
+
+    const { result } = renderHook(() => useCompanionPartner(true))
+    await waitFor(() => {
+      expect(result.current.status).toBe('unavailable')
+    })
+  })
+
+  it('resolves unavailable on a network failure', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'))
+
+    const { result } = renderHook(() => useCompanionPartner(true))
+    await waitFor(() => {
+      expect(result.current.status).toBe('unavailable')
+    })
+  })
+
+  it('never fetches when disabled (practice entries)', () => {
+    const { result } = renderHook(() => useCompanionPartner(false))
+    expect(result.current.status).toBe('unavailable')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/game-bombsquad/src/hooks/useCompanionPartner.ts
+++ b/packages/game-bombsquad/src/hooks/useCompanionPartner.ts
@@ -1,0 +1,86 @@
+/**
+ * Companion co-play availability for the BombSquad entry flow.
+ *
+ * The connect page defaults a signed-in player WITH a companion into the
+ * platform voice partner (mode②) instead of the BYO manual handoff. This hook
+ * answers exactly that gate with two same-origin reads — the session cookie
+ * rides along, no owner id is ever sent:
+ *
+ *   GET /api/auth/session  ->  authenticated?
+ *   GET /api/companion     ->  companion identity (404 = not set up)
+ *
+ * `checking` keeps the page on neutral chrome (no flash of the wrong entry);
+ * any failure resolves to `unavailable`, which leaves the anonymous /
+ * companion-less flow byte-identical to today.
+ */
+
+import { useEffect, useState } from 'react'
+import { API_BASE } from '@shared/api-base'
+import { isVoicePosture } from '@shared/companion-types'
+import { writeCachedVoicePosture } from '@shared/companion-presence'
+
+export type CompanionPartnerState =
+  | { status: 'checking' }
+  | { status: 'available'; name: string }
+  | { status: 'unavailable' }
+
+interface SessionBody {
+  authenticated?: boolean
+}
+
+interface CompanionBody {
+  name?: unknown
+  voice_posture?: unknown
+}
+
+export function useCompanionPartner(enabled: boolean): CompanionPartnerState {
+  const [state, setState] = useState<CompanionPartnerState>(
+    enabled ? { status: 'checking' } : { status: 'unavailable' }
+  )
+
+  useEffect(() => {
+    if (!enabled) return
+    let active = true
+    void (async () => {
+      try {
+        const sessionRes = await fetch(`${API_BASE}/api/auth/session`, {
+          credentials: 'include',
+        })
+        const session = sessionRes.ok ? ((await sessionRes.json()) as SessionBody) : null
+        if (!session?.authenticated) {
+          if (active) setState({ status: 'unavailable' })
+          return
+        }
+        const companionRes = await fetch(`${API_BASE}/api/companion`, {
+          credentials: 'include',
+        })
+        if (!companionRes.ok) {
+          if (active) setState({ status: 'unavailable' })
+          return
+        }
+        const companion = (await companionRes.json()) as CompanionBody
+        // Opportunistic posture-cache sync: the account value is the SSOT, so
+        // any surface holding a fresh identity read refreshes the local cache
+        // (narrows the game SPA's cache-first staleness window — e.g. a
+        // cross-device mute lands here before the run's settlement beat).
+        if (isVoicePosture(companion.voice_posture)) {
+          writeCachedVoicePosture(companion.voice_posture)
+        }
+        if (active) {
+          setState(
+            typeof companion.name === 'string' && companion.name.length > 0
+              ? { status: 'available', name: companion.name }
+              : { status: 'unavailable' }
+          )
+        }
+      } catch {
+        if (active) setState({ status: 'unavailable' })
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [enabled])
+
+  return state
+}

--- a/packages/game-bombsquad/src/pages/ConnectPage.companion.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.companion.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * ConnectPage companion co-play entry tests (the arcade closure plan's entry
+ * fix + companion-presence-design).
+ *
+ * A signed-in player WITH a companion entering the DAILY challenge defaults to
+ * the platform voice partner (mode②): one tap into the run with
+ * `?partner=platform`, no manual handoff. The BYO manual flow stays reachable
+ * as the visible alternative, and practice entries never consult the gate.
+ *
+ * `useCompanionPartner` is mocked per test — the gate's own fetch behaviour is
+ * covered by useCompanionPartner.test.ts.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import type { CompanionPartnerState } from '@/hooks/useCompanionPartner'
+
+const DAILY_URL = 'https://claw.amio.fans/manual/2026-05-22'
+const PRACTICE_URL = 'https://claw.amio.fans/manual/practice'
+
+vi.mock('@/hooks/useDailyChallenge', () => ({
+  useDailyChallenge: () => ({
+    dailyUrl: DAILY_URL,
+    practiceUrl: PRACTICE_URL,
+    attemptNumber: 1,
+    incrementAttempt: () => {},
+  }),
+}))
+
+vi.mock('@/utils/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('@/audio/audio-context', () => ({
+  getAudioContext: vi.fn().mockReturnValue(null),
+}))
+
+const partnerState = vi.hoisted(() => ({
+  current: { status: 'unavailable' } as CompanionPartnerState,
+}))
+
+vi.mock('@/hooks/useCompanionPartner', () => ({
+  useCompanionPartner: (enabled: boolean) =>
+    enabled ? partnerState.current : { status: 'unavailable' },
+}))
+
+import ConnectPage from './ConnectPage'
+import { getAudioContext } from '@/audio/audio-context'
+import { GameProvider } from '@/store/game-context'
+import { readEntryRecoveryState } from '@/utils/session'
+
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="location">{location.pathname + location.search}</div>
+}
+
+function renderConnect(mode: 'daily' | 'practice') {
+  return render(
+    <MemoryRouter initialEntries={[`/bombsquad/connect?mode=${mode}`]}>
+      <Routes>
+        <Route
+          path="/bombsquad/connect"
+          element={
+            <GameProvider>
+              <ConnectPage />
+            </GameProvider>
+          }
+        />
+        <Route path="/bombsquad/run" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('ConnectPage — companion co-play entry', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    partnerState.current = { status: 'available', name: '阿澈' }
+    vi.mocked(getAudioContext).mockReset()
+    vi.mocked(getAudioContext).mockReturnValue(null)
+  })
+
+  it('defaults a companion user into the co-play entry with the BYO alternative visible', () => {
+    renderConnect('daily')
+
+    // The co-play chooser is the default — no manual-copy step 1 in sight.
+    expect(screen.getByRole('heading', { level: 2, name: /阿澈/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /和 阿澈 一起进入/ })).toBeInTheDocument()
+    expect(screen.queryByText('第 1/2 步')).not.toBeInTheDocument()
+    // The BYO manual handoff stays reachable as the visible alternative.
+    expect(screen.getByRole('button', { name: /自带 AI/ })).toBeInTheDocument()
+  })
+
+  it('hands off to the mode② run with partner=platform and unlocks audio in the tap', () => {
+    renderConnect('daily')
+
+    fireEvent.click(screen.getByRole('button', { name: /和 阿澈 一起进入/ }))
+
+    const location = screen.getByTestId('location').textContent ?? ''
+    expect(location).toContain('/bombsquad/run')
+    expect(location).toContain('mode=daily')
+    expect(location).toContain(`url=${encodeURIComponent(DAILY_URL)}`)
+    expect(location).toContain('partner=platform')
+    expect(getAudioContext).toHaveBeenCalledTimes(1)
+
+    // Recovery state records the mode② entry so replay/recovery preserves it.
+    expect(readEntryRecoveryState()).toEqual({
+      mode: 'daily',
+      manualUrl: DAILY_URL,
+      manualHandoffComplete: true,
+      platformPartner: true,
+    })
+  })
+
+  it('steps off to the BYO manual flow on the alternative CTA', () => {
+    renderConnect('daily')
+
+    fireEvent.click(screen.getByRole('button', { name: /自带 AI/ }))
+
+    // The original two-step handoff takes over.
+    expect(screen.getByText('第 1/2 步')).toBeInTheDocument()
+    expect(screen.getByText(DAILY_URL)).toBeInTheDocument()
+  })
+
+  it('holds the entry choice on neutral chrome while the gate resolves', () => {
+    partnerState.current = { status: 'checking' }
+    renderConnect('daily')
+
+    expect(screen.getByText('正在准备…')).toBeInTheDocument()
+    expect(screen.queryByText('第 1/2 步')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /一起进入/ })).not.toBeInTheDocument()
+  })
+
+  it('keeps the BYO flow for a player without a companion', () => {
+    partnerState.current = { status: 'unavailable' }
+    renderConnect('daily')
+
+    expect(screen.getByText('第 1/2 步')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /一起进入/ })).not.toBeInTheDocument()
+  })
+
+  it('never consults the gate for practice entries', () => {
+    // Even with a companion available, practice keeps the BYO flow — the
+    // platform partner is a daily-only surface.
+    renderConnect('practice')
+
+    expect(screen.getByText('第 1/2 步')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /一起进入/ })).not.toBeInTheDocument()
+  })
+})

--- a/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
@@ -44,6 +44,14 @@ vi.mock('@/utils/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
 }))
 
+// These tests cover the anonymous / companion-less flow, which must stay
+// byte-identical to the pre-companion-entry behaviour: pin the co-play gate to
+// `unavailable`. The companion default entry has its own test file
+// (ConnectPage.companion.test.tsx).
+vi.mock('@/hooks/useCompanionPartner', () => ({
+  useCompanionPartner: () => ({ status: 'unavailable' }),
+}))
+
 // The 进入游戏 tap unlocks the shared AudioContext inside the user gesture (iOS
 // Safari needs the gesture). Mock the singleton so the test can assert the call
 // without a real Web Audio context in jsdom.

--- a/packages/game-bombsquad/src/pages/ConnectPage.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.tsx
@@ -4,23 +4,30 @@ import { Scenery, ConicAvatar } from '@amiclaw/ui'
 import Eyebrow from '@/components/bombsquad/Eyebrow'
 import Button from '@/components/bombsquad/Button'
 import { useDailyChallenge } from '@/hooks/useDailyChallenge'
+import { useCompanionPartner } from '@/hooks/useCompanionPartner'
 import { copyToClipboard } from '@/utils/clipboard'
 import { getAudioContext } from '@/audio/audio-context'
 import { useGame } from '@/store/game-context'
 import { clearPersistedState } from '@/store/persistence'
 import { saveEntryRecoveryState } from '@/utils/session'
+import { MODE2_PARTNER_PARAM, MODE2_PARTNER_VALUE } from '@/voice/voice-panel-inputs'
 import styles from './ConnectPage.module.css'
 
 type ConnectMode = 'daily' | 'practice'
 
-/* Connect-AI flow — design_handoff_bombsquad README §6.2. Two steps swap in
-   place: copy the manual link in one tap, then switch the AI to voice mode and
-   hand off to the run. The AI-readiness sync prompt now lives here, on step 2
-   (where the player is actually setting their AI up); there is no separate
-   GamePage gate — "进入游戏" starts the run directly. Tapping it also unlocks
-   iOS audio inside the user gesture. The manual URL is derived by
-   useDailyChallenge; voice AIs auto-read a bare pasted link and adopt the role
-   from the now-self-framing manual, so the link alone suffices. */
+/* Connect-AI flow — design_handoff_bombsquad README §6.2, plus the companion
+   co-play default (companion-presence-design + the arcade closure plan's entry
+   fix). A signed-in player WITH a companion entering the DAILY challenge gets
+   the platform voice partner (mode②) as the default path — one tap into the
+   run, the companion already holds the manual — with the BYO manual handoff as
+   the visible alternative. Anonymous / companion-less / practice entries keep
+   the original two-step BYO flow: copy the manual link in one tap, then switch
+   the AI to voice mode and hand off to the run. The AI-readiness sync prompt
+   lives on step 2; there is no separate GamePage gate — "进入游戏" starts the
+   run directly. Tapping either start CTA also unlocks iOS audio inside the
+   user gesture. The manual URL is derived by useDailyChallenge; voice AIs
+   auto-read a bare pasted link and adopt the role from the now-self-framing
+   manual, so the link alone suffices. */
 export default function ConnectPage() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
@@ -31,12 +38,25 @@ export default function ConnectPage() {
   const { dailyUrl, practiceUrl } = useDailyChallenge()
   const manualUrl = mode === 'daily' ? dailyUrl : practiceUrl
 
+  // Companion co-play gate — only a daily entry consults it; practice never
+  // mounts the platform partner. `checking` holds the entry choice briefly
+  // (two same-origin reads); any failure lands `unavailable` = the BYO flow.
+  const partner = useCompanionPartner(mode === 'daily')
+  // The player can explicitly step off the co-play default onto the BYO flow.
+  const [byoChosen, setByoChosen] = useState(false)
+  const companionEntry = mode === 'daily' && partner.status === 'available' && !byoChosen
+
   const [step, setStep] = useState<1 | 2>(1)
   const [copied, setCopied] = useState(false)
   const [copyFailed, setCopyFailed] = useState(false)
 
   useEffect(() => {
-    saveEntryRecoveryState({ mode, manualUrl, manualHandoffComplete: false })
+    saveEntryRecoveryState({
+      mode,
+      manualUrl,
+      manualHandoffComplete: false,
+      platformPartner: false,
+    })
   }, [mode, manualUrl])
 
   /* Once the manual link is copied, the card turns green and the flow
@@ -74,7 +94,7 @@ export default function ConnectPage() {
      outside one. getAudioContext() is idempotent; the run calls it again at
      game start as a fallback. */
   const confirmStart = () => {
-    saveEntryRecoveryState({ mode, manualUrl, manualHandoffComplete: true })
+    saveEntryRecoveryState({ mode, manualUrl, manualHandoffComplete: true, platformPartner: false })
     clearPersistedState()
     dispatch({ type: 'RESET' })
     getAudioContext()
@@ -83,6 +103,24 @@ export default function ConnectPage() {
     } else {
       navigate('/bombsquad/run?mode=practice')
     }
+  }
+
+  /* Companion co-play start (mode②) — no manual handoff: the manual rides the
+     voice session's create message, so this single tap IS the whole connect
+     flow. Same audio unlock + state reset as the BYO start. */
+  const confirmCompanionStart = () => {
+    saveEntryRecoveryState({
+      mode: 'daily',
+      manualUrl: dailyUrl,
+      manualHandoffComplete: true,
+      platformPartner: true,
+    })
+    clearPersistedState()
+    dispatch({ type: 'RESET' })
+    getAudioContext()
+    navigate(
+      `/bombsquad/run?mode=daily&url=${encodeURIComponent(dailyUrl)}&${MODE2_PARTNER_PARAM}=${MODE2_PARTNER_VALUE}`
+    )
   }
 
   // SVG thread between the player and the AI: a faint guide path plus a
@@ -119,117 +157,136 @@ export default function ConnectPage() {
           <span className={styles.headerSpacer} aria-hidden="true" />
         </header>
 
-        <div className={styles.connect}>
-          <Eyebrow dot color="var(--y)">
-            第 {step}/2 步
-          </Eyebrow>
+        {/* Companion co-play gate resolving — hold the entry choice on neutral
+            chrome so the page never flashes the BYO steps at a companion user
+            (or vice versa). Practice entries skip the check entirely. */}
+        {mode === 'daily' && partner.status === 'checking' && !byoChosen && (
+          <div className={styles.connect}>
+            <p className={styles.hint}>正在准备…</p>
+          </div>
+        )}
 
-          <h2 className={styles.title}>
-            {step === 1 && (
-              <>
-                把<span className={styles.titleAccent}>手册</span>发给 AI。
-              </>
-            )}
-            {step === 2 && (
-              <>
-                切到<span className={styles.titleAccent}>语音模式</span>。
-              </>
-            )}
-          </h2>
+        {/* Companion co-play default (mode②) — signed in, companion exists. */}
+        {companionEntry && (
+          <div className={styles.connect}>
+            <Eyebrow dot color="var(--y)">
+              你的伙伴
+            </Eyebrow>
 
-          {/* Player ↔ AI connection visualization. */}
-          <div className={styles.vis}>
-            <div className={styles.visSide}>
-              <ConicAvatar size={64} letter="你" ariaHidden />
-              <div className={styles.visLabel}>你</div>
-            </div>
-            <div className={styles.thread} aria-hidden="true">
-              <svg viewBox="0 0 200 80" preserveAspectRatio="none">
-                <path
-                  d="M 5 40 Q 100 5 195 40"
-                  stroke="rgba(255,229,62,.35)"
-                  strokeWidth="1.5"
-                  fill="none"
-                  strokeDasharray={step === 2 ? '0' : '4 4'}
-                />
-                <path
-                  className={styles.threadDraw}
-                  d="M 5 40 Q 100 5 195 40"
-                  stroke="var(--y)"
-                  strokeWidth="1.5"
-                  fill="none"
-                  strokeDasharray="200"
-                  style={{ strokeDashoffset: threadOffset }}
-                />
-              </svg>
-              {step === 2 && <div className={styles.spark}>✦</div>}
-            </div>
-            <div className={styles.visSide}>
-              <div className={styles.aiAvatar}>
-                <ConicAvatar size={64} letter="AI" ariaHidden />
-                <span className={styles.aiPulse} />
+            <h2 className={styles.title}>
+              和<span className={styles.titleAccent}>{partner.name}</span>一起拆弹。
+            </h2>
+
+            <div className={styles.vis}>
+              <div className={styles.visSide}>
+                <ConicAvatar size={64} letter="你" ariaHidden />
+                <div className={styles.visLabel}>你</div>
               </div>
-              {/* BYO-neutral: the player supplies their own voice AI (Claude /
-                  ChatGPT / Gemini / …), so this mirrors "你" rather than naming
-                  one tool. */}
-              <div className={styles.visLabel}>你的 AI</div>
+              <div className={styles.thread} aria-hidden="true">
+                <svg viewBox="0 0 200 80" preserveAspectRatio="none">
+                  <path d="M 5 40 Q 100 5 195 40" stroke="var(--y)" strokeWidth="1.5" fill="none" />
+                </svg>
+                <div className={styles.spark}>✦</div>
+              </div>
+              <div className={styles.visSide}>
+                <div className={styles.aiAvatar}>
+                  <ConicAvatar size={64} letter={partner.name.charAt(0)} ariaHidden />
+                  <span className={styles.aiPulse} />
+                </div>
+                <div className={styles.visLabel}>{partner.name}</div>
+              </div>
+            </div>
+
+            <div className={styles.action}>
+              {/* No manual handoff in this path: the manual rides the voice
+                  session itself, so the truthful copy says exactly that. */}
+              <p className={styles.hint}>
+                {partner.name} 已经拿到今天的手册。进入后直接开口说话，它会全程语音陪你拆。
+              </p>
+            </div>
+
+            <div className={styles.cta}>
+              <Button variant="primary" full onClick={confirmCompanionStart}>
+                和 {partner.name} 一起进入 →
+              </Button>
+              <Button variant="ghost" full onClick={() => setByoChosen(true)}>
+                自带 AI，手动对接
+              </Button>
             </div>
           </div>
+        )}
 
-          {/* Step 1 — copy the manual link. Before a copy failure, the URL card
+        {(mode === 'practice' || partner.status === 'unavailable' || byoChosen) && (
+          <div className={styles.connect}>
+            <Eyebrow dot color="var(--y)">
+              第 {step}/2 步
+            </Eyebrow>
+
+            <h2 className={styles.title}>
+              {step === 1 && (
+                <>
+                  把<span className={styles.titleAccent}>手册</span>发给 AI。
+                </>
+              )}
+              {step === 2 && (
+                <>
+                  切到<span className={styles.titleAccent}>语音模式</span>。
+                </>
+              )}
+            </h2>
+
+            {/* Player ↔ AI connection visualization. */}
+            <div className={styles.vis}>
+              <div className={styles.visSide}>
+                <ConicAvatar size={64} letter="你" ariaHidden />
+                <div className={styles.visLabel}>你</div>
+              </div>
+              <div className={styles.thread} aria-hidden="true">
+                <svg viewBox="0 0 200 80" preserveAspectRatio="none">
+                  <path
+                    d="M 5 40 Q 100 5 195 40"
+                    stroke="rgba(255,229,62,.35)"
+                    strokeWidth="1.5"
+                    fill="none"
+                    strokeDasharray={step === 2 ? '0' : '4 4'}
+                  />
+                  <path
+                    className={styles.threadDraw}
+                    d="M 5 40 Q 100 5 195 40"
+                    stroke="var(--y)"
+                    strokeWidth="1.5"
+                    fill="none"
+                    strokeDasharray="200"
+                    style={{ strokeDashoffset: threadOffset }}
+                  />
+                </svg>
+                {step === 2 && <div className={styles.spark}>✦</div>}
+              </div>
+              <div className={styles.visSide}>
+                <div className={styles.aiAvatar}>
+                  <ConicAvatar size={64} letter="AI" ariaHidden />
+                  <span className={styles.aiPulse} />
+                </div>
+                {/* BYO-neutral: the player supplies their own voice AI (Claude /
+                  ChatGPT / Gemini / …), so this mirrors "你" rather than naming
+                  one tool. */}
+                <div className={styles.visLabel}>你的 AI</div>
+              </div>
+            </div>
+
+            {/* Step 1 — copy the manual link. Before a copy failure, the URL card
               and bottom primary CTA share the same copy action. After failure,
               the card becomes a stable manual-link fallback while the CTA is
               the single retry surface. */}
-          {step === 1 && (
-            <div className={styles.action}>
-              {copyFailed && !copied ? (
-                <div className={`${styles.urlPreview} ${styles.urlPreviewFailed}`}>
-                  <div className={styles.copyCardText}>
-                    <div className={styles.copyCardLabel}>复制失败，链接仍可用</div>
-                    <div className={styles.copyCardUrl}>{manualUrl}</div>
-                  </div>
-                  <div className={styles.copyCardIcon} aria-hidden="true">
-                    <svg
-                      viewBox="0 0 24 24"
-                      width="20"
-                      height="20"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.6"
-                      strokeLinecap="round"
-                    >
-                      <rect x="8" y="8" width="12" height="12" rx="2" />
-                      <path d="M16 8 V5 a2 2 0 0 0 -2 -2 H6 a2 2 0 0 0 -2 2 v9 a2 2 0 0 0 2 2 h3" />
-                    </svg>
-                  </div>
-                </div>
-              ) : (
-                <button
-                  type="button"
-                  className={`${styles.urlPreview} ${copied ? styles.urlPreviewDone : ''}`}
-                  onClick={handleCopy}
-                  aria-label={copied ? '已复制手册链接' : '复制手册链接'}
-                >
-                  <div className={styles.copyCardText}>
-                    <div className={styles.copyCardLabel}>
-                      {copied ? '已复制到剪贴板' : '手册链接'}
+            {step === 1 && (
+              <div className={styles.action}>
+                {copyFailed && !copied ? (
+                  <div className={`${styles.urlPreview} ${styles.urlPreviewFailed}`}>
+                    <div className={styles.copyCardText}>
+                      <div className={styles.copyCardLabel}>复制失败，链接仍可用</div>
+                      <div className={styles.copyCardUrl}>{manualUrl}</div>
                     </div>
-                    <div className={styles.copyCardUrl}>{manualUrl}</div>
-                  </div>
-                  <div className={styles.copyCardIcon} aria-hidden="true">
-                    {copied ? (
-                      <svg
-                        viewBox="0 0 24 24"
-                        width="20"
-                        height="20"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="1.8"
-                        strokeLinecap="round"
-                      >
-                        <path d="M5 12 L10 17 L19 7" />
-                      </svg>
-                    ) : (
+                    <div className={styles.copyCardIcon} aria-hidden="true">
                       <svg
                         viewBox="0 0 24 24"
                         width="20"
@@ -242,92 +299,134 @@ export default function ConnectPage() {
                         <rect x="8" y="8" width="12" height="12" rx="2" />
                         <path d="M16 8 V5 a2 2 0 0 0 -2 -2 H6 a2 2 0 0 0 -2 2 v9 a2 2 0 0 0 2 2 h3" />
                       </svg>
-                    )}
+                    </div>
                   </div>
-                </button>
-              )}
+                ) : (
+                  <button
+                    type="button"
+                    className={`${styles.urlPreview} ${copied ? styles.urlPreviewDone : ''}`}
+                    onClick={handleCopy}
+                    aria-label={copied ? '已复制手册链接' : '复制手册链接'}
+                  >
+                    <div className={styles.copyCardText}>
+                      <div className={styles.copyCardLabel}>
+                        {copied ? '已复制到剪贴板' : '手册链接'}
+                      </div>
+                      <div className={styles.copyCardUrl}>{manualUrl}</div>
+                    </div>
+                    <div className={styles.copyCardIcon} aria-hidden="true">
+                      {copied ? (
+                        <svg
+                          viewBox="0 0 24 24"
+                          width="20"
+                          height="20"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.8"
+                          strokeLinecap="round"
+                        >
+                          <path d="M5 12 L10 17 L19 7" />
+                        </svg>
+                      ) : (
+                        <svg
+                          viewBox="0 0 24 24"
+                          width="20"
+                          height="20"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.6"
+                          strokeLinecap="round"
+                        >
+                          <rect x="8" y="8" width="12" height="12" rx="2" />
+                          <path d="M16 8 V5 a2 2 0 0 0 -2 -2 H6 a2 2 0 0 0 -2 2 v9 a2 2 0 0 0 2 2 h3" />
+                        </svg>
+                      )}
+                    </div>
+                  </button>
+                )}
 
-              <p className={styles.hint}>
-                {copyFailed
-                  ? '浏览器没有允许自动复制，但上面的链接就是同一份手册。手动把它发给 AI，和复制后粘贴完全一样；等它读完后继续。'
-                  : '粘贴到你常用的 AI，让它读完手册后说「好了」。'}
-              </p>
-              {/* /compatibility discovery link — re-homed here from the
+                <p className={styles.hint}>
+                  {copyFailed
+                    ? '浏览器没有允许自动复制，但上面的链接就是同一份手册。手动把它发给 AI，和复制后粘贴完全一样；等它读完后继续。'
+                    : '粘贴到你常用的 AI，让它读完手册后说「好了」。'}
+                </p>
+                {/* /compatibility discovery link — re-homed here from the
                  retired PromptModal, which placed it directly under the
                  same send-to-AI content. Step 1 is that moment now. */}
-              <Link to="/bombsquad/compatibility" className={styles.compatLink}>
-                不确定用哪个 AI？查看支持工具 →
-              </Link>
-            </div>
-          )}
+                <Link to="/bombsquad/compatibility" className={styles.compatLink}>
+                  不确定用哪个 AI？查看支持工具 →
+                </Link>
+              </div>
+            )}
 
-          {/* Step 2 — a passive reminder of the one thing to do on the AI
+            {/* Step 2 — a passive reminder of the one thing to do on the AI
               side: switch it to voice mode. Deliberately NOT a button — the
               UI cannot flip the player's AI into voice mode, so a tappable
               card here would fake an action the app does not perform. The
               only real action on this step is the 进入游戏 handoff below. */}
-          {step === 2 && (
-            <div className={styles.action}>
-              <div className={styles.voiceStep}>
-                <div className={styles.voiceStepIcon} aria-hidden="true">
-                  <svg
-                    viewBox="0 0 24 24"
-                    width="22"
-                    height="22"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.6"
-                  >
-                    <rect x="9" y="3" width="6" height="12" rx="3" />
-                    <path d="M5 11 a7 7 0 0 0 14 0 M12 18 V21 M9 21 H15" />
-                  </svg>
+            {step === 2 && (
+              <div className={styles.action}>
+                <div className={styles.voiceStep}>
+                  <div className={styles.voiceStepIcon} aria-hidden="true">
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="22"
+                      height="22"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.6"
+                    >
+                      <rect x="9" y="3" width="6" height="12" rx="3" />
+                      <path d="M5 11 a7 7 0 0 0 14 0 M12 18 V21 M9 21 H15" />
+                    </svg>
+                  </div>
+                  <div className={styles.voiceStepText}>
+                    <div className={styles.voiceStepLabel}>切到语音模式</div>
+                    <div className={styles.voiceStepSub}>AI 端 → 麦克风</div>
+                  </div>
                 </div>
-                <div className={styles.voiceStepText}>
-                  <div className={styles.voiceStepLabel}>切到语音模式</div>
-                  <div className={styles.voiceStepSub}>AI 端 → 麦克风</div>
-                </div>
-              </div>
-              <p className={styles.hint}>这样你描述、AI 回应，全程不用手离开屏幕。</p>
-              {/* AI-readiness sync prompt — re-homed from the deleted GamePage
+                <p className={styles.hint}>这样你描述、AI 回应，全程不用手离开屏幕。</p>
+                {/* AI-readiness sync prompt — re-homed from the deleted GamePage
                   「开始」gate to the place the player is actually setting up
                   their AI. Anchors to step 1's canonical「让它读完手册后说
                   『好了』」wording and names the one consequence of the next
                   tap: 进入游戏 starts the run, and the stopwatch starts with
                   it. Calm, not a countdown — time is a score, not a deadline. */}
-              <p className={styles.hint}>
-                等 AI 说完「好了」，点「进入游戏」就开始，计时随即启动。
-              </p>
-            </div>
-          )}
+                <p className={styles.hint}>
+                  等 AI 说完「好了」，点「进入游戏」就开始，计时随即启动。
+                </p>
+              </div>
+            )}
 
-          <div className={styles.cta}>
-            {step === 1 ? (
-              /* The CTA mirrors the URL card's copy action: tap copies the
+            <div className={styles.cta}>
+              {step === 1 ? (
+                /* The CTA mirrors the URL card's copy action: tap copies the
                  manual URL, flips to the green confirmed state, and the 0.7s
                  effect above auto-advances to step 2. No disabled / dead
                  control on this step. */
-              <>
-                <Button
-                  variant="primary"
-                  full
-                  accent={copied ? 'green' : copyFailed ? 'rose' : 'yellow'}
-                  onClick={handleCopy}
-                >
-                  {copied ? '已复制 ✓' : copyFailed ? '重试复制' : '复制手册'}
-                </Button>
-                {copyFailed && !copied && (
-                  <Button variant="ghost" full onClick={continueAfterManualHandoff}>
-                    我已手动发给 AI，继续 →
+                <>
+                  <Button
+                    variant="primary"
+                    full
+                    accent={copied ? 'green' : copyFailed ? 'rose' : 'yellow'}
+                    onClick={handleCopy}
+                  >
+                    {copied ? '已复制 ✓' : copyFailed ? '重试复制' : '复制手册'}
                   </Button>
-                )}
-              </>
-            ) : (
-              <Button variant="primary" full onClick={confirmStart}>
-                进入游戏 →
-              </Button>
-            )}
+                  {copyFailed && !copied && (
+                    <Button variant="ghost" full onClick={continueAfterManualHandoff}>
+                      我已手动发给 AI，继续 →
+                    </Button>
+                  )}
+                </>
+              ) : (
+                <Button variant="primary" full onClick={confirmStart}>
+                  进入游戏 →
+                </Button>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </main>
   )

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -38,9 +38,12 @@ import {
   createGameRunId,
   getAttemptNumberForMode,
   getRunSeed,
+  readEntryRecoveryState,
+  saveEntryRecoveryState,
 } from '@/utils/session'
 import { getAudioContext, setSfxSuppressed } from '@/audio/audio-context'
-import VoicePanel, { type VoicePanelHandle } from '@/voice/VoicePanel'
+import VoicePanel, { type VoicePanelHandle, type VoiceUtterance } from '@/voice/VoicePanel'
+import CompanionSubtitleStrip from '@/voice/CompanionSubtitleStrip'
 import { deriveVoicePanelInputs, isPlatformVoicePartner } from '@/voice/voice-panel-inputs'
 import styles from './GamePage.module.css'
 
@@ -214,6 +217,32 @@ export default function GamePage() {
   // run stay mode① (BYO-AI) and never mount the panel. Additive — derives from
   // game state only, never alters game logic.
   const usePlatformVoice = isPlatformVoicePartner(mode, searchParams.get('partner'))
+
+  // Record the platform-partner flag on the entry-recovery state so replay /
+  // recovery paths preserve mode②. Covers the deep-link entry too (a mode② run
+  // reached by URL never passed through the connect page's co-play save); a
+  // mode① run leaves whatever the connect flow wrote untouched.
+  useEffect(() => {
+    if (!usePlatformVoice) return
+    const recovery = readEntryRecoveryState()
+    if (recovery && recovery.platformPartner) return
+    saveEntryRecoveryState({
+      mode: 'daily',
+      manualUrl: recovery?.manualUrl || customUrl || '',
+      manualHandoffComplete: true,
+      platformPartner: true,
+    })
+  }, [usePlatformVoice, customUrl])
+
+  // Live companion utterance from the voice panel, driving the top-of-screen
+  // subtitle strip (visible only while the companion is audibly speaking).
+  const [companionUtterance, setCompanionUtterance] = useState<VoiceUtterance>({
+    text: '',
+    speaking: false,
+  })
+  const handleUtterance = useCallback((utterance: VoiceUtterance) => {
+    setCompanionUtterance(utterance)
+  }, [])
 
   // Ref to the mounted VoicePanel — used to call requestClosing() imperatively
   // on a successful daily defuse before navigating to the results screen.
@@ -739,6 +768,13 @@ export default function GamePage() {
         </div>
       </div>
 
+      {/* Companion subtitle strip (mode② only) — top of the game screen, in
+          flow under the top bar so it never covers the stopwatch. Visible only
+          while the companion is audibly speaking; gone the moment voice ends. */}
+      {usePlatformVoice && companionUtterance.speaking && (
+        <CompanionSubtitleStrip text={companionUtterance.text} />
+      )}
+
       <div className={styles.moduleArea}>
         <div className={styles.modulePanel}>
           <div className={styles.modLabelRow}>
@@ -763,6 +799,7 @@ export default function GamePage() {
           manualData={voiceInputs.manualData}
           gameState={voiceInputs.gameState}
           gameRunId={voiceInputs.gameRunId}
+          onUtterance={handleUtterance}
         />
       )}
 

--- a/packages/game-bombsquad/src/pages/ResultPage.module.css
+++ b/packages/game-bombsquad/src/pages/ResultPage.module.css
@@ -160,6 +160,30 @@
   letter-spacing: 0.02em;
 }
 
+/* ----------  companion post-game reaction (节拍 3, mode② only)  ---------- */
+.companionReaction {
+  margin-top: 10px;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 229, 62, 0.22);
+  border-radius: 12px;
+  background: rgba(10, 10, 26, 0.72);
+  text-align: left;
+}
+
+.companionReactionName {
+  font: 600 11px var(--font-body);
+  color: var(--y);
+}
+
+.companionReactionText {
+  font: 400 13px/1.5 var(--font-body);
+  color: #fff;
+}
+
 /* ----------  ranking card (success · daily defuse only)  ---------- */
 .rankCard {
   margin-top: 8px;

--- a/packages/game-bombsquad/src/pages/ResultPage.recovery.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.recovery.test.tsx
@@ -135,6 +135,7 @@ describe('ResultPage no-run-data recovery', () => {
       mode: 'daily',
       manualUrl,
       manualHandoffComplete: true,
+      platformPartner: false,
     })
     renderRecovery()
 
@@ -153,6 +154,7 @@ describe('ResultPage no-run-data recovery', () => {
       mode: 'practice',
       manualUrl: 'https://claw.amio.fans/manual/practice',
       manualHandoffComplete: true,
+      platformPartner: false,
     })
     renderRecovery()
 

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -26,6 +26,15 @@ import {
 } from '@/utils/leaderboard-player-metadata'
 import { hasAnsweredSurvey, markSurveyAnswered } from '@/utils/survey'
 import { readEntryRecoveryState } from '@/utils/session'
+import { useCompanionPartner } from '@/hooks/useCompanionPartner'
+import {
+  buildPostGameReaction,
+  canFirePostGameBeat,
+  readBeatLog,
+  readCachedVoicePosture,
+  recordBeatFired,
+  writeBeatLog,
+} from '@shared/companion-presence'
 import { playSfx } from '@/audio/useSfx'
 import type { ScoreSubmission, ScoreSubmissionResponse } from '@shared/leaderboard-types'
 import styles from './ResultPage.module.css'
@@ -123,6 +132,48 @@ export default function ResultPage() {
     state.totalStartTime !== null && state.totalEndTime !== null
       ? state.totalEndTime - state.totalStartTime
       : null
+
+  // --- Companion post-game reaction (节拍 3, mode② settlements only) ----------
+  // Template-filled from the run's real facts (companion-presence-design
+  // register: factual, relaxed on a clear, never consoling). Computed once in
+  // the initializer (pure — no writes); the beat-log recording side effect
+  // lives in the mount effect below, which is StrictMode/refresh idempotent
+  // via the per-run `lastPostGameRunId` dedupe. A quiet/denied remembered
+  // posture freezes all proactive beats, this one included. The posture read
+  // is cache-first by design; the cache refreshes on every companion identity
+  // read (the connect-page co-play gate and this page's partner read both
+  // sync it via useCompanionPartner), so a cross-device mute can lag at most
+  // one settlement on a deep-linked run — an accepted cache-first trade-off.
+  const companionRunId = entryRecovery?.platformPartner === true ? state.gameRunId : null
+  const [companionReaction] = useState<string | null>(() => {
+    if (noRunData || companionRunId === null || state.outcome === null) return null
+    const posture = readCachedVoicePosture()
+    const muted = posture === 'quiet-remembered' || posture === 'denied-remembered'
+    const log = readBeatLog(getTodayString())
+    const alreadyReacted = log.lastPostGameRunId === companionRunId
+    if (!alreadyReacted && !canFirePostGameBeat({ log, gameRunId: companionRunId, muted })) {
+      return null
+    }
+    return buildPostGameReaction({
+      outcome: state.outcome,
+      durationMs: totalMs,
+      moduleCount: state.moduleSequence.length,
+      completedModules: state.moduleStats.length,
+      strikeCount: state.strikeCount,
+    })
+  })
+  // The companion identity read powers the speaker label; a failed read keeps
+  // the line with the generic label rather than dropping the reaction.
+  const companionPartner = useCompanionPartner(companionReaction !== null)
+  useEffect(() => {
+    if (companionReaction === null || companionRunId === null) return
+    const log = readBeatLog(getTodayString())
+    if (log.lastPostGameRunId !== companionRunId) {
+      writeBeatLog(recordBeatFired(log, { kind: 'post-game', gameRunId: companionRunId }))
+    }
+    // Mount-once recording; the dedupe above absorbs StrictMode's double run.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     if (noRunData) return
@@ -478,7 +529,12 @@ export default function ResultPage() {
       attemptNumber: state.attemptNumber,
     })
     dispatch({ type: 'RESET' })
-    navigate(`/bombsquad/run?mode=${state.mode}`)
+    // A mode② run replays as mode②: the player never handed a manual to their
+    // own AI, so dropping the partner param would strand the next run in mode①
+    // with no partner connected at all.
+    const partnerParam =
+      state.mode === 'daily' && entryRecovery?.platformPartner === true ? '&partner=platform' : ''
+    navigate(`/bombsquad/run?mode=${state.mode}${partnerParam}`)
   }
 
   // No game in memory at all — distinct from a finished run that solved zero
@@ -492,11 +548,12 @@ export default function ResultPage() {
   if (noRunData) {
     const recoveryMode = entryRecovery?.mode ?? 'daily'
     const manualHandoffComplete = entryRecovery?.manualHandoffComplete === true
+    const recoveryPartner = entryRecovery?.platformPartner === true ? '&partner=platform' : ''
     const recoveryRunTarget =
       recoveryMode === 'daily'
         ? `/bombsquad/run?mode=daily${
             entryRecovery?.manualUrl ? `&url=${encodeURIComponent(entryRecovery.manualUrl)}` : ''
-          }`
+          }${recoveryPartner}`
         : '/bombsquad/run?mode=practice'
     const recoveryConnectTarget = `/bombsquad/connect?mode=${recoveryMode}`
     const recoveryTitle =
@@ -601,6 +658,15 @@ export default function ResultPage() {
           {totalMs !== null && <div className={styles.totalTime}>{formatMs(totalMs)}</div>}
 
           <p className={styles.subtitle}>{subtitle}</p>
+
+          {companionReaction !== null && (
+            <div className={styles.companionReaction} role="status" aria-label="伙伴的反应">
+              <span className={styles.companionReactionName}>
+                {companionPartner.status === 'available' ? companionPartner.name : '伙伴'}
+              </span>
+              <span className={styles.companionReactionText}>{companionReaction}</span>
+            </div>
+          )}
 
           {showRankCard && (
             <div className={styles.rankCard}>

--- a/packages/game-bombsquad/src/utils/session.test.ts
+++ b/packages/game-bombsquad/src/utils/session.test.ts
@@ -93,6 +93,7 @@ describe('session utilities', () => {
         mode: 'practice',
         manualUrl: 'https://claw.amio.fans/manual/practice',
         manualHandoffComplete: true,
+        platformPartner: false,
       },
       storage
     )
@@ -101,7 +102,40 @@ describe('session utilities', () => {
       mode: 'practice',
       manualUrl: 'https://claw.amio.fans/manual/practice',
       manualHandoffComplete: true,
+      platformPartner: false,
     })
+  })
+
+  it('defaults platformPartner to false for pre-flag recovery state', () => {
+    const storage = createStorageStub({
+      'bombsquad:entry-recovery': JSON.stringify({
+        mode: 'daily',
+        manualUrl: 'https://claw.amio.fans/manual/2026-07-08',
+        manualHandoffComplete: true,
+      }),
+    })
+
+    expect(readEntryRecoveryState(storage)).toEqual({
+      mode: 'daily',
+      manualUrl: 'https://claw.amio.fans/manual/2026-07-08',
+      manualHandoffComplete: true,
+      platformPartner: false,
+    })
+  })
+
+  it('preserves platformPartner for a mode② run', () => {
+    const storage = createStorageStub()
+    saveEntryRecoveryState(
+      {
+        mode: 'daily',
+        manualUrl: 'https://claw.amio.fans/manual/2026-07-08',
+        manualHandoffComplete: true,
+        platformPartner: true,
+      },
+      storage
+    )
+
+    expect(readEntryRecoveryState(storage)?.platformPartner).toBe(true)
   })
 
   it('ignores invalid entry recovery state', () => {

--- a/packages/game-bombsquad/src/utils/session.ts
+++ b/packages/game-bombsquad/src/utils/session.ts
@@ -8,6 +8,13 @@ export interface EntryRecoveryState {
   mode: SessionMode
   manualUrl: string
   manualHandoffComplete: boolean
+  /**
+   * True when the run used the platform voice partner (mode②,
+   * `?partner=platform`). Replay / recovery paths must preserve it: a mode②
+   * player never completed the manual handoff, so dropping the flag would
+   * route their next run into mode① with no AI partner connected.
+   */
+  platformPartner: boolean
 }
 
 /**
@@ -141,6 +148,7 @@ export function readEntryRecoveryState(
       mode: parsed.mode,
       manualUrl: parsed.manualUrl,
       manualHandoffComplete: parsed.manualHandoffComplete === true,
+      platformPartner: parsed.platformPartner === true,
     }
   } catch {
     return null

--- a/packages/game-bombsquad/src/voice/CompanionSubtitleStrip.module.css
+++ b/packages/game-bombsquad/src/voice/CompanionSubtitleStrip.module.css
@@ -1,0 +1,24 @@
+/* Top-of-screen companion subtitle — a narrow banner in flow directly under
+   the top bar, so it never covers the stopwatch or the module panel. */
+
+.strip {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  max-width: 640px;
+  padding: 6px 12px;
+  border: 1px solid rgba(255, 229, 62, 0.25);
+  border-radius: 10px;
+  background: rgba(10, 10, 26, 0.82);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+.text {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font: 400 13px/1.45 var(--font-body, sans-serif);
+  color: #fff;
+}

--- a/packages/game-bombsquad/src/voice/CompanionSubtitleStrip.tsx
+++ b/packages/game-bombsquad/src/voice/CompanionSubtitleStrip.tsx
@@ -1,0 +1,24 @@
+import styles from './CompanionSubtitleStrip.module.css'
+
+/**
+ * In-game companion subtitle strip (companion-presence-design §字幕条).
+ *
+ * A narrow banner at the top of the game screen showing the sentence the
+ * companion is currently speaking during a mode② voice session. It updates
+ * live with the streamed reply and disappears the moment the voice ends — no
+ * dwell time (that is the dock bubble's behaviour, on non-game pages). Top
+ * placement is deliberate: the bomb-module interaction area owns the bottom.
+ *
+ * Presentation only — GamePage feeds it the live utterance reported by
+ * VoicePanel's `onUtterance`; it renders nothing when there is no active
+ * speech. Proactive beats stay frozen during the run (§游戏内共存规则): the
+ * only text that can appear here is the collaboration channel's own reply.
+ */
+export default function CompanionSubtitleStrip({ text }: { text: string }) {
+  if (!text) return null
+  return (
+    <div className={styles.strip} role="status" aria-label="伙伴字幕">
+      <span className={styles.text}>{text}</span>
+    </div>
+  )
+}

--- a/packages/game-bombsquad/src/voice/VoicePanel.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.tsx
@@ -1,8 +1,16 @@
-import { memo, useImperativeHandle, forwardRef } from 'react'
+import { memo, useImperativeHandle, forwardRef, useEffect } from 'react'
 import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
 import { useVoiceSession } from './useVoiceSession'
 import type { ConversationPhase, VoiceStatus } from './voice-session-protocol'
 import styles from './VoicePanel.module.css'
+
+/** Live companion utterance, reported upward for the top subtitle strip. */
+export interface VoiceUtterance {
+  /** The AI's streamed reply text for the current turn ('' between turns). */
+  text: string
+  /** True while the reply is audibly playing (TTS frames scheduled). */
+  speaking: boolean
+}
 
 interface VoicePanelProps {
   /** Stable per-run join key shared by voice summary and score settlement. */
@@ -13,6 +21,13 @@ interface VoicePanelProps {
   gameState: GameState
   /** Platform game id; defaults to `'bombsquad'` inside the hook. */
   gameId?: string
+  /**
+   * Observer for the live utterance (text + speaking), so GamePage can render
+   * the top-of-screen companion subtitle strip without lifting the whole
+   * voice-session hook out of the panel. Called from an effect on every
+   * utterance change; must be reference-stable (GamePage memoizes it).
+   */
+  onUtterance?: (utterance: VoiceUtterance) => void
 }
 
 /**
@@ -67,7 +82,7 @@ function placeholderFor(status: VoiceStatus, phase: ConversationPhase): string {
 }
 
 function VoicePanelImpl(
-  { gameRunId, manualData, gameState, gameId }: VoicePanelProps,
+  { gameRunId, manualData, gameState, gameId, onUtterance }: VoicePanelProps,
   ref: React.ForwardedRef<VoicePanelHandle>
 ) {
   const {
@@ -86,6 +101,15 @@ function VoicePanelImpl(
   })
 
   useImperativeHandle(ref, () => ({ requestClosing }), [requestClosing])
+
+  // Report the live utterance for the top subtitle strip. Cleared on unmount
+  // so the strip vanishes with the session (run exit / navigation).
+  useEffect(() => {
+    onUtterance?.({ text: aiText, speaking: isAiSpeaking })
+  }, [onUtterance, aiText, isAiSpeaking])
+  useEffect(() => {
+    return () => onUtterance?.({ text: '', speaking: false })
+  }, [onUtterance])
 
   const isLive = status === 'ready'
   // While live, the prominent indicator is the conversation phase; before that

--- a/packages/platform/src/components/companion/CompanionDock.lobby-voice.test.tsx
+++ b/packages/platform/src/components/companion/CompanionDock.lobby-voice.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * CompanionDock — the ratified auto-voice-on-login sequence, pinned FLAG-ON.
+ *
+ * `LOBBY_VOICE_CAPABLE` is module-mocked to true here so the full design
+ * sequence (§自动语音登录序列) stays live and regression-pinned for the slice
+ * that ships the lobby voice channel and flips the flag: greeting text first
+ * → 300ms → permission request → grant keeps voice-default / denial persists
+ * `denied-remembered` (never auto-repeated; the mic button is the sole,
+ * user-gesture retry whose grant corrects back to voice-default).
+ *
+ * The shipping (flag-off) behaviour — the lobby never touching mic APIs — is
+ * pinned in CompanionDock.test.tsx.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { CompanionIdentity, VoicePosture } from '@shared/companion-types'
+import { VOICE_POSTURE_STORAGE_KEY } from '@shared/companion-presence'
+
+const authState = vi.hoisted(() => ({
+  current: { status: 'anon', user: null } as { status: string; user: unknown },
+}))
+const companionState = vi.hoisted(() => ({
+  current: { status: 'loading', companion: null } as {
+    status: string
+    companion: CompanionIdentity | null
+    stats?: unknown
+  },
+}))
+const apiMocks = vi.hoisted(() => ({
+  fetchMemories: vi.fn(),
+  putVoicePosture: vi.fn(),
+}))
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ ...authState.current, logout: async () => {} }),
+}))
+vi.mock('@/hooks/useCompanion', () => ({
+  useCompanion: () => ({ state: companionState.current, reload: () => {} }),
+}))
+vi.mock('@/lib/companion-api', () => ({
+  fetchMemories: apiMocks.fetchMemories,
+  putVoicePosture: apiMocks.putVoicePosture,
+}))
+// Flip the capability: this file pins the sequence the next slice engages.
+vi.mock('./lobby-voice', () => ({
+  LOBBY_VOICE_CAPABLE: true,
+  LOBBY_VOICE_NOTE: '语音陪伴在拆弹局内可用，进入每日挑战开启。',
+}))
+
+import CompanionDock from './CompanionDock'
+
+const COMPANION: CompanionIdentity = {
+  name: '阿澈',
+  address_style: '',
+  voice_id: 'companion-warm',
+  profile_enabled: true,
+  voice_posture: 'voice-default',
+  created_at: '2026-06-30T00:00:00.000Z',
+}
+
+function signInWithCompanion(posture: VoicePosture = 'voice-default') {
+  authState.current = { status: 'authed', user: { user_id: 'u1', email: 'a@b.c' } }
+  companionState.current = {
+    status: 'exists',
+    companion: { ...COMPANION, voice_posture: posture },
+    stats: { games_completed: 0, successes: 0 },
+  }
+}
+
+function installMemoryStorage(): void {
+  const map = new Map<string, string>()
+  const storage = {
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, String(value)),
+    removeItem: (key: string) => void map.delete(key),
+    clear: () => map.clear(),
+    key: (index: number) => [...map.keys()][index] ?? null,
+    get length() {
+      return map.size
+    },
+  }
+  Object.defineProperty(window, 'localStorage', { configurable: true, value: storage })
+}
+
+function stubMic(outcome: 'granted' | 'denied') {
+  const getUserMedia =
+    outcome === 'granted'
+      ? vi.fn().mockResolvedValue({ getTracks: () => [{ stop: () => {} }] })
+      : vi.fn().mockRejectedValue(new DOMException('denied', 'NotAllowedError'))
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia },
+  })
+  return getUserMedia
+}
+
+function renderDock(path = '/') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <CompanionDock />
+    </MemoryRouter>
+  )
+}
+
+describe('CompanionDock — auto-voice sequence (lobby voice capability ON)', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    installMemoryStorage()
+    authState.current = { status: 'anon', user: null }
+    companionState.current = { status: 'loading', companion: null }
+    apiMocks.fetchMemories.mockReset()
+    apiMocks.fetchMemories.mockResolvedValue({ kind: 'ok', memories: [] })
+    apiMocks.putVoicePosture.mockReset()
+    apiMocks.putVoicePosture.mockResolvedValue({ kind: 'ok' })
+  })
+
+  it('greeting text lands BEFORE the mic request; grant keeps voice-default', async () => {
+    signInWithCompanion()
+    const getUserMedia = stubMic('granted')
+    renderDock()
+
+    // Text first — never blocked on the permission dialog.
+    await screen.findAllByText('我在这。今天的每日挑战等你。')
+    expect(getUserMedia).not.toHaveBeenCalled()
+
+    // 300ms later the sequence requests the mic exactly once.
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(1))
+    // Grant: posture stays voice-default — nothing is persisted.
+    expect(apiMocks.putVoicePosture).not.toHaveBeenCalled()
+    expect(window.localStorage.getItem(VOICE_POSTURE_STORAGE_KEY)).toBe('voice-default')
+  })
+
+  it('a REAL denial persists denied-remembered; the greeting text stays', async () => {
+    signInWithCompanion()
+    stubMic('denied')
+    renderDock()
+
+    await screen.findAllByText('我在这。今天的每日挑战等你。')
+    await waitFor(() => expect(apiMocks.putVoicePosture).toHaveBeenCalledWith('denied-remembered'))
+    expect(window.localStorage.getItem(VOICE_POSTURE_STORAGE_KEY)).toBe('denied-remembered')
+    expect(screen.getAllByText('我在这。今天的每日挑战等你。').length).toBeGreaterThan(0)
+  })
+
+  it('denied-remembered never auto-requests; the mic button retry corrects on grant', async () => {
+    signInWithCompanion('denied-remembered')
+    const getUserMedia = stubMic('granted')
+    renderDock()
+
+    expect(screen.getByText('阿澈在这（静音中）')).toBeInTheDocument()
+    expect(getUserMedia).not.toHaveBeenCalled()
+
+    // Manual retry (user gesture): granted → posture corrects back to
+    // voice-default and the dock elevates.
+    fireEvent.click(screen.getByRole('button', { name: '开启语音' }))
+    await waitFor(() => expect(apiMocks.putVoicePosture).toHaveBeenCalledWith('voice-default'))
+    expect(window.localStorage.getItem(VOICE_POSTURE_STORAGE_KEY)).toBe('voice-default')
+    await screen.findByText('阿澈在这')
+  })
+
+  it('a failed posture PUT rolls the cache back (cheap durability)', async () => {
+    signInWithCompanion()
+    stubMic('granted')
+    apiMocks.putVoicePosture.mockResolvedValue({ kind: 'error' })
+    renderDock('/leaderboard')
+
+    fireEvent.click(screen.getByRole('button', { name: '阿澈 控制菜单' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: '静音' }))
+
+    // This visit still mutes (session behaviour honoured)…
+    expect(screen.getByText('阿澈在这（静音中）')).toBeInTheDocument()
+    // …but the cache never claims a posture the account did not accept.
+    await waitFor(() =>
+      expect(window.localStorage.getItem(VOICE_POSTURE_STORAGE_KEY)).toBe('voice-default')
+    )
+  })
+})

--- a/packages/platform/src/components/companion/CompanionDock.module.css
+++ b/packages/platform/src/components/companion/CompanionDock.module.css
@@ -1,0 +1,266 @@
+/* 伙伴坞 — 48px presence bar pinned above the tab bar (companion-presence-design
+   §形态). Desktop has no bottom tab bar (TopNav carries the tabs), so the dock
+   sits at the viewport bottom; at ≤768px it rides above the fixed BottomNav. */
+
+.dock {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 49; /* under the BottomNav's 50 — its own layer, never its cover */
+  height: 48px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 14px;
+  background: rgba(5, 5, 17, 0.88);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border-top: 1px solid var(--border-hairline);
+}
+
+@media (max-width: 768px) {
+  .dock {
+    bottom: calc(56px + env(safe-area-inset-bottom));
+  }
+}
+
+/* In-flow clearance so page content is pushed up past the fixed bottom bars
+   (design: 页面内容向上推让出空间). The bottom-band math is co-located here
+   with the dock's own offset above:
+   - desktop: the dock is the only fixed bottom bar (BottomNav exists only at
+     ≤768px), so the clearance equals the dock's 48px band;
+   - ≤768px: the fixed stack is BottomNav (6px padding + 44px tab row + 6px
+     padding = 56px) + env(safe-area-inset-bottom) + the 48px dock riding
+     above it (the dock's `bottom: calc(56px + safe-area)` mirrors the same
+     figure), so the spacer clears the whole 104px + safe-area stack.
+   Verified in the jsdom/Playwright harness only — the real-device (iOS
+   Safari safe-area) check rides the PR preview + the Phase C device pass. */
+.spacer {
+  height: 48px;
+}
+
+@media (max-width: 768px) {
+  .spacer {
+    height: calc(104px + env(safe-area-inset-bottom));
+  }
+}
+
+/* --- name region + pulse dot ------------------------------------------------- */
+
+.nameRegion {
+  position: relative;
+  flex: none;
+}
+
+.nameButton {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: 600 14px var(--font-body);
+  color: var(--amio-yellow);
+}
+
+.name {
+  letter-spacing: 0.02em;
+}
+
+/* The breathing pulse dot — the companion's entire visual presence signal. */
+.pulseDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #35d07f;
+  animation: dock-breathe 2.8s ease-in-out infinite;
+}
+
+.pulseDot[data-status='listening'] {
+  background: #4aa8ff;
+  animation-duration: 1.1s;
+}
+
+.pulseDot[data-status='speaking'] {
+  background: var(--amio-yellow);
+  animation-duration: 0.7s;
+}
+
+.pulseDot[data-status='muted'] {
+  background: rgba(255, 255, 255, 0.35);
+  animation: none;
+}
+
+@keyframes dock-breathe {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scale(1.35);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pulseDot {
+    animation: none;
+  }
+}
+
+/* --- text region --------------------------------------------------------------- */
+
+.textRegion {
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: none;
+  padding: 6px 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.textRegion:disabled {
+  cursor: default;
+}
+
+.textLine {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: 400 13px var(--font-body);
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.dock[data-status='muted'] .textLine {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+/* --- mic button ------------------------------------------------------------------ */
+
+.micButton {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--border-hairline);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+}
+
+.micButton[data-status='muted'] {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.micButton[data-status='speaking'] {
+  color: var(--amio-yellow);
+  border-color: var(--amio-yellow-glow-30);
+}
+
+/* --- create-companion entry (signed in, no companion yet) ------------------------ */
+
+.createEntry {
+  flex: 1;
+  text-align: center;
+  font: 600 14px var(--font-body);
+  color: var(--amio-yellow);
+  text-decoration: none;
+  padding: 8px 0;
+}
+
+/* --- bubble ------------------------------------------------------------------------ */
+
+/* Floats in the layer between page content and the dock; never covers the
+   core interaction area (design §气泡). */
+.bubbleLayer {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 60px;
+  z-index: 48;
+  display: flex;
+  justify-content: center;
+  padding: 0 16px;
+  pointer-events: none;
+}
+
+@media (max-width: 768px) {
+  .bubbleLayer {
+    bottom: calc(116px + env(safe-area-inset-bottom));
+  }
+}
+
+.bubble {
+  pointer-events: auto;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 14px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 14px;
+  background: rgba(10, 10, 26, 0.86);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  text-align: left;
+  cursor: pointer;
+}
+
+.bubbleName {
+  font: 600 11px var(--font-body);
+  color: var(--amio-yellow);
+}
+
+.bubbleText {
+  font: 400 14px/1.5 var(--font-body);
+  color: #fff;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.bubbleExpanded .bubbleText {
+  display: block;
+  -webkit-line-clamp: none;
+}
+
+/* --- control menu -------------------------------------------------------------------- */
+
+.menu {
+  position: absolute;
+  left: 0;
+  bottom: 44px;
+  min-width: 148px;
+  display: flex;
+  flex-direction: column;
+  padding: 6px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 12px;
+  background: rgba(10, 10, 26, 0.95);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.menuItem {
+  background: none;
+  border: none;
+  border-radius: 8px;
+  padding: 9px 12px;
+  text-align: left;
+  font: 500 13px var(--font-body);
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+}
+
+.menuItem:hover {
+  background: rgba(255, 255, 255, 0.08);
+}

--- a/packages/platform/src/components/companion/CompanionDock.test.tsx
+++ b/packages/platform/src/components/companion/CompanionDock.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * CompanionDock — the persistent presence bar.
+ *
+ * Covers the dock's identity gating (anonymous → nothing; signed-in without a
+ * companion → the create entry; companion → the live dock), the stub-era
+ * honesty pin (LOBBY_VOICE_CAPABLE=false → the lobby NEVER touches mic /
+ * permission APIs; the mic button surfaces the honest in-game-voice note),
+ * the quiet-remembered muted landing, and the mute control's posture write.
+ * The full ratified auto-voice sequence is pinned flag-on in
+ * CompanionDock.lobby-voice.test.tsx.
+ *
+ * useAuth / useCompanion / the companion API client are module-mocked; the
+ * localStorage-backed posture cache and beat log run for real against jsdom's
+ * localStorage (cleared per test).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { CompanionIdentity, VoicePosture } from '@shared/companion-types'
+import { COMPANION_BEAT_LOG_KEY, VOICE_POSTURE_STORAGE_KEY } from '@shared/companion-presence'
+
+const authState = vi.hoisted(() => ({
+  current: { status: 'anon', user: null } as { status: string; user: unknown },
+}))
+const companionState = vi.hoisted(() => ({
+  current: { status: 'loading', companion: null } as {
+    status: string
+    companion: CompanionIdentity | null
+    stats?: unknown
+  },
+}))
+const apiMocks = vi.hoisted(() => ({
+  fetchMemories: vi.fn(),
+  putVoicePosture: vi.fn(),
+}))
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ ...authState.current, logout: async () => {} }),
+}))
+vi.mock('@/hooks/useCompanion', () => ({
+  useCompanion: () => ({ state: companionState.current, reload: () => {} }),
+}))
+vi.mock('@/lib/companion-api', () => ({
+  fetchMemories: apiMocks.fetchMemories,
+  putVoicePosture: apiMocks.putVoicePosture,
+}))
+
+import CompanionDock from './CompanionDock'
+
+const COMPANION: CompanionIdentity = {
+  name: '阿澈',
+  address_style: '',
+  voice_id: 'companion-warm',
+  profile_enabled: true,
+  voice_posture: 'voice-default',
+  created_at: '2026-06-30T00:00:00.000Z',
+}
+
+function signInWithCompanion(posture: VoicePosture = 'voice-default') {
+  authState.current = { status: 'authed', user: { user_id: 'u1', email: 'a@b.c' } }
+  companionState.current = {
+    status: 'exists',
+    companion: { ...COMPANION, voice_posture: posture },
+    // Part of the exists shape; the dock never reads it.
+    stats: { games_completed: 0, successes: 0 },
+  }
+}
+
+/**
+ * The workspace jsdom exposes no functional localStorage (Node >= 22 ships an
+ * experimental undefined-without-flag global that wins), so install a real
+ * in-memory Storage per test — the posture cache and beat log then run their
+ * REAL read/write paths and stay assertable.
+ */
+function installMemoryStorage(): void {
+  const map = new Map<string, string>()
+  const storage = {
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, String(value)),
+    removeItem: (key: string) => void map.delete(key),
+    clear: () => map.clear(),
+    key: (index: number) => [...map.keys()][index] ?? null,
+    get length() {
+      return map.size
+    },
+  }
+  Object.defineProperty(window, 'localStorage', { configurable: true, value: storage })
+}
+
+function stubMic(outcome: 'granted' | 'denied') {
+  const getUserMedia =
+    outcome === 'granted'
+      ? vi.fn().mockResolvedValue({ getTracks: () => [{ stop: () => {} }] })
+      : vi.fn().mockRejectedValue(new DOMException('denied', 'NotAllowedError'))
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia },
+  })
+  return getUserMedia
+}
+
+function renderDock(path = '/') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <CompanionDock />
+    </MemoryRouter>
+  )
+}
+
+describe('CompanionDock', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    installMemoryStorage()
+    authState.current = { status: 'anon', user: null }
+    companionState.current = { status: 'loading', companion: null }
+    apiMocks.fetchMemories.mockReset()
+    apiMocks.fetchMemories.mockResolvedValue({ kind: 'ok', memories: [] })
+    apiMocks.putVoicePosture.mockReset()
+    apiMocks.putVoicePosture.mockResolvedValue({ kind: 'ok' })
+  })
+
+  it('renders nothing for an anonymous visitor', () => {
+    renderDock()
+    expect(screen.queryByRole('complementary', { name: '伙伴坞' })).not.toBeInTheDocument()
+  })
+
+  it('shows the create-companion entry for a signed-in player without one', () => {
+    authState.current = { status: 'authed', user: { user_id: 'u1', email: 'a@b.c' } }
+    companionState.current = { status: 'none', companion: null }
+    renderDock()
+
+    const entry = screen.getByRole('link', { name: '创建你的伙伴 →' })
+    expect(entry).toHaveAttribute('href', '/me/companion')
+  })
+
+  it('lands the arrival greeting and NEVER touches the mic APIs while lobby voice is off', async () => {
+    signInWithCompanion()
+    const getUserMedia = stubMic('granted')
+    apiMocks.fetchMemories.mockResolvedValue({
+      kind: 'ok',
+      memories: [
+        {
+          id: 'ep-1',
+          occurred_at: '2026-07-07T20:00:00.000Z',
+          game_id: 'bombsquad',
+          title: '最后三秒拆掉了炸弹',
+          narrative: 'n',
+        },
+      ],
+    })
+    renderDock()
+
+    // Greeting text (from the real recent episode) lands — in the bubble AND
+    // the dock text line.
+    const greetings = await screen.findAllByText(/上次最后三秒拆掉了炸弹，我还记着/)
+    expect(greetings.length).toBeGreaterThan(0)
+    // The beat log recorded the greeting (daily cap + re-open suppression).
+    expect(window.localStorage.getItem(COMPANION_BEAT_LOG_KEY)).toContain('"count":1')
+
+    // THE stub-era honesty pin: with LOBBY_VOICE_CAPABLE=false the lobby must
+    // never request the mic — wait well past the 300ms auto-voice delay and
+    // assert no permission API was touched and no posture was written, so a
+    // stub-era denial can never poison denied-remembered.
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(getUserMedia).not.toHaveBeenCalled()
+    expect(apiMocks.putVoicePosture).not.toHaveBeenCalled()
+    expect(window.localStorage.getItem(VOICE_POSTURE_STORAGE_KEY)).toBe('voice-default')
+  })
+
+  it('mic button surfaces the honest in-game-voice note instead of faking lobby voice', async () => {
+    signInWithCompanion()
+    const getUserMedia = stubMic('granted')
+    renderDock('/leaderboard') // no greeting in the way
+
+    fireEvent.click(screen.getByRole('button', { name: '语音陪伴说明' }))
+
+    // The note leads somewhere TRUE (voice runs in the daily run) — and the
+    // tap costs nothing: no permission call, no posture write.
+    await screen.findByText('语音陪伴在拆弹局内可用，进入每日挑战开启。')
+    expect(getUserMedia).not.toHaveBeenCalled()
+    expect(apiMocks.putVoicePosture).not.toHaveBeenCalled()
+  })
+
+  it('lands muted with no greeting and no permission request for a quiet-remembered visit', () => {
+    signInWithCompanion('quiet-remembered')
+    const getUserMedia = stubMic('granted')
+    renderDock()
+
+    expect(screen.getByText('阿澈在这（静音中）')).toBeInTheDocument()
+    expect(getUserMedia).not.toHaveBeenCalled()
+    expect(apiMocks.fetchMemories).not.toHaveBeenCalled()
+    // The mic button is present — while lobby voice is off it carries the
+    // honest note affordance rather than a fake 开启语音.
+    expect(screen.getByRole('button', { name: '语音陪伴说明' })).toBeInTheDocument()
+  })
+
+  it('never auto-requests permission on a denied-remembered visit', async () => {
+    signInWithCompanion('denied-remembered')
+    const getUserMedia = stubMic('granted')
+    renderDock()
+
+    expect(screen.getByText('阿澈在这（静音中）')).toBeInTheDocument()
+    expect(getUserMedia).not.toHaveBeenCalled()
+
+    // While lobby voice is off the mic tap surfaces the honest note only —
+    // the real permission-retry path is pinned (flag-on) in
+    // CompanionDock.lobby-voice.test.tsx.
+    fireEvent.click(screen.getByRole('button', { name: '语音陪伴说明' }))
+    await screen.findByText('语音陪伴在拆弹局内可用，进入每日挑战开启。')
+    expect(getUserMedia).not.toHaveBeenCalled()
+    expect(apiMocks.putVoicePosture).not.toHaveBeenCalled()
+  })
+
+  it('mutes from the control menu and persists quiet-remembered', async () => {
+    signInWithCompanion()
+    stubMic('granted')
+    renderDock('/leaderboard') // not the homepage — no greeting in the way
+
+    // Open the control menu from the name region and mute.
+    fireEvent.click(screen.getByRole('button', { name: '阿澈 控制菜单' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: '静音' }))
+
+    expect(screen.getByText('阿澈在这（静音中）')).toBeInTheDocument()
+    await waitFor(() => expect(apiMocks.putVoicePosture).toHaveBeenCalledWith('quiet-remembered'))
+    expect(window.localStorage.getItem(VOICE_POSTURE_STORAGE_KEY)).toBe('quiet-remembered')
+
+    // 恢复自动语音 restores the default posture.
+    fireEvent.click(screen.getByRole('button', { name: '阿澈 控制菜单' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: '恢复自动语音' }))
+    await waitFor(() => expect(apiMocks.putVoicePosture).toHaveBeenCalledWith('voice-default'))
+    expect(screen.getByText('阿澈在这')).toBeInTheDocument()
+  })
+
+  it('fires no greeting away from the homepage', () => {
+    signInWithCompanion()
+    stubMic('granted')
+    renderDock('/community')
+
+    expect(apiMocks.fetchMemories).not.toHaveBeenCalled()
+    expect(screen.getByText('阿澈在这')).toBeInTheDocument()
+  })
+})

--- a/packages/platform/src/components/companion/CompanionDock.tsx
+++ b/packages/platform/src/components/companion/CompanionDock.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { CompanionIdentity } from '@shared/companion-types'
+import type { DockStatus } from '@shared/companion-presence'
+import { useAuth } from '@/hooks/useAuth'
+import { useCompanion } from '@/hooks/useCompanion'
+import { useCompanionPresence } from './useCompanionPresence'
+import { LOBBY_VOICE_CAPABLE } from './lobby-voice'
+import styles from './CompanionDock.module.css'
+
+/**
+ * 伙伴坞 — the persistent companion presence bar (companion-presence-design
+ * §存在层). A 48px strip pinned above the tab bar on every platform page:
+ * name + breathing pulse dot (the entire visual presence signal — no avatar,
+ * no face), the one-line text region, and the mic button. Anonymous visitors
+ * see nothing; a signed-in player without a companion sees the
+ * 「创建你的伙伴 →」 entry into onboarding.
+ *
+ * The dock also renders the floating utterance bubble (proactive beats land
+ * there, dwell 5s, then collapse into the text line) and the control menu
+ * (静音 / 恢复自动语音 — opened from the name region by click or long-press).
+ */
+
+const LONG_PRESS_MS = 500
+
+/** Dock-line status phrases (design §状态机 坞内文字 column). */
+function statusPhrase(status: DockStatus, name: string): string {
+  switch (status) {
+    case 'listening':
+      return '在听…'
+    case 'muted':
+      return `${name}在这（静音中）`
+    default:
+      return `${name}在这`
+  }
+}
+
+function micAriaLabel(status: DockStatus): string {
+  // While lobby voice is off the button opens the honest in-game-voice note —
+  // labelling it 开启/关闭语音 would imply a live lobby voice channel.
+  if (!LOBBY_VOICE_CAPABLE) return '语音陪伴说明'
+  return status === 'muted' ? '开启语音' : '关闭语音'
+}
+
+function ActiveDock({ companion }: { companion: CompanionIdentity }) {
+  const presence = useCompanionPresence(companion)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const longPressRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const menuRef = useRef<HTMLDivElement | null>(null)
+
+  // Close the menu on any outside pointerdown.
+  useEffect(() => {
+    if (!menuOpen) return
+    const onPointerDown = (event: PointerEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) setMenuOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [menuOpen])
+
+  const startLongPress = () => {
+    longPressRef.current = setTimeout(() => setMenuOpen(true), LONG_PRESS_MS)
+  }
+  const cancelLongPress = () => {
+    if (longPressRef.current) {
+      clearTimeout(longPressRef.current)
+      longPressRef.current = null
+    }
+  }
+
+  const { dockStatus, bubble, lastUtterance } = presence
+  // The muted status phrase (「X在这（静音中）」) and the live listening cue win
+  // over the last-utterance summary; otherwise the dock line carries the
+  // companion's most recent words (design §状态机 坞内文字 column).
+  const line =
+    dockStatus === 'muted' || dockStatus === 'listening'
+      ? statusPhrase(dockStatus, companion.name)
+      : (lastUtterance ?? statusPhrase(dockStatus, companion.name))
+
+  return (
+    <>
+      {bubble && (
+        <div className={styles.bubbleLayer}>
+          <button
+            type="button"
+            className={`${styles.bubble} ${bubble.expanded ? styles.bubbleExpanded : ''}`}
+            onClick={bubble.expanded ? presence.dismissBubble : presence.expandBubble}
+            aria-label={bubble.expanded ? '收起伙伴的话' : '展开伙伴的话'}
+          >
+            <span className={styles.bubbleName}>{companion.name}</span>
+            <span className={styles.bubbleText}>{bubble.text}</span>
+          </button>
+        </div>
+      )}
+      <aside className={styles.dock} aria-label="伙伴坞" data-status={dockStatus}>
+        <div className={styles.nameRegion} ref={menuRef}>
+          <button
+            type="button"
+            className={styles.nameButton}
+            onClick={() => setMenuOpen((open) => !open)}
+            onPointerDown={startLongPress}
+            onPointerUp={cancelLongPress}
+            onPointerLeave={cancelLongPress}
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            aria-label={`${companion.name} 控制菜单`}
+          >
+            <span className={styles.pulseDot} data-status={dockStatus} aria-hidden="true" />
+            <span className={styles.name}>{companion.name}</span>
+          </button>
+          {menuOpen && (
+            <div className={styles.menu} role="menu" aria-label="伙伴控制">
+              <button
+                type="button"
+                role="menuitem"
+                className={styles.menuItem}
+                onClick={() => {
+                  presence.onMute()
+                  setMenuOpen(false)
+                }}
+              >
+                静音
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className={styles.menuItem}
+                onClick={() => {
+                  presence.onRestoreVoice()
+                  setMenuOpen(false)
+                }}
+              >
+                恢复自动语音
+              </button>
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          className={styles.textRegion}
+          onClick={presence.reopenBubble}
+          disabled={lastUtterance === null}
+          aria-label={lastUtterance === null ? undefined : '回看伙伴的话'}
+        >
+          <span className={styles.textLine} role="status">
+            {line}
+          </span>
+        </button>
+        <button
+          type="button"
+          className={styles.micButton}
+          data-status={dockStatus}
+          onClick={presence.onMicClick}
+          aria-label={micAriaLabel(dockStatus)}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            width="18"
+            height="18"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            aria-hidden="true"
+          >
+            <rect x="9" y="3" width="6" height="12" rx="3" />
+            <path d="M5 11 a7 7 0 0 0 14 0 M12 18 V21 M9 21 H15" />
+            {dockStatus === 'muted' && <path d="M4 4 L20 20" />}
+          </svg>
+        </button>
+      </aside>
+      <div className={styles.spacer} aria-hidden="true" />
+    </>
+  )
+}
+
+function CreateEntryDock() {
+  return (
+    <>
+      <aside className={styles.dock} aria-label="伙伴坞" data-status="setup">
+        <Link to="/me/companion" className={styles.createEntry}>
+          创建你的伙伴 →
+        </Link>
+      </aside>
+      <div className={styles.spacer} aria-hidden="true" />
+    </>
+  )
+}
+
+/**
+ * Host: resolves auth + companion identity and renders the matching dock
+ * variant. Renders nothing while loading (no signed-out flash), for anonymous
+ * visitors (design §匿名态 — the dock's slot is simply empty), and on an
+ * identity read error (an honest absence beats a wrong presence).
+ */
+export default function CompanionDock() {
+  const auth = useAuth()
+  const { state } = useCompanion(auth.status === 'authed')
+
+  if (auth.status !== 'authed') return null
+  if (state.status === 'none') return <CreateEntryDock />
+  if (state.status !== 'exists') return null
+  return <ActiveDock companion={state.companion} />
+}

--- a/packages/platform/src/components/companion/lobby-voice.ts
+++ b/packages/platform/src/components/companion/lobby-voice.ts
@@ -1,0 +1,20 @@
+/**
+ * Lobby-voice capability flag.
+ *
+ * FALSE until a lobby voice channel actually exists (a `companion-lobby`
+ * provider-config entry + a manual-less session assembly on the platform-ai
+ * Worker — the next companion slice). While false, the platform shell must
+ * never touch mic / permission APIs: a permission prompt in a context that
+ * cannot deliver voice is dishonest, and a stub-era denial would permanently
+ * poison the `denied-remembered` posture before lobby voice ever ships.
+ *
+ * Flipping this to true engages the full ratified auto-voice-on-login
+ * sequence in `useCompanionPresence` (greeting text -> 300ms -> permission
+ * request -> voice greeting / denial memory) exactly as designed — the
+ * sequence code is kept live and test-pinned behind this flag
+ * (CompanionDock.lobby-voice.test.tsx).
+ */
+export const LOBBY_VOICE_CAPABLE = false
+
+/** The honest mic-button note while lobby voice is off (restrained register). */
+export const LOBBY_VOICE_NOTE = '语音陪伴在拆弹局内可用，进入每日挑战开启。'

--- a/packages/platform/src/components/companion/useCompanionPresence.ts
+++ b/packages/platform/src/components/companion/useCompanionPresence.ts
@@ -1,0 +1,338 @@
+/**
+ * Companion-presence orchestration for the 伙伴坞 (companion dock).
+ *
+ * Owns everything stateful behind the dock UI for a signed-in player whose
+ * companion exists:
+ *
+ *  - voice-posture memory (account SSOT adopted on mount, localStorage cache
+ *    mirrored on every write, `PUT /api/companion/settings` sync; a failed
+ *    PUT rolls the cache back so cross-visit state never silently diverges
+ *    from the account);
+ *  - the auto-voice login sequence (design §自动语音登录序列): the arrival
+ *    greeting TEXT lands first, the mic permission request follows 300ms
+ *    later, a denial persists `denied-remembered` and is never auto-repeated
+ *    — ACTIVE ONLY behind `LOBBY_VOICE_CAPABLE` (see `lobby-voice.ts`);
+ *  - the arrival beat (节拍 1) — template fill from the most recent visible
+ *    memory + the local arcade streak, gated by `canFireArrivalBeat`;
+ *  - mute / restore / mic-button posture transitions (§控制面).
+ *
+ * KNOWN SLICE GAP — voice channel outside a game: the platform-ai provider
+ * registry has no lobby/homepage gameId and the session `create` contract
+ * requires a per-run manual, so no voice session can open on platform pages
+ * yet. While `LOBBY_VOICE_CAPABLE` is false the lobby therefore NEVER touches
+ * mic / permission APIs — no permission prompt in a context that cannot
+ * deliver voice, so a stub-era denial can never poison `denied-remembered`
+ * (that posture may only ever be written from a REAL denial in a
+ * working-voice context). The mic button instead surfaces the honest
+ * in-game-voice note. Flipping the flag engages the full ratified sequence.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import type { CompanionIdentity, VoicePosture } from '@shared/companion-types'
+import {
+  buildArrivalGreeting,
+  canFireArrivalBeat,
+  deriveDockStatus,
+  readBeatLog,
+  readCachedVoicePosture,
+  recordBeatFired,
+  transitionPosture,
+  writeBeatLog,
+  writeCachedVoicePosture,
+  type DockStatus,
+  type PostureEvent,
+} from '@shared/companion-presence'
+import { getTodayString } from '@shared/date'
+import { readArcadeLocalProfile, summarizeArcadeLocalProfile } from '@amiclaw/arcade-profile/local'
+import { fetchMemories, putVoicePosture } from '@/lib/companion-api'
+import { LOBBY_VOICE_CAPABLE, LOBBY_VOICE_NOTE } from './lobby-voice'
+
+/** Delay between the greeting text landing and the mic permission request. */
+const MIC_REQUEST_DELAY_MS = 300
+/** Bubble dwell before it collapses into the dock's one-line summary. */
+const BUBBLE_DWELL_MS = 5000
+
+export interface CompanionPresence {
+  /** The dock's single visual state (在线/倾听/说话/静音/离线). */
+  dockStatus: DockStatus
+  /** Persisted posture — drives the mic button's affordance + aria label. */
+  posture: VoicePosture
+  /** The companion's last utterance this visit (dock text line), or null. */
+  lastUtterance: string | null
+  /** The floating bubble: visible while a beat dwells or when re-expanded. */
+  bubble: { text: string; expanded: boolean } | null
+  /** Expand the (clamped) bubble to full content; cancels auto-collapse. */
+  expandBubble: () => void
+  /** Close the bubble (a tap on an already-expanded bubble dismisses it). */
+  dismissBubble: () => void
+  /** Re-open the collapsed bubble from the dock text line. */
+  reopenBubble: () => void
+  /** Mic button action (elevate / retry-permission / downgrade by state). */
+  onMicClick: () => void
+  /** Control menu — 静音. */
+  onMute: () => void
+  /** Control menu — 恢复自动语音. */
+  onRestoreVoice: () => void
+}
+
+function readLocalPlayContext(): {
+  lastPlayedAt: number | null
+  streakDays: number
+  hasPlayedBefore: boolean
+} {
+  const summary = summarizeArcadeLocalProfile(readArcadeLocalProfile())
+  const lastPlayedAt =
+    summary.last_activity_at !== null ? Date.parse(summary.last_activity_at) : null
+  return {
+    lastPlayedAt: Number.isFinite(lastPlayedAt as number) ? lastPlayedAt : null,
+    streakDays: summary.daily_loop.streak.current_days,
+    hasPlayedBefore: summary.last_activity_at !== null,
+  }
+}
+
+/**
+ * Request mic permission and immediately release the probe stream.
+ * `unsupported` (no mediaDevices — insecure context, legacy browser) is NOT a
+ * denial: it must never write `denied-remembered`.
+ */
+async function probeMicPermission(): Promise<'granted' | 'denied' | 'unsupported'> {
+  if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+    return 'unsupported'
+  }
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    stream.getTracks().forEach((track) => track.stop())
+    return 'granted'
+  } catch {
+    return 'denied'
+  }
+}
+
+export function useCompanionPresence(companion: CompanionIdentity): CompanionPresence {
+  const location = useLocation()
+
+  // Account posture is the SSOT; adopt it on mount and mirror it to the cache
+  // (the cache exists for pre-API reads and stays in sync on every write).
+  const [posture, setPosture] = useState<VoicePosture>(companion.voice_posture)
+  useEffect(() => {
+    if (readCachedVoicePosture() !== companion.voice_posture) {
+      writeCachedVoicePosture(companion.voice_posture)
+    }
+    // Mount-time reconcile only — later writes go through applyPostureEvent.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const [sessionMuted, setSessionMuted] = useState(false)
+  const [sessionElevated, setSessionElevated] = useState(false)
+  const [lastUtterance, setLastUtterance] = useState<string | null>(null)
+  const [bubble, setBubble] = useState<{ text: string; expanded: boolean } | null>(null)
+  /** True while the arrival greeting dwells — the dock reads 说话 (speaking). */
+  const [greetingDwell, setGreetingDwell] = useState(false)
+
+  // Mirrored to refs (in an effect, mirroring the useVoiceSession pattern) so
+  // timer callbacks and async continuations read current values.
+  const postureRef = useRef(posture)
+  const sessionMutedRef = useRef(sessionMuted)
+  useEffect(() => {
+    postureRef.current = posture
+    sessionMutedRef.current = sessionMuted
+  })
+
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([])
+  const schedule = useCallback((fn: () => void, ms: number) => {
+    timersRef.current.push(setTimeout(fn, ms))
+  }, [])
+  useEffect(
+    () => () => {
+      timersRef.current.forEach(clearTimeout)
+      timersRef.current = []
+    },
+    []
+  )
+
+  /**
+   * Persist a posture transition: state + localStorage cache + account.
+   * Cheap durability without a retry queue: if the account PUT fails, the
+   * cache is rolled back to the previous value so the cache never claims a
+   * posture the account did not accept (this visit keeps the new behaviour in
+   * session state; the mount-time account-wins reconcile covers the rest).
+   */
+  const applyPostureEvent = useCallback((event: PostureEvent) => {
+    const previous = postureRef.current
+    const next = transitionPosture(previous, event)
+    if (next !== previous) {
+      postureRef.current = next
+      setPosture(next)
+      writeCachedVoicePosture(next)
+      void putVoicePosture(next).then((result) => {
+        if (result.kind !== 'ok') writeCachedVoicePosture(previous)
+      })
+    }
+    return next
+  }, [])
+
+  // --- Arrival beat + auto-voice sequence (homepage only) ---------------------
+  const onHomepage = location.pathname === '/'
+  useEffect(() => {
+    if (!onHomepage) return
+    // 静音回访 (design step 6): quiet/denied postures land muted — no bubble,
+    // no permission request; the mic button is the only elevation path.
+    if (postureRef.current !== 'voice-default' || sessionMutedRef.current) return
+
+    const today = getTodayString()
+    const log = readBeatLog(today)
+    const playContext = readLocalPlayContext()
+    if (
+      !canFireArrivalBeat({
+        log,
+        now: Date.now(),
+        lastPlayedAt: playContext.lastPlayedAt,
+        muted: false,
+      })
+    ) {
+      return
+    }
+
+    let cancelled = false
+    void (async () => {
+      // Most recent visible memory (first page, newest first); an error or an
+      // empty album degrades to the no-episode greeting variant.
+      const memories = await fetchMemories()
+      if (cancelled) return
+      const recentEpisodeTitle =
+        memories.kind === 'ok' && memories.memories.length > 0 ? memories.memories[0].title : null
+      const text = buildArrivalGreeting({
+        addressStyle: companion.address_style,
+        recentEpisodeTitle,
+        streakDays: playContext.streakDays,
+        hasPlayedBefore: playContext.hasPlayedBefore,
+      })
+
+      // Greeting TEXT lands first — never blocked on the permission dialog.
+      setBubble({ text, expanded: false })
+      setLastUtterance(text)
+      setGreetingDwell(true)
+      writeBeatLog(recordBeatFired(log, { kind: 'arrival', now: Date.now() }))
+
+      // Auto-voice step 3 (design): 300ms after the text renders, request the
+      // mic — ONLY once lobby voice can actually deliver (flag in
+      // lobby-voice.ts). While the flag is off, no permission API is ever
+      // touched here, so a stub-era denial can never write denied-remembered.
+      // When on: grant proceeds to the voice greeting; denial persists
+      // denied-remembered and is never auto-repeated.
+      if (LOBBY_VOICE_CAPABLE) {
+        schedule(() => {
+          if (postureRef.current !== 'voice-default') return
+          void probeMicPermission().then((outcome) => {
+            if (outcome === 'denied') applyPostureEvent('permission-denied')
+          })
+        }, MIC_REQUEST_DELAY_MS)
+      }
+
+      // Bubble dwell → collapse to the dock text line (unless expanded).
+      schedule(() => {
+        setGreetingDwell(false)
+        setBubble((current) => (current && !current.expanded ? null : current))
+      }, BUBBLE_DWELL_MS)
+    })()
+    return () => {
+      cancelled = true
+    }
+    // Fires on homepage entry; the beat log's 5-minute re-open window keeps
+    // SPA back-and-forth navigation (and StrictMode's dev double-mount, whose
+    // first run is cancelled before it records) from repeating the greeting.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onHomepage])
+
+  // --- Controls ---------------------------------------------------------------
+
+  const onMute = useCallback(() => {
+    setSessionMuted(true)
+    setSessionElevated(false)
+    setBubble(null)
+    setGreetingDwell(false)
+    applyPostureEvent('mute')
+  }, [applyPostureEvent])
+
+  const onRestoreVoice = useCallback(() => {
+    setSessionMuted(false)
+    applyPostureEvent('restore-default')
+  }, [applyPostureEvent])
+
+  const onMicClick = useCallback(() => {
+    // Lobby voice not shipped yet: the mic button must lead somewhere TRUE.
+    // It surfaces the honest note pointing at where voice genuinely runs (the
+    // in-game co-play channel) — no permission call, no posture write.
+    if (!LOBBY_VOICE_CAPABLE) {
+      setBubble({ text: LOBBY_VOICE_NOTE, expanded: true })
+      return
+    }
+    const muted =
+      sessionMutedRef.current ||
+      ((postureRef.current === 'quiet-remembered' || postureRef.current === 'denied-remembered') &&
+        !sessionElevated)
+    if (muted) {
+      if (postureRef.current === 'denied-remembered') {
+        // Manual retry is the ONLY re-request path after a denial; the user
+        // gesture lets the browser re-prompt. Grant corrects the old denial
+        // back to voice-default; a second denial changes nothing.
+        void probeMicPermission().then((outcome) => {
+          if (outcome === 'granted') {
+            applyPostureEvent('manual-grant')
+            setSessionMuted(false)
+            setSessionElevated(true)
+          }
+        })
+        return
+      }
+      // quiet-remembered / session mute: elevate THIS visit only — an explicit
+      // mute is undone only by the explicit 恢复自动语音 (least surprise).
+      setSessionMuted(false)
+      setSessionElevated(true)
+      return
+    }
+    // Voice nominally on → the mic button is the manual downgrade (design:
+    // 手动降级语音 → quiet-remembered).
+    setSessionMuted(true)
+    setSessionElevated(false)
+    applyPostureEvent('mute')
+  }, [applyPostureEvent, sessionElevated])
+
+  const expandBubble = useCallback(() => {
+    setBubble((current) => (current ? { ...current, expanded: true } : current))
+  }, [])
+
+  const dismissBubble = useCallback(() => {
+    setBubble(null)
+    setGreetingDwell(false)
+  }, [])
+
+  const reopenBubble = useCallback(() => {
+    if (lastUtterance !== null) setBubble({ text: lastUtterance, expanded: true })
+  }, [lastUtterance])
+
+  const dockStatus = deriveDockStatus({
+    signedInWithCompanion: true,
+    posture,
+    sessionMuted,
+    sessionElevated,
+    // No live voice channel exists on platform pages in this slice; the
+    // greeting dwell is the one 说话 (speaking) window the dock can honestly
+    // show. 倾听 (listening) becomes reachable with the lobby voice session.
+    voicePhase: greetingDwell && !sessionMuted ? 'speaking' : 'idle',
+  })
+
+  return {
+    dockStatus,
+    posture,
+    lastUtterance,
+    bubble,
+    expandBubble,
+    dismissBubble,
+    reopenBubble,
+    onMicClick,
+    onMute,
+    onRestoreVoice,
+  }
+}

--- a/packages/platform/src/components/platform/PlatformLayout.tsx
+++ b/packages/platform/src/components/platform/PlatformLayout.tsx
@@ -3,11 +3,14 @@ import { Scenery } from '@amiclaw/ui'
 import TopNav from './TopNav'
 import BottomNav from './BottomNav'
 import PlatformFooter from './PlatformFooter'
+import CompanionDock from '../companion/CompanionDock'
 import styles from './PlatformLayout.module.css'
 
 /* Layout route for the 4 platform pages (/、/leaderboard、/community、/me).
    Owns the cosmic gradient background — applied to this root element, NOT
-   <body>, so the BombSquad game routes keep global.css's #1a1a2e. */
+   <body>, so the BombSquad game routes keep global.css's #1a1a2e.
+   CompanionDock is the persistent presence bar above the tab bar — it renders
+   itself only for a signed-in player (companion or create-entry variant). */
 export default function PlatformLayout() {
   return (
     <div className={styles.root}>
@@ -17,6 +20,7 @@ export default function PlatformLayout() {
         <Outlet />
       </main>
       <PlatformFooter />
+      <CompanionDock />
       <BottomNav />
     </div>
   )

--- a/packages/platform/src/lib/companion-api.ts
+++ b/packages/platform/src/lib/companion-api.ts
@@ -21,6 +21,7 @@ import { API_BASE } from '@shared/api-base'
 import type {
   CompanionIdentity,
   CompanionResponse,
+  CompanionSettingsBody,
   CompanionSetupBody,
   CompanionSetupResponse,
   MemoriesResponse,
@@ -28,6 +29,7 @@ import type {
   ProfileClaimView,
   ProfileCorrectionResponse,
   ProfileResponse,
+  VoicePosture,
 } from '@shared/companion-types'
 import {
   companionSeedEnabled,
@@ -273,6 +275,29 @@ export async function setProfileEnabled(enabled: boolean): Promise<ProfileToggle
     })
     if (!res.ok) return { kind: 'error' }
     return { kind: 'ok', profileEnabled: enabled }
+  } catch {
+    return { kind: 'error' }
+  }
+}
+
+// --- Presence settings (voice posture) ----------------------------------------
+
+/**
+ * Persist the remembered auto-voice posture (`PUT /api/companion/settings`).
+ * Fire-and-forget from the dock's point of view: the localStorage cache is
+ * written first (the client's fast path), this call syncs the account SSOT.
+ */
+export async function putVoicePosture(posture: VoicePosture): Promise<MutationResult> {
+  if (companionSeedEnabled()) return { kind: 'ok' }
+  try {
+    const body: CompanionSettingsBody = { voice_posture: posture }
+    const res = await fetch(`${BASE}/settings`, {
+      method: 'PUT',
+      headers: JSON_HEADERS,
+      credentials: 'include',
+      body: JSON.stringify(body),
+    })
+    return res.ok ? { kind: 'ok' } : { kind: 'error' }
   } catch {
     return { kind: 'error' }
   }

--- a/packages/platform/src/lib/companion-presence.test.ts
+++ b/packages/platform/src/lib/companion-presence.test.ts
@@ -1,0 +1,247 @@
+/**
+ * shared/companion-presence — the presence layer's pure rule set.
+ *
+ * Covers the three rule families the dock and the result-page reaction both
+ * depend on: the posture transition table (incl. the denied path), the dock
+ * 5-state machine, and the proactive-beat gating (arrival idle threshold,
+ * 5-minute re-open suppression, daily cap, per-run post-game dedupe), plus the
+ * template-fill copy builders.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  ARRIVAL_IDLE_THRESHOLD_MS,
+  ARRIVAL_REOPEN_SUPPRESS_MS,
+  STANDARD_PROACTIVITY_TIER,
+  VOICE_POSTURE_STORAGE_KEY,
+  buildArrivalGreeting,
+  buildPostGameReaction,
+  canFireArrivalBeat,
+  canFirePostGameBeat,
+  deriveDockStatus,
+  emptyBeatLog,
+  formatDurationSpeech,
+  readBeatLog,
+  readCachedVoicePosture,
+  recordBeatFired,
+  transitionPosture,
+  writeBeatLog,
+  writeCachedVoicePosture,
+} from '@shared/companion-presence'
+
+const NOW = Date.parse('2026-07-08T12:00:00.000Z')
+const TODAY = '2026-07-08'
+
+function storageStub(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial))
+  return {
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, value),
+    map,
+  }
+}
+
+describe('voice-posture cache', () => {
+  it('round-trips a posture and rejects junk', () => {
+    const storage = storageStub()
+    expect(readCachedVoicePosture(storage)).toBeNull()
+    writeCachedVoicePosture('quiet-remembered', storage)
+    expect(storage.map.get(VOICE_POSTURE_STORAGE_KEY)).toBe('quiet-remembered')
+    expect(readCachedVoicePosture(storage)).toBe('quiet-remembered')
+    storage.map.set(VOICE_POSTURE_STORAGE_KEY, 'shouting')
+    expect(readCachedVoicePosture(storage)).toBeNull()
+  })
+})
+
+describe('transitionPosture', () => {
+  it('mute / manual downgrade remembers quiet', () => {
+    expect(transitionPosture('voice-default', 'mute')).toBe('quiet-remembered')
+    expect(transitionPosture('quiet-remembered', 'mute')).toBe('quiet-remembered')
+  })
+
+  it('a browser denial remembers denied and outranks mute memory', () => {
+    expect(transitionPosture('voice-default', 'permission-denied')).toBe('denied-remembered')
+    expect(transitionPosture('quiet-remembered', 'permission-denied')).toBe('denied-remembered')
+    // Muting while denied keeps the denial memory (both suppress auto-voice,
+    // only denied also blocks the auto permission request).
+    expect(transitionPosture('denied-remembered', 'mute')).toBe('denied-remembered')
+  })
+
+  it('a granted manual retry corrects a denial back to voice-default', () => {
+    expect(transitionPosture('denied-remembered', 'manual-grant')).toBe('voice-default')
+    // …but never un-mutes an explicit quiet choice (least surprise: a mic tap
+    // elevates the session only; the persisted mute needs the explicit restore).
+    expect(transitionPosture('quiet-remembered', 'manual-grant')).toBe('quiet-remembered')
+  })
+
+  it('the explicit restore always returns to voice-default', () => {
+    expect(transitionPosture('quiet-remembered', 'restore-default')).toBe('voice-default')
+    expect(transitionPosture('denied-remembered', 'restore-default')).toBe('voice-default')
+  })
+})
+
+describe('deriveDockStatus', () => {
+  const base = {
+    signedInWithCompanion: true,
+    posture: 'voice-default' as const,
+    sessionMuted: false,
+    sessionElevated: false,
+    voicePhase: 'idle' as const,
+  }
+
+  it('is offline without a signed-in companion', () => {
+    expect(deriveDockStatus({ ...base, signedInWithCompanion: false })).toBe('offline')
+  })
+
+  it('lands muted for quiet-remembered AND denied-remembered visits', () => {
+    expect(deriveDockStatus({ ...base, posture: 'quiet-remembered' })).toBe('muted')
+    // The denied-remembered landing is the design's 静音回访 entry path too.
+    expect(deriveDockStatus({ ...base, posture: 'denied-remembered' })).toBe('muted')
+  })
+
+  it('a session elevation lifts a remembered-quiet visit to online', () => {
+    expect(deriveDockStatus({ ...base, posture: 'quiet-remembered', sessionElevated: true })).toBe(
+      'online'
+    )
+  })
+
+  it('session mute wins over voice-default; live phases win over everything', () => {
+    expect(deriveDockStatus({ ...base, sessionMuted: true })).toBe('muted')
+    expect(deriveDockStatus({ ...base, voicePhase: 'speaking' })).toBe('speaking')
+    expect(deriveDockStatus({ ...base, voicePhase: 'listening' })).toBe('listening')
+    expect(deriveDockStatus(base)).toBe('online')
+  })
+})
+
+describe('arrival beat gating (节拍 1)', () => {
+  const eligible = {
+    log: emptyBeatLog(TODAY),
+    now: NOW,
+    lastPlayedAt: NOW - ARRIVAL_IDLE_THRESHOLD_MS - 1,
+    muted: false,
+    rng: () => 0,
+  }
+
+  it('fires after >12h idle, and for a never-played account', () => {
+    expect(canFireArrivalBeat(eligible)).toBe(true)
+    expect(canFireArrivalBeat({ ...eligible, lastPlayedAt: null })).toBe(true)
+  })
+
+  it('stays quiet within the 12h play window', () => {
+    expect(canFireArrivalBeat({ ...eligible, lastPlayedAt: NOW - 60_000 })).toBe(false)
+  })
+
+  it('never repeats within the 5-minute re-open window', () => {
+    const fired = recordBeatFired(emptyBeatLog(TODAY), { kind: 'arrival', now: NOW })
+    expect(
+      canFireArrivalBeat({ ...eligible, log: fired, now: NOW + ARRIVAL_REOPEN_SUPPRESS_MS - 1 })
+    ).toBe(false)
+    expect(
+      canFireArrivalBeat({ ...eligible, log: fired, now: NOW + ARRIVAL_REOPEN_SUPPRESS_MS + 1 })
+    ).toBe(true)
+  })
+
+  it('respects the daily cap and the mute freeze', () => {
+    const capped = { ...emptyBeatLog(TODAY), count: STANDARD_PROACTIVITY_TIER.dailyCap }
+    expect(canFireArrivalBeat({ ...eligible, log: capped })).toBe(false)
+    expect(canFireArrivalBeat({ ...eligible, muted: true })).toBe(false)
+  })
+})
+
+describe('post-game beat gating (节拍 3)', () => {
+  it('fires once per run within the cap, frozen while muted', () => {
+    const log = emptyBeatLog(TODAY)
+    expect(canFirePostGameBeat({ log, gameRunId: 'run-1', muted: false, rng: () => 0 })).toBe(true)
+
+    const fired = recordBeatFired(log, { kind: 'post-game', gameRunId: 'run-1' })
+    expect(canFirePostGameBeat({ log: fired, gameRunId: 'run-1', muted: false })).toBe(false)
+    expect(
+      canFirePostGameBeat({ log: fired, gameRunId: 'run-2', muted: false, rng: () => 0 })
+    ).toBe(true)
+
+    const capped = { ...log, count: STANDARD_PROACTIVITY_TIER.dailyCap }
+    expect(canFirePostGameBeat({ log: capped, gameRunId: 'run-3', muted: false })).toBe(false)
+    expect(canFirePostGameBeat({ log, gameRunId: 'run-1', muted: true })).toBe(false)
+  })
+})
+
+describe('beat log persistence', () => {
+  it('round-trips today and resets a stale or malformed log', () => {
+    const storage = storageStub()
+    const fired = recordBeatFired(emptyBeatLog(TODAY), { kind: 'arrival', now: NOW })
+    writeBeatLog(fired, storage)
+    expect(readBeatLog(TODAY, storage)).toEqual(fired)
+    // Next product day: the log resets (caps are per-day).
+    expect(readBeatLog('2026-07-09', storage)).toEqual(emptyBeatLog('2026-07-09'))
+    storage.map.set('amio_companion_beat_log', 'not-json')
+    expect(readBeatLog(TODAY, storage)).toEqual(emptyBeatLog(TODAY))
+  })
+})
+
+describe('copy builders', () => {
+  it('formats speech-register durations', () => {
+    expect(formatDurationSpeech(23_000)).toBe('23 秒')
+    expect(formatDurationSpeech(60_000)).toBe('1 分钟')
+    expect(formatDurationSpeech(67_400)).toBe('1 分 7 秒')
+  })
+
+  it('builds the arrival greeting from real data only', () => {
+    expect(
+      buildArrivalGreeting({
+        addressStyle: '队长',
+        recentEpisodeTitle: '最后三秒拆掉了炸弹',
+        streakDays: 3,
+        hasPlayedBefore: true,
+      })
+    ).toBe('队长，上次最后三秒拆掉了炸弹，我还记着。今天第 4 天了。')
+
+    expect(
+      buildArrivalGreeting({
+        addressStyle: '',
+        recentEpisodeTitle: null,
+        streakDays: 0,
+        hasPlayedBefore: true,
+      })
+    ).toBe('回来了。今天的题目是新的。')
+
+    expect(
+      buildArrivalGreeting({
+        addressStyle: '',
+        recentEpisodeTitle: null,
+        streakDays: 0,
+        hasPlayedBefore: false,
+      })
+    ).toBe('我在这。今天的每日挑战等你。')
+  })
+
+  it('builds the post-game reaction from run facts, factual on failure', () => {
+    expect(
+      buildPostGameReaction({
+        outcome: 'defused',
+        durationMs: 143_000,
+        moduleCount: 4,
+        completedModules: 4,
+        strikeCount: 1,
+      })
+    ).toBe('2 分 23 秒，4 个模块全拆完。')
+
+    expect(
+      buildPostGameReaction({
+        outcome: 'exploded',
+        durationMs: 200_000,
+        moduleCount: 4,
+        completedModules: 2,
+        strikeCount: 3,
+      })
+    ).toBe('三次失误，停在第 3 个模块。')
+
+    expect(
+      buildPostGameReaction({
+        outcome: 'daily-timeout',
+        durationMs: null,
+        moduleCount: 4,
+        completedModules: 3,
+        strikeCount: 0,
+      })
+    ).toBe('时间用完，停在第 4 个模块。')
+  })
+})

--- a/packages/platform/src/lib/companion-seed.ts
+++ b/packages/platform/src/lib/companion-seed.ts
@@ -88,6 +88,7 @@ export const SEED_COMPANION: CompanionIdentity = {
   address_style: '队长',
   voice_id: 'companion-warm',
   profile_enabled: true,
+  voice_posture: 'voice-default',
   created_at: '2026-05-30T09:12:00.000Z',
 }
 

--- a/packages/platform/src/pages/CompanionOnboardingPage.test.tsx
+++ b/packages/platform/src/pages/CompanionOnboardingPage.test.tsx
@@ -52,6 +52,7 @@ function stubServer(options: ServerOptions = {}) {
             address_style: '',
             voice_id: 'companion-bright',
             profile_enabled: true,
+            voice_posture: 'voice-default',
             created_at: '2026-06-01T00:00:00.000Z',
           }
           return Promise.resolve(json({ error: 'companion already exists' }, 409))
@@ -61,6 +62,7 @@ function stubServer(options: ServerOptions = {}) {
           address_style: body.address_style ?? '',
           voice_id: body.voice_id,
           profile_enabled: true,
+          voice_posture: 'voice-default',
           created_at: '2026-06-30T00:00:00.000Z',
         }
         return Promise.resolve(json({ companion }, 201))
@@ -119,6 +121,7 @@ describe('CompanionOnboardingPage /me/companion', () => {
         address_style: '队长',
         voice_id: 'companion-warm',
         profile_enabled: true,
+        voice_posture: 'voice-default',
         created_at: '2026-05-30T09:12:00.000Z',
       },
     })

--- a/shared/companion-presence.ts
+++ b/shared/companion-presence.ts
@@ -1,0 +1,371 @@
+/**
+ * Companion presence layer — pure domain logic for the 伙伴坞 (companion dock).
+ *
+ * SSOT for the presence-layer rules from companion-presence-design.md:
+ *
+ *  - voice-posture memory: the localStorage cache + the transition table
+ *    (§姿态记忆模型 — mute / downgrade / permission-denied / manual retry /
+ *    explicit restore, under the least-surprise principle);
+ *  - the dock's 5-state machine (在线 / 倾听 / 说话 / 静音 / 离线);
+ *  - proactive-beat gating (§主动性节拍清单): the 标准 tier daily cap, the
+ *    arrival beat's >12h-idle trigger and 5-minute re-open suppression, the
+ *    once-per-run post-game beat;
+ *  - the beat copy builders (arrival greeting, post-game reaction) — template
+ *    fill from REAL data only, in the design doc's restrained register.
+ *
+ * Pure and dependency-light (types from `shared/companion-types` only) so both
+ * SPAs (`@amiclaw/platform` dock, `@amiclaw/game-bombsquad` result reaction)
+ * consume ONE rule set, unit-testable without a browser. Storage access takes
+ * an injectable `Pick<Storage, ...>` like `arcade-profile/local.ts`.
+ */
+
+import { isVoicePosture, type VoicePosture } from './companion-types'
+
+// --- Voice-posture cache -------------------------------------------------------
+
+/** localStorage key for the posture cache (design §姿态记忆模型 — exact key). */
+export const VOICE_POSTURE_STORAGE_KEY = 'amio_companion_voice_posture'
+
+type ReadableStorage = Pick<Storage, 'getItem'>
+type WritableStorage = Pick<Storage, 'setItem'>
+
+function browserLocalStorage(): Storage | null {
+  try {
+    // Resolve via `window` (not the bare global): Node >= 22 defines its own
+    // experimental `localStorage` global that is undefined without a flag and
+    // would shadow jsdom's in the test environments.
+    if (typeof window === 'undefined') return null
+    return window.localStorage ?? null
+  } catch {
+    // SecurityError in restricted contexts (private mode, sandboxed embeds).
+    return null
+  }
+}
+
+/**
+ * Read the cached posture at page load (before the `GET /api/companion` round
+ * trip). `null` = no cache — callers fall back to `voice-default` for a fresh
+ * companion, per the design's initial posture.
+ */
+export function readCachedVoicePosture(
+  storage: ReadableStorage | null = browserLocalStorage()
+): VoicePosture | null {
+  if (!storage) return null
+  try {
+    const raw = storage.getItem(VOICE_POSTURE_STORAGE_KEY)
+    return isVoicePosture(raw) ? raw : null
+  } catch {
+    return null
+  }
+}
+
+/** Mirror an account-level posture change into the local cache. */
+export function writeCachedVoicePosture(
+  posture: VoicePosture,
+  storage: WritableStorage | null = browserLocalStorage()
+): void {
+  if (!storage) return
+  try {
+    storage.setItem(VOICE_POSTURE_STORAGE_KEY, posture)
+  } catch {
+    // Cache write failure is non-fatal — the account preference is the SSOT.
+  }
+}
+
+// --- Voice-posture transitions ---------------------------------------------------
+
+/**
+ * The player/browser events that can move the persisted posture
+ * (design §姿态记忆模型 转换规则). Technical downgrades (blur, disconnect,
+ * scene switch) are deliberately NOT events here — they never change the
+ * persisted posture.
+ */
+export type PostureEvent =
+  /** Manual mute via the dock long-press menu, or manual voice downgrade. */
+  | 'mute'
+  /** The browser permission dialog was denied during the auto-voice sequence. */
+  | 'permission-denied'
+  /** The mic button retry was granted by the browser (user-gesture re-request). */
+  | 'manual-grant'
+  /** Control menu → 恢复自动语音 (the explicit, symmetric restore). */
+  | 'restore-default'
+
+/**
+ * Posture transition table. Least-surprise rules encoded:
+ *
+ *  - a mic-button tap on `quiet-remembered` elevates THE SESSION ONLY and is
+ *    not an event here (no persisted change — "接完这个电话不等于取消静音模式");
+ *  - `manual-grant` flips `denied-remembered` back to `voice-default` (the
+ *    player is correcting an earlier denial) but leaves `quiet-remembered`
+ *    alone (an explicit mute needs the explicit restore);
+ *  - `permission-denied` from a quiet posture stays quiet-shaped but records
+ *    the denial, so no future auto-request can fire.
+ */
+export function transitionPosture(current: VoicePosture, event: PostureEvent): VoicePosture {
+  switch (event) {
+    case 'mute':
+      // Denial memory outranks mute memory: both suppress auto-voice, but only
+      // denied-remembered also blocks the auto permission request forever.
+      return current === 'denied-remembered' ? 'denied-remembered' : 'quiet-remembered'
+    case 'permission-denied':
+      return 'denied-remembered'
+    case 'manual-grant':
+      return current === 'quiet-remembered' ? 'quiet-remembered' : 'voice-default'
+    case 'restore-default':
+      return 'voice-default'
+  }
+}
+
+// --- Dock state machine ----------------------------------------------------------
+
+/** The dock's five states (design §状态机). */
+export type DockStatus = 'online' | 'listening' | 'speaking' | 'muted' | 'offline'
+
+/** Live voice-conversation phase, when a voice channel is active. */
+export type DockVoicePhase = 'idle' | 'listening' | 'speaking'
+
+export interface DockStatusInput {
+  /** A session cookie exists AND the companion is set up. */
+  signedInWithCompanion: boolean
+  /** Persisted posture (cache-first, account-verified). */
+  posture: VoicePosture
+  /** The player muted this visit via the dock menu (session flag). */
+  sessionMuted: boolean
+  /** The player elevated voice this visit via the mic button (session flag). */
+  sessionElevated: boolean
+  /** Live conversation phase from an active voice session, else 'idle'. */
+  voicePhase: DockVoicePhase
+}
+
+/**
+ * Derive the single dock state (design §状态机). Offline (no dock) for
+ * anonymous / companion-less; muted for a remembered-quiet or session-muted
+ * visit unless the session was explicitly elevated; the live voice phases win
+ * while a channel is active.
+ */
+export function deriveDockStatus(input: DockStatusInput): DockStatus {
+  if (!input.signedInWithCompanion) return 'offline'
+  if (input.voicePhase === 'speaking') return 'speaking'
+  if (input.voicePhase === 'listening') return 'listening'
+  if (input.sessionMuted) return 'muted'
+  if (
+    (input.posture === 'quiet-remembered' || input.posture === 'denied-remembered') &&
+    !input.sessionElevated
+  ) {
+    return 'muted'
+  }
+  return 'online'
+}
+
+// --- Proactive-beat gating --------------------------------------------------------
+
+/**
+ * 标准 tier (the ruled default — design §主动性档位): every beat may fire, at
+ * most `dailyCap` companion utterances per product day. `fireProbability` is
+ * the tier's per-beat trigger probability knob; the 标准 tier ships at 1 in
+ * this slice — the arrival greeting doubles as the auto-voice sequence's
+ * first line, which must land deterministically on login — and the quieter
+ * probabilistic shaping arrives with the tier-picker slice.
+ */
+export const STANDARD_PROACTIVITY_TIER = {
+  fireProbability: 1,
+  dailyCap: 5,
+} as const
+
+/** Arrival beat (节拍 1) fires only when the last play is older than this. */
+export const ARRIVAL_IDLE_THRESHOLD_MS = 12 * 60 * 60 * 1000
+/** Re-opening the homepage within this window never repeats the greeting. */
+export const ARRIVAL_REOPEN_SUPPRESS_MS = 5 * 60 * 1000
+
+/** localStorage key for the per-day beat log. */
+export const COMPANION_BEAT_LOG_KEY = 'amio_companion_beat_log'
+
+/** Per-product-day record of fired beats (caps + suppression windows). */
+export interface CompanionBeatLog {
+  /** Product day (`getTodayString()` shape, YYYY-MM-DD). */
+  date: string
+  /** Companion utterances fired today (all beats). */
+  count: number
+  /** Epoch ms of the last arrival greeting, for the 5-min re-open window. */
+  lastArrivalAt?: number
+  /** gameRunId of the last post-game reaction, so one run reacts once. */
+  lastPostGameRunId?: string
+}
+
+export function emptyBeatLog(date: string): CompanionBeatLog {
+  return { date, count: 0 }
+}
+
+/** Read today's beat log; a stale (previous-day) or malformed log resets. */
+export function readBeatLog(
+  today: string,
+  storage: ReadableStorage | null = browserLocalStorage()
+): CompanionBeatLog {
+  if (!storage) return emptyBeatLog(today)
+  try {
+    const raw = storage.getItem(COMPANION_BEAT_LOG_KEY)
+    if (!raw) return emptyBeatLog(today)
+    const parsed = JSON.parse(raw) as Partial<CompanionBeatLog>
+    if (parsed.date !== today || typeof parsed.count !== 'number' || parsed.count < 0) {
+      return emptyBeatLog(today)
+    }
+    return {
+      date: today,
+      count: parsed.count,
+      ...(typeof parsed.lastArrivalAt === 'number' ? { lastArrivalAt: parsed.lastArrivalAt } : {}),
+      ...(typeof parsed.lastPostGameRunId === 'string'
+        ? { lastPostGameRunId: parsed.lastPostGameRunId }
+        : {}),
+    }
+  } catch {
+    return emptyBeatLog(today)
+  }
+}
+
+export function writeBeatLog(
+  log: CompanionBeatLog,
+  storage: WritableStorage | null = browserLocalStorage()
+): void {
+  if (!storage) return
+  try {
+    storage.setItem(COMPANION_BEAT_LOG_KEY, JSON.stringify(log))
+  } catch {
+    // Losing the log means at worst one extra greeting — never fatal.
+  }
+}
+
+export interface ArrivalBeatInput {
+  log: CompanionBeatLog
+  /** Now, epoch ms. */
+  now: number
+  /** Epoch ms of the last recorded play, or null when never played. */
+  lastPlayedAt: number | null
+  /** Beats are frozen while muted (session or remembered posture). */
+  muted: boolean
+  /** Injectable RNG for the tier probability (tests pin it). */
+  rng?: () => number
+}
+
+/**
+ * Arrival-greeting gate (节拍 1): companion exists (caller-guaranteed), the
+ * player has been away >12h (a never-played account IS an arrival), the
+ * greeting was not already shown in the last 5 minutes, the daily cap has
+ * room, beats are not frozen, and the tier probability passes.
+ */
+export function canFireArrivalBeat(input: ArrivalBeatInput): boolean {
+  const { log, now, lastPlayedAt, muted, rng = Math.random } = input
+  if (muted) return false
+  if (log.count >= STANDARD_PROACTIVITY_TIER.dailyCap) return false
+  if (log.lastArrivalAt !== undefined && now - log.lastArrivalAt < ARRIVAL_REOPEN_SUPPRESS_MS) {
+    return false
+  }
+  if (lastPlayedAt !== null && now - lastPlayedAt < ARRIVAL_IDLE_THRESHOLD_MS) return false
+  return rng() < STANDARD_PROACTIVITY_TIER.fireProbability
+}
+
+export interface PostGameBeatInput {
+  log: CompanionBeatLog
+  /** The settled run's id — one reaction per run, replay-proof. */
+  gameRunId: string
+  muted: boolean
+  rng?: () => number
+}
+
+/** Post-game-reaction gate (节拍 3): once per run, within the daily cap. */
+export function canFirePostGameBeat(input: PostGameBeatInput): boolean {
+  const { log, gameRunId, muted, rng = Math.random } = input
+  if (muted) return false
+  if (log.count >= STANDARD_PROACTIVITY_TIER.dailyCap) return false
+  if (log.lastPostGameRunId === gameRunId) return false
+  return rng() < STANDARD_PROACTIVITY_TIER.fireProbability
+}
+
+/** Fold a fired beat into the log (caller persists via `writeBeatLog`). */
+export function recordBeatFired(
+  log: CompanionBeatLog,
+  beat: { kind: 'arrival'; now: number } | { kind: 'post-game'; gameRunId: string }
+): CompanionBeatLog {
+  if (beat.kind === 'arrival') {
+    return { ...log, count: log.count + 1, lastArrivalAt: beat.now }
+  }
+  return { ...log, count: log.count + 1, lastPostGameRunId: beat.gameRunId }
+}
+
+// --- Beat copy builders ------------------------------------------------------------
+
+/**
+ * Speech-register duration: 「二十三秒」-> "23 秒", 「1 分 07 秒」-> "1 分 7 秒".
+ * Plain zh numerals-as-digits keep it honest and TTS-safe.
+ */
+export function formatDurationSpeech(durationMs: number): string {
+  const totalSeconds = Math.max(0, Math.round(durationMs / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes === 0) return `${seconds} 秒`
+  if (seconds === 0) return `${minutes} 分钟`
+  return `${minutes} 分 ${seconds} 秒`
+}
+
+export interface ArrivalGreetingInput {
+  /** How the companion addresses the player; empty string = no address. */
+  addressStyle: string
+  /** Most recent visible memory's title, or null when the album is empty. */
+  recentEpisodeTitle: string | null
+  /** Current arcade streak in days (0 = no streak). */
+  streakDays: number
+  /** Whether any local play record exists at all. */
+  hasPlayedBefore: boolean
+}
+
+/**
+ * 节拍 1 template fill (design 文案示例 register: cite one concrete thing from
+ * the last episode, then the streak — factual, no profile-layer reference, no
+ * kitsch). Every clause is backed by real data; missing data drops the clause
+ * instead of inventing one.
+ */
+export function buildArrivalGreeting(input: ArrivalGreetingInput): string {
+  const address = input.addressStyle.trim()
+  const prefix = address.length > 0 ? `${address}，` : ''
+  const streakLine = input.streakDays >= 2 ? `今天第 ${input.streakDays + 1} 天了。` : ''
+
+  if (input.recentEpisodeTitle) {
+    return `${prefix}上次${input.recentEpisodeTitle}，我还记着。${streakLine || '今天再来一局？'}`
+  }
+  if (input.hasPlayedBefore) {
+    return `${prefix}回来了。${streakLine}今天的题目是新的。`
+  }
+  return `${prefix}我在这。今天的每日挑战等你。`
+}
+
+/** The subset of a settled run the post-game reaction may cite. */
+export interface PostGameReactionInput {
+  outcome: 'defused' | 'exploded' | 'practice-cleared' | 'practice-timeout' | 'daily-timeout'
+  durationMs: number | null
+  moduleCount: number
+  completedModules: number
+  strikeCount: number
+}
+
+/**
+ * 节拍 3 template fill (design register: cite what actually just happened —
+ * time, modules; relaxed on a clear; on a failure FACTS ONLY, no consolation
+ * — 「失败时不安慰，只说事实」). Only real run facts are cited; no fabricated
+ * per-run analysis.
+ */
+export function buildPostGameReaction(input: PostGameReactionInput): string {
+  const duration = input.durationMs !== null ? formatDurationSpeech(input.durationMs) : null
+  const stoppedAt = Math.min(input.completedModules + 1, input.moduleCount)
+
+  switch (input.outcome) {
+    case 'defused':
+    case 'practice-cleared': {
+      const head = duration ? `${duration}，` : ''
+      return `${head}${input.moduleCount} 个模块全拆完。`
+    }
+    case 'exploded':
+      return `三次失误，停在第 ${stoppedAt} 个模块。`
+    case 'practice-timeout':
+    case 'daily-timeout':
+      return `时间用完，停在第 ${stoppedAt} 个模块。`
+  }
+}

--- a/shared/companion-types.ts
+++ b/shared/companion-types.ts
@@ -4,7 +4,8 @@
  * SSOT for the companion wire contract: the platform-neutral voice catalog and
  * every JSON shape that crosses the `/api/companion/*` HTTP boundary — the
  * setup body/response, the identity read, the profile claims + evidence views,
- * the memory-album page, and the four control-plane mutation bodies.
+ * the memory-album page, and the control-plane mutation bodies (profile switch,
+ * correction, voice-posture settings).
  *
  * Lives in `shared/` alongside `auth-types.ts` so ONE definition is consumed by
  * both the Workers handlers (`packages/api`, via `packages/companion-memory`
@@ -46,6 +47,31 @@ export function isPlatformVoiceId(value: unknown): value is PlatformVoiceId {
   return typeof value === 'string' && (PLATFORM_VOICE_IDS as readonly string[]).includes(value)
 }
 
+// --- Voice posture (companion presence layer) ---------------------------------
+
+/**
+ * The three remembered voice postures of the companion presence layer
+ * (companion-presence-design §姿态记忆模型):
+ *
+ *  - `voice-default`     auto-voice on login (a new companion's initial posture)
+ *  - `quiet-remembered`  the player muted / downgraded voice — future visits
+ *                        land quiet, mic button elevates per-session
+ *  - `denied-remembered` the browser mic permission was denied — never
+ *                        auto-re-prompt; the mic button is the only retry path
+ *
+ * Account-level SSOT is the companion row's `voice_posture` column
+ * (`PUT /api/companion/settings`); a localStorage cache
+ * (`amio_companion_voice_posture`) covers the pre-API-roundtrip read on page
+ * load. Transition rules live in `shared/companion-presence.ts`.
+ */
+export const VOICE_POSTURES = ['voice-default', 'quiet-remembered', 'denied-remembered'] as const
+
+export type VoicePosture = (typeof VOICE_POSTURES)[number]
+
+export function isVoicePosture(value: unknown): value is VoicePosture {
+  return typeof value === 'string' && (VOICE_POSTURES as readonly string[]).includes(value)
+}
+
 // --- Companion identity (Variant 3 read path) --------------------------------
 
 /**
@@ -58,6 +84,8 @@ export interface CompanionIdentity {
   address_style: string
   voice_id: string
   profile_enabled: boolean
+  /** Remembered auto-voice posture (account-level; cross-device). */
+  voice_posture: VoicePosture
   created_at: string
 }
 
@@ -112,6 +140,18 @@ export interface ProfileResponse {
 /** Body of `PUT /api/companion/profile` (the profile switch). */
 export interface ProfileSettingsBody {
   profile_enabled: boolean
+}
+
+// --- Companion settings (presence-layer control plane) ------------------------
+
+/** Body of `PUT /api/companion/settings` (the voice-posture write). */
+export interface CompanionSettingsBody {
+  voice_posture: VoicePosture
+}
+
+/** Response of `PUT /api/companion/settings` — echoes the persisted value. */
+export interface CompanionSettingsResponse {
+  voice_posture: VoicePosture
 }
 
 /** Body of `POST /api/companion/profile/<id>/correction`. */


### PR DESCRIPTION
## Summary
- 伙伴坞: 5-state persistent presence bar on all logged-in pages (name + pulse + last utterance + mic; no avatar per vision); fullscreen collapse
- Proactive beats: arrival greeting citing a real recent episode + streak; factual post-game reaction — standard tier, capped
- Posture memory (voice-default / quiet-remembered / denied-remembered): migration 0004 (additive) + `PUT /api/companion/settings` + local cache reconciliation
- Auto-voice engages where voice actually runs (game co-play); lobby never touches mic APIs behind `LOBBY_VOICE_CAPABLE` flag — stub-era denials cannot poison posture memory
- In-game subtitle strip; proactivity frozen during defusal; daily-challenge entry defaults to companion co-play for companioned users (hidden `?partner=platform` door now has real UI)

Per user-approved companion-presence-design (task Decisions 2026-07-07/08). Independent 3-axis verify + one fix round (7 findings incl. the stub-era auto-voice trap).

## Test plan
- [x] unit: platform 138 / bombsquad 451 / api 196 / companion-memory 48 / platform-ai 337 green; typecheck + lint clean
- [x] e2e audit 28↔28; full Playwright 32/32 on rebuilt artifact
- [ ] CI full run; prod migration 0004 applied post-merge (manager-owned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w79dZWZzh7A7W6A7deN31