### PR TITLE
fix(platform): send session end at settlement - restore memory capture

### DIFF
--- a/packages/game-bombsquad/src/game-closing-recap.test.tsx
+++ b/packages/game-bombsquad/src/game-closing-recap.test.tsx
@@ -93,9 +93,14 @@ const closingControl = vi.hoisted(() => {
   let pendingReject: ((err: Error) => void) | null = null
 
   const requestClosing = vi.fn()
+  // The memory-capture seam: GamePage must call this exactly once, on the clean
+  // recap-drained path, so the server hands the co-play summary to the
+  // consolidator. Shared spy so the test body can assert the call.
+  const endSession = vi.fn()
 
   return {
     requestClosing,
+    endSession,
     /** Resolve the current pending requestClosing promise (recap finished). */
     resolveClosing: () => {
       pendingResolve?.()
@@ -129,7 +134,7 @@ vi.mock('@/voice/useVoiceSession', () => ({
     isAiSpeaking: false,
     error: null,
     summary: null,
-    endSession: vi.fn(),
+    endSession: closingControl.endSession,
     requestClosing: closingControl.requestClosing,
   }),
 }))
@@ -158,6 +163,7 @@ describe('GamePage closing-recap gating', () => {
     vi.mocked(loadManual).mockResolvedValue(yaml.load(practiceYamlRaw) as Manual)
     closingControl.requestClosing.mockReset()
     closingControl.setupPending()
+    closingControl.endSession.mockReset()
     recapLog.record.mockReset()
   })
 
@@ -185,13 +191,21 @@ describe('GamePage closing-recap gating', () => {
     expect(recapLog.record).toHaveBeenCalledTimes(1)
     expect(screen.queryByRole('heading', { name: /拆弹成功/ })).toBeNull()
 
-    // Resolve the recap — the .then(doNavigate) handler fires.
+    // No `end` yet — the recap is still draining, so memory capture must not
+    // fire until the session actually concludes.
+    expect(closingControl.endSession).not.toHaveBeenCalled()
+
+    // Resolve the recap — the .then handler sends `end` (memory capture) then
+    // navigates.
     closingControl.resolveClosing()
 
     await waitFor(
       () => expect(screen.getByRole('heading', { name: /拆弹成功/ })).toBeInTheDocument(),
       { timeout: 3000 }
     )
+    // The clean conclusion sent `end` exactly once — the server hands the
+    // co-play summary off to the consolidator (companion-memory capture).
+    expect(closingControl.endSession).toHaveBeenCalledTimes(1)
   }, 15000)
 
   it('fallback: navigates even when requestClosing rejects (error-recovery, same path as timeout)', async () => {
@@ -218,5 +232,9 @@ describe('GamePage closing-recap gating', () => {
       () => expect(screen.getByRole('heading', { name: /拆弹成功/ })).toBeInTheDocument(),
       { timeout: 3000 }
     )
+    // The reject / timeout fallback does NOT send `end` — an abrupt close on a
+    // degraded path loses the capture (acceptable this round; not guaranteed on
+    // crash/network paths).
+    expect(closingControl.endSession).not.toHaveBeenCalled()
   }, 15000)
 })

--- a/packages/game-bombsquad/src/game-mode2-settlement.test.tsx
+++ b/packages/game-bombsquad/src/game-mode2-settlement.test.tsx
@@ -66,8 +66,15 @@ vi.mock('./voice/VoicePanel', async () => {
   return {
     __esModule: true,
     default: React.forwardRef(
-      (_props: unknown, ref: React.Ref<{ requestClosing: () => Promise<void> }>) => {
-        React.useImperativeHandle(ref, () => ({ requestClosing: () => closing.promise }))
+      (
+        _props: unknown,
+        ref: React.Ref<{ requestClosing: () => Promise<void>; endSession: () => void }>
+      ) => {
+        React.useImperativeHandle(ref, () => ({
+          requestClosing: () => closing.promise,
+          // GamePage calls this on the clean recap-drained settlement path.
+          endSession: () => {},
+        }))
         return React.createElement('div', { 'data-testid': 'mock-voice-panel' })
       }
     ),

--- a/packages/game-bombsquad/src/pages/GamePage.tsx
+++ b/packages/game-bombsquad/src/pages/GamePage.tsx
@@ -576,7 +576,18 @@ export default function GamePage() {
       return
     }
 
-    panel.requestClosing(recapOutcome).then(doNavigate, doNavigate)
+    panel.requestClosing(recapOutcome).then(() => {
+      // Clean session conclusion: the closing recap drained. Send `{type:'end'}`
+      // (exactly once, guarded in the hook) so the server hands this co-play
+      // run's summary to the companion consolidator — this is the seam that
+      // turns a finished game into a memory. THEN navigate; the panel unmounts
+      // on navigation and its cleanup does an abrupt `ws.close()`, which without
+      // the `end` above would skip the capture entirely. The reject / hard-max
+      // timeout paths fall through to `doNavigate` with NO `end` — an abrupt
+      // close there loses the capture, which is acceptable on a degraded path.
+      panel.endSession()
+      doNavigate()
+    }, doNavigate)
 
     return () => {
       settled = true

--- a/packages/game-bombsquad/src/voice/VoicePanel.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.tsx
@@ -42,6 +42,14 @@ export interface VoicePanelHandle {
    * contract.
    */
   requestClosing: (outcome?: RecapOutcome) => Promise<void>
+  /**
+   * End the session cleanly: send `{type:'end'}` exactly once so the server
+   * hands the session summary to the consolidator (companion-memory capture).
+   * Called on settlement, AFTER the closing recap drains, so the finished
+   * co-play run becomes a memory. The abrupt unmount-close remains the
+   * crash / network fallback (no capture). See `useVoiceSession.endSession`.
+   */
+  endSession: () => void
 }
 
 /**
@@ -94,6 +102,7 @@ function VoicePanelImpl(
     isAiSpeaking,
     error,
     requestClosing,
+    endSession,
   } = useVoiceSession({
     gameRunId,
     manualData,
@@ -101,7 +110,7 @@ function VoicePanelImpl(
     gameId,
   })
 
-  useImperativeHandle(ref, () => ({ requestClosing }), [requestClosing])
+  useImperativeHandle(ref, () => ({ requestClosing, endSession }), [requestClosing, endSession])
 
   // Report the live utterance for the top subtitle strip. Cleared on unmount
   // so the strip vanishes with the session (run exit / navigation).

--- a/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.test.ts
@@ -344,6 +344,27 @@ describe('useVoiceSession — hands-free lifecycle', () => {
     expect(result.current.status).toBe('closed')
     expect(result.current.summary).toMatchObject({ turnCount: 1 })
   })
+
+  it('endSession sends end exactly once even when called twice (no double capture)', async () => {
+    const { result, ws } = await ready()
+    act(() => result.current.endSession())
+    act(() => result.current.endSession())
+    expect(ws.controlMessages().filter((m) => m.type === 'end')).toHaveLength(1)
+  })
+
+  it('settlement end then unmount sends end once — the unmount close does not resend', async () => {
+    const { result, ws, unmount } = await ready()
+    act(() => result.current.endSession())
+    unmount()
+    expect(ws.controlMessages().filter((m) => m.type === 'end')).toHaveLength(1)
+  })
+
+  it('an abrupt unmount with no settlement sends NO end (crash / exit fallback)', async () => {
+    const { ws, unmount } = await ready()
+    unmount()
+    expect(ws.controlMessages().some((m) => m.type === 'end')).toBe(false)
+    expect(ws.readyState).toBe(MockWebSocket.CLOSED)
+  })
 })
 
 /**

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -664,6 +664,12 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
   // --- Public actions ---
 
   const endSession = useCallback(() => {
+    // Exactly-once: the settlement seam (GamePage's RESULT effect) and any
+    // teardown path can both reach here, and a duplicate `{type:'end'}` would
+    // double the server's memory-capture hand-off. `endedRef` — the same flag
+    // the clean-close `onclose` reads — is set the instant `end` is sent, so a
+    // second call is a no-op.
+    if (endedRef.current) return
     stopCapture()
     const ws = wsRef.current
     if (ws && ws.readyState === WebSocket.OPEN) {

--- a/packages/platform-ai/src/session-end-cleanup.test.ts
+++ b/packages/platform-ai/src/session-end-cleanup.test.ts
@@ -50,6 +50,7 @@ import {
   waitFor,
   waitForMessage,
 } from './session-do-test-kit'
+import type { SessionDoEnv } from './session-do'
 
 beforeEach(() => {
   providerControl.override = undefined
@@ -299,5 +300,54 @@ describe('real VoiceSessionDO — end teardown gate, only the owner socket ends 
     await waitForMessage(owner, 'summary')
     const summary = messagesOfType(owner, 'summary')[0].summary as { turnCount: number }
     expect(summary.turnCount).toBe(1)
+  })
+})
+
+// --- end -> companion memory-capture hand-off (the wiring the client relies on) --
+
+describe('real VoiceSessionDO — end hands the summary off to the consolidator', () => {
+  it('POSTs the finished summary to the consolidator DO on a clean end', async () => {
+    // The vitest env deliberately omits COMPANION_CONSOLIDATOR (so the default
+    // suites make no cross-DO call). Inject a structural double at the same
+    // `instance.env` seam the usage-flush suite uses, then drive a real `end`:
+    // the `end` branch's fire-and-forget `handOffSummaryCapture` must reach it.
+    // Parse the request INSIDE the double's fetch — it runs in the DO's I/O
+    // context, and a Request body created there cannot be read from the test's
+    // context (workerd cross-DO I/O rule). Store plain values only.
+    const captured: Array<{ method: string; pathname: string; body: unknown }> = []
+    const consolidatorDouble = {
+      idFromName: (name: string) => name,
+      get: () => ({
+        fetch: async (request: Request) => {
+          captured.push({
+            method: request.method,
+            pathname: new URL(request.url).pathname,
+            body: await request.json(),
+          })
+          return new Response('{}')
+        },
+      }),
+    }
+
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    // The credential-free `demo-mock` game (default) — the hand-off wiring is
+    // game-agnostic, so it exercises the same `end` branch a real bombsquad
+    // co-play run hits.
+    await createSessionOverWs(socket)
+    await session.run((instance) => {
+      ;(instance as unknown as { env: SessionDoEnv }).env = {
+        COMPANION_CONSOLIDATOR: consolidatorDouble,
+      } as unknown as SessionDoEnv
+    })
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    await waitFor(() => captured.length === 1, 'consolidator capture POST')
+
+    expect(captured).toHaveLength(1)
+    expect(captured[0].method).toBe('POST')
+    expect(captured[0].pathname).toBe('/capture')
+    expect(captured[0].body).toMatchObject({ userId: 'user-A', gameId: 'demo-mock' })
   })
 })

--- a/packages/platform/src/lib/companion-format.test.ts
+++ b/packages/platform/src/lib/companion-format.test.ts
@@ -1,0 +1,53 @@
+/**
+ * `daysTogether` tests — companion day-age must derive from CALENDAR product
+ * days (UTC dates, rolling over at 08:00 Beijing), not elapsed 24h periods.
+ *
+ * Regression for prod-verify F-B3: a companion created late at night showed
+ * "今天认识你" a full calendar day too long because the old formula floored
+ * (now - created) / 86_400_000. The fix keys off the product-day difference,
+ * so the day-age flips the morning after creation, at the 08:00 Beijing / UTC
+ * midnight boundary.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { daysTogether } from './companion-format'
+
+// The report's real account: 伙伴「阿澈」created 2026-07-06T15:48:54Z
+// (== 07-06 23:48 Beijing).
+const CREATED_LATE_NIGHT = '2026-07-06T15:48:54.396Z'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function at(iso: string): void {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(iso))
+}
+
+describe('daysTogether — product-day derivation', () => {
+  it('is 0 on the creation product day (card shows 今天认识你)', () => {
+    at('2026-07-06T15:55:00Z') // minutes after creation, same UTC date
+    expect(daysTogether(CREATED_LATE_NIGHT)).toBe(0)
+  })
+
+  it('flips to 1 the next morning at the 08:00 Beijing boundary (the F-B3 fix)', () => {
+    at('2026-07-07T00:01:00Z') // 07-07 08:01 Beijing — the old 24h-floor still read 0
+    expect(daysTogether(CREATED_LATE_NIGHT)).toBe(1)
+  })
+
+  it('is still 0 at 07:59 Beijing, before the product-day rollover', () => {
+    at('2026-07-06T23:59:00Z') // 07-07 07:59 Beijing — same product day as creation
+    expect(daysTogether(CREATED_LATE_NIGHT)).toBe(0)
+  })
+
+  it('reads 2 on the third calendar product day, matching user intuition ("认识了 2 天")', () => {
+    at('2026-07-08T06:00:00Z') // 07-08 afternoon Beijing; creation product day 07-06
+    expect(daysTogether(CREATED_LATE_NIGHT)).toBe(2)
+  })
+
+  it('never goes negative for a future timestamp, and returns 0 for garbage', () => {
+    at('2026-07-06T00:00:00Z')
+    expect(daysTogether('2026-07-10T00:00:00Z')).toBe(0)
+    expect(daysTogether('not-a-date')).toBe(0)
+  })
+})

--- a/packages/platform/src/lib/companion-format.ts
+++ b/packages/platform/src/lib/companion-format.ts
@@ -1,4 +1,4 @@
-import { toChineseDateString } from '@shared/date'
+import { productDayDelta, toChineseDateString } from '@shared/date'
 
 /**
  * Render an episode's `occurred_at` (an ISO 8601 datetime) as the Chinese date
@@ -20,16 +20,18 @@ export function gameLabel(gameId: string): string {
   return GAME_LABELS[gameId] ?? gameId
 }
 
-const MS_PER_DAY = 86_400_000
-
 /**
- * Whole days between a companion's `created_at` (ISO 8601) and now, floored,
- * never negative. Real data — `created_at` is returned by `GET /api/companion`
- * — so this renders in production too. Returns 0 for an unparseable or
- * future-dated timestamp (the card shows the "今天认识" copy for 0).
+ * Product-day age of a companion: how many CALENDAR product days (UTC dates,
+ * rolling over at 08:00 Beijing) separate its `created_at` (ISO 8601) from
+ * today, never negative. Derived from the product-day difference — NOT elapsed
+ * 24h periods — so a companion met late at night is "1 天在一起" the next
+ * morning rather than lagging a full calendar day (认识第 N 天 == this + 1).
+ * Real data: `created_at` is returned by `GET /api/companion`, so this renders
+ * in production too. Returns 0 for an unparseable or future-dated timestamp
+ * (the card shows the "今天认识" copy for 0).
  */
 export function daysTogether(createdAt: string): number {
-  const created = new Date(createdAt).getTime()
-  if (Number.isNaN(created)) return 0
-  return Math.max(0, Math.floor((Date.now() - created) / MS_PER_DAY))
+  const delta = productDayDelta(createdAt)
+  if (Number.isNaN(delta)) return 0
+  return Math.max(0, delta)
 }

--- a/packages/platform/src/lib/shared-date.test.ts
+++ b/packages/platform/src/lib/shared-date.test.ts
@@ -13,6 +13,7 @@ import {
   getProductDaysEndingAt,
   getRecentProductDays,
   getTodayString,
+  productDayDelta,
   toChineseDateString,
 } from '@shared/date'
 
@@ -85,5 +86,43 @@ describe('getDailyResetHint', () => {
 describe('toChineseDateString', () => {
   it('renders a product-day string in the Chinese date form', () => {
     expect(toChineseDateString('2026-07-06')).toBe('2026 年 7 月 6 日')
+  })
+})
+
+describe('productDayDelta — companion day-age from CALENDAR product days', () => {
+  // The report's F-B3 scenario: a companion created late at night (23:48
+  // Beijing on 07-06 == 15:48Z) must age by CALENDAR product days, not by
+  // elapsed 24h periods — the old floor((now-created)/86400000) lagged a day.
+  const createdLateNight = '2026-07-06T15:48:54.396Z'
+
+  it('is 0 on the creation product day (still "今天认识")', () => {
+    // 07-06 23:50 Beijing == 15:50Z — same UTC date as creation.
+    expect(productDayDelta(createdLateNight, new Date('2026-07-06T15:50:00Z'))).toBe(0)
+  })
+
+  it('is 1 the very next morning — the moment the 08:00 Beijing boundary is crossed', () => {
+    // 07-07 08:01 Beijing == 07-07T00:01Z — the first product-day rollover.
+    // The old 24h-floor formula would still read 0 here (only ~8h elapsed).
+    expect(productDayDelta(createdLateNight, new Date('2026-07-07T00:01:00Z'))).toBe(1)
+  })
+
+  it('still belongs to day 0 at 07:59 Beijing (before the boundary)', () => {
+    // 07-07 07:59 Beijing == 07-06T23:59Z — same product day as creation.
+    expect(productDayDelta(createdLateNight, new Date('2026-07-06T23:59:00Z'))).toBe(0)
+  })
+
+  it('is 2 on the third calendar product day — matching the report ("认识了 2 天")', () => {
+    // 07-08 afternoon Beijing; creation product day 07-06 → delta 2.
+    expect(productDayDelta(createdLateNight, new Date('2026-07-08T06:00:00Z'))).toBe(2)
+  })
+
+  it('counts product-day boundaries, not full 24h periods, across midnight creation', () => {
+    // Created 00:30 Beijing (07-06T16:30Z); one minute past the next boundary.
+    expect(productDayDelta('2026-07-06T16:30:00Z', new Date('2026-07-07T00:01:00Z'))).toBe(1)
+  })
+
+  it('is negative for a future creation and NaN for an unparseable timestamp', () => {
+    expect(productDayDelta('2026-07-10T00:00:00Z', new Date('2026-07-08T00:00:00Z'))).toBe(-2)
+    expect(Number.isNaN(productDayDelta('not-a-date'))).toBe(true)
   })
 })

--- a/shared/date.ts
+++ b/shared/date.ts
@@ -23,6 +23,21 @@ export function getRecentProductDays(count: number, now: Date = new Date()): str
   return getProductDaysEndingAt(getTodayString(now), count)
 }
 
+/* Whole product days (UTC dates) from `fromIso` up to `now`: the number of
+   UTC-midnight (08:00 Beijing) rollovers crossed between the two instants. Both
+   ends are anchored to their product day FIRST, so this counts CALENDAR
+   product-day boundaries, not elapsed 24h periods — a companion met at 23:48
+   Beijing is 1 product day old the very next morning, not a full day later.
+   Negative if `fromIso` is in the future; `NaN` for an unparseable `fromIso`.
+   The day-age source for companion presence: 认识第 N 天 == this delta + 1. */
+export function productDayDelta(fromIso: string, now: Date = new Date()): number {
+  const fromMs = Date.parse(fromIso)
+  if (Number.isNaN(fromMs)) return NaN
+  const [fy, fm, fd] = getTodayString(new Date(fromMs)).split('-').map(Number)
+  const [ty, tm, td] = getTodayString(now).split('-').map(Number)
+  return Math.round((Date.UTC(ty, tm - 1, td) - Date.UTC(fy, fm - 1, fd)) / 86_400_000)
+}
+
 /* Render a `YYYY-MM-DD` string as the Chinese date form
    `YYYY 年 M 月 D 日`, stripping leading zeros from month and day.
    Defaults to today when no argument is given. */


### PR DESCRIPTION
## Summary
- **Critical (thesis-core)**: the client never sent `{type:'end'}` — `endSession()` had zero call sites, unmount did abrupt `ws.close()`, so summary capture/consolidation/episodes NEVER happened in production (2 days of real play = empty memory tables; prod-verify evidence). GamePage now ends the session at the settlement seam, exactly once, after the closing recap drains.
- Lobby sessions keep their deliberate abrupt-close (no capture) — pin test untouched
- Companion day-age: product-day delta (08:00 Beijing boundary) replaces the 24h floor

## Test plan
- [x] game-bombsquad 475 / platform 162 / platform-ai 345 (independently re-run by verifier); typecheck; lint
- [x] adversarial paths verified: recap timeout, loss/timeout settlements, mid-recap tab close, mode① no-signal, re-run second session
- [ ] CI full run; post-merge live re-verify of the memory chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w79dZWZzh7A7W6A7deN31