### PR TITLE
fix(platform): five real-device play-green fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Finishing a co-play daily run no longer flashes a phantom fifth module** -
+Fix. Completing all four modules while playing WITH your companion briefly
+showed a 「模块 5/4」 counter over an empty panel while the AI wrapped up, instead
+of the win screen. The run now holds on a 拆除成功 settling screen during the
+closing recap, then opens the result page.
+
+**Your companion's words no longer show twice during a run** - Fix. In a co-play
+run the companion's spoken line appeared in both the top subtitle strip and the
+lower voice panel at once. It now renders once, in the top subtitle strip; the
+panel keeps only its listening / thinking / speaking status.
+
+**Your name on the streak board, not a placeholder** - Fix. A signed-in player
+who joined the public streak board showed a generated 「Player XXXX」 label. The
+board now surfaces your chosen nickname, falling back to your account name
+before ever using a generated placeholder.
+
+**Sharing your result no longer dead-ends in "分享失败"** - Fix. Sharing a result
+now uses the device share sheet when available, falls back to copying the text,
+and finally offers the text to select and copy by hand — and dismissing the
+share sheet counts as a cancel, not a failure.
+
+**Companion owners go straight into playing together** - Change. Signed-in
+players with a companion now default directly into companion co-play when they
+enter the daily challenge, with bring-your-own-AI demoted to a low-key link
+rather than a co-equal choice. Anonymous players keep the original flow.
+
 **Your companion now lives on the platform** - Feature. Signed-in players with
 a companion get a persistent companion dock above the tab bar on every platform
 page: the companion's name, a breathing status dot, its latest line, and a

--- a/e2e/companion-dock.gherkin
+++ b/e2e/companion-dock.gherkin
@@ -36,7 +36,7 @@ Feature: Companion presence dock and co-play entry
   Scenario: A companion user enters the daily challenge with co-play by default
     Given I open /
     When I enter the daily challenge from the BombSquad landing
-    Then the co-play entry is the default and the BYO handoff stays visible
+    Then the co-play entry is the default and BYO is a low-key secondary link
 
     When I start the run together with "阿澈"
     Then the run starts in mode② with the platform voice partner connected

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -325,8 +325,9 @@ flows:
       companion co-play path (mode②, the platform voice partner) as the DEFAULT:
       the connect page replaces the two-step manual handoff with a one-tap
       「和 X 一起进入」 that navigates straight to the run carrying
-      ?partner=platform (the manual rides the voice session's create message),
-      while the BYO manual handoff stays visible as the explicit alternative.
+      ?partner=platform (the manual rides the voice session's create message).
+      Per the owner ruling there is no co-equal platform-AI-vs-BYO chooser — BYO
+      (mode①) is demoted to a low-key secondary link, still one tap away.
       Anonymous and companion-less players keep the original two-step BYO flow
       unchanged (covered by landing-to-daily). The in-game voice panel connects
       over the stubbed /ai-ws/* bridge and the AI greets first, proving the
@@ -337,7 +338,7 @@ flows:
         bombsquad-landing,
         cta-daily,
         coplay-default,
-        byo-alternative,
+        byo-secondary-link,
         mode2-run,
         voice-connected,
       ]

--- a/e2e/steps/companion.steps.ts
+++ b/e2e/steps/companion.steps.ts
@@ -98,14 +98,15 @@ When('I enter the daily challenge from the BombSquad landing', async ({ page, wo
 })
 
 Then(
-  'the co-play entry is the default and the BYO handoff stays visible',
+  'the co-play entry is the default and BYO is a low-key secondary link',
   async ({ page, world }) => {
     const name = world.companion?.name ?? ''
-    // The co-play chooser is the default surface — no manual-copy step 1.
+    // Co-play is the single default surface — no manual-copy step 1, no chooser.
     await expect(page.getByRole('button', { name: `和 ${name} 一起进入 →` })).toBeVisible()
     await expect(page.getByText('第 1/2 步')).toHaveCount(0)
-    // The BYO manual handoff remains the visible alternative.
-    await expect(page.getByRole('button', { name: '自带 AI，手动对接' })).toBeVisible()
+    // BYO (mode①) is demoted to a low-key secondary link, still one tap away —
+    // not a co-equal full-width alternative button (owner ruling).
+    await expect(page.getByRole('button', { name: '自带 AI 手动对接' })).toBeVisible()
   }
 )
 

--- a/packages/api/src/handlers/arcade-profile.test.ts
+++ b/packages/api/src/handlers/arcade-profile.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ArcadeStreakLeaderboardResponse } from '@amiclaw/arcade-profile/types'
 import { createTestDb } from '../../../arcade-profile/src/test-support/sqlite-db'
 import { FakeKV } from '../auth/fake-kv'
@@ -68,6 +68,20 @@ function getRequest(url: string, cookie = SESSION_COOKIE): Request {
 }
 
 describe('arcade profile handlers', () => {
+  // The bombsquad fixture run finished on 2026-07-06; pin "today" to that day
+  // (only `Date` is faked, so async D1 work is unaffected) so the account-read
+  // streak assertion (current_days: 1 = active today) is date-stable instead of
+  // depending on the real wall clock. The streak-board tests already fix the
+  // "as of" day via `?date=2026-07-06`.
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-07-06T08:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('requires a session for account profile reads', async () => {
     const response = await handleGetArcadeProfile(request(undefined, ''), await env())
 
@@ -86,8 +100,11 @@ describe('arcade profile handlers', () => {
       inserted: 1,
       source_keys: ['bombsquad:run-1'],
       public_profile: {
+        // F-C: with no client nickname, the label derives from the account
+        // email local-part ('a@example.com' -> 'a'), NOT a Player XXXX
+        // placeholder — a logged-in user always has a real name signal.
         claimed: true,
-        public_label: expect.stringMatching(/^Player [0-9A-F]{4}$/),
+        public_label: 'a',
       },
     })
     expect(await replay.json()).toMatchObject({ inserted: 0, source_keys: ['bombsquad:run-1'] })
@@ -156,6 +173,9 @@ describe('arcade profile handlers', () => {
   it('returns public streak entries without private identity fields', async () => {
     const testEnv = await env()
 
+    // An email-shaped client label is rejected (never stored raw) and falls
+    // through to the account-derived default (local-part) — the full address
+    // and domain never leak onto the public board.
     await handlePostArcadeProfileClaim(
       request({ ...CLAIM_BODY, public_label: 'a@example.com' }),
       testEnv
@@ -169,12 +189,32 @@ describe('arcade profile handlers', () => {
 
     expect(response.status).toBe(200)
     expect(body.entries).toHaveLength(1)
-    expect(body.entries[0].public_label).toMatch(/^Player [0-9A-F]{4}$/)
+    expect(body.entries[0].public_label).toBe('a')
     expect(serialized).not.toContain('user-a')
     expect(serialized).not.toContain('a@example.com')
     expect(serialized).not.toContain('example.com')
     expect(serialized).not.toContain('local-profile')
     expect(serialized).not.toContain('profile_id')
     expect(serialized).not.toContain('user_id')
+  })
+
+  it('surfaces the chosen nickname on the public board when the claim carries one', async () => {
+    const testEnv = await env()
+
+    // A logged-in player who supplies their chosen nickname surfaces it on the
+    // streak board — never the generated placeholder (F-C).
+    await handlePostArcadeProfileClaim(
+      request({ ...CLAIM_BODY, public_label: '海阔天空' }),
+      testEnv
+    )
+    const response = await handleGetArcadeStreakLeaderboard(
+      getRequest('https://claw.amio.fans/api/arcade/streaks?date=2026-07-06'),
+      testEnv
+    )
+    const body = (await response.json()) as ArcadeStreakLeaderboardResponse
+
+    expect(response.status).toBe(200)
+    expect(body.entries).toHaveLength(1)
+    expect(body.entries[0].public_label).toBe('海阔天空')
   })
 })

--- a/packages/api/src/handlers/arcade-profile.ts
+++ b/packages/api/src/handlers/arcade-profile.ts
@@ -12,7 +12,7 @@ import {
   upsertArcadePublicProfile,
 } from '@amiclaw/arcade-profile/store'
 import {
-  sanitizeArcadePublicLabel,
+  resolveArcadePublicLabel,
   parseArcadeProfileClaimBody,
   parseArcadeProfileEvent,
 } from '@amiclaw/arcade-profile/validation'
@@ -84,12 +84,15 @@ export async function handlePostArcadeProfileClaim(
     env.COMPANION_DB,
     auth.session.user_id
   )
-  const publicLabel =
-    claim.public_label === undefined &&
-    existingPublicProfile.claimed &&
-    existingPublicProfile.public_label
-      ? existingPublicProfile.public_label
-      : sanitizeArcadePublicLabel(claim.public_label, auth.session.user_id)
+  // Honest label precedence: chosen nickname (client) > existing real name >
+  // account email local-part > anonymous placeholder. A logged-in user never
+  // lands on `Player XXXX`, and an existing placeholder row is upgraded here.
+  const publicLabel = resolveArcadePublicLabel({
+    clientLabel: claim.public_label,
+    existingLabel: existingPublicProfile.claimed ? existingPublicProfile.public_label : null,
+    email: auth.session.email,
+    userId: auth.session.user_id,
+  })
   const publicProfile = await upsertArcadePublicProfile(env.COMPANION_DB, auth.session.user_id, {
     profileId: claim.profile_id,
     publicLabel,

--- a/packages/arcade-profile/src/validation.test.ts
+++ b/packages/arcade-profile/src/validation.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  accountDerivedPublicLabel,
   defaultArcadePublicLabel,
+  isGeneratedArcadePublicLabel,
   parseArcadeProfileClaimBody,
   parseArcadeProfileEvent,
+  resolveArcadePublicLabel,
   sanitizeArcadePublicLabel,
 } from './validation'
 
@@ -59,5 +62,48 @@ describe('arcade profile validation', () => {
     expect(sanitizeArcadePublicLabel('a@example.com', 'user-a')).toBe(fallback)
     expect(sanitizeArcadePublicLabel('', 'user-a')).toBe(fallback)
     expect(sanitizeArcadePublicLabel('x'.repeat(40), 'user-a')).toBe('x'.repeat(28))
+  })
+})
+
+describe('arcade public label precedence (F-C)', () => {
+  it('detects the generated Player <hex> placeholder', () => {
+    expect(isGeneratedArcadePublicLabel('Player 53CD')).toBe(true)
+    expect(isGeneratedArcadePublicLabel(defaultArcadePublicLabel('user-x'))).toBe(true)
+    expect(isGeneratedArcadePublicLabel('小明')).toBe(false)
+    expect(isGeneratedArcadePublicLabel('Player One')).toBe(false)
+    expect(isGeneratedArcadePublicLabel('byheaven0912')).toBe(false)
+  })
+
+  it('derives the account default from the email local-part', () => {
+    expect(accountDerivedPublicLabel('byheaven0912@gmail.com', 'user-a')).toBe('byheaven0912')
+    // No usable local-part → the anonymous placeholder, not an empty label.
+    expect(accountDerivedPublicLabel('@gmail.com', 'user-a')).toBe(
+      defaultArcadePublicLabel('user-a')
+    )
+  })
+
+  it('resolves by precedence: chosen nickname > existing real name > email > placeholder', () => {
+    const base = { email: 'byheaven0912@gmail.com', userId: 'user-a' }
+
+    // 1. Client-provided nickname wins.
+    expect(
+      resolveArcadePublicLabel({ ...base, clientLabel: '海阔天空', existingLabel: 'Player 53CD' })
+    ).toBe('海阔天空')
+
+    // 2. An existing REAL name is preserved when no client label is sent.
+    expect(resolveArcadePublicLabel({ ...base, existingLabel: '海阔天空' })).toBe('海阔天空')
+
+    // 3. No client label + no real existing label → account email local-part
+    //    (never the generated placeholder for a logged-in user).
+    expect(resolveArcadePublicLabel({ ...base, existingLabel: null })).toBe('byheaven0912')
+
+    // 4. An existing PLACEHOLDER is upgraded to the account default on re-claim.
+    expect(resolveArcadePublicLabel({ ...base, existingLabel: 'Player 53CD' })).toBe('byheaven0912')
+
+    // A client label that sanitizes to the placeholder (email / illegal chars)
+    // never overwrites with Player XXXX — it falls through to the account email.
+    expect(resolveArcadePublicLabel({ ...base, clientLabel: 'a@b.com', existingLabel: null })).toBe(
+      'byheaven0912'
+    )
   })
 })

--- a/packages/arcade-profile/src/validation.ts
+++ b/packages/arcade-profile/src/validation.ts
@@ -42,6 +42,62 @@ export function defaultArcadePublicLabel(userId: string): string {
   return `Player ${((hash >>> 0) & 0xffff).toString(16).toUpperCase().padStart(4, '0')}`
 }
 
+/** Shape of the anonymous `defaultArcadePublicLabel` output: `Player <4-hex>`. */
+const GENERATED_LABEL_PATTERN = /^Player [0-9A-F]{4}$/
+
+/**
+ * True when `label` is the anonymous generated placeholder (`Player 53CD`) and
+ * carries no real name signal. Used so a real name never gets overwritten AND a
+ * stale placeholder can be upgraded once a better signal (chosen nickname or
+ * account email) is available.
+ */
+export function isGeneratedArcadePublicLabel(label: string): boolean {
+  return GENERATED_LABEL_PATTERN.test(label)
+}
+
+/**
+ * Account-derived default label: the email local-part, sanitized as a public
+ * label. Falls back to the anonymous `Player <hex>` placeholder only when the
+ * local-part sanitizes to nothing (no usable name signal at all).
+ */
+export function accountDerivedPublicLabel(email: string, userId: string): string {
+  const localPart = email.split('@')[0] ?? ''
+  return sanitizeArcadePublicLabel(localPart, userId)
+}
+
+/**
+ * Resolve the public label to store for a claim, by honest precedence:
+ *
+ *   1. client-provided label (the player's chosen nickname) when it sanitizes
+ *      to a real name — NOT to the generated placeholder;
+ *   2. an existing stored label that is already a real name (never clobber a
+ *      name the user set);
+ *   3. the account-derived default (email local-part);
+ *   4. the anonymous `Player <hex>` placeholder (last resort — only when there
+ *      is no email signal, which should not happen for a logged-in user).
+ *
+ * A logged-in user with any real name signal therefore never lands on
+ * `Player XXXX`, and an existing placeholder row is upgraded on the next claim.
+ */
+export function resolveArcadePublicLabel(input: {
+  clientLabel?: string
+  existingLabel: string | null
+  email: string
+  userId: string
+}): string {
+  if (typeof input.clientLabel === 'string' && input.clientLabel.trim().length > 0) {
+    const sanitized = sanitizeArcadePublicLabel(input.clientLabel, input.userId)
+    // A client label that survives sanitization as a real name wins. If it
+    // sanitizes down to the generated placeholder (only illegal chars), fall
+    // through to the account-derived default rather than storing `Player XXXX`.
+    if (!isGeneratedArcadePublicLabel(sanitized)) return sanitized
+  }
+  if (input.existingLabel && !isGeneratedArcadePublicLabel(input.existingLabel)) {
+    return input.existingLabel
+  }
+  return accountDerivedPublicLabel(input.email, input.userId)
+}
+
 export function sanitizeArcadePublicLabel(value: unknown, userId: string): string {
   if (typeof value !== 'string') return defaultArcadePublicLabel(userId)
   const trimmed = value.trim().replace(/\s+/g, ' ')

--- a/packages/game-bombsquad/src/game-mode2-settlement.test.tsx
+++ b/packages/game-bombsquad/src/game-mode2-settlement.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * F-A regression: mode② (companion co-play, `?partner=platform`) 4-module
+ * completion must reach settlement, never a phantom 「模块 5/4」.
+ *
+ * Root cause: `NEXT_MODULE`'s ALL_COMPLETE branch advances `currentModuleIndex`
+ * to `moduleSequence.length` (past the last module). mode① navigates to the
+ * result screen instantly, so that out-of-range index never renders. mode②
+ * deliberately HOLDS the player on GamePage while the closing recap plays before
+ * navigating — and during that hold the active-play module view computed
+ * `模块 {index+1}/{length}` = 「模块 5/4」 over an empty panel.
+ *
+ * This test pins: while the mode② closing recap is held (requestClosing never
+ * resolves), the game shows the settling screen — NOT 「模块 5/4」 — and once the
+ * recap resolves it navigates to the win result page.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import yaml from 'js-yaml'
+import type { Manual } from '@shared/manual-schema'
+
+vi.mock('./modules/wire/WireModule', () => ({
+  default: ({ onComplete }: { onComplete: () => void }) => (
+    <button data-testid="mock-wire-complete" onClick={onComplete}>
+      complete-wire
+    </button>
+  ),
+}))
+vi.mock('./modules/dial/DialModule', () => ({
+  default: ({ onComplete }: { onComplete: () => void }) => (
+    <button data-testid="mock-dial-complete" onClick={onComplete}>
+      complete-dial
+    </button>
+  ),
+}))
+vi.mock('./modules/button/ButtonModule', () => ({
+  default: ({ onComplete }: { onComplete: () => void }) => (
+    <button data-testid="mock-button-complete" onClick={onComplete}>
+      complete-button
+    </button>
+  ),
+}))
+vi.mock('./modules/keypad/KeypadModule', () => ({
+  default: ({ onComplete }: { onComplete: () => void }) => (
+    <button data-testid="mock-keypad-complete" onClick={onComplete}>
+      complete-keypad
+    </button>
+  ),
+}))
+
+// A deferred that stands in for the closing-recap turn: while it stays pending
+// the run is held on GamePage in the RESULT state — exactly the window the
+// 「模块 5/4」 bug was visible in.
+const closing = vi.hoisted(() => {
+  let resolveClosing: () => void = () => {}
+  const promise = new Promise<void>((res) => {
+    resolveClosing = res
+  })
+  return { promise, resolve: () => resolveClosing() }
+})
+
+// Mock VoicePanel so mode② mounts without a real WebSocket / mic, and its
+// imperative `requestClosing()` returns our controllable promise.
+vi.mock('./voice/VoicePanel', async () => {
+  const React = await import('react')
+  return {
+    __esModule: true,
+    default: React.forwardRef(
+      (_props: unknown, ref: React.Ref<{ requestClosing: () => Promise<void> }>) => {
+        React.useImperativeHandle(ref, () => ({ requestClosing: () => closing.promise }))
+        return React.createElement('div', { 'data-testid': 'mock-voice-panel' })
+      }
+    ),
+  }
+})
+
+vi.mock('@shared/leaderboard-api', () => ({
+  submitScore: vi.fn().mockResolvedValue({ ok: true, data: { rank: 5, total_players: 100 } }),
+  fetchLeaderboard: vi.fn().mockResolvedValue({ date: '2026-07-08', entries: [] }),
+}))
+
+vi.mock('@/hooks/useCompanionPartner', () => ({
+  useCompanionPartner: () => ({ status: 'unavailable' }),
+}))
+
+vi.mock('./utils/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('./audio/audio-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./audio/audio-context')>()
+  return {
+    ...actual,
+    getAudioContext: vi.fn().mockReturnValue(null),
+    setSfxSuppressed: vi.fn(),
+  }
+})
+
+vi.mock('./utils/yaml-loader', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./utils/yaml-loader')>()
+  return { ...actual, loadManual: vi.fn() }
+})
+
+import App from './App'
+import practiceYamlRaw from '../../manual/data/practice.yaml?raw'
+import { loadManual } from './utils/yaml-loader'
+
+const DAILY_MODULE_TESTIDS = [
+  'mock-wire-complete',
+  'mock-dial-complete',
+  'mock-button-complete',
+  'mock-keypad-complete',
+]
+
+async function completeModules(testIds: string[]) {
+  for (const testId of testIds) {
+    await waitFor(() => expect(screen.getByTestId(testId)).toBeInTheDocument(), { timeout: 3000 })
+    fireEvent.click(screen.getByTestId(testId))
+  }
+}
+
+describe('mode② daily settlement (F-A regression)', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.mocked(loadManual).mockResolvedValue(yaml.load(practiceYamlRaw) as Manual)
+  })
+
+  it('holds on a settling screen — never 「模块 5/4」 — then reaches the win page', async () => {
+    render(
+      <MemoryRouter initialEntries={['/bombsquad/run?mode=daily&partner=platform']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('mock-wire-complete')).toBeInTheDocument(), {
+      timeout: 3000,
+    })
+
+    await completeModules(DAILY_MODULE_TESTIDS)
+
+    // The run is now held on GamePage while the (never-resolving) closing recap
+    // plays: it must show the settling screen, NOT the phantom module counter.
+    await waitFor(() => expect(screen.getByText(/正在收尾/)).toBeInTheDocument(), { timeout: 4000 })
+    expect(document.body.textContent).not.toContain('5/4')
+    expect(document.body.textContent).not.toContain('模块 5')
+    // The active-play module panel is gone; the win result page has not arrived
+    // yet (navigation is gated on the recap).
+    expect(screen.queryByRole('heading', { name: /拆弹成功/ })).not.toBeInTheDocument()
+
+    // Resolving the closing recap releases navigation to the win result page.
+    closing.resolve()
+    await waitFor(
+      () => expect(screen.getByRole('heading', { name: /拆弹成功/ })).toBeInTheDocument(),
+      { timeout: 5000 }
+    )
+  }, 15000)
+})

--- a/packages/game-bombsquad/src/pages/ConnectPage.companion.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.companion.test.tsx
@@ -4,8 +4,9 @@
  *
  * A signed-in player WITH a companion entering the DAILY challenge defaults to
  * the platform voice partner (mode②): one tap into the run with
- * `?partner=platform`, no manual handoff. The BYO manual flow stays reachable
- * as the visible alternative, and practice entries never consult the gate.
+ * `?partner=platform`, no manual handoff. There is no co-equal platform-AI vs
+ * BYO chooser (owner ruling) — the BYO manual flow is demoted to a low-key
+ * secondary link, still one tap away. Practice entries never consult the gate.
  *
  * `useCompanionPartner` is mocked per test — the gate's own fetch behaviour is
  * covered by useCompanionPartner.test.ts.
@@ -80,15 +81,18 @@ describe('ConnectPage — companion co-play entry', () => {
     vi.mocked(getAudioContext).mockReturnValue(null)
   })
 
-  it('defaults a companion user into the co-play entry with the BYO alternative visible', () => {
+  it('defaults a companion user into co-play with BYO demoted to a low-key link', () => {
     renderConnect('daily')
 
-    // The co-play chooser is the default — no manual-copy step 1 in sight.
+    // Co-play is the single default — no manual-copy step 1, no chooser.
     expect(screen.getByRole('heading', { level: 2, name: /阿澈/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /和 阿澈 一起进入/ })).toBeInTheDocument()
     expect(screen.queryByText('第 1/2 步')).not.toBeInTheDocument()
-    // The BYO manual handoff stays reachable as the visible alternative.
-    expect(screen.getByRole('button', { name: /自带 AI/ })).toBeInTheDocument()
+    // BYO stays reachable but is demoted to a low-key secondary link (not a
+    // co-equal full-width button): asserted via its link styling class.
+    const byo = screen.getByRole('button', { name: /自带 AI/ })
+    expect(byo).toBeInTheDocument()
+    expect(byo.className).toContain('byoLink')
   })
 
   it('hands off to the mode② run with partner=platform and unlocks audio in the tap', () => {

--- a/packages/game-bombsquad/src/pages/ConnectPage.module.css
+++ b/packages/game-bombsquad/src/pages/ConnectPage.module.css
@@ -361,6 +361,40 @@
   border-radius: 4px;
 }
 
+/* Low-key secondary affordance for BYO (mode①) on the companion co-play card.
+   A muted, centered text link under the primary 一起进入 CTA — deliberately not
+   a co-equal full-width button, so co-play reads as the single default path
+   while bring-your-own-AI stays reachable in one tap. */
+.byoLink {
+  align-self: center;
+  margin-top: 4px;
+  min-height: var(--touch-target);
+  padding: 6px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  font: 500 13px var(--font-body);
+  color: rgba(255, 255, 255, 0.5);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.byoLink:hover,
+.byoLink:focus-visible {
+  color: var(--y);
+  outline: none;
+}
+
+.byoLink:focus-visible {
+  outline: 2px solid var(--y);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
 /* ----------  bottom CTA  ---------- */
 .cta {
   margin-top: auto;

--- a/packages/game-bombsquad/src/pages/ConnectPage.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.tsx
@@ -209,9 +209,13 @@ export default function ConnectPage() {
               <Button variant="primary" full onClick={confirmCompanionStart}>
                 和 {partner.name} 一起进入 →
               </Button>
-              <Button variant="ghost" full onClick={() => setByoChosen(true)}>
-                自带 AI，手动对接
-              </Button>
+              {/* BYO (mode①) is demoted to a low-key secondary link: a logged-in
+                  companion owner defaults straight into co-play and no longer
+                  sees a co-equal platform-AI-vs-BYO chooser (owner ruling).
+                  Bring-your-own-AI stays one tap away for those who want it. */}
+              <button type="button" className={styles.byoLink} onClick={() => setByoChosen(true)}>
+                自带 AI 手动对接
+              </button>
             </div>
           </div>
         )}

--- a/packages/game-bombsquad/src/pages/GamePage.module.css
+++ b/packages/game-bombsquad/src/pages/GamePage.module.css
@@ -161,6 +161,28 @@
   margin-bottom: 20px;
 }
 
+/* Run-complete settling screen — shown in the module panel while the run
+   resolves and (mode②) the closing recap plays before navigation, in place of
+   the active-play module view. Reuses the .defusedText / .defusedBurst payoff
+   visuals; the hint reassures the player the result screen is coming. */
+.settling {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 220px;
+  text-align: center;
+}
+
+.settlingHint {
+  position: relative;
+  z-index: 1;
+  font: 400 0.95rem/1.5 var(--font-body);
+  color: var(--soft);
+}
+
 .bottomArea {
   position: relative;
   z-index: 2;

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -742,6 +742,16 @@ export default function GamePage() {
   const currentKind = state.moduleSequence[state.currentModuleIndex]
   const moduleLabel = currentKind ? MODULE_LABEL[currentKind] : ''
 
+  // Every module is solved and the run is resolving, but the page is still
+  // mounted — mode② deliberately holds here so the closing recap can play
+  // before navigating to the result screen. `NEXT_MODULE`'s ALL_COMPLETE branch
+  // advances `currentModuleIndex` to `moduleSequence.length` (past the last
+  // module), so the active-play module view no longer applies: rendering it
+  // would show a phantom "模块 5/4" over an empty panel (mode① navigates away
+  // instantly so it never surfaces; mode②'s recap hold made it visible for
+  // seconds). Show a settling screen instead until navigation fires.
+  const runSettling = state.currentModuleIndex >= state.moduleSequence.length
+
   return (
     <main className={styles.page}>
       <Scenery accent="yellow" />
@@ -777,12 +787,22 @@ export default function GamePage() {
 
       <div className={styles.moduleArea}>
         <div className={styles.modulePanel}>
-          <div className={styles.modLabelRow}>
-            <Eyebrow dot>
-              模块 {state.currentModuleIndex + 1}/{state.moduleSequence.length} · {moduleLabel}
-            </Eyebrow>
-          </div>
-          {renderModule()}
+          {runSettling ? (
+            <div className={styles.settling} role="status">
+              <div className={styles.defusedBurst} aria-hidden="true" />
+              <p className={styles.defusedText}>拆除成功</p>
+              <p className={styles.settlingHint}>正在收尾，马上给你今天的结算…</p>
+            </div>
+          ) : (
+            <>
+              <div className={styles.modLabelRow}>
+                <Eyebrow dot>
+                  模块 {state.currentModuleIndex + 1}/{state.moduleSequence.length} · {moduleLabel}
+                </Eyebrow>
+              </div>
+              {renderModule()}
+            </>
+          )}
         </div>
         {errorPulseKey > 0 && (
           <div key={`err-${errorPulseKey}`} className={styles.errorPulse} aria-hidden="true" />

--- a/packages/game-bombsquad/src/pages/ResultPage.module.css
+++ b/packages/game-bombsquad/src/pages/ResultPage.module.css
@@ -317,6 +317,31 @@
   color: var(--y);
 }
 
+/* Terminal share fallback: a selectable, read-only field the player copies by
+   hand when neither native share nor the clipboard is available. */
+.shareManual {
+  margin-top: 8px;
+}
+
+.shareManualText {
+  margin-top: 6px;
+  width: 100%;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md, 10px);
+  color: #fff;
+  font: 400 12px / 1.5 var(--font-body);
+  resize: none;
+  -webkit-user-select: all;
+  user-select: all;
+}
+
+.shareManualText:focus-visible {
+  outline: 2px solid var(--y);
+  outline-offset: 2px;
+}
+
 /* Day-boundary hint under the daily-loop status text. */
 .loopHint {
   margin: 8px 0 0;

--- a/packages/game-bombsquad/src/pages/ResultPage.share.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.share.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * F-D regression: result-page share must degrade gracefully and never dead-end
+ * in a bare 「分享失败」 (audit F26, reproduced on a real phone).
+ *
+ * Ladder:
+ *   1. Web Share API present + resolves        → 「已打开系统分享。」
+ *   2. Web Share API present + user cancels     → silent (AbortError is not a
+ *      failure; no error line, no fallback UI)
+ *   3. Web Share API present + real rejection   → falls back to clipboard copy
+ *   4. No Web Share, clipboard blocked too      → select-and-copy fallback UI,
+ *      never a bare failure message
+ *
+ * Setup mirrors ResultPage.nickname.test.tsx: pre-seed a finished daily run so
+ * the daily-loop card (which carries 分享今日成绩) renders.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('@/utils/device-fingerprint', () => ({
+  getDeviceId: () => 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee',
+}))
+
+vi.mock('@shared/leaderboard-api', () => ({
+  submitScore: vi.fn().mockResolvedValue({ ok: true, data: { rank: 5, total_players: 100 } }),
+  fetchLeaderboard: vi.fn(),
+}))
+
+vi.mock('@/utils/event-log', () => ({ logEvent: vi.fn() }))
+vi.mock('@/utils/survey', () => ({ hasAnsweredSurvey: () => true, markSurveyAnswered: vi.fn() }))
+vi.mock('@amiclaw/arcade-profile/api-client', () => ({
+  submitArcadeProfileEvent: vi.fn().mockResolvedValue({ kind: 'anon' }),
+}))
+
+import ResultPage from './ResultPage'
+import { GameProvider, type GameState } from '@/store/game-context'
+
+const PERSISTENCE_KEY = 'bombsquad:game-state:v4'
+const NICKNAME_KEY = 'bombsquad-nickname'
+const AI_TOOL_KEY = 'bombsquad-leaderboard-ai-tool'
+
+function installFakeLocalStorage() {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => store.clear(),
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  })
+  return store
+}
+
+function finishedDailyState(): GameState {
+  return {
+    status: 'RESULT',
+    mode: 'daily',
+    manual: null,
+    manualUrl: null,
+    gameRunId: 'run-daily-share',
+    sceneInfo: null,
+    moduleSequence: ['wire', 'dial', 'button', 'keypad'],
+    moduleConfigs: [null, null, null, null],
+    moduleAnswers: [null, null, null, null],
+    currentModuleIndex: 4,
+    moduleStats: [
+      { moduleType: 'wire', timeMs: 30_000, errorCount: 0 },
+      { moduleType: 'dial', timeMs: 45_000, errorCount: 1 },
+      { moduleType: 'button', timeMs: 25_000, errorCount: 0 },
+      { moduleType: 'keypad', timeMs: 50_000, errorCount: 0 },
+    ],
+    totalStartTime: 1_700_000_000_000,
+    totalEndTime: 1_700_000_150_000,
+    currentModuleStartTime: null,
+    currentModuleErrorCount: 0,
+    strikeCount: 0,
+    timeBudgetMs: 600_000,
+    outcome: 'defused',
+    errorMessage: null,
+    errorKind: null,
+    attemptNumber: 3,
+    rngSeed: 12345,
+  }
+}
+
+function renderResultPage() {
+  return render(
+    <MemoryRouter initialEntries={['/bombsquad/result']}>
+      <GameProvider>
+        <ResultPage />
+      </GameProvider>
+    </MemoryRouter>
+  )
+}
+
+async function clickShare() {
+  const btn = await screen.findByRole('button', { name: '分享今日成绩' })
+  fireEvent.click(btn)
+}
+
+describe('ResultPage share fallback ladder (F-D)', () => {
+  beforeEach(() => {
+    installFakeLocalStorage()
+    sessionStorage.clear()
+    localStorage.setItem(NICKNAME_KEY, '小红')
+    localStorage.setItem(AI_TOOL_KEY, 'chatgpt')
+    sessionStorage.setItem(PERSISTENCE_KEY, JSON.stringify(finishedDailyState()))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    sessionStorage.clear()
+  })
+
+  it('uses the Web Share API when present and succeeds', async () => {
+    const share = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { ...navigator, share })
+
+    renderResultPage()
+    await clickShare()
+
+    await waitFor(() => expect(share).toHaveBeenCalledTimes(1))
+    expect(share.mock.calls[0][0]).toMatchObject({ text: expect.stringContaining('BombSquad') })
+    expect(await screen.findByText('已打开系统分享。')).toBeInTheDocument()
+  })
+
+  it('treats a user-canceled share (AbortError) as silent, not a failure', async () => {
+    const share = vi.fn().mockRejectedValue(new DOMException('canceled', 'AbortError'))
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { ...navigator, share, clipboard: { writeText } })
+
+    renderResultPage()
+    await clickShare()
+
+    await waitFor(() => expect(share).toHaveBeenCalledTimes(1))
+    // A cancel neither copies nor shows any status/failure line.
+    expect(writeText).not.toHaveBeenCalled()
+    expect(screen.queryByText('已打开系统分享。')).not.toBeInTheDocument()
+    expect(screen.queryByText(/不支持一键分享/)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('分享文案')).not.toBeInTheDocument()
+  })
+
+  it('falls back to clipboard copy when a present share API really fails', async () => {
+    const share = vi.fn().mockRejectedValue(new DOMException('blocked', 'NotAllowedError'))
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { ...navigator, share, clipboard: { writeText } })
+
+    renderResultPage()
+    await clickShare()
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    expect(writeText.mock.calls[0][0]).toContain('BombSquad 每日挑战')
+    expect(await screen.findByText('分享文案已复制。')).toBeInTheDocument()
+  })
+
+  it('offers a select-and-copy field when neither share nor clipboard is usable', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+    // jsdom does not implement execCommand; define it as a failing stub so the
+    // legacy clipboard path in copyToClipboard also fails on this device.
+    ;(document as unknown as { execCommand: () => boolean }).execCommand = () => false
+
+    renderResultPage()
+    await clickShare()
+
+    // No bare 「分享失败」 — the share text is surfaced for manual selection.
+    const field = (await screen.findByLabelText('分享文案')) as HTMLTextAreaElement
+    expect(field.value).toContain('BombSquad 每日挑战')
+    expect(screen.getByText(/不支持一键分享/)).toBeInTheDocument()
+    expect(screen.queryByText('分享失败，请稍后再试。')).not.toBeInTheDocument()
+  })
+})

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -20,6 +20,7 @@ import { formatMs } from '@shared/format-time'
 import { submitScore, type SubmitScoreResult } from '@shared/leaderboard-api'
 import { saveOptimisticEntry } from '@shared/leaderboard-optimistic'
 import { getStoredNickname } from '@/utils/nickname'
+import { copyToClipboard } from '@/utils/clipboard'
 import {
   getStoredLeaderboardPlayerMetadata,
   type LeaderboardPlayerMetadata,
@@ -66,7 +67,10 @@ const RESULT_FEEDBACK_SURVEY_DELAY_MS = 1800
 type ResultVariant = 'success' | 'failure'
 type PostGameModalPurpose = 'leaderboard' | 'survey'
 type ProfileSaveState = 'idle' | 'saved-local' | 'synced' | 'account-error' | 'unavailable'
-type ShareState = 'idle' | 'shared' | 'copied' | 'error'
+// `manual` is the terminal fallback: neither the Web Share API nor the
+// clipboard was usable, so the share text is surfaced in a selectable field for
+// the player to copy by hand. No path dead-ends in a bare 「分享失败」.
+type ShareState = 'idle' | 'shared' | 'copied' | 'manual'
 
 /**
  * Map a frozen game outcome to a result variant. `defused` and
@@ -107,6 +111,8 @@ export default function ResultPage() {
   const [profileSaveState, setProfileSaveState] = useState<ProfileSaveState>('idle')
   const [dailyLoop, setDailyLoop] = useState<ArcadeDailyLoopSummary | null>(null)
   const [shareState, setShareState] = useState<ShareState>('idle')
+  // Holds the share text for the terminal select-and-copy fallback (`manual`).
+  const [shareText, setShareText] = useState('')
 
   // Fall back to `defused` for any legacy RESULT state persisted before the
   // game-modes rework added the `outcome` field.
@@ -499,11 +505,20 @@ export default function ResultPage() {
     return `${mode} ${result}：${time}${streak}。来 AMIO 游乐场一起玩：${window.location.origin}/bombsquad/`
   }, [dailyLoop, outcome, state.mode, totalMs, variant])
 
+  // Robust share with graceful degradation (audit F26 — 真机分享失败). No path
+  // dead-ends in a bare failure message:
+  //   1. Web Share API when present. A user-canceled share (AbortError) is
+  //      NOT a failure — leave the state untouched so no error copy shows.
+  //      Any real share error falls through to the clipboard path.
+  //   2. Clipboard copy (navigator.clipboard, then legacy execCommand via the
+  //      shared `copyToClipboard`) with explicit success feedback.
+  //   3. Terminal fallback: surface the text in a selectable field to copy by
+  //      hand — never a bare 「分享失败」.
   const handleShareResult = useCallback(async () => {
     const text = buildShareText()
-    try {
-      const share = (navigator as Navigator & { share?: (data: ShareData) => Promise<void> }).share
-      if (share) {
+    const share = (navigator as Navigator & { share?: (data: ShareData) => Promise<void> }).share
+    if (share) {
+      try {
         await share({
           title: 'AMIO Arcade BombSquad',
           text,
@@ -511,13 +526,21 @@ export default function ResultPage() {
         })
         setShareState('shared')
         return
+      } catch (err) {
+        // User dismissed the native share sheet — a deliberate cancel, not a
+        // failure. Stay silent rather than nagging with an error line.
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        // Any other share failure (real-device NotAllowedError etc.) falls
+        // through to the clipboard path below.
       }
-      if (!navigator.clipboard?.writeText) throw new Error('clipboard unavailable')
-      await navigator.clipboard.writeText(text)
-      setShareState('copied')
-    } catch {
-      setShareState('error')
     }
+    if (await copyToClipboard(text)) {
+      setShareState('copied')
+      return
+    }
+    // Clipboard blocked too — reveal the text for manual selection.
+    setShareText(text)
+    setShareState('manual')
   }, [buildShareText])
 
   const handlePlayAgain = () => {
@@ -759,8 +782,23 @@ export default function ResultPage() {
                       ? '本局已保存；连续打卡状态以今日活动为准。'
                       : '本局已保存；练习、失败和超时不计入连续打卡。'}
                 </p>
-                {shareState !== 'idle' && (
+                {shareState !== 'idle' && shareState !== 'manual' && (
                   <p className={styles.shareStatus}>{shareStatusText(shareState)}</p>
+                )}
+                {shareState === 'manual' && (
+                  <div className={styles.shareManual}>
+                    <p className={styles.shareStatus}>
+                      这台设备不支持一键分享，长按下面的文字复制：
+                    </p>
+                    <textarea
+                      className={styles.shareManualText}
+                      readOnly
+                      rows={3}
+                      value={shareText}
+                      aria-label="分享文案"
+                      onFocus={(e) => e.currentTarget.select()}
+                    />
+                  </div>
                 )}
                 <p className={styles.loopHint}>{getDailyResetHint()}</p>
               </div>
@@ -888,8 +926,6 @@ function shareStatusText(state: ShareState): string {
       return '已打开系统分享。'
     case 'copied':
       return '分享文案已复制。'
-    case 'error':
-      return '分享失败，请稍后再试。'
     default:
       return ''
   }

--- a/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.test.tsx
@@ -83,9 +83,29 @@ describe('VoicePanel — live 3-state conversation phase', () => {
 })
 
 describe('VoicePanel — cues and content', () => {
-  it('renders the accumulated AI text', () => {
-    renderPanel({ aiText: 'Hold the button.' })
-    expect(screen.getByText('Hold the button.')).toBeInTheDocument()
+  it('does NOT render the AI utterance text (the top subtitle strip owns it)', () => {
+    // One utterance = one surface. In-game the companion's spoken sentence
+    // renders only in GamePage's top subtitle strip (fed via `onUtterance`);
+    // the panel must not duplicate it as a second subtitle. It keeps only the
+    // status line (聆听中/思考中/说话中 + placeholder).
+    renderPanel({ aiText: 'Hold the button.', conversationPhase: 'speaking', isAiSpeaking: true })
+    expect(screen.queryByText('Hold the button.')).not.toBeInTheDocument()
+    // The status placeholder still shows so the panel never looks dead.
+    expect(screen.getByText('AI 正在回应…')).toBeInTheDocument()
+  })
+
+  it('reports the live utterance upward for the top subtitle strip', () => {
+    const onUtterance = vi.fn()
+    mockHook.mockReturnValue(hookState({ aiText: 'Hold the button.', isAiSpeaking: true }))
+    render(
+      <VoicePanel
+        gameRunId={gameRunId}
+        manualData={manualData}
+        gameState={gameState}
+        onUtterance={onUtterance}
+      />
+    )
+    expect(onUtterance).toHaveBeenCalledWith({ text: 'Hold the button.', speaking: true })
   })
 
   it('renders the player subtitle (their own recognized speech) labeled 你：', () => {

--- a/packages/game-bombsquad/src/voice/VoicePanel.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.tsx
@@ -148,12 +148,14 @@ function VoicePanelImpl(
         </p>
       )}
 
-      <div className={styles.reply} role="log" aria-live="polite">
-        {aiText ? (
-          <p className={styles.replyText}>{aiText}</p>
-        ) : (
-          <p className={styles.replyPlaceholder}>{placeholderFor(status, conversationPhase)}</p>
-        )}
+      {/* Status line only — NOT the AI's spoken sentence. In-game, the
+          companion's words render exactly once, in the top subtitle strip
+          (fed by `onUtterance` above; companion-presence-design §字幕条). This
+          panel keeps the connection / phase status so the surface never looks
+          dead, but must not re-render `aiText` or the same utterance would show
+          on two surfaces at once. */}
+      <div className={styles.reply} role="status" aria-live="polite">
+        <p className={styles.replyPlaceholder}>{placeholderFor(status, conversationPhase)}</p>
       </div>
 
       {error && (

--- a/packages/platform/src/lib/arcade-nickname.ts
+++ b/packages/platform/src/lib/arcade-nickname.ts
@@ -1,0 +1,26 @@
+/**
+ * Reads the player's chosen daily nickname so the account claim can adopt it as
+ * the public streak-board label (the highest-precedence real name signal — see
+ * the arcade label precedence in packages/api/.../arcade-profile.ts).
+ *
+ * The nickname is written by the BombSquad game SPA under `bombsquad-nickname`.
+ * BombSquad and this platform SPA are served from the same origin, so they
+ * share localStorage — this reads the same key without coupling to the game
+ * package. Returns `undefined` when there is no usable nickname (never set,
+ * whitespace-only, or localStorage unavailable), so the caller falls back to
+ * the account-derived default instead of forcing an empty label.
+ */
+
+// Kept in sync with `NICKNAME_KEY` in packages/game-bombsquad/src/utils/nickname.ts.
+const BOMBSQUAD_NICKNAME_KEY = 'bombsquad-nickname'
+
+export function readChosenArcadeNickname(): string | undefined {
+  try {
+    const raw = localStorage.getItem(BOMBSQUAD_NICKNAME_KEY)
+    if (raw === null) return undefined
+    const trimmed = raw.trim()
+    return trimmed.length > 0 ? trimmed : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/packages/platform/src/pages/AccountPage.tsx
+++ b/packages/platform/src/pages/AccountPage.tsx
@@ -14,6 +14,7 @@ import {
   summarizeArcadeLocalProfile,
 } from '@amiclaw/arcade-profile/local'
 import { claimArcadeProfile, fetchArcadeProfile } from '@amiclaw/arcade-profile/api-client'
+import { readChosenArcadeNickname } from '@/lib/arcade-nickname'
 import { formatMs } from '@shared/format-time'
 import { getDailyResetHint, toChineseDateString } from '@shared/date'
 import { useAuth, type DisplayUser } from '@/hooks/useAuth'
@@ -298,9 +299,14 @@ function ClaimLocalProfileCard({
 
   const handleClaim = async () => {
     setStatus('claiming')
+    // Adopt the player's chosen daily nickname as the public streak-board label
+    // so a logged-in player surfaces their name, not a generated placeholder.
+    // Omitted when unset — the server then derives from the account email.
+    const chosenLabel = readChosenArcadeNickname()
     const result = await claimArcadeProfile({
       profile_id: localProfile.profile_id,
       events: claimableEvents,
+      ...(chosenLabel ? { public_label: chosenLabel } : {}),
     })
     if (result.kind !== 'ok') {
       setStatus('error')
@@ -415,9 +421,13 @@ function PublicProfileCard({
   const handleEnable = async () => {
     if (!profile.profile_id) return
     setStatus('saving')
+    // Adopt the chosen daily nickname as the public label (server falls back to
+    // the account email when it is unset) — never the generated placeholder.
+    const chosenLabel = readChosenArcadeNickname()
     const result = await claimArcadeProfile({
       profile_id: profile.profile_id,
       events: [],
+      ...(chosenLabel ? { public_label: chosenLabel } : {}),
     })
     if (result.kind !== 'ok') {
       setStatus('error')


### PR DESCRIPTION
## Summary
Five issues from the owner's first real-device mode② play-green:
- 「模块 5/4」 settlement bug (latent display bug exposed by the closing-recap hold — root cause independently verified against the reducer); success settling screen during recap, all outcome paths covered
- Duplicate in-game subtitles → single top strip
- Leaderboard shows real nickname for logged-in users (no more Player XXXX; legacy rows heal at claim time)
- Share: proper feature-detect → clipboard → select-text fallback chain
- Logged-in companioned users skip the AI chooser (BYO demoted to secondary link)

Verified 3-axis approve; regression test per fix.

## Test plan
- [x] game-bombsquad 457 / platform 138 / api 197 / arcade-profile 22; typecheck 10 pkgs; lint clean; e2e audit 28↔28; both SPA builds
- [ ] CI full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w79dZWZzh7A7W6A7deN31