### PR TITLE
feat(platform): streak becomes companion familiarity narrative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ that public name. The times are real and stay correct as they age. You can like
 a post and the like sticks; liking asks you to sign in first. On a quiet day the
 page says it is quiet rather than padding the feed with fakes.
 
+**Your companion grows more familiar the longer your streak** - New. As your
+daily streak lengthens, your companion's manner shifts with it: a week in it
+warms up and drops the formal address for a closer tone, a month in it speaks
+with the ease of an old partner and leans on more of your shared history. There
+are no points, badges, or rewards — the growth shows only in how your companion
+talks to you.
+
+**Your companion marks the milestones out loud** - New. At 7, 14, 30, and 60
+days of an unbroken streak your companion says one short line — 「认识一周了。你第一
+天…，我还记得。」 — recalling something from your first day together, once per
+milestone, never repeated. No trophy, no popup: just a word that it noticed.
+
+**An honest note about breaking your streak** - New. The 我的 page now says, once
+and plainly, what happens if you miss a day: the streak count starts over, but
+your longest record and every saved result stay, and there is no penalty.
+
 **Finishing a co-play daily run no longer flashes a phantom fifth module** -
 Fix. Completing all four modules while playing WITH your companion briefly
 showed a 「模块 5/4」 counter over an empty panel while the AI wrapped up, instead

--- a/packages/api/src/handlers/companion-memories.ts
+++ b/packages/api/src/handlers/companion-memories.ts
@@ -22,10 +22,14 @@ export async function handleGetMemories(request: Request, env: CompanionApiEnv):
   const limitRaw = url.searchParams.get('limit')
   const limit = limitRaw === null ? undefined : Number.parseInt(limitRaw, 10)
   const cursor = url.searchParams.get('cursor') ?? undefined
+  // `order=oldest` returns earliest-first (the milestone callback's earliest
+  // episode); any other value keeps the default newest-first album order.
+  const order = url.searchParams.get('order') === 'oldest' ? 'oldest' : undefined
 
   const page = await listMemories(env.COMPANION_DB, auth.session.user_id, {
     ...(limit !== undefined && Number.isFinite(limit) ? { limit } : {}),
     ...(cursor !== undefined ? { cursor } : {}),
+    ...(order !== undefined ? { order } : {}),
   })
   const body: MemoriesResponse = {
     memories: page.memories,

--- a/packages/arcade-profile/package.json
+++ b/packages/arcade-profile/package.json
@@ -5,6 +5,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./api-client": "./src/api-client.ts",
+    "./companion-streak": "./src/companion-streak.ts",
     "./local": "./src/local.ts",
     "./store": "./src/store.ts",
     "./types": "./src/types.ts",

--- a/packages/arcade-profile/src/community.ts
+++ b/packages/arcade-profile/src/community.ts
@@ -1,3 +1,4 @@
+import { MILESTONE_STREAK_DAYS } from '../../../shared/companion-familiarity'
 import { getProductDaysEndingAt } from '../../../shared/date'
 import {
   computeArcadeStreak,
@@ -13,14 +14,12 @@ import type { ArcadeCommunityFeedItem, ArcadeCommunityFeedTemplate } from './typ
    the window); only event EMISSION is capped to this recent window. */
 export const COMMUNITY_FEED_WINDOW_DAYS = 14
 
-/* Streak lengths that surface a milestone card.
-   SSOT NOTE: these thresholds must eventually come from the shared
-   companion-familiarity SSOT (a parallel worktree is landing
-   `shared/companion-familiarity.ts` with 7 / 14 / 30 / 60). That module is NOT
-   on this branch yet, so the thresholds live here in ONE clearly-named constant;
-   integration will reconcile this against the shared module. Until then this
-   mirrors the PRD streak-reward thresholds (7 / 14 / 30 / 60 days). */
-export const COMMUNITY_STREAK_MILESTONES: readonly number[] = [7, 14, 30, 60]
+/* Streak lengths that surface a milestone card — the SAME thresholds the
+   companion milestone beats use. One SSOT for 7 / 14 / 30 / 60 across the feed's
+   streak-milestone events and the companion's narrative milestone beats: the
+   shared `companion-familiarity.MILESTONE_STREAK_DAYS`. Widened to
+   `readonly number[]` so `.includes(<number>)` type-checks against a raw length. */
+export const COMMUNITY_STREAK_MILESTONES: readonly number[] = MILESTONE_STREAK_DAYS
 
 /**
  * Deterministic, opaque feed-event id derived ONLY from the anchor row's

--- a/packages/arcade-profile/src/companion-streak.test.ts
+++ b/packages/arcade-profile/src/companion-streak.test.ts
@@ -1,0 +1,98 @@
+/**
+ * companion-streak — account-anchored streak resolution (B9).
+ *
+ * The relationship lives at the account, so the streak that drives companion
+ * familiarity MUST be the account value: the fresh account fetch WINS over any
+ * cached / device-local value, and the device-local streak is only ever a
+ * last-resort stale fallback.
+ */
+import { describe, expect, it } from 'vitest'
+import { deriveFamiliarityTier } from '../../../shared/companion-familiarity'
+import type { ArcadeProfileReadResult } from './api-client'
+import {
+  COMPANION_ACCOUNT_STREAK_CACHE_KEY,
+  deviceLocalStreakDays,
+  readCachedAccountStreak,
+  resolveAccountStreak,
+  writeCachedAccountStreak,
+} from './companion-streak'
+import { summarizeArcadeProfile } from './summary'
+
+const TODAY = '2026-07-08'
+
+/** A full in-memory Storage so the real read/write paths run under the typecheck. */
+function memoryStorage(initial: Record<string, string> = {}): Storage {
+  const map = new Map(Object.entries(initial))
+  return {
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, String(value)),
+    removeItem: (key: string) => void map.delete(key),
+    clear: () => map.clear(),
+    key: (index: number) => [...map.keys()][index] ?? null,
+    get length() {
+      return map.size
+    },
+  }
+}
+
+/** A real, typed profile read whose derived streak is exactly `days`. */
+function profileWithStreak(days: number): ArcadeProfileReadResult {
+  const dates = Array.from({ length: days }, (_, i) => {
+    const date = new Date(Date.UTC(2026, 6, 8) - i * 86_400_000).toISOString().slice(0, 10)
+    return { date, completed_at: `${date}T10:00:00.000Z` }
+  })
+  const profile = summarizeArcadeProfile({
+    bombsquadRuns: [],
+    oracleSigns: [],
+    today: TODAY,
+    qualifiedBombSquadDates: dates,
+    qualifiedOracleDates: [],
+  })
+  return { kind: 'ok', profile, publicProfile: { claimed: false, public_label: null } }
+}
+
+describe('resolveAccountStreak', () => {
+  it('returns the account value and refreshes the cache — the account WINS over a stale cache', async () => {
+    const storage = memoryStorage({ [COMPANION_ACCOUNT_STREAK_CACHE_KEY]: '7' })
+    const days = await resolveAccountStreak({
+      fetchProfile: () => Promise.resolve(profileWithStreak(30)),
+      storage,
+    })
+    expect(days).toBe(30)
+    expect(readCachedAccountStreak(storage)).toBe(30)
+    // Tier follows the ACCOUNT value, not the stale cache (which would be familiar).
+    expect(deriveFamiliarityTier(days)).toBe('close')
+    expect(deriveFamiliarityTier(7)).toBe('familiar')
+  })
+
+  it('falls back to the cached account value when the fetch fails', async () => {
+    const storage = memoryStorage({ [COMPANION_ACCOUNT_STREAK_CACHE_KEY]: '12' })
+    const days = await resolveAccountStreak({
+      fetchProfile: () => Promise.resolve({ kind: 'error' }),
+      storage,
+    })
+    expect(days).toBe(12)
+  })
+
+  it('falls back to the device-local streak only when the fetch fails and no cache exists', async () => {
+    const storage = memoryStorage()
+    const days = await resolveAccountStreak({
+      fetchProfile: () => Promise.resolve({ kind: 'error' }),
+      storage,
+    })
+    // An empty device profile is a 0-day streak — the last-resort fallback.
+    expect(days).toBe(deviceLocalStreakDays(storage))
+    expect(days).toBe(0)
+  })
+})
+
+describe('account-streak cache', () => {
+  it('round-trips and rejects junk', () => {
+    const storage = memoryStorage()
+    expect(readCachedAccountStreak(storage)).toBeNull()
+    writeCachedAccountStreak(9, storage)
+    expect(readCachedAccountStreak(storage)).toBe(9)
+    storage.setItem(COMPANION_ACCOUNT_STREAK_CACHE_KEY, 'abc')
+    expect(readCachedAccountStreak(storage)).toBeNull()
+  })
+})

--- a/packages/arcade-profile/src/companion-streak.ts
+++ b/packages/arcade-profile/src/companion-streak.ts
@@ -1,0 +1,94 @@
+/**
+ * Companion streak resolution — ACCOUNT-anchored (B9 叙事型成长).
+ *
+ * The companion familiarity a streak drives expresses the RELATIONSHIP, which
+ * lives at the account (the companion is account-anchored; 连续性高于一切). So the
+ * streak MUST be the account value, not a per-device count that would jump when
+ * the player switches devices.
+ *
+ * Resolution order:
+ *   1. the account profile API (`/api/arcade/profile` → `daily_loop.streak`) —
+ *      the PRIMARY source; its value is cached on success for offline / latency;
+ *   2. the last cached account value (stale-but-account, for a failed fetch);
+ *   3. the device-local streak — ONLY ever a last-resort stale fallback, never
+ *      the primary;
+ *   4. 0.
+ *
+ * All companion surfaces require login, so the account value is normally
+ * available; the cache and device fallbacks cover offline / latency / the brief
+ * window before the first successful fetch.
+ */
+
+import { fetchArcadeProfile, type ArcadeProfileReadResult } from './api-client'
+import { readArcadeLocalProfile, summarizeArcadeLocalProfile } from './local'
+
+/** localStorage key for the last-known account streak (the offline cache). */
+export const COMPANION_ACCOUNT_STREAK_CACHE_KEY = 'amio_companion_account_streak'
+
+function browserStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined') return null
+    return window.localStorage ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Read the cached account streak (last known), or `null` when unset / invalid. */
+export function readCachedAccountStreak(storage: Storage | null = browserStorage()): number | null {
+  if (!storage) return null
+  try {
+    const raw = storage.getItem(COMPANION_ACCOUNT_STREAK_CACHE_KEY)
+    if (raw === null) return null
+    const days = Number.parseInt(raw, 10)
+    return Number.isFinite(days) && days >= 0 ? days : null
+  } catch {
+    return null
+  }
+}
+
+/** Cache the account streak for offline / latency reads. */
+export function writeCachedAccountStreak(
+  days: number,
+  storage: Storage | null = browserStorage()
+): void {
+  if (!storage) return
+  try {
+    storage.setItem(COMPANION_ACCOUNT_STREAK_CACHE_KEY, String(Math.max(0, Math.floor(days))))
+  } catch {
+    // Cache write failure is non-fatal — the account is the SSOT.
+  }
+}
+
+/** The device-local streak — the last-resort stale fallback, never primary. */
+export function deviceLocalStreakDays(storage: Storage | null = browserStorage()): number {
+  return summarizeArcadeLocalProfile(readArcadeLocalProfile(storage)).daily_loop.streak.current_days
+}
+
+export interface ResolveAccountStreakDeps {
+  /** Injectable for tests; defaults to the real profile fetch. */
+  fetchProfile?: () => Promise<ArcadeProfileReadResult>
+  /** Injectable storage; defaults to `window.localStorage`. */
+  storage?: Storage | null
+}
+
+/**
+ * Resolve the companion streak, account-anchored. On a successful fetch the
+ * account value WINS over any cached value and refreshes the cache; on failure
+ * it falls back to the cache, then the device-local streak, then 0.
+ */
+export async function resolveAccountStreak(deps: ResolveAccountStreakDeps = {}): Promise<number> {
+  const fetchProfile = deps.fetchProfile ?? fetchArcadeProfile
+  const storage = deps.storage === undefined ? browserStorage() : deps.storage
+
+  const result = await fetchProfile()
+  if (result.kind === 'ok') {
+    const days = result.profile.daily_loop.streak.current_days
+    writeCachedAccountStreak(days, storage)
+    return days
+  }
+
+  const cached = readCachedAccountStreak(storage)
+  if (cached !== null) return cached
+  return deviceLocalStreakDays(storage)
+}

--- a/packages/companion-memory/src/injection-policy.ts
+++ b/packages/companion-memory/src/injection-policy.ts
@@ -6,8 +6,10 @@
  * are deliberately configuration, not code constants scattered through the
  * resolver: tuning how many claims / episodes are injected, or what counts as
  * "high salience", is an edit to this file's data — global default + per-game
- * override — never an architecture change.
+ * override + streak-tier bonus — never an architecture change.
  */
+
+import { deriveFamiliarityTier, type FamiliarityTier } from '../../../shared/companion-familiarity'
 
 export interface InjectionPolicy {
   /** Max active profile claims injected per session. */
@@ -38,4 +40,42 @@ export const GAME_INJECTION_OVERRIDES: Record<string, Partial<InjectionPolicy>> 
 export function resolveInjectionPolicy(gameId?: string): InjectionPolicy {
   const override = gameId === undefined ? undefined : GAME_INJECTION_OVERRIDES[gameId]
   return { ...DEFAULT_INJECTION_POLICY, ...override }
+}
+
+/**
+ * Per-tier additive bonus to the memory-injection budget (B9 叙事型成长 (b) —
+ * memory-reference frequency rises with the streak). Config-as-data on the same
+ * plane as `DEFAULT_INJECTION_POLICY`: raising how much a long-streak companion
+ * recalls is an edit to these numbers, never a resolver change. Restrained — the
+ * salience floor and the high-salience slot are untouched; only recency depth
+ * and claim count grow, so a familiar companion recalls MORE of the recent
+ * shared history, not more noise.
+ */
+export const STREAK_TIER_POLICY_BONUS: Record<
+  FamiliarityTier,
+  Pick<InjectionPolicy, 'maxClaims' | 'recentEpisodes'>
+> = {
+  newcomer: { maxClaims: 0, recentEpisodes: 0 },
+  familiar: { maxClaims: 1, recentEpisodes: 1 },
+  close: { maxClaims: 2, recentEpisodes: 2 },
+}
+
+/**
+ * Resolve the effective policy for a game AND the player's streak tier: the base
+ * policy (global default + per-game override) plus the streak-tier bonus. A
+ * newcomer (a sub-week streak, or a session that carries no streak) resolves to
+ * the EXACT base policy — the streak seam is byte-identical below the first tier,
+ * so it changes nothing until the relationship has actually accrued.
+ */
+export function resolveInjectionPolicyForStreak(
+  gameId: string | undefined,
+  streakDays: number
+): InjectionPolicy {
+  const base = resolveInjectionPolicy(gameId)
+  const bonus = STREAK_TIER_POLICY_BONUS[deriveFamiliarityTier(streakDays)]
+  return {
+    ...base,
+    maxClaims: base.maxClaims + bonus.maxClaims,
+    recentEpisodes: base.recentEpisodes + bonus.recentEpisodes,
+  }
 }

--- a/packages/companion-memory/src/resolver.test.ts
+++ b/packages/companion-memory/src/resolver.test.ts
@@ -5,7 +5,11 @@
 
 import { describe, expect, it } from 'vitest'
 import type { CompanionDb } from './db'
-import { resolveInjectionPolicy } from './injection-policy'
+import {
+  DEFAULT_INJECTION_POLICY,
+  resolveInjectionPolicy,
+  resolveInjectionPolicyForStreak,
+} from './injection-policy'
 import { resolveCompanionContext } from './resolver'
 import { createTestDb } from './test-support/sqlite-db'
 
@@ -168,5 +172,68 @@ describe('resolveCompanionContext', () => {
 describe('resolveInjectionPolicy', () => {
   it('returns the global default for an unknown game', () => {
     expect(resolveInjectionPolicy('bombsquad')).toEqual(resolveInjectionPolicy())
+  })
+})
+
+describe('resolveInjectionPolicyForStreak (B9b — memory budget scales with streak)', () => {
+  it('is byte-identical to the base policy for a newcomer / no streak', () => {
+    expect(resolveInjectionPolicyForStreak(undefined, 0)).toEqual(DEFAULT_INJECTION_POLICY)
+    expect(resolveInjectionPolicyForStreak(undefined, 6)).toEqual(DEFAULT_INJECTION_POLICY)
+  })
+
+  it('adds recency depth + claim count at the familiar and close tiers', () => {
+    expect(resolveInjectionPolicyForStreak(undefined, 7)).toEqual({
+      ...DEFAULT_INJECTION_POLICY,
+      maxClaims: DEFAULT_INJECTION_POLICY.maxClaims + 1,
+      recentEpisodes: DEFAULT_INJECTION_POLICY.recentEpisodes + 1,
+    })
+    expect(resolveInjectionPolicyForStreak(undefined, 30)).toEqual({
+      ...DEFAULT_INJECTION_POLICY,
+      maxClaims: DEFAULT_INJECTION_POLICY.maxClaims + 2,
+      recentEpisodes: DEFAULT_INJECTION_POLICY.recentEpisodes + 2,
+    })
+  })
+
+  it('leaves the salience floor and high-salience slot untouched', () => {
+    const close = resolveInjectionPolicyForStreak(undefined, 60)
+    expect(close.salientEpisodes).toBe(DEFAULT_INJECTION_POLICY.salientEpisodes)
+    expect(close.minSalience).toBe(DEFAULT_INJECTION_POLICY.minSalience)
+  })
+})
+
+describe('resolveCompanionContext — streak familiarity (B9)', () => {
+  it('attaches no familiarity for a newcomer or a session with no streak', async () => {
+    const db = createTestDb()
+    await seedCompanion(db, 'user-a')
+    expect((await resolveCompanionContext(db, 'user-a'))?.familiarity).toBeUndefined()
+    expect(
+      (await resolveCompanionContext(db, 'user-a', undefined, undefined, 6))?.familiarity
+    ).toBeUndefined()
+  })
+
+  it('attaches the tier + streak once the relationship reaches the first tier', async () => {
+    const db = createTestDb()
+    await seedCompanion(db, 'user-a')
+    expect(
+      (await resolveCompanionContext(db, 'user-a', undefined, undefined, 7))?.familiarity
+    ).toEqual({ streakDays: 7, tier: 'familiar' })
+    expect(
+      (await resolveCompanionContext(db, 'user-a', undefined, undefined, 45))?.familiarity
+    ).toEqual({ streakDays: 45, tier: 'close' })
+  })
+
+  it('scales the injected recent-episode budget with the streak tier', async () => {
+    const db = createTestDb()
+    await seedCompanion(db, 'user-a', false) // profile off → episodes only
+    // Four episodes, newest first ep-4..ep-1 (all low salience).
+    for (let i = 1; i <= 4; i += 1) {
+      await seedEpisode(db, `ep-${i}`, 'user-a', `2026-06-0${i}T10:00:00.000Z`, 10)
+    }
+    // Newcomer: base recentEpisodes (3).
+    const newcomer = await resolveCompanionContext(db, 'user-a', undefined, undefined, 0)
+    expect(newcomer?.episodes).toHaveLength(DEFAULT_INJECTION_POLICY.recentEpisodes)
+    // Familiar: +1 recent episode injected (the memory reaches deeper).
+    const familiar = await resolveCompanionContext(db, 'user-a', undefined, undefined, 7)
+    expect(familiar?.episodes).toHaveLength(DEFAULT_INJECTION_POLICY.recentEpisodes + 1)
   })
 })

--- a/packages/companion-memory/src/resolver.ts
+++ b/packages/companion-memory/src/resolver.ts
@@ -15,8 +15,9 @@
  *                            (the companion exists from setup, memory or not)
  */
 
+import { deriveFamiliarityTier } from '../../../shared/companion-familiarity'
 import type { CompanionDb } from './db'
-import { resolveInjectionPolicy, type InjectionPolicy } from './injection-policy'
+import { resolveInjectionPolicyForStreak, type InjectionPolicy } from './injection-policy'
 import { getCompanion } from './store'
 import type { CompanionContext, CompanionContextEpisode } from './types'
 
@@ -32,11 +33,12 @@ export async function resolveCompanionContext(
   db: CompanionDb,
   userId: string,
   gameId?: string,
-  policyOverride?: InjectionPolicy
+  policyOverride?: InjectionPolicy,
+  streakDays?: number
 ): Promise<CompanionContext | null> {
   const companion = await getCompanion(db, userId)
   if (companion === null) return null
-  const policy = policyOverride ?? resolveInjectionPolicy(gameId)
+  const policy = policyOverride ?? resolveInjectionPolicyForStreak(gameId, streakDays ?? 0)
 
   // Claims: only while the profile switch is on, and only claims holding >=1
   // ACTIVE evidence episode (the no-black-box invariant, read-side).
@@ -95,6 +97,12 @@ export async function resolveCompanionContext(
     })
   }
 
+  // Familiarity (B9 叙事型成长): attach only once the relationship has reached
+  // the first tier AND a streak was supplied. Below the first tier — or with no
+  // streak passed — nothing is attached, so the injected prompt is byte-identical
+  // to the pre-B9 shape (a young relationship shapes no register).
+  const tier = deriveFamiliarityTier(streakDays ?? 0)
+
   return {
     companion: {
       name: companion.name,
@@ -103,5 +111,8 @@ export async function resolveCompanionContext(
     },
     claims,
     episodes,
+    ...(streakDays !== undefined && tier !== 'newcomer'
+      ? { familiarity: { streakDays, tier } }
+      : {}),
   }
 }

--- a/packages/companion-memory/src/store.test.ts
+++ b/packages/companion-memory/src/store.test.ts
@@ -118,6 +118,27 @@ describe('listMemories', () => {
     const page = await listMemories(db, 'user-a', { cursor: '!!not-a-cursor!!' })
     expect(page.memories).toHaveLength(1)
   })
+
+  it('returns the EARLIEST episode first with order=oldest (B20 milestone callback)', async () => {
+    const db = createTestDb()
+    await createCompanion(
+      db,
+      { userId: 'user-a', name: 'Ami', voiceId: 'companion-warm' },
+      testDeps()
+    )
+    for (let i = 1; i <= 5; i += 1) {
+      await seedEpisode(db, `ep-${i}`, 'user-a', `2026-06-0${i}T10:00:00.000Z`)
+    }
+    const oldest = await listMemories(db, 'user-a', { order: 'oldest', limit: 1 })
+    expect(oldest.memories.map((m) => m.id)).toEqual(['ep-1'])
+    // Oldest-first pagination stays valid: the next page continues ascending.
+    const next = await listMemories(db, 'user-a', {
+      order: 'oldest',
+      limit: 2,
+      cursor: oldest.nextCursor,
+    })
+    expect(next.memories.map((m) => m.id)).toEqual(['ep-2', 'ep-3'])
+  })
 })
 
 describe('deleteMemory', () => {

--- a/packages/companion-memory/src/store.ts
+++ b/packages/companion-memory/src/store.ts
@@ -131,17 +131,25 @@ function decodeCursor(raw: string): MemoryCursor | null {
 }
 
 /**
- * Keyset-paginated active episodes, newest first (occurred_at DESC, id DESC
- * tiebreak). A malformed cursor is treated as "first page" rather than an
- * error — the cursor is opaque convenience state, not a correctness input.
+ * Keyset-paginated active episodes. `order` (default `'newest'`,
+ * occurred_at DESC) flips to oldest-first (`'oldest'`, occurred_at ASC) — the
+ * milestone-beat callback (B20) fetches the EARLIEST episode via
+ * `order=oldest&limit=1`. The keyset comparison flips with the order so cursor
+ * pagination stays valid in both directions. A malformed cursor is treated as
+ * "first page" rather than an error — the cursor is opaque convenience state.
  */
 export async function listMemories(
   db: CompanionDb,
   userId: string,
-  options: { limit?: number; cursor?: string } = {}
+  options: { limit?: number; cursor?: string; order?: 'newest' | 'oldest' } = {}
 ): Promise<MemoryPage> {
   const limit = Math.min(Math.max(options.limit ?? MEMORY_PAGE_DEFAULT, 1), MEMORY_PAGE_MAX)
   const cursor = options.cursor === undefined ? null : decodeCursor(options.cursor)
+  const oldest = options.order === 'oldest'
+  const orderClause = oldest
+    ? 'ORDER BY occurred_at ASC, id ASC'
+    : 'ORDER BY occurred_at DESC, id DESC'
+  const cmp = oldest ? '>' : '<'
 
   let statement: CompanionDbStatement
   if (cursor === null) {
@@ -150,7 +158,7 @@ export async function listMemories(
         `SELECT id, occurred_at, game_id, title, narrative
          FROM episode
          WHERE user_id = ? AND status = 'active'
-         ORDER BY occurred_at DESC, id DESC
+         ${orderClause}
          LIMIT ?`
       )
       .bind(userId, limit + 1)
@@ -160,8 +168,8 @@ export async function listMemories(
         `SELECT id, occurred_at, game_id, title, narrative
          FROM episode
          WHERE user_id = ? AND status = 'active'
-           AND (occurred_at < ? OR (occurred_at = ? AND id < ?))
-         ORDER BY occurred_at DESC, id DESC
+           AND (occurred_at ${cmp} ? OR (occurred_at = ? AND id ${cmp} ?))
+         ${orderClause}
          LIMIT ?`
       )
       .bind(userId, cursor.o, cursor.o, cursor.id, limit + 1)

--- a/packages/companion-memory/src/types.ts
+++ b/packages/companion-memory/src/types.ts
@@ -55,6 +55,7 @@ export {
 } from '../../../shared/companion-types'
 
 import type { ProfileClaimStatus } from '../../../shared/companion-types'
+import type { FamiliarityTier } from '../../../shared/companion-familiarity'
 
 // --- Entity records (D1 row shapes) ------------------------------------------
 
@@ -210,4 +211,14 @@ export interface CompanionContext {
   }
   claims: CompanionContextClaim[]
   episodes: CompanionContextEpisode[]
+  /**
+   * Streak-derived familiarity (B9 叙事型成长). Present ONLY once the
+   * relationship has reached the first tier (a week's streak) and a streak was
+   * passed to the resolver; absent for a newcomer or a session that carries no
+   * streak, so the injected prompt stays byte-identical below the first tier.
+   */
+  familiarity?: {
+    streakDays: number
+    tier: FamiliarityTier
+  }
 }

--- a/packages/game-bombsquad/src/test-setup.ts
+++ b/packages/game-bombsquad/src/test-setup.ts
@@ -3,4 +3,7 @@ import { vi } from 'vitest'
 
 vi.mock('@amiclaw/arcade-profile/api-client', () => ({
   submitArcadeProfileEvent: vi.fn(() => Promise.resolve({ kind: 'anon' })),
+  // VoicePanel resolves the account streak (B9); default to no account read so
+  // the streak degrades to 0 (device-local) and the create message omits it.
+  fetchArcadeProfile: vi.fn(() => Promise.resolve({ kind: 'error' })),
 }))

--- a/packages/game-bombsquad/src/voice/VoicePanel.tsx
+++ b/packages/game-bombsquad/src/voice/VoicePanel.tsx
@@ -1,5 +1,9 @@
-import { memo, useImperativeHandle, forwardRef, useEffect } from 'react'
+import { memo, useImperativeHandle, forwardRef, useEffect, useState } from 'react'
 import type { GameState, ManualData, RecapOutcome } from '@amiclaw/platform-ai/contract'
+import {
+  readCachedAccountStreak,
+  resolveAccountStreak,
+} from '@amiclaw/arcade-profile/companion-streak'
 import { useVoiceSession } from './useVoiceSession'
 import type { ConversationPhase, VoiceStatus } from './voice-session-protocol'
 import styles from './VoicePanel.module.css'
@@ -94,6 +98,25 @@ function VoicePanelImpl(
   { gameRunId, manualData, gameState, gameId, onUtterance }: VoicePanelProps,
   ref: React.ForwardedRef<VoicePanelHandle>
 ) {
+  // The player's ACCOUNT streak (B9): it rides the create message so the
+  // companion's tone follows the relationship's age. The relationship lives at
+  // the account, so this is account-anchored, not a per-device count. Seeded
+  // synchronously from the cache (warmed by the homepage presence layer) so the
+  // create message carries a value immediately, then refreshed from the account
+  // API — the fresh value wins for any later session.
+  const [streakDays, setStreakDays] = useState<number | undefined>(
+    () => readCachedAccountStreak() ?? undefined
+  )
+  useEffect(() => {
+    let active = true
+    void resolveAccountStreak().then((days) => {
+      if (active) setStreakDays(days)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
   const {
     status,
     conversationPhase,
@@ -108,6 +131,7 @@ function VoicePanelImpl(
     manualData,
     gameState,
     gameId,
+    streakDays,
   })
 
   useImperativeHandle(ref, () => ({ requestClosing, endSession }), [requestClosing, endSession])

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -125,6 +125,13 @@ export interface UseVoiceSessionOptions {
   gameState: GameState
   /** Platform game id. Defaults to `'bombsquad'`. */
   gameId?: string
+  /**
+   * The player's current arcade streak in days (B9 叙事型成长). Rides the
+   * `create` message so the companion's tone follows the relationship's age
+   * (register + memory budget). Omitted / 0 leaves the session byte-identical to
+   * the pre-B9 behaviour.
+   */
+  streakDays?: number
 }
 
 export interface UseVoiceSessionResult {
@@ -167,7 +174,7 @@ export interface UseVoiceSessionResult {
  * and only after the session is `created`; an unchanged re-render sends nothing.
  */
 export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessionResult {
-  const { gameRunId, manualData, gameState, gameId = 'bombsquad' } = options
+  const { gameRunId, manualData, gameState, gameId = 'bombsquad', streakDays } = options
 
   const [state, dispatch] = useReducer(voiceReducer, initialVoiceState)
   const [isAiSpeaking, setIsAiSpeaking] = useState(false)
@@ -190,11 +197,13 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
   const gameStateRef = useRef<GameState>(gameState)
   const gameIdRef = useRef<string>(gameId)
   const gameRunIdRef = useRef<string | undefined>(gameRunId)
+  const streakDaysRef = useRef<number | undefined>(streakDays)
   useEffect(() => {
     manualDataRef.current = manualData
     gameStateRef.current = gameState
     gameIdRef.current = gameId
     gameRunIdRef.current = gameRunId
+    streakDaysRef.current = streakDays
   })
 
   // Side-effect handles (never trigger re-render).
@@ -565,6 +574,12 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         manualData: manualDataRef.current,
         gameState: gameStateRef.current,
         ...(gameRunIdRef.current ? { gameRunId: gameRunIdRef.current } : {}),
+        // Only ride the streak when there IS one (>0): a fresh player's create
+        // stays byte-identical, and the server maps a sub-week streak to the
+        // newcomer tier (no tone change) regardless.
+        ...(streakDaysRef.current !== undefined && streakDaysRef.current > 0
+          ? { streakDays: streakDaysRef.current }
+          : {}),
       }
       try {
         ws.send(JSON.stringify(create))

--- a/packages/platform-ai/src/companion-injection.test.ts
+++ b/packages/platform-ai/src/companion-injection.test.ts
@@ -82,6 +82,23 @@ describe('assembleLlmContext — companion injection', () => {
     const b = assembleLlmContext({ ...BASE_INPUT, companionContext: CONTEXT })
     expect(a).toEqual(b)
   })
+
+  it('injects no familiarity line when the context carries none (B9c — byte-identical below the first tier)', () => {
+    const content = assembleLlmContext({ ...BASE_INPUT, companionContext: CONTEXT })[0].content
+    expect(content).not.toContain('Familiarity:')
+  })
+
+  it('appends a streak-familiarity tone line, outside the data fence, when present (B9c)', () => {
+    const content = assembleLlmContext({
+      ...BASE_INPUT,
+      companionContext: { ...CONTEXT, familiarity: { streakDays: 12, tier: 'familiar' } },
+    })[0].content
+    expect(content).toContain('shown up together 12 days in a row')
+    expect(content).toContain('warmer, more familiar tone')
+    // The streak count is a platform fact, not player data → outside the fence.
+    const close = content.indexOf(COMPANION_DATA_FENCE_CLOSE)
+    expect(content.indexOf('Familiarity:')).toBeGreaterThan(close)
+  })
 })
 
 describe('assembleLlmContext — player-memory data fence', () => {

--- a/packages/platform-ai/src/manual-injection.ts
+++ b/packages/platform-ai/src/manual-injection.ts
@@ -19,6 +19,7 @@
  * model in the loop here.
  */
 
+import { familiarityRegisterHint } from '../../../shared/companion-familiarity'
 import type { CompanionContext } from '../../companion-memory/src/types'
 import type { GameState, ManualData } from './contract'
 import type { ChatMessage } from './providers/types'
@@ -134,7 +135,7 @@ function buildCompanionInjection(context: CompanionContext): string {
       )
     }
   }
-  return [
+  const blocks = [
     'Companion memory (platform-injected):',
     COMPANION_DATA_GUARD,
     COMPANION_DATA_FENCE_OPEN,
@@ -142,7 +143,21 @@ function buildCompanionInjection(context: CompanionContext): string {
     // markers — present fields or ones added later — can ever escape.
     neutralizeFenceMarkers(data.join('\n')),
     COMPANION_DATA_FENCE_CLOSE,
-  ].join('\n')
+  ]
+  // Streak familiarity (B9c): a trusted platform tone instruction OUTSIDE the
+  // data fence — `streakDays` is a platform-computed integer (not player free
+  // text) and the register hint is platform-authored, so neither is fenced
+  // player data. Present only when the resolver attached familiarity (>= the
+  // first tier), so a newcomer session's block is byte-identical to before.
+  if (context.familiarity !== undefined) {
+    const hint = familiarityRegisterHint(context.familiarity.tier)
+    blocks.push(
+      `Familiarity: you and the player have shown up together ${context.familiarity.streakDays} days in a row.${
+        hint ? ` ${hint}` : ''
+      }`
+    )
+  }
+  return blocks.join('\n')
 }
 
 /**

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -139,6 +139,17 @@ interface CreateSessionMessage {
    */
   gameRunId?: string
   /**
+   * The player's current ACCOUNT streak in days (B9 叙事型成长). Optional and
+   * client-asserted — it only shapes the companion's TONE (register + memory
+   * budget), never a security decision. The client resolves it account-first
+   * (arcade-profile `resolveAccountStreak`: account API primary, cached value
+   * on failure, device-local only as a last-resort stale fallback) so the
+   * relationship's familiarity is account-anchored, not per-device. Absent (or
+   * below the first familiarity tier) leaves the assembled prompt byte-identical
+   * to the pre-B9 shape.
+   */
+  streakDays?: number
+  /**
    * Whether the AI opens the conversation with an unprompted greeting turn
    * (LLM->TTS, no player audio) right after the session is established. Defaults
    * to `true` — AI-first is the product behaviour. A consumer (or a test) sets
@@ -752,12 +763,13 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
    */
   private async resolveCompanionContextBestEffort(
     userId: string,
-    gameId: string
+    gameId: string,
+    streakDays?: number
   ): Promise<CompanionContext | undefined> {
     const db = this.env.COMPANION_DB
     if (db === undefined) return undefined
     try {
-      const context = await resolveCompanionContext(db, userId, gameId)
+      const context = await resolveCompanionContext(db, userId, gameId, undefined, streakDays)
       return context ?? undefined
     } catch (error) {
       console.warn('session-do: companion-context resolution failed (memory-less session)', error)
@@ -1237,7 +1249,8 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
         // a memory-less session (the companion context is simply absent).
         const companionContext = await this.resolveCompanionContextBestEffort(
           socketUserId,
-          msg.gameId
+          msg.gameId,
+          msg.streakDays
         )
         // Re-check the create guard AFTER the await above: a second `create`
         // could have interleaved across the resolver read. The check + the

--- a/packages/platform/src/components/companion/CompanionDock.lobby-voice.test.tsx
+++ b/packages/platform/src/components/companion/CompanionDock.lobby-voice.test.tsx
@@ -29,6 +29,8 @@ const companionState = vi.hoisted(() => ({
 }))
 const apiMocks = vi.hoisted(() => ({
   fetchMemories: vi.fn(),
+  fetchAccountStreak: vi.fn(),
+  fetchEarliestMemoryTitle: vi.fn(),
   putVoicePosture: vi.fn(),
 }))
 // The lobby voice session is mocked: `open` / `close` are spies, and `current`
@@ -54,6 +56,8 @@ vi.mock('@/hooks/useCompanion', () => ({
 }))
 vi.mock('@/lib/companion-api', () => ({
   fetchMemories: apiMocks.fetchMemories,
+  fetchAccountStreak: apiMocks.fetchAccountStreak,
+  fetchEarliestMemoryTitle: apiMocks.fetchEarliestMemoryTitle,
   putVoicePosture: apiMocks.putVoicePosture,
 }))
 // Flip the capability: this file pins the sequence the next slice engages.
@@ -132,6 +136,10 @@ describe('CompanionDock — auto-voice sequence (lobby voice capability ON)', ()
     companionState.current = { status: 'loading', companion: null }
     apiMocks.fetchMemories.mockReset()
     apiMocks.fetchMemories.mockResolvedValue({ kind: 'ok', memories: [] })
+    apiMocks.fetchAccountStreak.mockReset()
+    apiMocks.fetchAccountStreak.mockResolvedValue(0)
+    apiMocks.fetchEarliestMemoryTitle.mockReset()
+    apiMocks.fetchEarliestMemoryTitle.mockResolvedValue(null)
     apiMocks.putVoicePosture.mockReset()
     apiMocks.putVoicePosture.mockResolvedValue({ kind: 'ok' })
     lobbyMock.current = {

--- a/packages/platform/src/components/companion/CompanionDock.test.tsx
+++ b/packages/platform/src/components/companion/CompanionDock.test.tsx
@@ -17,7 +17,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import type { CompanionIdentity, VoicePosture } from '@shared/companion-types'
-import { COMPANION_BEAT_LOG_KEY, VOICE_POSTURE_STORAGE_KEY } from '@shared/companion-presence'
+import {
+  COMPANION_BEAT_LOG_KEY,
+  COMPANION_MILESTONE_LOG_KEY,
+  VOICE_POSTURE_STORAGE_KEY,
+} from '@shared/companion-presence'
 
 const authState = vi.hoisted(() => ({
   current: { status: 'anon', user: null } as { status: string; user: unknown },
@@ -31,6 +35,8 @@ const companionState = vi.hoisted(() => ({
 }))
 const apiMocks = vi.hoisted(() => ({
   fetchMemories: vi.fn(),
+  fetchAccountStreak: vi.fn(),
+  fetchEarliestMemoryTitle: vi.fn(),
   putVoicePosture: vi.fn(),
 }))
 
@@ -42,6 +48,8 @@ vi.mock('@/hooks/useCompanion', () => ({
 }))
 vi.mock('@/lib/companion-api', () => ({
   fetchMemories: apiMocks.fetchMemories,
+  fetchAccountStreak: apiMocks.fetchAccountStreak,
+  fetchEarliestMemoryTitle: apiMocks.fetchEarliestMemoryTitle,
   putVoicePosture: apiMocks.putVoicePosture,
 }))
 // Pin the flag OFF for this file: it is the flag-OFF honesty suite (the lobby
@@ -125,6 +133,11 @@ describe('CompanionDock', () => {
     companionState.current = { status: 'loading', companion: null }
     apiMocks.fetchMemories.mockReset()
     apiMocks.fetchMemories.mockResolvedValue({ kind: 'ok', memories: [] })
+    apiMocks.fetchAccountStreak.mockReset()
+    // Default: a fresh account with no streak (newcomer tier, no milestone).
+    apiMocks.fetchAccountStreak.mockResolvedValue(0)
+    apiMocks.fetchEarliestMemoryTitle.mockReset()
+    apiMocks.fetchEarliestMemoryTitle.mockResolvedValue(null)
     apiMocks.putVoicePosture.mockReset()
     apiMocks.putVoicePosture.mockResolvedValue({ kind: 'ok' })
   })
@@ -175,6 +188,31 @@ describe('CompanionDock', () => {
     expect(getUserMedia).not.toHaveBeenCalled()
     expect(apiMocks.putVoicePosture).not.toHaveBeenCalled()
     expect(window.localStorage.getItem(VOICE_POSTURE_STORAGE_KEY)).toBe('voice-default')
+  })
+
+  it('fires the milestone beat once (account streak) with the early-episode callback (B20)', async () => {
+    signInWithCompanion()
+    stubMic('granted')
+    // The ACCOUNT streak just reached a week; the earliest shared episode backs
+    // the design's 「你第一天…」 callback.
+    apiMocks.fetchAccountStreak.mockResolvedValue(7)
+    apiMocks.fetchEarliestMemoryTitle.mockResolvedValue('连题目都没看完就开剪')
+    renderDock()
+
+    // The milestone line lands (bubble + dock text line), composed with the
+    // early-episode callback — NOT a plain arrival greeting.
+    const beats = await screen.findAllByText('认识一周了。你第一天连题目都没看完就开剪，我还记得。')
+    expect(beats.length).toBeGreaterThan(0)
+    expect(screen.queryByText(/今天的每日挑战等你/)).not.toBeInTheDocument()
+
+    // Once-per-milestone dedup persisted, and it counts against the daily cap
+    // (design's reserved 5th slot — it does not bypass the cap).
+    await waitFor(() =>
+      expect(window.localStorage.getItem(COMPANION_MILESTONE_LOG_KEY)).toContain('7')
+    )
+    expect(window.localStorage.getItem(COMPANION_BEAT_LOG_KEY)).toContain('"count":1')
+    // The milestone path fetches the earliest episode, never the recent album.
+    expect(apiMocks.fetchMemories).not.toHaveBeenCalled()
   })
 
   it('mic button surfaces the honest in-game-voice note instead of faking lobby voice', async () => {

--- a/packages/platform/src/components/companion/useCompanionPresence.ts
+++ b/packages/platform/src/components/companion/useCompanionPresence.ts
@@ -32,21 +32,35 @@ import { useLocation } from 'react-router-dom'
 import type { CompanionIdentity, VoicePosture } from '@shared/companion-types'
 import {
   buildArrivalGreeting,
+  buildMilestoneGreeting,
   canFireArrivalBeat,
+  canFireMilestoneBeat,
   deriveDockStatus,
   readBeatLog,
   readCachedVoicePosture,
+  readMilestoneLog,
   recordBeatFired,
   transitionPosture,
   writeBeatLog,
   writeCachedVoicePosture,
+  writeMilestoneLog,
   type DockStatus,
   type DockVoicePhase,
   type PostureEvent,
 } from '@shared/companion-presence'
+import {
+  deriveFamiliarityTier,
+  pickMilestone,
+  MILESTONE_STREAK_DAYS,
+} from '@shared/companion-familiarity'
 import { getTodayString } from '@shared/date'
 import { readArcadeLocalProfile, summarizeArcadeLocalProfile } from '@amiclaw/arcade-profile/local'
-import { fetchMemories, putVoicePosture } from '@/lib/companion-api'
+import {
+  fetchAccountStreak,
+  fetchEarliestMemoryTitle,
+  fetchMemories,
+  putVoicePosture,
+} from '@/lib/companion-api'
 import { LOBBY_VOICE_CAPABLE, LOBBY_VOICE_NOTE } from './lobby-voice'
 import { useLobbyVoiceSession } from './useLobbyVoiceSession'
 
@@ -78,9 +92,11 @@ export interface CompanionPresence {
   onRestoreVoice: () => void
 }
 
+// Device-local play recency for the arrival IDLE gate only (this device's
+// session recency — "back after being away"). The STREAK that drives tier +
+// milestone is the account value (fetchAccountStreak), never this.
 function readLocalPlayContext(): {
   lastPlayedAt: number | null
-  streakDays: number
   hasPlayedBefore: boolean
 } {
   const summary = summarizeArcadeLocalProfile(readArcadeLocalProfile())
@@ -88,7 +104,6 @@ function readLocalPlayContext(): {
     summary.last_activity_at !== null ? Date.parse(summary.last_activity_at) : null
   return {
     lastPlayedAt: Number.isFinite(lastPlayedAt as number) ? lastPlayedAt : null,
-    streakDays: summary.daily_loop.streak.current_days,
     hasPlayedBefore: summary.last_activity_at !== null,
   }
 }
@@ -198,19 +213,75 @@ export function useCompanionPresence(companion: CompanionIdentity): CompanionPre
     const today = getTodayString()
     const log = readBeatLog(today)
     const playContext = readLocalPlayContext()
-    if (
-      !canFireArrivalBeat({
-        log,
-        now: Date.now(),
-        lastPlayedAt: playContext.lastPlayedAt,
-        muted: false,
-      })
-    ) {
-      return
-    }
+    const milestoneLog = readMilestoneLog()
+
+    // Sync eligibility gates (no streak needed yet): whether the arrival beat is
+    // due (device-local idle gate — this device's session recency), and whether
+    // any milestone remains un-fired. If neither could fire, skip the network
+    // round-trips entirely — a within-12h return whose milestones are all
+    // delivered stays byte-identical (no fetch, no beat).
+    const arrivalEligible = canFireArrivalBeat({
+      log,
+      now: Date.now(),
+      lastPlayedAt: playContext.lastPlayedAt,
+      muted: false,
+    })
+    const anyMilestoneUnfired = MILESTONE_STREAK_DAYS.some((day) => !milestoneLog.includes(day))
+    if (!arrivalEligible && !anyMilestoneUnfired) return
 
     let cancelled = false
     void (async () => {
+      // The ACCOUNT streak drives the tier + milestone (the relationship lives
+      // at the account — familiarity must not jump when the player switches
+      // devices). The arrival idle gate above stays device-local. All state is
+      // set HERE, inside the async continuation — never synchronously in the
+      // effect body (react-hooks/set-state-in-effect).
+      const streakDays = await fetchAccountStreak()
+      if (cancelled) return
+      const tier = deriveFamiliarityTier(streakDays)
+
+      // 节拍 4 里程碑 (B20): a newly reached 7 / 14 / 30 / 60-day streak. Decided
+      // from the account streak, independent of the >12h idle threshold (a
+      // milestone can land right after the qualifying play). Deduped
+      // once-per-milestone FOR LIFE via the persistent milestone log, and it
+      // counts against the 标准 daily cap (design reserves the 5th slot). A
+      // reached milestone takes this homepage load's beat — the plain arrival
+      // greeting is skipped (recordBeatFired stamps lastArrivalAt so the 5-min
+      // window suppresses one anyway).
+      const milestonePick = anyMilestoneUnfired ? pickMilestone(streakDays, milestoneLog) : null
+      const milestone =
+        milestonePick !== null && canFireMilestoneBeat({ log, muted: false }) ? milestonePick : null
+
+      // Neither the streak crossed a milestone nor is the arrival beat due.
+      if (milestone === null && !arrivalEligible) return
+
+      // --- Milestone beat (takes precedence on a milestone load) ---
+      if (milestone !== null) {
+        // The earliest shared episode backs the design's 「你第一天…」 callback
+        // (real data — null when the album is genuinely empty).
+        const earlyEpisodeTitle = await fetchEarliestMemoryTitle()
+        if (cancelled) return
+        // Persist the consumed thresholds (dedup) then fire, with no await
+        // between — the double-crossing lower threshold is retired here too. The
+        // `cancelled` guards above fenced a StrictMode double-invoke first.
+        writeMilestoneLog([...milestoneLog, ...milestone.consumed])
+        const text = buildMilestoneGreeting({
+          threshold: milestone.fire,
+          streakDays,
+          earlyEpisodeTitle,
+        })
+        setBubble({ text, expanded: false })
+        setLastUtterance(text)
+        setGreetingDwell(true)
+        writeBeatLog(recordBeatFired(log, { kind: 'milestone', now: Date.now() }))
+        schedule(() => {
+          setGreetingDwell(false)
+          setBubble((current) => (current && !current.expanded ? null : current))
+        }, BUBBLE_DWELL_MS)
+        return
+      }
+
+      // --- Arrival greeting (节拍 1) ---
       // Most recent visible memory (first page, newest first); an error or an
       // empty album degrades to the no-episode greeting variant.
       const memories = await fetchMemories()
@@ -220,8 +291,9 @@ export function useCompanionPresence(companion: CompanionIdentity): CompanionPre
       const text = buildArrivalGreeting({
         addressStyle: companion.address_style,
         recentEpisodeTitle,
-        streakDays: playContext.streakDays,
+        streakDays,
         hasPlayedBefore: playContext.hasPlayedBefore,
+        tier,
       })
 
       // Greeting TEXT lands first — never blocked on the permission dialog.

--- a/packages/platform/src/lib/companion-api.test.ts
+++ b/packages/platform/src/lib/companion-api.test.ts
@@ -13,6 +13,7 @@ import {
   fetchCompanion,
   setupCompanion,
   fetchMemories,
+  fetchEarliestMemoryTitle,
   deleteMemory,
   fetchProfile,
   correctClaim,
@@ -124,6 +125,29 @@ describe('companion-api (real path)', () => {
 
     stubFetch(() => Promise.resolve(jsonResponse({ error: 'memory not found' }, 404)))
     expect(await deleteMemory('ep-1')).toEqual({ kind: 'error' })
+  })
+
+  it('fetchEarliestMemoryTitle queries oldest-first and returns the title, null when empty', async () => {
+    const fn = stubFetch(() =>
+      Promise.resolve(
+        jsonResponse(
+          {
+            memories: [
+              { id: 'ep-1', occurred_at: 'x', game_id: 'g', title: '第一颗炸弹', narrative: 'n' },
+            ],
+          },
+          200
+        )
+      )
+    )
+    expect(await fetchEarliestMemoryTitle()).toBe('第一颗炸弹')
+    expect(String(fn.mock.calls[0][0])).toContain('/api/companion/memories?order=oldest&limit=1')
+
+    stubFetch(() => Promise.resolve(jsonResponse({ memories: [] }, 200)))
+    expect(await fetchEarliestMemoryTitle()).toBeNull()
+
+    stubFetch(() => Promise.resolve(jsonResponse({}, 500)))
+    expect(await fetchEarliestMemoryTitle()).toBeNull()
   })
 
   it('fetchProfile maps 200 / 404 / error', async () => {

--- a/packages/platform/src/lib/companion-api.ts
+++ b/packages/platform/src/lib/companion-api.ts
@@ -18,6 +18,7 @@
  */
 
 import { API_BASE } from '@shared/api-base'
+import { resolveAccountStreak } from '@amiclaw/arcade-profile/companion-streak'
 import type {
   CompanionIdentity,
   CompanionResponse,
@@ -150,6 +151,38 @@ export async function fetchMemories(cursor?: string): Promise<MemoriesResult> {
     }
   } catch {
     return { kind: 'error' }
+  }
+}
+
+/**
+ * The player's account-anchored streak in days (B9 叙事型成长). Wraps the
+ * arcade-profile resolver (account API primary, cached value on failure,
+ * device-local only as a last-resort stale fallback). Routed through this
+ * module so the dock's data layer stays the single mock boundary for the
+ * presence hook.
+ */
+export async function fetchAccountStreak(): Promise<number> {
+  if (companionSeedEnabled()) return 0
+  return resolveAccountStreak()
+}
+
+/**
+ * The EARLIEST shared episode's title (B20 milestone callback — the design's
+ * 「你第一天…」 register), or null when the album is empty / unreadable. Uses the
+ * memories endpoint's oldest-first ordering.
+ */
+export async function fetchEarliestMemoryTitle(): Promise<string | null> {
+  if (companionSeedEnabled()) {
+    const seeded = seedMemories()
+    return seeded.length > 0 ? (seeded[seeded.length - 1]?.title ?? null) : null
+  }
+  try {
+    const res = await fetch(`${BASE}/memories?order=oldest&limit=1`, { credentials: 'include' })
+    if (!res.ok) return null
+    const data = (await res.json()) as MemoriesResponse
+    return data.memories.length > 0 ? (data.memories[0]?.title ?? null) : null
+  } catch {
+    return null
   }
 }
 

--- a/packages/platform/src/lib/companion-familiarity.test.ts
+++ b/packages/platform/src/lib/companion-familiarity.test.ts
@@ -1,0 +1,89 @@
+/**
+ * shared/companion-familiarity — the streak → relationship rules (B9 + B20).
+ *
+ * Covers the two pure families: the 3-tier familiarity ladder (derivation +
+ * per-tier register rules) and the milestone pick (labels + the once-per-
+ * milestone selection, including the 7→14 double-crossing edge).
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  CLOSE_STREAK_DAYS,
+  FAMILIAR_STREAK_DAYS,
+  MILESTONE_STREAK_DAYS,
+  deriveFamiliarityTier,
+  familiarityRegisterHint,
+  milestoneLabel,
+  pickMilestone,
+  tierUsesAddressPrefix,
+} from '@shared/companion-familiarity'
+
+describe('deriveFamiliarityTier', () => {
+  it('maps streak days onto the three tiers at the pinned thresholds', () => {
+    expect(deriveFamiliarityTier(0)).toBe('newcomer')
+    expect(deriveFamiliarityTier(FAMILIAR_STREAK_DAYS - 1)).toBe('newcomer')
+    expect(deriveFamiliarityTier(FAMILIAR_STREAK_DAYS)).toBe('familiar')
+    expect(deriveFamiliarityTier(CLOSE_STREAK_DAYS - 1)).toBe('familiar')
+    expect(deriveFamiliarityTier(CLOSE_STREAK_DAYS)).toBe('close')
+    expect(deriveFamiliarityTier(120)).toBe('close')
+  })
+})
+
+describe('tier register rules', () => {
+  it('keeps the address only for the newcomer tier (fuller → closer)', () => {
+    expect(tierUsesAddressPrefix('newcomer')).toBe(true)
+    expect(tierUsesAddressPrefix('familiar')).toBe(false)
+    expect(tierUsesAddressPrefix('close')).toBe(false)
+  })
+
+  it('injects no prompt hint for a newcomer, a warmer one for higher tiers', () => {
+    expect(familiarityRegisterHint('newcomer')).toBeNull()
+    expect(familiarityRegisterHint('familiar')).toContain('warmer')
+    expect(familiarityRegisterHint('close')).toContain('old')
+  })
+})
+
+describe('milestoneLabel', () => {
+  it('names each milestone on the human time scale', () => {
+    expect(milestoneLabel(7)).toBe('一周')
+    expect(milestoneLabel(14)).toBe('两周')
+    expect(milestoneLabel(30)).toBe('一个月')
+    expect(milestoneLabel(60)).toBe('两个月')
+  })
+})
+
+describe('pickMilestone', () => {
+  it('returns null before the first milestone is reached', () => {
+    expect(pickMilestone(6, [])).toBeNull()
+    expect(pickMilestone(0, [])).toBeNull()
+  })
+
+  it('fires exactly the reached milestone the first time', () => {
+    expect(pickMilestone(7, [])).toEqual({ fire: 7, consumed: [7] })
+    expect(pickMilestone(9, [])).toEqual({ fire: 7, consumed: [7] })
+    expect(pickMilestone(30, [7, 14])).toEqual({ fire: 30, consumed: [30] })
+  })
+
+  it('never repeats an already-fired milestone', () => {
+    expect(pickMilestone(7, [7])).toBeNull()
+    expect(pickMilestone(13, [7])).toBeNull()
+    expect(pickMilestone(60, [7, 14, 30, 60])).toBeNull()
+  })
+
+  it('fires ONE beat and silently consumes the lower on a 7→14 double-crossing', () => {
+    // A player who returns already past two thresholds sees the HIGHER beat once;
+    // the 7-day beat is retired without firing (you never go back to a week in).
+    expect(pickMilestone(15, [])).toEqual({ fire: 14, consumed: [7, 14] })
+    // Three at once (fresh device already deep into a streak): highest only.
+    expect(pickMilestone(31, [])).toEqual({ fire: 30, consumed: [7, 14, 30] })
+    // Mixed: 7 already fired, 14 + 30 newly crossed → 30 fires, 14 retired.
+    expect(pickMilestone(30, [7])).toEqual({ fire: 30, consumed: [14, 30] })
+  })
+
+  it('fires each declared threshold in turn once the lower ones are consumed', () => {
+    const consumed: number[] = []
+    for (const day of MILESTONE_STREAK_DAYS) {
+      expect(pickMilestone(day, consumed)).toEqual({ fire: day, consumed: [day] })
+      consumed.push(day)
+    }
+  })
+})

--- a/packages/platform/src/lib/companion-presence.test.ts
+++ b/packages/platform/src/lib/companion-presence.test.ts
@@ -11,21 +11,26 @@ import { describe, expect, it } from 'vitest'
 import {
   ARRIVAL_IDLE_THRESHOLD_MS,
   ARRIVAL_REOPEN_SUPPRESS_MS,
+  COMPANION_MILESTONE_LOG_KEY,
   STANDARD_PROACTIVITY_TIER,
   VOICE_POSTURE_STORAGE_KEY,
   buildArrivalGreeting,
+  buildMilestoneGreeting,
   buildPostGameReaction,
   canFireArrivalBeat,
+  canFireMilestoneBeat,
   canFirePostGameBeat,
   deriveDockStatus,
   emptyBeatLog,
   formatDurationSpeech,
   readBeatLog,
   readCachedVoicePosture,
+  readMilestoneLog,
   recordBeatFired,
   transitionPosture,
   writeBeatLog,
   writeCachedVoicePosture,
+  writeMilestoneLog,
 } from '@shared/companion-presence'
 
 const NOW = Date.parse('2026-07-08T12:00:00.000Z')
@@ -243,5 +248,72 @@ describe('copy builders', () => {
         strikeCount: 0,
       })
     ).toBe('时间用完，停在第 4 个模块。')
+  })
+
+  it('modulates the arrival address by familiarity tier (B9a)', () => {
+    const base = {
+      addressStyle: '队长',
+      recentEpisodeTitle: '最后三秒拆掉了炸弹',
+      streakDays: 8,
+      hasPlayedBefore: true,
+    }
+    // Newcomer (default / explicit) keeps the fuller address.
+    expect(buildArrivalGreeting(base)).toBe(
+      '队长，上次最后三秒拆掉了炸弹，我还记着。今天第 9 天了。'
+    )
+    expect(buildArrivalGreeting({ ...base, tier: 'newcomer' })).toBe(
+      '队长，上次最后三秒拆掉了炸弹，我还记着。今天第 9 天了。'
+    )
+    // Familiar / close drop the explicit name for a closer register.
+    expect(buildArrivalGreeting({ ...base, tier: 'familiar' })).toBe(
+      '上次最后三秒拆掉了炸弹，我还记着。今天第 9 天了。'
+    )
+    expect(buildArrivalGreeting({ ...base, tier: 'close' })).toBe(
+      '上次最后三秒拆掉了炸弹，我还记着。今天第 9 天了。'
+    )
+  })
+})
+
+describe('milestone beat (B20)', () => {
+  it('round-trips the milestone log and rejects junk / non-thresholds', () => {
+    const storage = storageStub()
+    expect(readMilestoneLog(storage)).toEqual([])
+    writeMilestoneLog([7, 14], storage)
+    expect(readMilestoneLog(storage)).toEqual([7, 14])
+    // Only recognized thresholds survive a defensive re-read.
+    storage.map.set(COMPANION_MILESTONE_LOG_KEY, JSON.stringify([7, 999, 'oops']))
+    expect(readMilestoneLog(storage)).toEqual([7])
+    storage.map.set(COMPANION_MILESTONE_LOG_KEY, 'not json')
+    expect(readMilestoneLog(storage)).toEqual([])
+  })
+
+  it('gates on the daily cap and the mute freeze, deterministically otherwise', () => {
+    expect(canFireMilestoneBeat({ log: emptyBeatLog(TODAY), muted: false })).toBe(true)
+    expect(canFireMilestoneBeat({ log: emptyBeatLog(TODAY), muted: true })).toBe(false)
+    const capped = { date: TODAY, count: STANDARD_PROACTIVITY_TIER.dailyCap }
+    expect(canFireMilestoneBeat({ log: capped, muted: false })).toBe(false)
+  })
+
+  it('records a milestone against the cap and stamps the arrival window', () => {
+    const next = recordBeatFired(emptyBeatLog(TODAY), { kind: 'milestone', now: NOW })
+    expect(next.count).toBe(1)
+    // Stamping lastArrivalAt suppresses a plain arrival stacking in the same visit.
+    expect(next.lastArrivalAt).toBe(NOW)
+  })
+
+  it('builds the milestone line: time scale + honest fact, or an early callback', () => {
+    expect(buildMilestoneGreeting({ threshold: 7, streakDays: 7, earlyEpisodeTitle: null })).toBe(
+      '认识一周了。这 7 天，你一天没落。'
+    )
+    expect(buildMilestoneGreeting({ threshold: 30, streakDays: 31, earlyEpisodeTitle: null })).toBe(
+      '认识一个月了。这 31 天，你一天没落。'
+    )
+    expect(
+      buildMilestoneGreeting({
+        threshold: 7,
+        streakDays: 7,
+        earlyEpisodeTitle: '连题目都没看完就开剪',
+      })
+    ).toBe('认识一周了。你第一天连题目都没看完就开剪，我还记得。')
   })
 })

--- a/packages/platform/src/pages/AccountPage.module.css
+++ b/packages/platform/src/pages/AccountPage.module.css
@@ -154,6 +154,13 @@
   color: rgba(255, 255, 255, 0.38);
 }
 
+.streakBreakNote {
+  margin: 0;
+  font: 400 12px var(--font-body);
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.5);
+}
+
 .statBlock {
   min-width: 0;
   padding: 18px;

--- a/packages/platform/src/pages/AccountPage.test.tsx
+++ b/packages/platform/src/pages/AccountPage.test.tsx
@@ -298,6 +298,13 @@ describe('AccountPage /me', () => {
     expect(screen.getByText('练习 · 00:42 · 最快 00:42')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: '登录' })).toBeInTheDocument()
 
+    // B12 断签说明 — one honest, non-punitive line where the streak is visible.
+    expect(
+      screen.getByText(
+        '断一天，连续天数会从头算起。最长记录和已保存的成绩都还在，错过一天不会有惩罚。'
+      )
+    ).toBeInTheDocument()
+
     // None of the retired mock-profile content may render for anyone now.
     expect(screen.queryByText('星海')).not.toBeInTheDocument()
     expect(screen.queryByText('林星海')).not.toBeInTheDocument()

--- a/packages/platform/src/pages/AccountPage.tsx
+++ b/packages/platform/src/pages/AccountPage.tsx
@@ -23,6 +23,15 @@ import CompanionCard from '@/components/companion/CompanionCard'
 import { companionSeedEnabled } from '@/lib/companion-seed'
 import styles from './AccountPage.module.css'
 
+/* B12 断签后果说明 — the honest streak-break line. Verified against
+   computeArcadeStreak (arcade-profile/summary): a missed product day breaks the
+   current run so `current_days` restarts from zero on the next qualifying day,
+   while `longest_days` and every stored record persist untouched (the companion
+   memory in COMPANION_DB is a separate store the streak never touches). Register
+   matches the presence design's「伙伴会想你，但不会惩罚你」— no punishment framing. */
+const STREAK_BREAK_NOTE =
+  '断一天，连续天数会从头算起。最长记录和已保存的成绩都还在，错过一天不会有惩罚。'
+
 /* Account page — handoff §6.11. Reads identity from useAuth():
      - loading → hold the page chrome only (no profile, no guide) so neither
        state flashes before the session resolves.
@@ -394,6 +403,11 @@ function ArcadeStatsCard({
         />
       </div>
       <p className={styles.statsHint}>{getDailyResetHint()}</p>
+      {/* B12 断签说明 — one honest line where the streak is visible. States the
+          truth of the implementation: a break restarts the count from zero, but
+          the longest record and every saved result stay, and there is no
+          penalty (companion-presence register:「不会惩罚你」). */}
+      <p className={styles.streakBreakNote}>{STREAK_BREAK_NOTE}</p>
       {!hasAnyRecord && (
         <a className={styles.emptyCta} href={emptyCtaHref}>
           开始玩

--- a/shared/companion-familiarity.ts
+++ b/shared/companion-familiarity.ts
@@ -1,0 +1,123 @@
+/**
+ * Companion familiarity — pure streak → relationship logic (B9 叙事型成长 + B20
+ * 里程碑).
+ *
+ * SSOT for the streak-driven narrative rules from companion-presence-design
+ * §主动性节拍 4 and the arcade closure plan's fork ②B (streak growth is
+ * expressed through the companion's FAMILIARITY, never numbers / rewards /
+ * badges — the vision's anti-anxiety principle holds):
+ *
+ *  - the 3-tier familiarity ladder (初识 / 熟络 / 默契) a streak maps to, and how
+ *    each tier shifts the companion's register (client address rule + server
+ *    prompt tone hint);
+ *  - the milestone thresholds (7 / 14 / 30 / 60 days) and the once-per-milestone
+ *    pick that resolves the 7→14 double-crossing edge.
+ *
+ * PURE and dependency-free (no browser globals, no I/O, no imports) so ONE tier
+ * definition is consumed by both sides of the boundary: the browser presence
+ * layer (`shared/companion-presence.ts`, `@amiclaw/platform`, `@amiclaw/game-
+ * bombsquad`) AND the Workers read path (`packages/companion-memory`
+ * injection-policy + resolver, which the Workers typecheck compiles). Keep it
+ * free of `window` / `Storage` / DOM so the Workers typecheck accepts it (unlike
+ * the browser-only `shared/companion-presence.ts`).
+ */
+
+// --- Familiarity tiers (B9) ---------------------------------------------------
+
+/** The relationship ladder a streak maps to (design: 陌生 → 熟悉). */
+export type FamiliarityTier = 'newcomer' | 'familiar' | 'close'
+
+/**
+ * Tier thresholds in streak-days, aligned with the early milestones so the
+ * register shift and the milestone beat move together (a week in the companion
+ * warms; a month in it is at ease). Below the first threshold everything is
+ * byte-identical to the pre-B9 behaviour — a young relationship shapes nothing.
+ */
+export const FAMILIAR_STREAK_DAYS = 7
+export const CLOSE_STREAK_DAYS = 30
+
+export function deriveFamiliarityTier(streakDays: number): FamiliarityTier {
+  if (streakDays >= CLOSE_STREAK_DAYS) return 'close'
+  if (streakDays >= FAMILIAR_STREAK_DAYS) return 'familiar'
+  return 'newcomer'
+}
+
+/**
+ * Client copy rule (B9a 称呼): the newcomer tier keeps the fuller address (the
+ * companion names the player), the warmer tiers drop the explicit address for a
+ * closer register — a friend does not announce your name every sentence.
+ */
+export function tierUsesAddressPrefix(tier: FamiliarityTier): boolean {
+  return tier === 'newcomer'
+}
+
+/**
+ * Server prompt tone guidance (B9c). An English platform instruction (the
+ * system prompt is English) that shapes the companion's Chinese speech register.
+ * `null` for the base tier — nothing is injected, so a sub-week session's prompt
+ * is byte-identical to the pre-B9 shape.
+ */
+export function familiarityRegisterHint(tier: FamiliarityTier): string | null {
+  switch (tier) {
+    case 'newcomer':
+      return null
+    case 'familiar':
+      return (
+        'You and the player have been showing up together for a while now; ' +
+        'you may speak in a warmer, more familiar tone and lean on your shared ' +
+        'memories a little more.'
+      )
+    case 'close':
+      return (
+        'You know this player well by now; speak with the ease of an old ' +
+        'partner — you may drop formal address and reference your shared ' +
+        'history naturally.'
+      )
+  }
+}
+
+// --- Milestones (B20) ---------------------------------------------------------
+
+/** The streak lengths that earn one narrative milestone beat (design 节拍 4). */
+export const MILESTONE_STREAK_DAYS = [7, 14, 30, 60] as const
+export type MilestoneStreakDay = (typeof MILESTONE_STREAK_DAYS)[number]
+
+/** Human time-scale label for a milestone (design 文案示例 register). */
+export function milestoneLabel(day: MilestoneStreakDay): string {
+  switch (day) {
+    case 7:
+      return '一周'
+    case 14:
+      return '两周'
+    case 30:
+      return '一个月'
+    case 60:
+      return '两个月'
+  }
+}
+
+export interface MilestonePick {
+  /** The single milestone to announce now — the highest newly reached. */
+  fire: MilestoneStreakDay
+  /**
+   * Every threshold to mark consumed: the fired one plus any LOWER thresholds
+   * this visit crossed at once (the 7→14 double-crossing edge). A player who
+   * returns already past two milestones sees only the higher beat once; the
+   * lower one is retired silently — you never go back to being a week in.
+   */
+  consumed: MilestoneStreakDay[]
+}
+
+/**
+ * Pick the milestone to announce for a current streak, given the thresholds
+ * already fired (persistent, once-per-milestone-for-life dedup). Returns the
+ * highest un-fired threshold at or below the streak, and every un-fired
+ * threshold ≤ streak as `consumed` (so the double-crossing edge fires ONE beat
+ * and silently retires the lower). `null` when no un-fired threshold is reached.
+ */
+export function pickMilestone(streakDays: number, fired: readonly number[]): MilestonePick | null {
+  const firedSet = new Set(fired)
+  const reached = MILESTONE_STREAK_DAYS.filter((day) => streakDays >= day && !firedSet.has(day))
+  if (reached.length === 0) return null
+  return { fire: reached[reached.length - 1], consumed: reached }
+}

--- a/shared/companion-presence.ts
+++ b/shared/companion-presence.ts
@@ -19,6 +19,13 @@
  * an injectable `Pick<Storage, ...>` like `arcade-profile/local.ts`.
  */
 
+import {
+  milestoneLabel,
+  tierUsesAddressPrefix,
+  MILESTONE_STREAK_DAYS,
+  type FamiliarityTier,
+  type MilestoneStreakDay,
+} from './companion-familiarity'
 import { isVoicePosture, type VoicePosture } from './companion-types'
 
 // --- Voice-posture cache -------------------------------------------------------
@@ -283,9 +290,15 @@ export function canFirePostGameBeat(input: PostGameBeatInput): boolean {
 /** Fold a fired beat into the log (caller persists via `writeBeatLog`). */
 export function recordBeatFired(
   log: CompanionBeatLog,
-  beat: { kind: 'arrival'; now: number } | { kind: 'post-game'; gameRunId: string }
+  beat:
+    | { kind: 'arrival'; now: number }
+    | { kind: 'milestone'; now: number }
+    | { kind: 'post-game'; gameRunId: string }
 ): CompanionBeatLog {
-  if (beat.kind === 'arrival') {
+  // A milestone rides the arrival moment (both land on homepage entry), so it
+  // also stamps `lastArrivalAt` — the 5-minute re-open window then suppresses a
+  // plain arrival greeting stacking on top within the same visit.
+  if (beat.kind === 'arrival' || beat.kind === 'milestone') {
     return { ...log, count: log.count + 1, lastArrivalAt: beat.now }
   }
   return { ...log, count: log.count + 1, lastPostGameRunId: beat.gameRunId }
@@ -315,16 +328,24 @@ export interface ArrivalGreetingInput {
   streakDays: number
   /** Whether any local play record exists at all. */
   hasPlayedBefore: boolean
+  /**
+   * Familiarity tier (B9a 称呼): the newcomer tier keeps the fuller address; the
+   * warmer tiers drop it for a closer register. Omitted → base tier (fuller
+   * address), so a caller that does not pass a tier gets the pre-B9 behaviour.
+   */
+  tier?: FamiliarityTier
 }
 
 /**
  * 节拍 1 template fill (design 文案示例 register: cite one concrete thing from
  * the last episode, then the streak — factual, no profile-layer reference, no
  * kitsch). Every clause is backed by real data; missing data drops the clause
- * instead of inventing one.
+ * instead of inventing one. The familiarity tier modulates the address register
+ * (B9a) — a closer relationship drops the explicit name.
  */
 export function buildArrivalGreeting(input: ArrivalGreetingInput): string {
-  const address = input.addressStyle.trim()
+  const useAddress = input.tier === undefined || tierUsesAddressPrefix(input.tier)
+  const address = useAddress ? input.addressStyle.trim() : ''
   const prefix = address.length > 0 ? `${address}，` : ''
   const streakLine = input.streakDays >= 2 ? `今天第 ${input.streakDays + 1} 天了。` : ''
 
@@ -368,4 +389,94 @@ export function buildPostGameReaction(input: PostGameReactionInput): string {
     case 'daily-timeout':
       return `时间用完，停在第 ${stoppedAt} 个模块。`
   }
+}
+
+// --- Milestone beat (节拍 4 里程碑, B20) -------------------------------------------
+
+/**
+ * localStorage key for the once-per-milestone-FOR-LIFE dedup log. Separate from
+ * the per-day beat log (which resets each product day): a milestone is a
+ * relationship marker, said once and never repeated — even across a streak
+ * break and rebuild, "认识一周了" is not a thing to say twice.
+ */
+export const COMPANION_MILESTONE_LOG_KEY = 'amio_companion_milestone_log'
+
+/** Read the set of milestone thresholds already delivered (defensive parse). */
+export function readMilestoneLog(
+  storage: ReadableStorage | null = browserLocalStorage()
+): MilestoneStreakDay[] {
+  if (!storage) return []
+  try {
+    const raw = storage.getItem(COMPANION_MILESTONE_LOG_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    // Keep only recognized thresholds — tamper / schema-drift resistant.
+    return MILESTONE_STREAK_DAYS.filter((day) => parsed.includes(day))
+  } catch {
+    return []
+  }
+}
+
+/** Persist the delivered milestone thresholds (normalized + deduped). */
+export function writeMilestoneLog(
+  fired: readonly MilestoneStreakDay[],
+  storage: WritableStorage | null = browserLocalStorage()
+): void {
+  if (!storage) return
+  try {
+    const unique = MILESTONE_STREAK_DAYS.filter((day) => fired.includes(day))
+    storage.setItem(COMPANION_MILESTONE_LOG_KEY, JSON.stringify(unique))
+  } catch {
+    // Losing the log means at worst one milestone repeats — never fatal.
+  }
+}
+
+export interface MilestoneBeatInput {
+  log: CompanionBeatLog
+  /** Beats are frozen while muted (session or remembered posture). */
+  muted: boolean
+}
+
+/**
+ * Milestone-beat gate (节拍 4): fires deterministically when a milestone is
+ * reached — a defining relationship moment is never probabilistically dropped —
+ * subject only to the freeze-while-muted rule and the 标准 daily cap. Per the
+ * design's 节拍总量 the milestone COUNTS against the cap (the reserved 5th slot),
+ * so it does not bypass it. The once-per-milestone dedup is the caller's job via
+ * `readMilestoneLog` / `pickMilestone`.
+ */
+export function canFireMilestoneBeat(input: MilestoneBeatInput): boolean {
+  if (input.muted) return false
+  if (input.log.count >= STANDARD_PROACTIVITY_TIER.dailyCap) return false
+  return true
+}
+
+export interface MilestoneGreetingInput {
+  /** The milestone reached (its label opens the line). */
+  threshold: MilestoneStreakDay
+  /** The current streak in days (backs the "no missed day" fact). */
+  streakDays: number
+  /**
+   * An EARLY shared memory's title for the callback clause, or null. Kept real:
+   * when absent the line falls back to the honest streak fact instead of
+   * inventing an early episode.
+   */
+  earlyEpisodeTitle: string | null
+}
+
+/**
+ * 节拍 4 template fill (design 文案示例 register: a time-scale opener + one
+ * callback — no badge, no reward, no number worship). The opener is always real
+ * (a streak IS consecutive days); the callback cites a real early episode when
+ * one is supplied, else falls back to the honest "not one missed day" fact. No
+ * address prefix — the design's milestone examples carry the intimacy in the
+ * time-scale opener, not the name.
+ */
+export function buildMilestoneGreeting(input: MilestoneGreetingInput): string {
+  const head = `认识${milestoneLabel(input.threshold)}了。`
+  const tail = input.earlyEpisodeTitle
+    ? `你第一天${input.earlyEpisodeTitle}，我还记得。`
+    : `这 ${input.streakDays} 天，你一天没落。`
+  return `${head}${tail}`
 }


### PR DESCRIPTION
## Summary
- B9: familiarity tiers (address/register + memory-reference frequency + prompt tone) driven by the ACCOUNT streak — the anti-anxiety principle holds: zero numeric rewards/badges
- B12: honest break copy on /me (counter resets; relationship and memories persist)
- B20: milestone beats at 7/14/30/60 with a real earliest-episode callback (「认识一周了。你第一天…」), once-per-milestone dedup
- Milestone thresholds unified into shared/companion-familiarity (community feed imports the same SSOT)

Phase B streak-narrative cluster. 3-axis verify + fix round (two declined simplifications reversed: account anchoring, real memory callback).

## Test plan
- [x] arcade-profile 45 / companion-memory 55 / platform-ai 347 / api 203 / platform 189 / game-bombsquad 475; typecheck; lint; e2e audit 30↔30
- [ ] CI full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w79dZWZzh7A7W6A7deN31