### PR TITLE
refactor(platform): single voice shell in shared/voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ milestone, never repeated. No trophy, no popup: just a word that it noticed.
 and plainly, what happens if you miss a day: the streak count starts over, but
 your longest record and every saved result stay, and there is no penalty.
 
+**Voice audio plumbing unified across the two voice sessions** - Internal
+refactor. The in-game and lobby voice hooks each carried their own copy of the
+imperative mic-capture, VAD, and TTS-playback shell (about 200 lines of
+duplicated Web Audio wiring, a drift risk between the two). That shell now lives
+once in `shared/voice`, so both hooks drive one implementation. No player-facing
+behavior changes.
+
 **Finishing a co-play daily run no longer flashes a phantom fifth module** -
 Fix. Completing all four modules while playing WITH your companion briefly
 showed a 「模块 5/4」 counter over an empty panel while the AI wrapped up, instead

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -16,6 +16,9 @@
     "../../shared/api-base.ts",
     "../../shared/companion-presence.ts",
     "../../shared/leaderboard-api.ts",
-    "../../shared/leaderboard-optimistic.ts"
+    "../../shared/leaderboard-optimistic.ts",
+    "../../shared/voice/audio-capture.ts",
+    "../../shared/voice/audio-context.ts",
+    "../../shared/voice/audio-playback.ts"
   ]
 }

--- a/packages/game-bombsquad/src/voice/useVoiceSession.ts
+++ b/packages/game-bombsquad/src/voice/useVoiceSession.ts
@@ -44,7 +44,7 @@
 
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import type { GameState, ManualData, RecapOutcome } from '@amiclaw/platform-ai/contract'
-import { base64ToBytes, floatTo16BitPCM, pcm16ToFloat32, resamplePcmFloat32 } from './audio-pcm'
+import { base64ToBytes } from './audio-pcm'
 import {
   buildSessionUrl,
   deriveConversationPhase,
@@ -55,13 +55,8 @@ import {
   type ServerFrame,
   type VoiceStatus,
 } from './voice-session-protocol'
-import {
-  computeRms,
-  DEFAULT_VAD_CONFIG,
-  initialVadState,
-  vadStep,
-  type VadState,
-} from './voice-vad'
+import { createPcmCapture, type PcmCapture } from '@shared/voice/audio-capture'
+import { createPcmPlayback, type PcmPlayback } from '@shared/voice/audio-playback'
 
 /** Volcengine TTS output sample rate (`volcengine.ts` `DEFAULT_SAMPLE_RATE`). */
 const TTS_OUTPUT_SAMPLE_RATE = 16000
@@ -77,12 +72,6 @@ const CAPTURE_BUFFER_SIZE = 4096
 const NO_RESPONSE_TIMEOUT_MS = 12000
 
 /**
- * Close an `AudioContext` and release its hardware resources, swallowing the
- * (possible) rejection. Browsers cap the number of concurrent `AudioContext`s,
- * so a leaked context across turns / panel remounts eventually starves the next
- * `new AudioContext(...)` — which is the failure this hardening guards against.
- */
-/**
  * Stable signature of the manual-subset selection, for change detection across
  * renders. A new selection (the player advanced modules) yields a different
  * string; an unchanged selection (a timer-frame re-render) yields the same one,
@@ -90,20 +79,6 @@ const NO_RESPONSE_TIMEOUT_MS = 12000
  */
 function sectionsSignature(gameState: GameState): string {
   return JSON.stringify(gameState.relevantSections ?? [])
-}
-
-function closeAudioContext(ctx: AudioContext | null): void {
-  if (!ctx) return
-  try {
-    const closing = ctx.close()
-    if (closing && typeof closing.then === 'function') {
-      closing.catch(() => {
-        /* ignore — context may already be closed */
-      })
-    }
-  } catch {
-    /* ignore — context may already be closed */
-  }
 }
 
 export interface UseVoiceSessionOptions {
@@ -218,24 +193,6 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
    */
   const sentSectionsRef = useRef<string | null>(null)
 
-  const mediaStreamRef = useRef<MediaStream | null>(null)
-  const captureCtxRef = useRef<AudioContext | null>(null)
-  const captureSourceRef = useRef<MediaStreamAudioSourceNode | null>(null)
-  const captureProcRef = useRef<ScriptProcessorNode | null>(null)
-  /** True once the mic is acquired and streaming; guards a double mic-open. */
-  const capturingRef = useRef(false)
-  /** Running VAD state, folded one capture frame at a time. */
-  const vadStateRef = useRef<VadState>(initialVadState)
-  /** Analyzed-frame wall-clock duration (`bufferSize / actualRate`), ms. */
-  const frameMsRef = useRef<number>((CAPTURE_BUFFER_SIZE / CAPTURE_SAMPLE_RATE) * 1000)
-
-  const playbackCtxRef = useRef<AudioContext | null>(null)
-  /** Next scheduled playback start time, for gapless PCM frame queueing. */
-  const playbackCursorRef = useRef(0)
-  /** Count of scheduled-but-not-ended buffers, driving `isAiSpeaking`. */
-  const playingCountRef = useRef(0)
-  /** Live scheduled sources, so barge-in can stop them without closing the context. */
-  const activeSourcesRef = useRef<Set<AudioBufferSourceNode>>(new Set())
   /** True while the AI's current turn is still streaming (last chunk not `done`). */
   const turnStreamingRef = useRef(false)
   /** True while dropping the tail of a barged-in turn (until its `done` chunk). */
@@ -273,124 +230,37 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     }
   }, [])
 
-  // --- TTS playback (Web Audio side effects) ---
+  // --- Imperative audio shells (TTS playback + mic capture) ---
+  //
+  // The game-agnostic Web Audio plumbing lives in `@shared/voice/*`; both this
+  // hook and the lobby hook drive ONE implementation. Each controller is a PURE
+  // state machine built once via a `useState` lazy initializer from numeric
+  // config alone (no ref access during render); the ref-reading lifecycle
+  // callbacks are supplied at CALL time, all in event-handler contexts.
 
-  const ensurePlaybackCtx = useCallback((): AudioContext | null => {
-    if (playbackCtxRef.current) return playbackCtxRef.current
-    try {
-      const ctx = new AudioContext()
-      void ctx.resume?.()
-      playbackCtxRef.current = ctx
-      playbackCursorRef.current = ctx.currentTime
-      return ctx
-    } catch {
-      return null
-    }
-  }, [])
-
-  const playAudioFrame = useCallback(
-    (bytes: Uint8Array) => {
-      const floats = pcm16ToFloat32(bytes)
-      if (floats.length === 0) return
-      const ctx = ensurePlaybackCtx()
-      if (!ctx) return
-      try {
-        const buffer = ctx.createBuffer(1, floats.length, TTS_OUTPUT_SAMPLE_RATE)
-        buffer.getChannelData(0).set(floats)
-        const source = ctx.createBufferSource()
-        source.buffer = buffer
-        source.connect(ctx.destination)
-        const startAt = Math.max(ctx.currentTime, playbackCursorRef.current)
-        source.start(startAt)
-        playbackCursorRef.current = startAt + buffer.duration
-        playingCountRef.current += 1
-        activeSourcesRef.current.add(source)
-        setIsAiSpeaking(true)
-        source.onended = () => {
-          activeSourcesRef.current.delete(source)
-          playingCountRef.current = Math.max(0, playingCountRef.current - 1)
-          if (playingCountRef.current === 0 && mountedRef.current) setIsAiSpeaking(false)
-          // If the closing recap's terminal `done` chunk already arrived and
-          // this was the last audio frame, resolve the pending requestClosing
-          // promise so GamePage can navigate to the results screen.
-          if (playingCountRef.current === 0 && closingDoneRef.current) {
-            const resolve = closingResolveRef.current
-            if (resolve) {
-              closingResolveRef.current = null
-              closingInProgressRef.current = false
-              closingDoneRef.current = false
-              resolve()
-            }
-          }
-        }
-      } catch {
-        // A playback failure must never break the turn — text still renders.
-      }
-    },
-    [ensurePlaybackCtx]
+  const [playback] = useState<PcmPlayback>(() => createPcmPlayback(TTS_OUTPUT_SAMPLE_RATE))
+  const [capture] = useState<PcmCapture>(() =>
+    createPcmCapture(CAPTURE_SAMPLE_RATE, CAPTURE_BUFFER_SIZE)
   )
 
-  /**
-   * Stop all scheduled playback immediately but KEEP the playback context alive
-   * for the next turn. Used by barge-in — the next AI turn reuses the context.
-   */
-  const interruptPlayback = useCallback(() => {
-    for (const source of activeSourcesRef.current) {
-      try {
-        // eslint-disable-next-line react-hooks/immutability -- a Web Audio node held in a ref, not React state; detach its callback before stopping so teardown doesn't re-enter the onended bookkeeping.
-        source.onended = null
-        source.stop?.()
-        source.disconnect?.()
-      } catch {
-        /* ignore — source may already have ended */
-      }
-    }
-    activeSourcesRef.current.clear()
-    playingCountRef.current = 0
-    playbackCursorRef.current = playbackCtxRef.current?.currentTime ?? 0
-    if (mountedRef.current) setIsAiSpeaking(false)
+  // `true` is unconditional; the `false` edge is mounted-guarded, as before.
+  const onSpeakingChange = useCallback((speaking: boolean) => {
+    if (speaking) setIsAiSpeaking(true)
+    else if (mountedRef.current) setIsAiSpeaking(false)
   }, [])
 
-  /** Stop playback AND release the context — full teardown (unmount / end). */
-  const teardownPlayback = useCallback(() => {
-    interruptPlayback()
-    const ctx = playbackCtxRef.current
-    playbackCtxRef.current = null
-    playbackCursorRef.current = 0
-    closeAudioContext(ctx)
-  }, [interruptPlayback])
-
-  // --- Mic capture (continuous, full session) ---
-
-  const stopCapture = useCallback(() => {
-    capturingRef.current = false
-    vadStateRef.current = initialVadState
-    const proc = captureProcRef.current
-    if (proc) {
-      proc.onaudioprocess = null
-      try {
-        proc.disconnect()
-      } catch {
-        /* ignore */
+  const onPlaybackDrained = useCallback(() => {
+    // If the closing recap's terminal `done` chunk already arrived and this was
+    // the last audio frame, resolve the pending requestClosing promise so GamePage
+    // can navigate to the results screen.
+    if (closingDoneRef.current) {
+      const resolve = closingResolveRef.current
+      if (resolve) {
+        closingResolveRef.current = null
+        closingInProgressRef.current = false
+        closingDoneRef.current = false
+        resolve()
       }
-      captureProcRef.current = null
-    }
-    const source = captureSourceRef.current
-    if (source) {
-      try {
-        source.disconnect()
-      } catch {
-        /* ignore */
-      }
-      captureSourceRef.current = null
-    }
-    const ctx = captureCtxRef.current
-    captureCtxRef.current = null
-    closeAudioContext(ctx)
-    const stream = mediaStreamRef.current
-    if (stream) {
-      stream.getTracks().forEach((t) => t.stop())
-      mediaStreamRef.current = null
     }
   }, [])
 
@@ -408,7 +278,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     // playback and flagged the interrupted turn (`suppressTurnRef`), so the player
     // has taken the floor and their next utterance is a real turn.
     const aiHoldsFloor =
-      playingCountRef.current > 0 ||
+      playback.isPlaying() ||
       awaitingResponseRef.current ||
       (turnStreamingRef.current && !suppressTurnRef.current)
     if (aiHoldsFloor) return
@@ -421,7 +291,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         /* non-fatal — a dropped turn just means this utterance isn't answered */
       }
     }
-  }, [setAwaiting])
+  }, [setAwaiting, playback])
 
   /** A VAD `speech-start`: the player began an utterance (incl. barge-in). */
   const onSpeechStart = useCallback(() => {
@@ -429,9 +299,9 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     // playback at once and drop the rest of the interrupted turn's streamed
     // chunks (text + audio) — the server keeps streaming them (it cancels nothing
     // in v1), so the client must locally discard them until that turn's `done`.
-    const bargeIn = playingCountRef.current > 0
+    const bargeIn = playback.isPlaying()
     if (bargeIn) {
-      interruptPlayback()
+      playback.interrupt(onSpeakingChange)
       if (turnStreamingRef.current) suppressTurnRef.current = true
       safeDispatch({ type: 'barge-in' })
     }
@@ -467,68 +337,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         /* non-fatal — a dropped speech-start just defers live transcription to the turn */
       }
     }
-  }, [interruptPlayback, safeDispatch])
-
-  const startCapture = useCallback(() => {
-    if (capturingRef.current) return
-    capturingRef.current = true
-    void (async () => {
-      let stream: MediaStream
-      try {
-        stream = await navigator.mediaDevices.getUserMedia({
-          audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
-        })
-      } catch {
-        capturingRef.current = false
-        safeDispatch({ type: 'mic-error', message: 'microphone permission denied' })
-        return
-      }
-      // The panel may have unmounted / the socket closed during the async acquire.
-      if (!mountedRef.current || !wsRef.current) {
-        stream.getTracks().forEach((t) => t.stop())
-        capturingRef.current = false
-        return
-      }
-      mediaStreamRef.current = stream
-      try {
-        const ctx = new AudioContext({ sampleRate: CAPTURE_SAMPLE_RATE })
-        captureCtxRef.current = ctx
-        // Browsers may ignore the requested 16 kHz and run the context at the
-        // hardware rate (e.g. 48000). The wire format is fixed at PCM16 16 kHz —
-        // resample each frame to the true target rate before encoding.
-        const actualRate = ctx.sampleRate
-        frameMsRef.current = (CAPTURE_BUFFER_SIZE / actualRate) * 1000
-        vadStateRef.current = initialVadState
-        const source = ctx.createMediaStreamSource(stream)
-        captureSourceRef.current = source
-        const proc = ctx.createScriptProcessor(CAPTURE_BUFFER_SIZE, 1, 1)
-        captureProcRef.current = proc
-        proc.onaudioprocess = (e) => {
-          const frame = e.inputBuffer.getChannelData(0)
-          // 1) VAD on the raw frame (energy is rate-independent), driving the
-          //    conversation phase + barge-in.
-          const rms = computeRms(frame)
-          const stepped = vadStep(vadStateRef.current, rms, frameMsRef.current, DEFAULT_VAD_CONFIG)
-          vadStateRef.current = stepped.state
-          if (stepped.event === 'speech-start') onSpeechStart()
-          else if (stepped.event === 'utterance-end') onUtteranceEnd()
-          // 2) Stream the frame continuously as PCM16 16 kHz.
-          const socket = wsRef.current
-          if (!socket || socket.readyState !== WebSocket.OPEN) return
-          const pcm =
-            actualRate === CAPTURE_SAMPLE_RATE
-              ? frame
-              : resamplePcmFloat32(frame, actualRate, CAPTURE_SAMPLE_RATE)
-          socket.send(floatTo16BitPCM(pcm))
-        }
-        source.connect(proc)
-        proc.connect(ctx.destination)
-      } catch {
-        stopCapture()
-        safeDispatch({ type: 'mic-error', message: 'microphone capture failed' })
-      }
-    })()
-  }, [onSpeechStart, onUtteranceEnd, safeDispatch, stopCapture])
+  }, [playback, safeDispatch, onSpeakingChange])
 
   // --- WebSocket lifecycle ---
 
@@ -604,7 +413,13 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         // The AI greets first: open the mic now and mark the opening greeting
         // pending (-> "thinking" until its audio plays).
         setAwaiting(true)
-        startCapture()
+        capture.start({
+          onSpeechStart,
+          onUtteranceEnd,
+          onError: (message) => safeDispatch({ type: 'mic-error', message }),
+          isMounted: () => mountedRef.current,
+          getSocket: () => wsRef.current,
+        })
         safeDispatch({ type: 'frame', frame })
         return
       }
@@ -622,7 +437,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         turnStreamingRef.current = !frame.done
         if (awaitingResponseRef.current) setAwaiting(false)
         if (frame.kind === 'audio' && frame.audio) {
-          playAudioFrame(base64ToBytes(frame.audio))
+          playback.play(base64ToBytes(frame.audio), onSpeakingChange, onPlaybackDrained)
         }
         safeDispatch({ type: 'frame', frame })
         // Closing-recap resolution: when the recap's terminal `done` chunk
@@ -631,7 +446,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         // otherwise `source.onended` resolves it once the last frame drains.
         if (frame.done && closingInProgressRef.current) {
           closingDoneRef.current = true
-          if (playingCountRef.current === 0) {
+          if (!playback.isPlaying()) {
             const resolve = closingResolveRef.current
             if (resolve) {
               closingResolveRef.current = null
@@ -674,7 +489,16 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         })
       }
     }
-  }, [playAudioFrame, safeDispatch, setAwaiting, startCapture])
+  }, [
+    capture,
+    playback,
+    onSpeechStart,
+    onUtteranceEnd,
+    onSpeakingChange,
+    onPlaybackDrained,
+    safeDispatch,
+    setAwaiting,
+  ])
 
   // --- Public actions ---
 
@@ -685,7 +509,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     // the clean-close `onclose` reads — is set the instant `end` is sent, so a
     // second call is a no-op.
     if (endedRef.current) return
-    stopCapture()
+    capture.stop()
     const ws = wsRef.current
     if (ws && ws.readyState === WebSocket.OPEN) {
       // Mark ended so the eventual close is treated as clean; let the socket stay
@@ -701,7 +525,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
       closeSocket(true)
       safeDispatch({ type: 'closed' })
     }
-  }, [stopCapture, closeSocket, safeDispatch])
+  }, [capture, closeSocket, safeDispatch])
 
   /**
    * Request the closing-recap turn from the DO. Returns a promise that resolves
@@ -747,11 +571,11 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         clearTimeout(awaitingTimeoutRef.current)
         awaitingTimeoutRef.current = null
       }
-      stopCapture()
-      teardownPlayback()
+      capture.stop()
+      playback.teardown(onSpeakingChange)
       closeSocket(true)
     }
-  }, [hasManual, connect, stopCapture, teardownPlayback, closeSocket])
+  }, [hasManual, connect, capture, playback, onSpeakingChange, closeSocket])
 
   // --- Module advance within one run: steer the live session, never reconnect ---
   //

--- a/packages/platform/src/components/companion/useLobbyVoiceSession.ts
+++ b/packages/platform/src/components/companion/useLobbyVoiceSession.ts
@@ -33,12 +33,7 @@
 
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
-import {
-  base64ToBytes,
-  floatTo16BitPCM,
-  pcm16ToFloat32,
-  resamplePcmFloat32,
-} from '@shared/voice/audio-pcm'
+import { base64ToBytes } from '@shared/voice/audio-pcm'
 import {
   buildSessionUrl,
   deriveConversationPhase,
@@ -48,13 +43,8 @@ import {
   type ServerFrame,
   type VoiceStatus,
 } from '@shared/voice/voice-session-protocol'
-import {
-  computeRms,
-  DEFAULT_VAD_CONFIG,
-  initialVadState,
-  vadStep,
-  type VadState,
-} from '@shared/voice/voice-vad'
+import { createPcmCapture, type PcmCapture } from '@shared/voice/audio-capture'
+import { createPcmPlayback, type PcmPlayback } from '@shared/voice/audio-playback'
 
 const TTS_OUTPUT_SAMPLE_RATE = 16000
 const CAPTURE_SAMPLE_RATE = 16000
@@ -79,18 +69,6 @@ export type LobbyEndReason = 'silence' | 'turn-cap' | 'max-duration' | 'caller' 
 
 function randomLobbySessionName(): string {
   return `lobby-${Math.random().toString(36).slice(2, 10)}`
-}
-
-function closeAudioContext(ctx: AudioContext | null): void {
-  if (!ctx) return
-  try {
-    const closing = ctx.close()
-    if (closing && typeof closing.then === 'function') {
-      closing.catch(() => {})
-    }
-  } catch {
-    /* already closed */
-  }
 }
 
 export interface UseLobbyVoiceSessionResult {
@@ -130,18 +108,6 @@ export function useLobbyVoiceSession(): UseLobbyVoiceSessionResult {
   /** A pre-granted stream handed to `open()`; consumed once by `startCapture`. */
   const pendingStreamRef = useRef<MediaStream | null>(null)
 
-  const mediaStreamRef = useRef<MediaStream | null>(null)
-  const captureCtxRef = useRef<AudioContext | null>(null)
-  const captureSourceRef = useRef<MediaStreamAudioSourceNode | null>(null)
-  const captureProcRef = useRef<ScriptProcessorNode | null>(null)
-  const capturingRef = useRef(false)
-  const vadStateRef = useRef<VadState>(initialVadState)
-  const frameMsRef = useRef<number>((CAPTURE_BUFFER_SIZE / CAPTURE_SAMPLE_RATE) * 1000)
-
-  const playbackCtxRef = useRef<AudioContext | null>(null)
-  const playbackCursorRef = useRef(0)
-  const playingCountRef = useRef(0)
-  const activeSourcesRef = useRef<Set<AudioBufferSourceNode>>(new Set())
   const turnStreamingRef = useRef(false)
   const suppressTurnRef = useRef(false)
 
@@ -171,112 +137,29 @@ export function useLobbyVoiceSession(): UseLobbyVoiceSessionResult {
     }
   }, [])
 
-  // --- TTS playback ---
-  const ensurePlaybackCtx = useCallback((): AudioContext | null => {
-    if (playbackCtxRef.current) return playbackCtxRef.current
-    try {
-      const ctx = new AudioContext()
-      void ctx.resume?.()
-      playbackCtxRef.current = ctx
-      playbackCursorRef.current = ctx.currentTime
-      return ctx
-    } catch {
-      return null
-    }
-  }, [])
+  // --- Imperative audio shells (TTS playback + mic capture) ---
+  //
+  // The game-agnostic Web Audio plumbing lives in `@shared/voice/*`; both this
+  // hook and the in-game hook drive ONE implementation. The controllers are built
+  // once via a `useState` lazy initializer (stable identity, no ref access during
+  // render); the option closures capture only stable refs / setters and defer
+  // every `.current` read to call time. The factories have no side effects.
 
-  const playAudioFrame = useCallback(
-    (bytes: Uint8Array) => {
-      const floats = pcm16ToFloat32(bytes)
-      if (floats.length === 0) return
-      const ctx = ensurePlaybackCtx()
-      if (!ctx) return
-      try {
-        const buffer = ctx.createBuffer(1, floats.length, TTS_OUTPUT_SAMPLE_RATE)
-        buffer.getChannelData(0).set(floats)
-        const source = ctx.createBufferSource()
-        source.buffer = buffer
-        source.connect(ctx.destination)
-        const startAt = Math.max(ctx.currentTime, playbackCursorRef.current)
-        source.start(startAt)
-        playbackCursorRef.current = startAt + buffer.duration
-        playingCountRef.current += 1
-        activeSourcesRef.current.add(source)
-        setIsAiSpeaking(true)
-        source.onended = () => {
-          activeSourcesRef.current.delete(source)
-          playingCountRef.current = Math.max(0, playingCountRef.current - 1)
-          if (playingCountRef.current === 0 && mountedRef.current) setIsAiSpeaking(false)
-        }
-      } catch {
-        /* a playback failure must never break the turn — text still renders */
-      }
-    },
-    [ensurePlaybackCtx]
+  const [playback] = useState<PcmPlayback>(() => createPcmPlayback(TTS_OUTPUT_SAMPLE_RATE))
+  const [capture] = useState<PcmCapture>(() =>
+    createPcmCapture(CAPTURE_SAMPLE_RATE, CAPTURE_BUFFER_SIZE)
   )
 
-  const interruptPlayback = useCallback(() => {
-    for (const source of activeSourcesRef.current) {
-      try {
-        // eslint-disable-next-line react-hooks/immutability -- Web Audio node in a ref; detach before stop to avoid re-entering onended bookkeeping.
-        source.onended = null
-        source.stop?.()
-        source.disconnect?.()
-      } catch {
-        /* already ended */
-      }
-    }
-    activeSourcesRef.current.clear()
-    playingCountRef.current = 0
-    playbackCursorRef.current = playbackCtxRef.current?.currentTime ?? 0
-    if (mountedRef.current) setIsAiSpeaking(false)
-  }, [])
-
-  const teardownPlayback = useCallback(() => {
-    interruptPlayback()
-    const ctx = playbackCtxRef.current
-    playbackCtxRef.current = null
-    playbackCursorRef.current = 0
-    closeAudioContext(ctx)
-  }, [interruptPlayback])
-
-  // --- Mic capture ---
-  const stopCapture = useCallback(() => {
-    capturingRef.current = false
-    vadStateRef.current = initialVadState
-    const proc = captureProcRef.current
-    if (proc) {
-      proc.onaudioprocess = null
-      try {
-        proc.disconnect()
-      } catch {
-        /* ignore */
-      }
-      captureProcRef.current = null
-    }
-    const source = captureSourceRef.current
-    if (source) {
-      try {
-        source.disconnect()
-      } catch {
-        /* ignore */
-      }
-      captureSourceRef.current = null
-    }
-    const ctx = captureCtxRef.current
-    captureCtxRef.current = null
-    closeAudioContext(ctx)
-    const stream = mediaStreamRef.current
-    if (stream) {
-      stream.getTracks().forEach((t) => t.stop())
-      mediaStreamRef.current = null
-    }
+  // `true` is unconditional; the `false` edge is mounted-guarded, as before.
+  const onSpeakingChange = useCallback((speaking: boolean) => {
+    if (speaking) setIsAiSpeaking(true)
+    else if (mountedRef.current) setIsAiSpeaking(false)
   }, [])
 
   const onUtteranceEnd = useCallback(() => {
     setPlayerSpeaking(false)
     const aiHoldsFloor =
-      playingCountRef.current > 0 ||
+      playback.isPlaying() ||
       awaitingResponseRef.current ||
       (turnStreamingRef.current && !suppressTurnRef.current)
     if (aiHoldsFloor) return
@@ -290,12 +173,12 @@ export function useLobbyVoiceSession(): UseLobbyVoiceSessionResult {
         /* non-fatal */
       }
     }
-  }, [setAwaiting])
+  }, [setAwaiting, playback])
 
   const onSpeechStart = useCallback(() => {
-    const bargeIn = playingCountRef.current > 0
+    const bargeIn = playback.isPlaying()
     if (bargeIn) {
-      interruptPlayback()
+      playback.interrupt(onSpeakingChange)
       if (turnStreamingRef.current) suppressTurnRef.current = true
       safeDispatch({ type: 'barge-in' })
     }
@@ -312,67 +195,25 @@ export function useLobbyVoiceSession(): UseLobbyVoiceSessionResult {
         /* non-fatal */
       }
     }
-  }, [interruptPlayback, safeDispatch])
+  }, [playback, safeDispatch, onSpeakingChange])
 
+  /**
+   * Open the mic. Consumes a pre-granted stream handed to `open()` (from the
+   * auto-voice permission probe) so the browser is not prompted a second time;
+   * with none pending, the capture controller acquires its own.
+   */
   const startCapture = useCallback(() => {
-    if (capturingRef.current) return
-    capturingRef.current = true
-    void (async () => {
-      let stream: MediaStream
-      const preGranted = pendingStreamRef.current
-      pendingStreamRef.current = null
-      if (preGranted) {
-        stream = preGranted
-      } else {
-        try {
-          stream = await navigator.mediaDevices.getUserMedia({
-            audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
-          })
-        } catch {
-          capturingRef.current = false
-          safeDispatch({ type: 'mic-error', message: 'microphone permission denied' })
-          return
-        }
-      }
-      if (!mountedRef.current || !wsRef.current) {
-        stream.getTracks().forEach((t) => t.stop())
-        capturingRef.current = false
-        return
-      }
-      mediaStreamRef.current = stream
-      try {
-        const ctx = new AudioContext({ sampleRate: CAPTURE_SAMPLE_RATE })
-        captureCtxRef.current = ctx
-        const actualRate = ctx.sampleRate
-        frameMsRef.current = (CAPTURE_BUFFER_SIZE / actualRate) * 1000
-        vadStateRef.current = initialVadState
-        const source = ctx.createMediaStreamSource(stream)
-        captureSourceRef.current = source
-        const proc = ctx.createScriptProcessor(CAPTURE_BUFFER_SIZE, 1, 1)
-        captureProcRef.current = proc
-        proc.onaudioprocess = (e) => {
-          const frame = e.inputBuffer.getChannelData(0)
-          const rms = computeRms(frame)
-          const stepped = vadStep(vadStateRef.current, rms, frameMsRef.current, DEFAULT_VAD_CONFIG)
-          vadStateRef.current = stepped.state
-          if (stepped.event === 'speech-start') onSpeechStart()
-          else if (stepped.event === 'utterance-end') onUtteranceEnd()
-          const socket = wsRef.current
-          if (!socket || socket.readyState !== WebSocket.OPEN) return
-          const pcm =
-            actualRate === CAPTURE_SAMPLE_RATE
-              ? frame
-              : resamplePcmFloat32(frame, actualRate, CAPTURE_SAMPLE_RATE)
-          socket.send(floatTo16BitPCM(pcm))
-        }
-        source.connect(proc)
-        proc.connect(ctx.destination)
-      } catch {
-        stopCapture()
-        safeDispatch({ type: 'mic-error', message: 'microphone capture failed' })
-      }
-    })()
-  }, [onSpeechStart, onUtteranceEnd, safeDispatch, stopCapture])
+    const preGranted = pendingStreamRef.current
+    pendingStreamRef.current = null
+    capture.start({
+      preGranted: preGranted ?? undefined,
+      onSpeechStart,
+      onUtteranceEnd,
+      onError: (message) => safeDispatch({ type: 'mic-error', message }),
+      isMounted: () => mountedRef.current,
+      getSocket: () => wsRef.current,
+    })
+  }, [capture, onSpeechStart, onUtteranceEnd, safeDispatch])
 
   // --- Guard timers ---
   const clearGuardTimers = useCallback(() => {
@@ -413,8 +254,8 @@ export function useLobbyVoiceSession(): UseLobbyVoiceSessionResult {
         clearTimeout(awaitingTimeoutRef.current)
         awaitingTimeoutRef.current = null
       }
-      stopCapture()
-      teardownPlayback()
+      capture.stop()
+      playback.teardown(onSpeakingChange)
       const hadSocket = wsRef.current !== null
       closeSocketOnly(true)
       awaitingResponseRef.current = false
@@ -424,7 +265,7 @@ export function useLobbyVoiceSession(): UseLobbyVoiceSessionResult {
       }
       if (hadSocket) safeDispatch({ type: 'closed' })
     },
-    [clearGuardTimers, stopCapture, teardownPlayback, closeSocketOnly, safeDispatch]
+    [clearGuardTimers, capture, playback, onSpeakingChange, closeSocketOnly, safeDispatch]
   )
 
   const open = useCallback(
@@ -492,7 +333,7 @@ export function useLobbyVoiceSession(): UseLobbyVoiceSessionResult {
           turnStreamingRef.current = !frame.done
           if (awaitingResponseRef.current) setAwaiting(false)
           if (frame.kind === 'audio' && frame.audio) {
-            playAudioFrame(base64ToBytes(frame.audio))
+            playback.play(base64ToBytes(frame.audio), onSpeakingChange)
           }
           safeDispatch({ type: 'frame', frame })
           return
@@ -520,7 +361,7 @@ export function useLobbyVoiceSession(): UseLobbyVoiceSessionResult {
         close('max-duration')
       }, LOBBY_MAX_DURATION_MS)
     },
-    [safeDispatch, setAwaiting, startCapture, playAudioFrame, close]
+    [safeDispatch, setAwaiting, startCapture, playback, onSpeakingChange, close]
   )
 
   const conversationPhase = useMemo(
@@ -582,11 +423,11 @@ export function useLobbyVoiceSession(): UseLobbyVoiceSessionResult {
         clearTimeout(awaitingTimeoutRef.current)
         awaitingTimeoutRef.current = null
       }
-      stopCapture()
-      teardownPlayback()
+      capture.stop()
+      playback.teardown(onSpeakingChange)
       closeSocketOnly(true)
     }
-  }, [clearGuardTimers, stopCapture, teardownPlayback, closeSocketOnly])
+  }, [clearGuardTimers, capture, playback, onSpeakingChange, closeSocketOnly])
 
   return {
     status: state.status,

--- a/shared/voice/audio-capture.ts
+++ b/shared/voice/audio-capture.ts
@@ -1,0 +1,180 @@
+/**
+ * `createPcmCapture` — the game-agnostic mic-capture + VAD shell for a voice
+ * session.
+ *
+ * Both voice hooks open the mic ONCE per session and stream continuous PCM16
+ * 16 kHz frames: a `ScriptProcessorNode` analyses each frame with the shared VAD
+ * (driving utterance-start / utterance-end callbacks), then resamples the frame
+ * to the fixed wire rate and sends it as a binary WebSocket frame. `getUserMedia`
+ * requests echo cancellation + noise suppression so the open mic does not pick up
+ * the AI's own voice.
+ *
+ * The controller owns exactly the imperative capture state that used to be
+ * duplicated in each hook (the media stream, the capture context + nodes, the
+ * capturing guard, and the running VAD state). It is a PURE state machine with no
+ * React coupling: the turn-floor arbitration (which READS the VAD events and
+ * decides whether to hand the floor to the server) and the socket lifecycle stay
+ * in each hook, and every callback is supplied to `start` at CALL time (an
+ * event-handler context), never at construction, so a hook never reads a ref
+ * during render:
+ *  - `onSpeechStart` / `onUtteranceEnd` — the VAD events, handled by the hook.
+ *  - `onError` — the hook's bounded mic-error surface.
+ *  - `isMounted` / `getSocket` — checked after the async mic acquire and per
+ *    frame, so a panel unmount / socket close mid-acquire aborts cleanly and PCM
+ *    is only sent over an OPEN socket.
+ *
+ * `start`'s optional `preGranted` REUSES an already-granted `MediaStream` (the
+ * lobby's permission probe) so the browser is not prompted a second time; with no
+ * stream it acquires its own (the in-game path).
+ */
+import { floatTo16BitPCM, resamplePcmFloat32 } from './audio-pcm'
+import {
+  computeRms,
+  DEFAULT_VAD_CONFIG,
+  initialVadState,
+  vadStep,
+  type VadState,
+} from './voice-vad'
+import { closeAudioContext } from './audio-context'
+
+export interface PcmCaptureStartOptions {
+  /**
+   * Optionally REUSE an already-granted `MediaStream` (the lobby's permission
+   * probe) so the browser is not prompted a second time.
+   */
+  preGranted?: MediaStream
+  /** VAD `speech-start`: the player began an utterance (incl. barge-in). */
+  onSpeechStart: () => void
+  /** VAD `utterance-end`: the player went silent after speaking. */
+  onUtteranceEnd: () => void
+  /** Bounded mic error surface (permission denied / capture failed). */
+  onError: (message: string) => void
+  /** Whether the owner is still mounted — checked after the async mic acquire. */
+  isMounted: () => boolean
+  /**
+   * The live socket to stream PCM over. Read after acquire (capture aborts if it
+   * is gone) and per frame (PCM is sent only over an OPEN socket).
+   */
+  getSocket: () => WebSocket | null
+}
+
+export interface PcmCapture {
+  /**
+   * Acquire the mic (or reuse `preGranted`), wire the VAD + PCM streaming, and
+   * begin. A no-op while already capturing.
+   */
+  start(startOptions: PcmCaptureStartOptions): void
+  /** Stop capture, tear down the nodes + context, and release the mic. */
+  stop(): void
+}
+
+export function createPcmCapture(captureSampleRate: number, bufferSize: number): PcmCapture {
+  let mediaStream: MediaStream | null = null
+  let captureCtx: AudioContext | null = null
+  let sourceNode: MediaStreamAudioSourceNode | null = null
+  let proc: ScriptProcessorNode | null = null
+  /** True once the mic is acquired and streaming; guards a double mic-open. */
+  let capturing = false
+  /** Running VAD state, folded one capture frame at a time. */
+  let vadState: VadState = initialVadState
+  /** Analyzed-frame wall-clock duration (`bufferSize / actualRate`), ms. */
+  let frameMs = (bufferSize / captureSampleRate) * 1000
+
+  function stop(): void {
+    capturing = false
+    vadState = initialVadState
+    if (proc) {
+      proc.onaudioprocess = null
+      try {
+        proc.disconnect()
+      } catch {
+        /* ignore */
+      }
+      proc = null
+    }
+    if (sourceNode) {
+      try {
+        sourceNode.disconnect()
+      } catch {
+        /* ignore */
+      }
+      sourceNode = null
+    }
+    const ctx = captureCtx
+    captureCtx = null
+    closeAudioContext(ctx)
+    if (mediaStream) {
+      mediaStream.getTracks().forEach((t) => t.stop())
+      mediaStream = null
+    }
+  }
+
+  function start(startOptions: PcmCaptureStartOptions): void {
+    if (capturing) return
+    capturing = true
+    const { preGranted, onSpeechStart, onUtteranceEnd, onError, isMounted, getSocket } =
+      startOptions
+    void (async () => {
+      let stream: MediaStream
+      if (preGranted) {
+        stream = preGranted
+      } else {
+        try {
+          stream = await navigator.mediaDevices.getUserMedia({
+            audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+          })
+        } catch {
+          capturing = false
+          onError('microphone permission denied')
+          return
+        }
+      }
+      // The panel may have unmounted / the socket closed during the async acquire.
+      if (!isMounted() || !getSocket()) {
+        stream.getTracks().forEach((t) => t.stop())
+        capturing = false
+        return
+      }
+      mediaStream = stream
+      try {
+        const ctx = new AudioContext({ sampleRate: captureSampleRate })
+        captureCtx = ctx
+        // Browsers may ignore the requested rate and run the context at the
+        // hardware rate (e.g. 48000). The wire format is fixed — resample each
+        // frame to the true target rate before encoding.
+        const actualRate = ctx.sampleRate
+        frameMs = (bufferSize / actualRate) * 1000
+        vadState = initialVadState
+        const src = ctx.createMediaStreamSource(stream)
+        sourceNode = src
+        const processor = ctx.createScriptProcessor(bufferSize, 1, 1)
+        proc = processor
+        processor.onaudioprocess = (e) => {
+          const frame = e.inputBuffer.getChannelData(0)
+          // 1) VAD on the raw frame (energy is rate-independent), driving the
+          //    conversation phase + barge-in.
+          const rms = computeRms(frame)
+          const stepped = vadStep(vadState, rms, frameMs, DEFAULT_VAD_CONFIG)
+          vadState = stepped.state
+          if (stepped.event === 'speech-start') onSpeechStart()
+          else if (stepped.event === 'utterance-end') onUtteranceEnd()
+          // 2) Stream the frame continuously as PCM16 at the wire rate.
+          const socket = getSocket()
+          if (!socket || socket.readyState !== WebSocket.OPEN) return
+          const pcm =
+            actualRate === captureSampleRate
+              ? frame
+              : resamplePcmFloat32(frame, actualRate, captureSampleRate)
+          socket.send(floatTo16BitPCM(pcm))
+        }
+        src.connect(processor)
+        processor.connect(ctx.destination)
+      } catch {
+        stop()
+        onError('microphone capture failed')
+      }
+    })()
+  }
+
+  return { start, stop }
+}

--- a/shared/voice/audio-context.ts
+++ b/shared/voice/audio-context.ts
@@ -1,0 +1,20 @@
+/**
+ * `closeAudioContext` — release an `AudioContext`'s hardware resources, swallowing
+ * the (possible) close() rejection. Browsers cap the number of concurrent
+ * `AudioContext`s, so a leaked context across turns / panel remounts eventually
+ * starves the next `new AudioContext(...)` — which is the failure this guards
+ * against. Shared by the game-agnostic voice capture + playback controllers.
+ */
+export function closeAudioContext(ctx: AudioContext | null): void {
+  if (!ctx) return
+  try {
+    const closing = ctx.close()
+    if (closing && typeof closing.then === 'function') {
+      closing.catch(() => {
+        /* ignore — context may already be closed */
+      })
+    }
+  } catch {
+    /* ignore — context may already be closed */
+  }
+}

--- a/shared/voice/audio-playback.ts
+++ b/shared/voice/audio-playback.ts
@@ -1,0 +1,136 @@
+/**
+ * `createPcmPlayback` — the game-agnostic TTS playback shell for a voice session.
+ *
+ * Both voice hooks (the in-game `useVoiceSession` and the lobby
+ * `useLobbyVoiceSession`) stream base64 PCM16 audio frames from the server and
+ * schedule them GAPLESSLY through one shared `AudioContext`: each frame is
+ * decoded (`pcm16ToFloat32`), wrapped in an `AudioBuffer` at the wire sample
+ * rate, and started at the running cursor so consecutive frames butt up against
+ * each other with no gap. The context runs at its native rate and resamples the
+ * fixed-rate buffers.
+ *
+ * The controller owns exactly the imperative Web Audio state that used to be
+ * duplicated in each hook (the playback context, the schedule cursor, the live
+ * scheduled sources, and the playing count that drives the "AI is speaking"
+ * signal). It is a PURE state machine with no React coupling: the lifecycle
+ * callbacks are supplied at CALL time (all in event-handler contexts), never at
+ * construction, so a hook never reads a ref during render.
+ *  - `onSpeakingChange(true)` fires the instant a frame is scheduled and
+ *    `onSpeakingChange(false)` when the last scheduled frame drains or playback
+ *    is interrupted — the caller applies its own mounted-guard on the `false`
+ *    edge, exactly as before.
+ *  - `onDrained` (optional, `play` only) fires after a frame ends and the queue
+ *    is fully drained; the in-game hook uses it to resolve the closing-recap
+ *    promise once the recap audio has finished, the lobby hook omits it.
+ */
+import { pcm16ToFloat32 } from './audio-pcm'
+import { closeAudioContext } from './audio-context'
+
+/**
+ * Called when playback transitions between speaking / silent: `true` the moment a
+ * frame is scheduled, `false` when the last scheduled frame drains or playback is
+ * interrupted. Mirrors the previous inline `setIsAiSpeaking` calls; the caller
+ * applies its own mounted-guard on the `false` edge.
+ */
+export type OnSpeakingChange = (speaking: boolean) => void
+
+export interface PcmPlayback {
+  /**
+   * Schedule one PCM16 frame for gapless playback. `onDrained` fires once the
+   * queue fully drains after this (or a later) frame ends.
+   */
+  play(bytes: Uint8Array, onSpeakingChange: OnSpeakingChange, onDrained?: () => void): void
+  /** Stop all scheduled playback immediately but KEEP the context alive. */
+  interrupt(onSpeakingChange: OnSpeakingChange): void
+  /** Stop playback AND release the context — full teardown (unmount / end). */
+  teardown(onSpeakingChange: OnSpeakingChange): void
+  /** True while any scheduled buffer has not yet ended. */
+  isPlaying(): boolean
+}
+
+export function createPcmPlayback(outputSampleRate: number): PcmPlayback {
+  let ctx: AudioContext | null = null
+  /** Next scheduled playback start time, for gapless PCM frame queueing. */
+  let cursor = 0
+  /** Count of scheduled-but-not-ended buffers, driving the speaking signal. */
+  let playingCount = 0
+  /** Live scheduled sources, so barge-in can stop them without closing the context. */
+  const activeSources = new Set<AudioBufferSourceNode>()
+
+  function ensureCtx(): AudioContext | null {
+    if (ctx) return ctx
+    try {
+      const created = new AudioContext()
+      void created.resume?.()
+      ctx = created
+      cursor = created.currentTime
+      return created
+    } catch {
+      return null
+    }
+  }
+
+  function play(
+    bytes: Uint8Array,
+    onSpeakingChange: OnSpeakingChange,
+    onDrained?: () => void
+  ): void {
+    const floats = pcm16ToFloat32(bytes)
+    if (floats.length === 0) return
+    const audioCtx = ensureCtx()
+    if (!audioCtx) return
+    try {
+      const buffer = audioCtx.createBuffer(1, floats.length, outputSampleRate)
+      buffer.getChannelData(0).set(floats)
+      const source = audioCtx.createBufferSource()
+      source.buffer = buffer
+      source.connect(audioCtx.destination)
+      const startAt = Math.max(audioCtx.currentTime, cursor)
+      source.start(startAt)
+      cursor = startAt + buffer.duration
+      playingCount += 1
+      activeSources.add(source)
+      onSpeakingChange(true)
+      source.onended = () => {
+        activeSources.delete(source)
+        playingCount = Math.max(0, playingCount - 1)
+        if (playingCount === 0) {
+          onSpeakingChange(false)
+          onDrained?.()
+        }
+      }
+    } catch {
+      // A playback failure must never break the turn — text still renders.
+    }
+  }
+
+  function interrupt(onSpeakingChange: OnSpeakingChange): void {
+    for (const source of activeSources) {
+      try {
+        source.onended = null
+        source.stop?.()
+        source.disconnect?.()
+      } catch {
+        /* ignore — source may already have ended */
+      }
+    }
+    activeSources.clear()
+    playingCount = 0
+    cursor = ctx?.currentTime ?? 0
+    onSpeakingChange(false)
+  }
+
+  function teardown(onSpeakingChange: OnSpeakingChange): void {
+    interrupt(onSpeakingChange)
+    const closing = ctx
+    ctx = null
+    cursor = 0
+    closeAudioContext(closing)
+  }
+
+  function isPlaying(): boolean {
+    return playingCount > 0
+  }
+
+  return { play, interrupt, teardown, isPlaying }
+}


### PR DESCRIPTION
## Summary
- The two voice hooks (in-game + lobby) duplicated ~200 lines of imperative audio/VAD/playback shell — extracted into three pure-state-machine modules under shared/voice; both hooks now drive ONE implementation
- Zero behavior change: every suite passes unmodified, including #221's end-signal exactly-once regressions and #222's streak integration tests (the semantic anchors for the endSession-hunk reconciliation)

Refactor debt flagged by the slice-2 verifier; 3-axis verified.

## Test plan
- [x] game-bombsquad 475 / platform 189 / platform-ai 347 — all unmodified; 10-project typecheck; full lint
- [ ] CI full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w79dZWZzh7A7W6A7deN31