### PR TITLE
fix(platform): sitewide copy honesty and polish batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Every visible promise now matches what the product actually does** - Fix. A
+sweep of the wording across the product to match today's reality. The BombSquad
+entry no longer reads「自带语音 AI · 支持 …」(which scanned as a built-in AI);
+it now says「自带任意语音 AI · 例如 …」, framing the tools as examples you can
+bring, with the real per-tool tested status on the compatibility page. The login
+page states what an account gives you today — a personal AI companion, a
+community feed of real player activity, and cross-device progress — instead of
+promising a「社交主场」the community is not yet. The homepage drops the「一周一新 /
+每周上新一款」weekly-cadence claim it does not keep.
+
+**The Oracle's image-picker no longer clips its third column** - Fix. On the
+起意 mind-image step the third column of tiles was cut off at the right screen
+edge and could not be scrolled into view. The tiles now shrink to fit, so all
+six are fully visible on narrow phones.
+
+**Completion times show in your own timezone** - Fix. The daily checklist showed
+a completion time labelled「… UTC」; it now shows your local wall-clock time, no
+UTC label.
+
+**The login page's escape link is no longer hidden behind the tab bar** - Fix.
+On phones the bottom of the login page (including the「直接开始玩」escape) could
+sit under the fixed tab bar with no room to scroll it clear. The page now
+reserves space for the bar. The heading also greets a neutral「欢迎你」instead of
+assuming「欢迎回来」for a first-time visitor.
+
+**You are greeted by your name, not your email** - Fix. The signed-in homepage
+and 我的 page greeted you by your raw email local-part (e.g. a long
+plus-addressed alias). They now greet you by your chosen leaderboard nickname if
+you have one, otherwise by the name your companion knows you as, and otherwise
+with a plain, name-free「你好」— the email is never used as a name.
+
+**The companion setup title updates once your companion exists** - Fix. After
+you created your companion, the page header still said「给它取个名字」above the
+just-created companion. It now switches to a present-tense line.
+
+**Anonymous play no longer logs a 401 after every run** - Fix. Each settlement
+tried to sync to an account even when you were not signed in, printing a red 401
+in the console every time. The server now accepts the anonymous sync as a no-op,
+so there is no error noise.
+
+**The first-screen game-count bubble no longer overlaps the tab bar** - Fix. On
+phones a floating stat bubble on the homepage hero drifted down behind the
+translucent bottom tab bar. The hero's floating pills now sit clear of it.
+
+**The button module tells you it can be held, not only tapped** - New. The
+button puzzle now shows a short player-side hint that a tap and a hold are both
+possible and how the hold's colour strip works — without revealing which one
+this button needs (that stays your AI's to read).
+
+**The practice win celebration is no longer cut short by the survey** - Fix. On
+a first practice win the feedback survey popped up a beat after the win screen,
+over the celebration. It now waits out the full celebration before appearing,
+matching how the daily survey already waits for the rank reveal.
+
 **The community page shows real player activity, not fabricated posts** - New.
 The community page used to show a fixed set of invented posts whose timestamps
 never moved. It is now a real feed, built from actual play: a player defusing

--- a/e2e/steps/auth.steps.ts
+++ b/e2e/steps/auth.steps.ts
@@ -20,7 +20,9 @@ Then('I see the honest framing and the direct-play escape', async ({ page }) => 
   // The page states the value of an account (the end-state product value) and
   // that playing with your own AI needs no account.
   await expect(page.getByText(/玩游戏不需要登录/)).toBeVisible()
-  await expect(page.getByText(/登录后，你将拥有专属于你的 AI 伙伴/)).toBeVisible()
+  // States the account's CURRENT value (companion + community + cross-device),
+  // not the old aspirational「你将拥有…社交主场」 (B6 copy-honesty sweep).
+  await expect(page.getByText(/登录后，你会有专属于你的 AI 伙伴/)).toBeVisible()
   // The direct-play escape into free anonymous play. It navigates via
   // window.location.assign('/bombsquad/'); presence + label is asserted here,
   // the navigation target is covered by the LoginPage unit test (no click, so

--- a/packages/api/src/handlers/arcade-profile.test.ts
+++ b/packages/api/src/handlers/arcade-profile.test.ts
@@ -118,6 +118,18 @@ describe('arcade profile handlers', () => {
     })
   })
 
+  it('answers 204 (not 401) for an anonymous settlement event so it makes no console noise (F27)', async () => {
+    // A fire-and-forget settlement sync with no session: the server accepts it
+    // as a no-op (nothing to attach to an account) rather than 401, so an
+    // anonymous run does not spray red 401s into the console.
+    const response = await handlePostArcadeProfileEvent(
+      request(CLAIM_BODY.events[0], ''),
+      await env()
+    )
+
+    expect(response.status).toBe(204)
+  })
+
   it('does not let event writes create public streak-board eligibility', async () => {
     const testEnv = await env()
 

--- a/packages/api/src/handlers/arcade-profile.ts
+++ b/packages/api/src/handlers/arcade-profile.ts
@@ -46,7 +46,15 @@ export async function handlePostArcadeProfileEvent(
   env: ArcadeProfileApiEnv
 ): Promise<Response> {
   const auth = await requireSession(env.AUTH, request)
-  if (!auth.ok) return auth.response
+  // Settlement events are a best-effort, fire-and-forget account sync fired
+  // after EVERY run/sign, including anonymous ones — but an anonymous session
+  // has no account to attach them to (they live in the device-local profile and
+  // sync on the login claim instead). Answer 204 (accepted, nothing to persist
+  // or return) rather than 401 so an anonymous player does not spray a red 401
+  // into the console after every settlement (audit F27). The client reads 204 as
+  //「not synced (anonymous)」and keeps its local record. GET profile / POST claim
+  // keep 401 — those are genuine authenticated reads/writes.
+  if (!auth.ok) return new Response(null, { status: 204 })
 
   const body = await parseJsonBody(request)
   const event = parseArcadeProfileEvent(body)

--- a/packages/arcade-profile/src/api-client.ts
+++ b/packages/arcade-profile/src/api-client.ts
@@ -66,7 +66,11 @@ export async function submitArcadeProfileEvent(
       credentials: 'include',
       body: JSON.stringify(event),
     })
-    if (res.status === 401) return { kind: 'anon' }
+    // 204 = anonymous best-effort sync (the server accepted the fire-and-forget
+    // event but has no account to attach it to — audit F27); 401 kept for
+    // defensiveness. Both resolve to `anon` so the caller keeps its local record
+    // without treating it as an error.
+    if (res.status === 204 || res.status === 401) return { kind: 'anon' }
     if (res.status === 422 || res.status === 400) return { kind: 'invalid' }
     if (!res.ok) return { kind: 'error' }
     const data = (await res.json()) as ArcadeProfileResponse

--- a/packages/game-bombsquad/src/modules/button/ButtonModule.module.css
+++ b/packages/game-bombsquad/src/modules/button/ButtonModule.module.css
@@ -4,9 +4,22 @@
 
 .wrapper {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
   width: 100%;
   animation: fade-in 300ms ease-out;
+}
+
+/* Player-side interaction hint above the button (audit F10), matching the dial
+   module's `.hint` treatment. */
+.hint {
+  margin: 0;
+  max-width: 320px;
+  text-align: center;
+  font: 400 13px var(--font-body);
+  line-height: 1.4;
+  color: var(--soft);
 }
 
 .wrapper.error {

--- a/packages/game-bombsquad/src/modules/button/ButtonModule.tsx
+++ b/packages/game-bombsquad/src/modules/button/ButtonModule.tsx
@@ -138,6 +138,12 @@ export default function ButtonModule({
       className={`${styles.wrapper} ${buttonState === 'error' ? styles.error : ''} ${buttonState === 'success' ? styles.success : ''}`}
       data-testid="button-module"
     >
+      {/* Player-side interaction hint (audit F10), mirroring the dial module's
+          hint pattern. It teaches that a tap AND a hold are both possible and
+          how the hold's release strip works — WITHOUT revealing which one this
+          button needs (that stays the AI's manual to read), so it never leaks
+          the answer the release-strip cue is deliberately target-agnostic about. */}
+      <p className={styles.hint}>轻按或按住都听 AI 的指示；按住时，松手要对上光带当前的颜色。</p>
       <div className={styles.stage}>
         <div className={styles.lightPanel}>
           <div

--- a/packages/game-bombsquad/src/pages/BombSquadLandingPage.test.tsx
+++ b/packages/game-bombsquad/src/pages/BombSquadLandingPage.test.tsx
@@ -63,8 +63,11 @@ describe('BombSquadLandingPage', () => {
     expect(screen.getByText(/人机协作 · 语音拆弹挑战/)).toBeInTheDocument()
     // Bring-your-own-AI premise eyebrow (not a status claim). The AI-tools
     // list now emphasizes each tool name in its own span, so the prefix is its
-    // own text node.
-    expect(screen.getByText(/自带语音 AI · 支持/)).toBeInTheDocument()
+    // own text node. 「自带任意 …· 例如」 frames the tools as EXAMPLES you can
+    // bring (BYO), not a roster of supported/verified providers — the audit-F2
+    // honesty fix that also kills the「支持 N 家 → 内置 AI」misread.
+    expect(screen.getByText(/自带任意语音 AI · 例如/)).toBeInTheDocument()
+    expect(screen.queryByText(/自带语音 AI · 支持/)).not.toBeInTheDocument()
     // Daily-countdown card — its label plus the mocked countdown digits.
     // The countdown splits the `:` separators into <span> elements, so the
     // digits are loose text nodes — match on the element's full textContent.

--- a/packages/game-bombsquad/src/pages/BombSquadLandingPage.tsx
+++ b/packages/game-bombsquad/src/pages/BombSquadLandingPage.tsx
@@ -34,11 +34,14 @@ export default function BombSquadLandingPage() {
           {/* Top strip — bring-your-own-AI premise label + exit-to-platform
               control. This is not a status: the player supplies their own
               voice AI, so the label invites rather than asserting any AI is
-              connected. Brand-yellow (not green) keeps it a label, not a
-              "ready/online" signal. */}
+              connected. 「自带任意 …· 例如」 frames the list as EXAMPLES of
+              tools you can bring, not a roster of supported/verified providers
+              (only Claude is acceptance-verified — see /bombsquad/compatibility);
+              「支持 N 家」 would misread as built-in AI. Brand-yellow (not green)
+              keeps it a label, not a "ready/online" signal. */}
           <div className={styles.top}>
             <Eyebrow dot color="var(--y)" className={styles.aiEyebrow}>
-              <AiToolList prefix="自带语音 AI · 支持" />
+              <AiToolList prefix="自带任意语音 AI · 例如" />
             </Eyebrow>
             <button
               type="button"
@@ -129,7 +132,7 @@ export default function BombSquadLandingPage() {
               </svg>
             </a>
 
-            <AiToolList prefix="支持" className={styles.chips} />
+            <AiToolList prefix="例如" className={styles.chips} />
           </div>
         </div>
       </div>

--- a/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
@@ -76,6 +76,10 @@ import { submitScore } from '@shared/leaderboard-api'
 
 const PERSISTENCE_KEY = 'bombsquad:game-state:v4'
 const RESULT_FEEDBACK_SURVEY_DELAY_MS = 1800
+// A practice win now waits a longer celebration window before the survey opens
+// (audit F11). advancePastResultFeedback advances by this max, which also covers
+// the shorter daily/failure delay.
+const RESULT_PRACTICE_CELEBRATION_MS = 4200
 
 interface FixtureOptions {
   mode: GameState['mode']
@@ -138,7 +142,10 @@ function answerRequiredSurvey({
 
 function advancePastResultFeedback() {
   act(() => {
-    vi.advanceTimersByTime(RESULT_FEEDBACK_SURVEY_DELAY_MS)
+    // Advance by the longest survey delay (the practice celebration window) so
+    // this helper covers both the practice-win and the shorter daily/failure
+    // timings.
+    vi.advanceTimersByTime(RESULT_PRACTICE_CELEBRATION_MS)
   })
 }
 
@@ -171,6 +178,25 @@ describe('ResultPage endgame survey', () => {
     expect(screen.getByText('你这局用的是哪个 AI 工具？')).toBeInTheDocument()
     // Survey-only modal — no nickname gate for a practice run.
     expect(screen.queryByLabelText(/昵称/)).not.toBeInTheDocument()
+  })
+
+  it('practice win: the survey waits out the celebration window, not the base delay (F11)', () => {
+    surveyMock.hasAnsweredSurvey.mockReturnValue(false)
+    renderResult(finishedState({ mode: 'practice', outcome: 'practice-cleared' }))
+
+    expect(screen.getByText('拆弹成功')).toBeInTheDocument()
+    // Past the base (daily/failure) delay the practice survey is STILL closed —
+    // the win payoff is not interrupted a beat after mount.
+    act(() => {
+      vi.advanceTimersByTime(RESULT_FEEDBACK_SURVEY_DELAY_MS)
+    })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    // It opens only once the full celebration window has elapsed.
+    act(() => {
+      vi.advanceTimersByTime(RESULT_PRACTICE_CELEBRATION_MS - RESULT_FEEDBACK_SURVEY_DELAY_MS)
+    })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 
   it('opens the survey modal even on a failed run', () => {

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -62,6 +62,12 @@ const MODULE_GLYPH: Record<string, GlyphKey> = {
 }
 
 const RESULT_FEEDBACK_SURVEY_DELAY_MS = 1800
+// A practice win has no rank reveal to settle behind (#209 defers the daily
+// survey until the rank card lands). Its celebration beat is the win payoff
+// itself — the success ring + glyph pop + time + companion reaction — so the
+// survey waits a longer, celebration-length window before opening, instead of
+// snapping up over the payoff a beat after mount (audit F11).
+const RESULT_PRACTICE_CELEBRATION_MS = 4200
 
 /** The result screen has two visual variants (handoff README §6.6 / §6.7). */
 type ResultVariant = 'success' | 'failure'
@@ -309,11 +315,19 @@ export default function ResultPage() {
   // on mount. A first win whose leaderboard gate stays unfilled never settles
   // this session — the once-per-device survey simply waits for a later one.
   const celebrationSettled = !hasFinishedDailyRun || rankResult !== null || submitFailed
+  // A practice WIN settles on mount (no rank), so it uses the longer celebration
+  // window to let the win payoff land first (audit F11); a daily win already
+  // waited for its rank reveal, and any failure has no celebration to protect —
+  // both keep the base delay.
+  const surveyDelayMs =
+    variant === 'success' && !hasFinishedDailyRun
+      ? RESULT_PRACTICE_CELEBRATION_MS
+      : RESULT_FEEDBACK_SURVEY_DELAY_MS
   useEffect(() => {
     if (!needSurvey || noRunData || !celebrationSettled) return
-    const id = setTimeout(() => setSurveyReady(true), RESULT_FEEDBACK_SURVEY_DELAY_MS)
+    const id = setTimeout(() => setSurveyReady(true), surveyDelayMs)
     return () => clearTimeout(id)
-  }, [needSurvey, noRunData, celebrationSettled])
+  }, [needSurvey, noRunData, celebrationSettled, surveyDelayMs])
 
   const buildSubmission = useCallback(
     (nicknameValue: string, metadataValue: LeaderboardPlayerMetadata): ScoreSubmission | null => {

--- a/packages/game-yijing/src/glyphs/ProjArt.tsx
+++ b/packages/game-yijing/src/glyphs/ProjArt.tsx
@@ -172,8 +172,11 @@ interface ProjArtProps {
   selected?: boolean
   /** Rank within the player's selection (1 or 2). Renders the corner badge. */
   selectionOrder?: 1 | 2
-  /* Default 120 mirrors handoff prototype tile size; the projection grid
-     overrides this with `aspect-ratio: 1 + width: 100%` via the tile CSS. */
+  /* Optional explicit pixel size. Omit it (the projection grid does) to let the
+     tile fill its grid track via the tile CSS (`aspect-ratio: 1 + width: 100%`).
+     An unconditional inline width would DEFEAT that CSS — inline styles win — and
+     force the 3-column grid to 3×120px, overflowing narrow viewports so the
+     third column is clipped by the page's `overflow-x: hidden` (audit F5). */
   size?: number
   onClick?: () => void
   className?: string
@@ -184,12 +187,15 @@ export function ProjArt({
   id,
   selected = false,
   selectionOrder,
-  size = 120,
+  size,
   onClick,
   className,
   style,
 }: ProjArtProps) {
-  const tileStyle: CSSProperties = { width: size, height: size, ...style }
+  // Pin an explicit box ONLY when a `size` is passed; otherwise defer to the
+  // tile CSS so the tile is fluid inside its grid track (audit F5).
+  const tileStyle: CSSProperties | undefined =
+    size !== undefined ? { width: size, height: size, ...style } : style
   const classes = [styles.tile, selected && styles.on, className].filter(Boolean).join(' ')
   return (
     <button type="button" className={classes} style={tileStyle} onClick={onClick}>

--- a/packages/game-yijing/src/pages/PageProjection.module.css
+++ b/packages/game-yijing/src/pages/PageProjection.module.css
@@ -115,9 +115,12 @@
 }
 
 /* ───── 3×2 grid ───── */
+/* `minmax(0, 1fr)` lets each track shrink below the tile's intrinsic min-content
+   width, so three fluid tiles always fit the viewport instead of overflowing and
+   clipping the third column (audit F5). */
 .grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
 }
 

--- a/packages/platform/src/components/home/AnonHero.module.css
+++ b/packages/platform/src/components/home/AnonHero.module.css
@@ -235,8 +235,12 @@
     font-size: 14px;
   }
 
+  /* Tighter stage + lifted floating pills on mobile so the lowest pill sits
+     clear of the fixed BottomNav band on the first screen — the old 360px stage
+     let 「最快拆弹 / 已上线游戏」 pills drift down behind the translucent bar
+     (audit F9). */
   .planetStage {
-    height: 360px;
+    height: 300px;
     margin-top: 20px;
   }
 
@@ -261,7 +265,7 @@
   }
 
   .s2 {
-    bottom: 30px;
+    bottom: 56px;
     left: -10px;
   }
 

--- a/packages/platform/src/components/home/DailyChecklist.tsx
+++ b/packages/platform/src/components/home/DailyChecklist.tsx
@@ -1,5 +1,5 @@
 import type { ArcadeProfileSummary } from '@amiclaw/arcade-profile/types'
-import { getDailyResetHint, toChineseDateString } from '@shared/date'
+import { formatLocalClockTime, getDailyResetHint, toChineseDateString } from '@shared/date'
 import styles from './DailyChecklist.module.css'
 
 interface DailyChecklistProps {
@@ -58,7 +58,7 @@ export default function DailyChecklist({ profile, scope, loading = false }: Dail
               <span className={styles.itemTitle}>{item.title}</span>
               <span className={styles.itemDetail}>
                 {item.completed
-                  ? `已完成${item.completedAt ? ` · ${item.completedAt.slice(11, 16)} UTC` : ''}`
+                  ? `已完成${item.completedAt ? ` · ${formatLocalClockTime(item.completedAt)}` : ''}`
                   : item.detail}
               </span>
             </span>

--- a/packages/platform/src/components/home/WelcomeStrip.tsx
+++ b/packages/platform/src/components/home/WelcomeStrip.tsx
@@ -1,5 +1,6 @@
 import { Button, ConicAvatar } from '@amiclaw/ui'
 import type { DisplayUser } from '@/hooks/useAuth'
+import { useGreetingName } from '@/hooks/useGreetingName'
 import styles from './WelcomeStrip.module.css'
 
 interface WelcomeStripProps {
@@ -16,13 +17,23 @@ interface WelcomeStripProps {
    So the right side is an honest「还没有成绩」prompt with a play CTA, not
    fabricated figures and not a「即将推出」placeholder. */
 export default function WelcomeStrip({ user }: WelcomeStripProps) {
+  // Greet by chosen nickname > companion-known name > a neutral, name-free
+  // greeting — never the account email (audit F19). The avatar stays a decorative
+  // ariaHidden glyph.
+  const greetingName = useGreetingName()
   return (
     <section className={styles.strip}>
       <div className={styles.left}>
         <ConicAvatar size={56} letter={user.avatarLetter} ariaHidden />
         <div>
           <div className={styles.greet}>
-            你好，<span className={styles.name}>{user.displayName}</span>。
+            {greetingName ? (
+              <>
+                你好，<span className={styles.name}>{greetingName}</span>。
+              </>
+            ) : (
+              '你好。'
+            )}
           </div>
           <div className={styles.meta}>还没有成绩，去玩一局，这里会记录你的战绩。</div>
         </div>

--- a/packages/platform/src/components/home/WhatIsAmiclaw.tsx
+++ b/packages/platform/src/components/home/WhatIsAmiclaw.tsx
@@ -20,9 +20,13 @@ const VALUE_PROPS: ValueProp[] = [
     body: '一局 5 到 8 分钟，等地铁、午休、睡前都来得及。',
   },
   {
+    /* No fixed cadence promise: BombSquad is in beta and the Oracle is a
+       playable preview, with more games coming on no committed schedule.
+       The old「一周一新 / 每周上新一款」claimed a weekly cadence the operation
+       does not keep (B6 copy-honesty sweep). */
     number: '03',
-    title: '一周一新',
-    body: 'BombSquad 公测中，每周上新一款人机协作小游戏。',
+    title: '陆续上新',
+    body: 'BombSquad 公测中，易经签卜可试玩，更多人机协作小游戏在路上。',
   },
 ]
 

--- a/packages/platform/src/hooks/useAuth.ts
+++ b/packages/platform/src/hooks/useAuth.ts
@@ -43,7 +43,12 @@ export type UseAuthResult = AuthState & {
 
 function deriveDisplayUser(identity: AuthIdentity): DisplayUser {
   const localPart = identity.email.split('@')[0] ?? identity.email
-  const displayName = localPart.length > 0 ? localPart : identity.email
+  // Strip the +tag plus-addressing suffix so a plus-aliased address
+  // (e.g. `name+arcade-newuser@…`) never surfaces its raw internal alias as a
+  // display name (audit F19). Greeting surfaces additionally prefer the
+  // player's chosen nickname over this account-derived handle.
+  const handle = localPart.split('+')[0] || localPart
+  const displayName = handle.length > 0 ? handle : identity.email
   const avatarLetter = displayName.charAt(0).toUpperCase()
   return { user_id: identity.user_id, email: identity.email, displayName, avatarLetter }
 }

--- a/packages/platform/src/hooks/useGreetingName.ts
+++ b/packages/platform/src/hooks/useGreetingName.ts
@@ -1,0 +1,27 @@
+import { readChosenArcadeNickname } from '@/lib/arcade-nickname'
+import { useCompanion } from './useCompanion'
+
+/**
+ * The name to greet a signed-in player by, decided from the shipped design —
+ * never the account email (audit F19):
+ *
+ *   1. the player's chosen board nickname (leaderboard identity), if set;
+ *   2. else the companion-known user name — the companion's `address_style`
+ *      (「它怎么称呼你」, e.g. 白舟 / 队长), read from GET /api/companion;
+ *   3. else `null` → the caller renders a NEUTRAL, name-free greeting.
+ *
+ * The companion read is skipped entirely when the nickname already decides the
+ * name (the hook passes `enabled: false` to `useCompanion`). `address_style` is
+ * optional in onboarding, so an empty / missing value falls through to neutral.
+ */
+export function useGreetingName(): string | null {
+  const nickname = readChosenArcadeNickname()
+  const { state } = useCompanion(nickname === undefined)
+
+  if (nickname !== undefined) return nickname
+  if (state.status === 'exists') {
+    const known = (state.companion.address_style ?? '').trim()
+    if (known.length > 0) return known
+  }
+  return null
+}

--- a/packages/platform/src/lib/shared-date.test.ts
+++ b/packages/platform/src/lib/shared-date.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import {
+  formatLocalClockTime,
   getDailyResetHint,
   getLocalRolloverTime,
   getProductDaysEndingAt,
@@ -86,6 +87,24 @@ describe('getDailyResetHint', () => {
 describe('toChineseDateString', () => {
   it('renders a product-day string in the Chinese date form', () => {
     expect(toChineseDateString('2026-07-06')).toBe('2026 年 7 月 6 日')
+  })
+})
+
+describe('formatLocalClockTime — completion time in the viewer timezone (audit F7)', () => {
+  // A daily challenge completed at 14:38 UTC.
+  const completedAtUtc = '2026-07-06T14:38:00Z'
+
+  it('renders the local wall-clock time, not raw UTC', () => {
+    // 14:38 UTC == 22:38 Beijing — the Chinese user sees their own clock.
+    expect(formatLocalClockTime(completedAtUtc, 'Asia/Shanghai')).toBe('22:38')
+  })
+
+  it('renders the same clock time in UTC itself', () => {
+    expect(formatLocalClockTime(completedAtUtc, 'UTC')).toBe('14:38')
+  })
+
+  it('returns an empty string for an unparseable timestamp', () => {
+    expect(formatLocalClockTime('not-a-date')).toBe('')
   })
 })
 

--- a/packages/platform/src/pages/AccountPage.test.tsx
+++ b/packages/platform/src/pages/AccountPage.test.tsx
@@ -383,10 +383,11 @@ describe('AccountPage /me', () => {
     })
     renderAccount('/me')
 
-    // Identity is derived from the session email local-part (nova@... → nova).
-    // The name appears twice (the title accent span + the profile-card name),
-    // so assert at least one match resolves once the session read returns.
-    expect((await screen.findAllByText('nova', { exact: true })).length).toBeGreaterThan(0)
+    // No chosen nickname and no companion → a neutral, name-free greeting; the
+    // email local-part「nova」is never rendered as a name (audit F19). The full
+    // email stays as the explicit account-identity line (not a name fallback).
+    expect(await screen.findByText('你的星轨。')).toBeInTheDocument()
+    expect(screen.queryByText('nova', { exact: true })).not.toBeInTheDocument()
     expect(screen.getByText('nova@amio.fans')).toBeInTheDocument()
     // Account stats are read from /api/arcade/profile, not invented locally.
     expect(await screen.findByText('账号记录')).toBeInTheDocument()
@@ -487,6 +488,29 @@ describe('AccountPage /me', () => {
     expect(screen.getByRole('link', { name: '画像控制面' })).toHaveAttribute('href', '/me/profile')
     // The voice is represented by name, not fabricated audio playback.
     expect(screen.getByText('暖声')).toBeInTheDocument()
+  })
+
+  it('greets by the companion-known name when there is no nickname (F19)', async () => {
+    stubApi({
+      session: AUTHED,
+      companion: {
+        status: 200,
+        body: {
+          name: '小南',
+          address_style: '白舟',
+          voice_id: 'companion-warm',
+          profile_enabled: true,
+          created_at: '2026-05-30T09:12:00.000Z',
+        },
+      },
+    })
+    renderAccount('/me')
+
+    // With no chosen nickname, the greeting falls to the companion-known name
+    // 「白舟」(address_style) — appearing in the title accent span and the
+    // profile-card name — never the email local-part「nova」.
+    expect((await screen.findAllByText('白舟', { exact: true })).length).toBeGreaterThan(0)
+    expect(screen.queryByText('nova', { exact: true })).not.toBeInTheDocument()
   })
 
   it('signs out via POST /api/auth/logout and returns to the anonymous state', async () => {

--- a/packages/platform/src/pages/AccountPage.tsx
+++ b/packages/platform/src/pages/AccountPage.tsx
@@ -15,6 +15,7 @@ import {
 } from '@amiclaw/arcade-profile/local'
 import { claimArcadeProfile, fetchArcadeProfile } from '@amiclaw/arcade-profile/api-client'
 import { readChosenArcadeNickname } from '@/lib/arcade-nickname'
+import { useGreetingName } from '@/hooks/useGreetingName'
 import { formatMs } from '@shared/format-time'
 import { getDailyResetHint, toChineseDateString } from '@shared/date'
 import { useAuth, type DisplayUser } from '@/hooks/useAuth'
@@ -155,10 +156,22 @@ function SignedInProfile({
 }) {
   const { state: accountProfile, reload: reloadAccountProfile } = useAccountArcadeProfile()
 
+  // Greet by chosen nickname > companion-known name > a neutral, name-free
+  // greeting — never the account email (audit F19). The full email stays as the
+  // explicit account-identity line below (that is the account id, not a name
+  // fallback, and not a local-part fragment).
+  const greetingName = useGreetingName()
+
   return (
     <>
       <h2 className={styles.title}>
-        <span className={styles.accent}>{user.displayName}</span> 的星轨。
+        {greetingName ? (
+          <>
+            <span className={styles.accent}>{greetingName}</span> 的星轨。
+          </>
+        ) : (
+          '你的星轨。'
+        )}
       </h2>
       <p className={styles.lead}>这里显示这个账号已经保存的真实记录。</p>
 
@@ -167,7 +180,7 @@ function SignedInProfile({
           <div className={styles.avatar}>
             <ConicAvatar size={96} letter={user.avatarLetter} ariaHidden />
           </div>
-          <div className={styles.name}>{user.displayName}</div>
+          {greetingName && <div className={styles.name}>{greetingName}</div>}
           <div className={styles.rank}>{user.email}</div>
           <Button variant="ghost" size="sm" className={styles.logout} onClick={onLogout}>
             退出登录

--- a/packages/platform/src/pages/CompanionOnboardingPage.tsx
+++ b/packages/platform/src/pages/CompanionOnboardingPage.tsx
@@ -23,12 +23,21 @@ export default function CompanionOnboardingPage() {
   const access = useCompanionAccess()
   const { state, reload } = useCompanion(access === 'ready')
 
+  // Once the companion exists, the header must stop inviting a first-time setup
+  // (「给它取个名字」) — that copy contradicted the identity panel shown right
+  // below it after creation (audit F20). It switches to a present-tense line.
+  const hasCompanion = access === 'ready' && state.status === 'exists'
+
   return (
     <div className={styles.page}>
       <CompanionPageHeader
         eyebrow="伙伴 · COMPANION"
-        title="认识你的伙伴"
-        lead="给它取个名字，挑一种声音。它的性格不预设，由你们一起的回忆慢慢长成。"
+        title={hasCompanion ? '你的伙伴' : '认识你的伙伴'}
+        lead={
+          hasCompanion
+            ? '它已经在这了。你们一起玩得越多，它越懂你。'
+            : '给它取个名字，挑一种声音。它的性格不预设，由你们一起的回忆慢慢长成。'
+        }
       />
 
       {access === 'loading' ? null : access === 'gate' ? (

--- a/packages/platform/src/pages/GamesPage.test.tsx
+++ b/packages/platform/src/pages/GamesPage.test.tsx
@@ -4,8 +4,8 @@
  * Covers the `/` route — the AMIO Arcade「星图 / Atlas」homepage:
  *   1. anonymous `/` renders the AnonHero
  *   2. the anonymous hero「开始玩」CTA routes to /bombsquad
- *   3. a signed-in visitor renders the WelcomeStrip (greeting by the
- *      session-derived display name), not the hero
+ *   3. a signed-in visitor renders the WelcomeStrip (greeting by nickname /
+ *      companion-known name, neutral otherwise — never the email), not the hero
  *
  * The homepage has a single in-page play CTA — the AnonHero primary「开始玩」
  * (the other play entry is the TopNav, rendered by the app shell, not here).
@@ -115,6 +115,13 @@ function stubApi(body: SessionResponse, arcadeProfile: unknown = EMPTY_ARCADE_PR
           )
         )
       }
+      // The WelcomeStrip greeting reads the companion for a companion-known name;
+      // default to 404 (no companion) so the greeting resolves to neutral.
+      if (url.includes('/api/companion')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'no companion set up' }), { status: 404 })
+        )
+      }
       return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))
     })
   )
@@ -200,8 +207,10 @@ describe('GamesPage homepage', () => {
     stubApi(AUTHED, ACCOUNT_ARCADE_PROFILE)
     renderHomepage('/')
 
-    // WelcomeStrip greets by the session-derived display name (nova@... → nova).
-    expect(await screen.findByText('nova', { exact: true })).toBeInTheDocument()
+    // With no chosen nickname and no companion, the WelcomeStrip greets
+    // neutrally — never the account email local-part (audit F19).
+    expect(await screen.findByText('你好。')).toBeInTheDocument()
+    expect(screen.queryByText('nova', { exact: true })).not.toBeInTheDocument()
     expect(await screen.findByText('今日已打卡')).toBeInTheDocument()
     expect(screen.getByText('连续天数 · 本账号')).toBeInTheDocument()
     // The anonymous hero eyebrow must NOT be present.
@@ -241,7 +250,12 @@ describe('GamesPage homepage', () => {
     renderHomepage('/')
 
     expect(await screen.findByText('今日已打卡')).toBeInTheDocument()
-    expect(screen.getByText('已完成 · 08:00 UTC')).toBeInTheDocument()
+    // C3/F7: the completion time renders in the viewer's local timezone as HH:MM
+    // and no longer carries a raw「… UTC」label. TZ-robust — assert the shape,
+    // not a fixed clock (the exact local time depends on the runner timezone).
+    const completionLine = screen.getByText(/^已完成 · \d{2}:\d{2}$/)
+    expect(completionLine).toBeInTheDocument()
+    expect(completionLine.textContent).not.toContain('UTC')
     expect(screen.getByText('连续天数 · 本设备')).toBeInTheDocument()
   })
 

--- a/packages/platform/src/pages/LoginPage.module.css
+++ b/packages/platform/src/pages/LoginPage.module.css
@@ -297,7 +297,11 @@
 
 @media (max-width: 768px) {
   .page {
-    padding: 56px 0 48px;
+    /* Bottom pad clears the fixed BottomNav (≈56px + iOS safe area) so the
+       escape link and the taller「已发送」panel are never tucked behind the
+       bar. The old 48px was shorter than the bar, so the last line sat under
+       it with no room to scroll it clear (audit F8). */
+    padding: 56px 0 calc(72px + env(safe-area-inset-bottom));
   }
 
   .title {

--- a/packages/platform/src/pages/LoginPage.test.tsx
+++ b/packages/platform/src/pages/LoginPage.test.tsx
@@ -75,13 +75,15 @@ describe('LoginPage /login', () => {
     // Playing does NOT require login — the free anonymous mode① line, now a
     // tight one-liner paired with the inline direct-play escape.
     expect(screen.getByText(/玩游戏不需要登录/)).toBeInTheDocument()
-    // The value-prop: an account unlocks the end-state product value — a
-    // dedicated AI companion, social features, and cross-device progress. An
-    // aspirational framing, not the old current-status caveat.
-    const value = screen.getByText(/登录后，你将拥有专属于你的 AI 伙伴/)
+    // The value-prop: an account delivers three things that are real today —
+    // the platform AI companion, a real-activity community feed, and
+    // cross-device progress. States current value, no「社交主场」overclaim and
+    // no aspirational「你将拥有」framing (B6 copy-honesty sweep).
+    const value = screen.getByText(/登录后，你会有专属于你的 AI 伙伴/)
     expect(value).toBeInTheDocument()
-    expect(value.textContent).toContain('社交')
+    expect(value.textContent).toContain('社区')
     expect(value.textContent).toContain('跨设备同步')
+    expect(screen.queryByText(/社交主场/)).not.toBeInTheDocument()
   })
 
   it('offers a direct-play escape into free anonymous play', () => {

--- a/packages/platform/src/pages/LoginPage.tsx
+++ b/packages/platform/src/pages/LoginPage.tsx
@@ -60,9 +60,11 @@ function startWithOwnAI() {
 /* The login page is one clean card, not a wall of text.
    - The card is the single focal point: the email magic-link form and the
      Google option converge on one server session.
-   - One quiet line under the card carries the honest why: login only builds an
-     account for the platform-AI path (mode②), which is decided but not yet live
-     — so it does not overpromise.
+   - One quiet line under the card carries the honest why: an account now
+     delivers three real things — the platform AI companion (mode②, live in
+     co-play), a community feed of real player activity, and cross-device
+     progress via account claim — so the line states current value, not a
+     promise.
    - The escape — playing needs no account — sits as a subtle footer link into
      free anonymous play.
    Platform chrome — brand yellow, dark-only, CSS-only transitions. */
@@ -141,8 +143,11 @@ export default function LoginPage() {
     <div className={styles.page}>
       <div className={styles.head}>
         <EyebrowTag variant="section">登录 · SIGN IN</EyebrowTag>
+        {/* /login is anonymous-by-default (new AND returning visitors land
+            here), so the greeting must not assume a return — a neutral
+            「欢迎你」 replaces the old「欢迎回来」(audit F8). */}
         <h2 className={styles.title}>
-          欢迎<span className={styles.accent}>回来</span>。
+          欢迎<span className={styles.accent}>你</span>。
         </h2>
       </div>
 
@@ -219,11 +224,14 @@ export default function LoginPage() {
         )}
       </GlassCard>
 
-      {/* The value of an account, stated as the end-state product value — a
-          dedicated AI companion, social features, and cross-device progress.
-          Aspirational ("你将拥有…"), not a literal instant-delivery claim. */}
+      {/* The value of an account, stated as CURRENT product value — three
+          things that are real today: the platform AI companion (mode②, live in
+          co-play), a community feed built from real player activity, and
+          cross-device progress via account claim. No「社交主场」overclaim (the
+          community is a real-but-small activity feed, not a bustling social
+          hub); no aspirational「你将拥有」framing (B6 copy-honesty sweep). */}
       <p className={styles.why}>
-        登录后，你将拥有专属于你的 AI 伙伴、与同好相连的社交主场，以及跨设备同步的战绩与排名。
+        登录后，你会有专属于你的 AI 伙伴、一处能看到同好动态的社区，以及跨设备同步的战绩与排名。
       </p>
 
       {/* The escape — playing needs no account. A subtle footer link into free

--- a/shared/date.ts
+++ b/shared/date.ts
@@ -66,3 +66,18 @@ export function getLocalRolloverTime(now: Date = new Date(), timeZone?: string):
 export function getDailyResetHint(now: Date = new Date(), timeZone?: string): string {
   return `每日内容按 UTC 日期刷新 · 本地时间每天 ${getLocalRolloverTime(now, timeZone)}`
 }
+
+/* Render a stored ISO timestamp's clock time (`HH:MM`) in the viewer's local
+   timezone (or an explicit `timeZone`, used by tests). Completion timestamps are
+   stored in UTC; a Chinese user should see their own wall-clock time, not a raw
+   「14:38 UTC」 (audit F7). Returns '' for an unparseable input. */
+export function formatLocalClockTime(iso: string, timeZone?: string): string {
+  const ms = Date.parse(iso)
+  if (Number.isNaN(ms)) return ''
+  return new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+    ...(timeZone ? { timeZone } : {}),
+  }).format(new Date(ms))
+}


### PR DESCRIPTION
## Summary
- B6: every visible claim now matches shipped reality (verifier did a per-row truth-check against production features + sitewide grep for residual overclaims)
- Greeting identity: nickname > companion-known name (白舟-class) > neutral — email fragments never render as names
- 9 audit C-items fixed (render-proofed at 390x844 where CSS-only); C2/C8/C11 verified already-done; C5 needs its own slice (TTS preview grant); C10 documented

Phase B/C closure batch. 3-axis verify + one fix round.

## Test plan
- [x] platform 193 / bombsquad 476 / yijing 269 / arcade-profile 45 / api 204; typecheck; lint; e2e audit 30↔30; CSS render proofs archived
- [ ] CI full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w79dZWZzh7A7W6A7deN31