### PR TITLE
feat(platform): anonymous first-run primer and stat integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**A first-time player learns how BombSquad is played before the manual step** - Fix.
+An anonymous newcomer was dropped straight onto 「把手册发给你的 AI」 with no
+explanation of the unusual premise — you and a separate voice AI split the bomb
+and the manual between you — and no path for someone without an AI at hand. The
+first entry into the connect flow now shows one short, honest 「怎么玩」 screen:
+the split-information premise, the bring-your-own-AI path (Claude / ChatGPT /
+Gemini …), and, for players with no AI, the platform voice companion behind login.
+It shows once per device, is one tap to skip into the same steps, and never
+appears again — returning players and signed-in companion owners see nothing new.
+
+**The board's rejection notice reads in plain Chinese** - Fix. A clear too fast
+for the plausibility check was refused with a half-English line that also spelled
+out the exact time threshold. The notice now reads 「成绩未通过合理性校验」 in full
+Chinese, and a pacing limit reads as its own 「提交太频繁」 message — neither leaks
+the raw server text or the threshold a would-be forger would want.
+
+**The board, the 「最快拆弹」 stat, and your submitted rank only count plausible
+times** - Fix. Rows recorded before the 60-second plausibility floor shipped could
+still headline the board, feed the homepage 「最快拆弹 / 日榜首」 stat with
+sub-minute times the floor itself calls implausible, and rank a genuine submitter
+behind them on the result page's 「全球排名」 card. The same floor now filters all
+three surfaces at display time — the board read, the homepage stat, and the rank
+returned when you submit — so none of them can show or count an implausible run.
+The data is filtered, not deleted, so it stays reversible and ages out on its own.
+
+**The homepage checklist time no longer looks like a game score** - Fix. A
+finished daily item read 「已完成 · 04:44」, where 04:44 was the local time you
+completed it — but sitting next to the result page's 用时 (e.g. 00:17) it read as
+a wildly different game time for the same run. The line now reads 「完成于 04:44」,
+labeling it clearly as when you finished; your run 用时 stays on the result page
+and 我的 as before.
+
+**The signed-in homepage drops the anonymous-only caveat** - Fix. A signed-in
+visitor's streak note still carried 「匿名状态只代表这台设备」, a line that only
+belongs to the anonymous device view. It now shows only in device scope.
+
+**The BombSquad top label truncates cleanly on narrow phones** - Fix. On a 360px
+screen the 「自带任意语音 AI · 例如 …」 label cut off mid-word with no ellipsis. It
+now ends with a clean 「…」; the full AI-tools list still shows in the chips row
+below.
+
 **The daily time board rejects clears no human could hit** - Fix. The board only
 blocked runs under 15 seconds, so a ~36-second automated clear could top it over
 real 3-to-5-minute human runs and feed the homepage 「最快拆弹」 stat. The

--- a/e2e/bombsquad-connect-intro.gherkin
+++ b/e2e/bombsquad-connect-intro.gherkin
@@ -1,0 +1,29 @@
+# BombSquad first-run connect primer (F1) — the once-per-device「怎么玩」screen
+# that bridges the unconventional「自带语音 AI + 人机分持信息」premise before an
+# anonymous player hits「把手册发给 AI」. It fronts the BYO connect flow on the
+# first entry only (per-device localStorage flag), explains the three honest
+# facts (the split-information premise, the bring-your-own-AI path, and the
+# no-AI platform-companion path behind login), and is skippable in one tap into
+# the same BYO steps. Returning players never see it (the default fixture seed
+# marks it seen; this scenario carries @connect-intro-fresh to opt out).
+
+Feature: BombSquad first-run connect primer
+  As a brand-new anonymous BombSquad player
+  I want a short honest explanation of how the game is played
+  So that the「自带语音 AI」premise does not lose me at the manual handoff
+
+  Background:
+    Given I open /
+
+  # Source: bombsquad-first-run-intro
+  @playwright @connect-intro-fresh
+  Scenario: First anonymous entry shows the skippable how-to primer, then the BYO steps
+    Given my viewport width is 360 pixels
+    When I enter the daily challenge from the homepage
+    Then I see the heading "开始之前"
+    And I see the tip "你看得到炸弹面板但查不了资料"
+    And I see the tip "把手册链接发给它"
+    And I see the tip "登录后可以让平台的语音伙伴"
+    And the connect screen has no horizontal overflow
+    When I click "知道了，开始对接 →"
+    Then the connect-AI flow opens at step 1

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -21,9 +21,9 @@
 #
 # --- Regression size budget --------------------------------------------------
 # Per the governance model (rule 3): the e2e regression suite is capped at
-# 2 x the journey-scenario count. With 30 active flows <-> 30 journey
-# scenarios, the regression size budget is 60 (2026-07-08, after the community
-# real-feed flow landed as a @playwright journey).
+# 2 x the journey-scenario count. With 31 active flows <-> 31 journey
+# scenarios, the regression size budget is 62 (2026-07-09, after the BombSquad
+# first-run connect primer flow landed as a @playwright journey).
 # Crossing it triggers a forced prune audit. Current regression count: 2.
 #
 # --- Retired scenario --------------------------------------------------------
@@ -142,6 +142,22 @@ flows:
       compatibility page to see the supported AIs, and returns to the BombSquad
       landing page.
     steps: [connect-step-1, compatibility-link, compatibility-page, back-to-landing]
+    status: active
+
+  - id: bombsquad-first-run-intro
+    name: BombSquad first-run connect primer
+    description: >-
+      A brand-new anonymous player entering the BombSquad connect flow gets a
+      once-per-device「怎么玩」primer (F1) BEFORE the「把手册发给 AI」step: it
+      bridges the unconventional premise (you + a voice AI partner splitting the
+      bomb vs the manual), points players WITH a voice AI at the manual handoff
+      and players WITHOUT one at the platform companion behind login, and is
+      skippable in one tap into the same BYO steps. It shows only on the first
+      BYO entry (per-device localStorage flag); returning players and signed-in
+      companion owners never see it, so the landing-to-daily / landing-to-practice
+      flows stay unchanged. The dedicated scenario carries @connect-intro-fresh to
+      opt out of the default already-seen fixture seed.
+    steps: [connect-first-entry, howto-primer, primer-dismiss, connect-step-1]
     status: active
 
   # === Atlas platform-shell flows =============================================

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -503,6 +503,24 @@ export const test = base.extend<{ world: World }>({
         })
       }
 
+      // First-run connect primer gating (F1). ConnectPage shows a once-per-device
+      //「怎么玩」screen on the first BYO connect entry, gated by the
+      // `bombsquad-connect-intro-seen` localStorage flag (exact key from
+      // packages/game-bombsquad/src/utils/connect-intro.ts). Every journey that
+      // walks the connect flow would otherwise trip the primer instead of the BYO
+      // steps, so it is seeded as already-seen by default. The dedicated
+      // bombsquad-first-run-intro scenario carries @connect-intro-fresh to opt out
+      // of the seed so the primer actually appears for it.
+      if (!testInfo.tags.includes('@connect-intro-fresh')) {
+        await page.addInitScript(() => {
+          try {
+            window.localStorage.setItem('bombsquad-connect-intro-seen', 'true')
+          } catch {
+            /* localStorage unavailable (private mode) — primer may show; rare in e2e */
+          }
+        })
+      }
+
       // Auth session read (useAuth). Returns the authenticated identity once a
       // scenario calls world.signIn(...), else the anonymous 200. The real
       // backend always answers 200 (asking "am I logged in?" is legal), so the

--- a/e2e/steps/survey.steps.ts
+++ b/e2e/steps/survey.steps.ts
@@ -5,7 +5,7 @@ import { Given, When, Then } from './fixtures'
 /** Stable test player metadata for the daily leaderboard gate — mirrors result.steps. */
 const E2E_NICKNAME = 'E2ERunner'
 const E2E_AI_ASSISTANT_LABEL = 'Claude'
-const SURVEY_DELAY_MS = 2000
+const SURVEY_DELAY_MS = 4400 // clears the longest (practice, 4200ms) celebration-to-survey delay
 
 /** Answer Q1/Q2/Q3 — the three required survey questions inside an open modal. */
 async function answerRequiredSurvey(dialog: import('@playwright/test').Locator): Promise<void> {

--- a/packages/api/src/handlers/get-leaderboard.test.ts
+++ b/packages/api/src/handlers/get-leaderboard.test.ts
@@ -55,6 +55,55 @@ describe('handleGetLeaderboard — internal key privacy', () => {
   })
 })
 
+describe('handleGetLeaderboard — plausibility-floor integrity sweep (F2)', () => {
+  // Legacy sub-floor rows (written before the 60s plausibility floor shipped,
+  // still inside the 48h KV TTL) must not headline the board or poison the
+  // homepage 最快拆弹 stat that reads entries[0]. The read path filters them out
+  // at display time — a reversible sweep that leaves the data in KV to age out.
+  it('hides sub-floor rows so only plausible times surface, and re-ranks', async () => {
+    const kv = new FakeKV()
+    const date = '2026-06-30'
+    await kv.put(
+      `leaderboard:${date}`,
+      JSON.stringify([
+        { rank: 1, nickname: '审计员W4', time_ms: 36_000, attempt_number: 1 }, // sub-60s junk
+        { rank: 2, nickname: '审计员W3', time_ms: 36_500, attempt_number: 1 }, // sub-60s junk
+        { rank: 3, nickname: '真人玩家', time_ms: 182_000, attempt_number: 2 },
+      ])
+    )
+
+    const response = await handleGetLeaderboard(request(date), kv as unknown as KVNamespace)
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as LeaderboardResponse
+    // The two implausible rows are gone; the plausible run is now #1, so the
+    // homepage 最快拆弹 (= entries[0].time_ms) reads 182_000, not 36_000.
+    expect(body.entries).toEqual([
+      { rank: 1, nickname: '真人玩家', time_ms: 182_000, attempt_number: 2 },
+    ])
+  })
+
+  it('keeps a player who has both an implausible and a plausible row, via the plausible one', async () => {
+    const kv = new FakeKV()
+    const date = '2026-06-30'
+    const device = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee'
+    await kv.put(
+      `leaderboard:${date}`,
+      JSON.stringify([
+        { rank: 1, nickname: '快手', time_ms: 40_000, attempt_number: 2, device_id: device },
+        { rank: 2, nickname: '快手', time_ms: 95_000, attempt_number: 1, device_id: device },
+      ])
+    )
+
+    const response = await handleGetLeaderboard(request(date), kv as unknown as KVNamespace)
+    const body = (await response.json()) as LeaderboardResponse
+    // Filtering runs BEFORE dedup, so the sub-floor 40s row does not win dedup
+    // and then vanish — the player still surfaces on their plausible 95s row.
+    expect(body.entries).toEqual([
+      { rank: 1, nickname: '快手', time_ms: 95_000, attempt_number: 1 },
+    ])
+  })
+})
+
 describe('handleGetLeaderboard — read-time dedup of historical rows', () => {
   // Rows written before write-time per-player dedup shipped can contain the
   // same player several times. The GET collapses them (best time wins) so

--- a/packages/api/src/handlers/get-leaderboard.ts
+++ b/packages/api/src/handlers/get-leaderboard.ts
@@ -1,5 +1,6 @@
 import type { LeaderboardEntry, LeaderboardResponse } from '../../../../shared/leaderboard-types'
 import { dedupeStoredEntries, type StoredEntry } from '../leaderboard-entries'
+import { MIN_GAME_TIME_MS } from '../validation'
 
 export async function handleGetLeaderboard(request: Request, kv: KVNamespace): Promise<Response> {
   const url = new URL(request.url)
@@ -13,12 +14,22 @@ export async function handleGetLeaderboard(request: Request, kv: KVNamespace): P
   }
 
   const raw = ((await kv.get(`leaderboard:${date}`, 'json')) as StoredEntry[] | null) ?? []
+  // Integrity sweep (F2): drop any row below the plausibility floor at read time
+  // — the same floor the write gate enforces (MIN_GAME_TIME_MS). Rows written
+  // before the floor shipped (e.g. legacy sub-60s entries still inside the 48h
+  // KV TTL) would otherwise headline the board and poison the homepage
+  // 「最快拆弹 / 日榜首」 stat (which reads entries[0]). This is a display filter,
+  // not a delete — the data stays in KV and ages out on its own, so the sweep is
+  // reversible and also catches any other legacy junk. Filtered BEFORE dedup so
+  // a player whose only implausible row is faster than a legit one still surfaces
+  // via their plausible row (dedup keeps the fastest surviving row per player).
+  const plausible = raw.filter((e) => e.time_ms >= MIN_GAME_TIME_MS)
   // Read-time dedup: rows written before write-time per-player dedup shipped
   // can still contain duplicates (same player, multiple runs). Collapsing at
   // read keeps historical boards honest until they age out of the 48h KV TTL.
   // Then strip the internal keys — run_id (per-run idempotency) and device_id
   // (per-player dedup) are backend keys, not part of the public contract.
-  const entries: LeaderboardEntry[] = dedupeStoredEntries(raw).map((e) => {
+  const entries: LeaderboardEntry[] = dedupeStoredEntries(plausible).map((e) => {
     const entry = { ...e } as Partial<StoredEntry>
     delete entry.run_id
     delete entry.device_id

--- a/packages/api/src/handlers/post-score.test.ts
+++ b/packages/api/src/handlers/post-score.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import type { LeaderboardEntry, ScoreSubmission } from '../../../../shared/leaderboard-types'
+import type {
+  LeaderboardEntry,
+  ScoreSubmission,
+  ScoreSubmissionResponse,
+} from '../../../../shared/leaderboard-types'
 import { createTestDb } from '../../../companion-memory/src/test-support/sqlite-db'
 import type {
   CaptureEventRecord,
@@ -371,5 +375,51 @@ describe('handlePostScore — one row per player per day', () => {
     expect(todayEntries?.[0]).toMatchObject({ time_ms: 130_000 })
     expect(yesterdayEntries).toHaveLength(1)
     expect(yesterdayEntries?.[0]).toMatchObject({ time_ms: 150_000 })
+  })
+})
+
+describe('handlePostScore — plausibility floor in the returned rank (F2)', () => {
+  type StoredRow = LeaderboardEntry & { device_id?: string }
+
+  it('ranks a legit submission ahead of legacy sub-floor rows and counts only plausible players', async () => {
+    const kv = new FakeKV()
+    const date = new Date().toISOString().slice(0, 10)
+    // Two legacy sub-60s junk rows already on the board (written before the
+    // plausibility floor shipped, still inside the 48h TTL).
+    await kv.put(
+      `leaderboard:${date}`,
+      JSON.stringify([
+        {
+          rank: 1,
+          nickname: '审计员W4',
+          time_ms: 36_000,
+          attempt_number: 1,
+          device_id: 'dddddddd-eeee-4fff-9aaa-bbbbbbbbbbbb',
+        },
+        {
+          rank: 2,
+          nickname: '审计员W3',
+          time_ms: 36_500,
+          attempt_number: 1,
+          device_id: 'cccccccc-1111-4222-9333-444444444444',
+        },
+      ])
+    )
+
+    // A genuine 130s run from a different device.
+    const response = await handlePostScore(request(submission()), kv.asKV())
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as ScoreSubmissionResponse
+    // The returned rank / count ignore the two sub-floor rows: the submitter is
+    // #1 of 1 plausible player, NOT #3 of 3 behind the 00:36 junk.
+    expect(body.rank).toBe(1)
+    expect(body.total_players).toBe(1)
+
+    // The KV write still PRESERVES the sub-floor rows — the sweep is a display
+    // filter, not a hard delete, so they age out with the TTL on their own.
+    const stored = (await kv.get(`leaderboard:${date}`, 'json')) as StoredRow[] | null
+    expect(stored?.some((e) => e.time_ms === 36_000)).toBe(true)
+    expect(stored?.some((e) => e.time_ms === 36_500)).toBe(true)
+    expect(stored?.some((e) => e.time_ms === 130_000)).toBe(true)
   })
 })

--- a/packages/api/src/handlers/post-score.ts
+++ b/packages/api/src/handlers/post-score.ts
@@ -11,6 +11,7 @@ import { dedupeStoredEntries, type StoredEntry } from '../leaderboard-entries'
 import {
   MAX_AI_MODEL_LEN,
   MAX_AI_TOOL_LEN,
+  MIN_GAME_TIME_MS,
   sanitizeLeaderboardText,
   sanitizeNickname,
   validateSubmission,
@@ -95,23 +96,38 @@ export async function handlePostScore(
   // therefore dropped here — the board always shows the day's best run.
   const updated = dedupeStoredEntries([...base, newEntry]).slice(0, MAX_ENTRIES)
 
+  // The KV write keeps the UNFILTERED set — the plausibility sweep is a
+  // display-time filter, not a hard delete, so legacy sub-floor rows age out
+  // with the TTL rather than being purged on the next write.
   await kv.put(leaderboardKey, JSON.stringify(updated), {
     expirationTtl: KV_TTL_SECONDS,
   })
 
+  // The rank / player count RETURNED to the result page must ignore legacy
+  // sub-floor rows (F2), matching the read-path integrity sweep in
+  // get-leaderboard.ts — otherwise the「全球排名」card ranks this legit
+  // submitter behind implausible junk still inside the 48h TTL, re-introducing
+  // the very board-vs-stat contradiction F2 set out to kill. Filter BEFORE
+  // dedup (same order as get-leaderboard) so the player's own legit row is
+  // never shadowed by an earlier sub-floor row on the same device; the just-
+  // submitted run already passed the write-time floor, so it always survives.
+  const ranked = dedupeStoredEntries(
+    [...base, newEntry].filter((e) => e.time_ms >= MIN_GAME_TIME_MS)
+  ).slice(0, MAX_ENTRIES)
+
   // The player's board rank is their kept (best) row — not necessarily the
   // run just submitted. Fall back to the legacy nickname+time match for rows
   // that predate device_id storage.
-  let rank = updated.findIndex((e) => e.device_id === body.device_id) + 1
+  let rank = ranked.findIndex((e) => e.device_id === body.device_id) + 1
   if (rank === 0) {
     rank =
-      updated.findIndex((e) => e.nickname === newEntry.nickname && e.time_ms === newEntry.time_ms) +
+      ranked.findIndex((e) => e.nickname === newEntry.nickname && e.time_ms === newEntry.time_ms) +
       1
   }
 
   const response: ScoreSubmissionResponse = {
-    rank: rank > 0 ? rank : updated.length + 1,
-    total_players: updated.length,
+    rank: rank > 0 ? rank : ranked.length + 1,
+    total_players: ranked.length,
     personal_best_ms: bestRecord.time_ms,
     ...(bestRecord.attempt_number !== undefined
       ? { personal_best_attempt: bestRecord.attempt_number }

--- a/packages/api/src/validation.ts
+++ b/packages/api/src/validation.ts
@@ -24,7 +24,12 @@ import { MODULE_ADVANCE_DELAY_MS } from '../../../shared/game-timing'
 // reached the board and ~3x below the fastest genuine human run observed
 // (3:02), leaving ample headroom for a skilled human+AI pair while rejecting
 // automation. Raise it as real human-run data accumulates.
-const MIN_GAME_TIME_MS = 60_000 // 60 seconds minimum — the collaborative-loop plausibility floor
+// Exported so the leaderboard READ path (get-leaderboard.ts) can apply the same
+// floor as this WRITE-time validation: an integrity sweep that hides any row
+// below the floor at display time (legacy sub-floor junk written before the
+// floor shipped, still inside the 48h KV TTL), without hard-deleting data. One
+// SSOT for the number so the write gate and the read filter can never drift.
+export const MIN_GAME_TIME_MS = 60_000 // 60 seconds minimum — the collaborative-loop plausibility floor
 const MAX_GAME_TIME_MS = 3_600_000 // 1 hour max
 // Structural per-module floor: no single module can be honestly solved faster
 // than one read→relay-to-AI→execute round-trip. A sub-floor module time means a

--- a/packages/game-bombsquad/src/game-flow.test.tsx
+++ b/packages/game-bombsquad/src/game-flow.test.tsx
@@ -69,6 +69,13 @@ vi.mock('./utils/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
 }))
 
+// The daily flow drives the connect page; pin the first-run primer (F1) as
+// already seen so the BYO steps render immediately instead of the「怎么玩」screen.
+vi.mock('./utils/connect-intro', () => ({
+  hasSeenConnectIntro: () => true,
+  markConnectIntroSeen: vi.fn(),
+}))
+
 vi.mock('./audio/audio-context', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./audio/audio-context')>()
   return {

--- a/packages/game-bombsquad/src/pages/BombSquadLandingPage.module.css
+++ b/packages/game-bombsquad/src/pages/BombSquadLandingPage.module.css
@@ -53,7 +53,21 @@
   flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
+}
+
+/* The eyebrow is `display: inline-flex`, so `text-overflow: ellipsis` on it does
+   nothing — the AI-tools run just clipped mid-word at 360px ("… · Chat", F8).
+   The truncation must live on a BLOCK inner element that directly wraps the
+   text. Making the AiToolList a shrinkable block flex-item gives it a clean
+   trailing ellipsis instead of a mid-glyph cut; the full list still shows in the
+   wrapping chips row lower on the page. */
+.aiList {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .iconBtn {

--- a/packages/game-bombsquad/src/pages/BombSquadLandingPage.tsx
+++ b/packages/game-bombsquad/src/pages/BombSquadLandingPage.tsx
@@ -41,7 +41,7 @@ export default function BombSquadLandingPage() {
               keeps it a label, not a "ready/online" signal. */}
           <div className={styles.top}>
             <Eyebrow dot color="var(--y)" className={styles.aiEyebrow}>
-              <AiToolList prefix="自带任意语音 AI · 例如" />
+              <AiToolList prefix="自带任意语音 AI · 例如" className={styles.aiList} />
             </Eyebrow>
             <button
               type="button"

--- a/packages/game-bombsquad/src/pages/ConnectPage.companion.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.companion.test.tsx
@@ -32,6 +32,13 @@ vi.mock('@/utils/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
 }))
 
+// The first-run primer (F1) fronts the BYO flow; pin it as already seen so these
+// companion-entry / BYO-secondary tests render their target views directly.
+vi.mock('@/utils/connect-intro', () => ({
+  hasSeenConnectIntro: () => true,
+  markConnectIntroSeen: vi.fn(),
+}))
+
 vi.mock('@/audio/audio-context', () => ({
   getAudioContext: vi.fn().mockReturnValue(null),
 }))

--- a/packages/game-bombsquad/src/pages/ConnectPage.intro.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.intro.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * ConnectPage first-run primer tests (F1).
+ *
+ * A brand-new anonymous player reaching the BYO connect flow gets one honest
+ *「怎么玩」screen ONCE per device: it explains the unconventional premise
+ * (you + a voice AI partner splitting the bomb vs the manual), points players
+ * WITH a voice AI at the manual handoff, and players WITHOUT one at the platform
+ * companion behind login. It is skippable (one tap into the same BYO steps) and
+ * never blocks the flow. `hasSeenConnectIntro` is mocked per test to drive the
+ * first-run vs returning-device branches; the util's own storage gating lives in
+ * connect-intro.test.ts.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+const DAILY_URL = 'https://claw.amio.fans/manual/2026-05-22'
+const PRACTICE_URL = 'https://claw.amio.fans/manual/practice'
+
+vi.mock('@/hooks/useDailyChallenge', () => ({
+  useDailyChallenge: () => ({
+    dailyUrl: DAILY_URL,
+    practiceUrl: PRACTICE_URL,
+    attemptNumber: 1,
+    incrementAttempt: () => {},
+  }),
+}))
+
+vi.mock('@/utils/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+}))
+
+// The co-play gate is mutable per test: default 'unavailable' (anonymous /
+// companion-less — the BYO flow the primer fronts); a signed-in companion owner
+// sets it 'available' to prove the primer is excluded from the co-play path.
+const partnerState = vi.hoisted(() => ({
+  current: { status: 'unavailable' } as { status: string; name?: string },
+}))
+vi.mock('@/hooks/useCompanionPartner', () => ({
+  useCompanionPartner: (enabled: boolean) =>
+    enabled ? partnerState.current : { status: 'unavailable' },
+}))
+
+vi.mock('@/audio/audio-context', () => ({
+  getAudioContext: vi.fn().mockReturnValue(null),
+}))
+
+const introMock = vi.hoisted(() => ({ seen: false, mark: vi.fn() }))
+vi.mock('@/utils/connect-intro', () => ({
+  hasSeenConnectIntro: () => introMock.seen,
+  markConnectIntroSeen: introMock.mark,
+}))
+
+import ConnectPage from './ConnectPage'
+import { GameProvider } from '@/store/game-context'
+
+function renderConnect(mode: 'daily' | 'practice') {
+  return render(
+    <MemoryRouter initialEntries={[`/bombsquad/connect?mode=${mode}`]}>
+      <Routes>
+        <Route
+          path="/bombsquad/connect"
+          element={
+            <GameProvider>
+              <ConnectPage />
+            </GameProvider>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('ConnectPage first-run primer (F1)', () => {
+  // jsdom's window.location.assign is non-configurable (spyOn throws), so replace
+  // the whole location object with a minimal stub. MemoryRouter uses an in-memory
+  // history and never reads window.location, so this is safe for the render.
+  const realLocation = window.location
+  let assignMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    introMock.seen = false
+    introMock.mark.mockReset()
+    partnerState.current = { status: 'unavailable' }
+    assignMock = vi.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { assign: assignMock },
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: realLocation })
+  })
+
+  it('shows the「怎么玩」primer on first anonymous daily entry, before the BYO steps', () => {
+    renderConnect('daily')
+    expect(screen.getByText('开始之前')).toBeInTheDocument()
+    expect(screen.getByText(/先弄清/)).toBeInTheDocument()
+    // The three honest points: premise, BYO-AI path, no-AI path.
+    expect(screen.getByText(/你看得到炸弹面板但查不了资料/)).toBeInTheDocument()
+    expect(screen.getByText(/把手册链接发给它/)).toBeInTheDocument()
+    expect(screen.getByText(/登录后可以让平台的语音伙伴/)).toBeInTheDocument()
+    // The BYO copy CTA is not reachable until the primer is dismissed.
+    expect(screen.queryByRole('button', { name: '复制手册' })).not.toBeInTheDocument()
+  })
+
+  it('dismissing the primer marks it seen and reveals the BYO step 1', () => {
+    renderConnect('daily')
+    fireEvent.click(screen.getByRole('button', { name: '知道了，开始对接 →' }))
+    expect(introMock.mark).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('button', { name: '复制手册' })).toBeInTheDocument()
+    expect(screen.queryByText('开始之前')).not.toBeInTheDocument()
+  })
+
+  it('the no-AI CTA marks the primer seen and navigates to login', () => {
+    renderConnect('daily')
+    fireEvent.click(screen.getByRole('button', { name: '没有 AI？登录用平台伙伴 →' }))
+    expect(introMock.mark).toHaveBeenCalledTimes(1)
+    expect(assignMock).toHaveBeenCalledWith('/login')
+  })
+
+  it('does NOT show the primer once the device has seen it (returning player)', () => {
+    introMock.seen = true
+    renderConnect('daily')
+    expect(screen.queryByText('开始之前')).not.toBeInTheDocument()
+    // The BYO step 1 renders directly — byte-identical to the returning flow.
+    expect(screen.getByRole('button', { name: '复制手册' })).toBeInTheDocument()
+  })
+
+  it('also fronts practice mode on first run', () => {
+    renderConnect('practice')
+    expect(screen.getByText('开始之前')).toBeInTheDocument()
+  })
+
+  it('never shows the primer to a signed-in companion owner entering co-play, even unseen', () => {
+    // Companion available + intro unseen: the co-play default owns the screen,
+    // and the「怎么玩」primer (whose no-AI path is irrelevant to them) is excluded.
+    partnerState.current = { status: 'available', name: '阿澈' }
+    renderConnect('daily')
+    expect(screen.queryByText('开始之前')).not.toBeInTheDocument()
+    // The co-play primary CTA renders instead.
+    expect(screen.getByRole('button', { name: '和 阿澈 一起进入 →' })).toBeInTheDocument()
+  })
+})

--- a/packages/game-bombsquad/src/pages/ConnectPage.module.css
+++ b/packages/game-bombsquad/src/pages/ConnectPage.module.css
@@ -106,6 +106,51 @@
   font-style: italic;
 }
 
+/* ----------  first-run primer (F1)  ----------
+   A once-per-device「怎么玩」screen fronting the BYO flow. Fluid layout: the
+   numbered rows are flex with min-width:0 so the text wraps cleanly at 360px
+   (no horizontal overflow), and the shared .cta pins the buttons to the bottom. */
+.introList {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.introItem {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.introNum {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(255, 229, 62, 0.12);
+  border: 1px solid rgba(255, 229, 62, 0.35);
+  color: var(--y);
+  font: 600 13px var(--amio-font-mono);
+}
+
+.introText {
+  flex: 1;
+  min-width: 0;
+  font: 400 15px/1.6 var(--font-body);
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.introText strong {
+  color: #fff;
+  font-weight: 600;
+}
+
 /* ----------  player ↔ AI visualization  ---------- */
 .vis {
   margin: 14px 0;

--- a/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.test.tsx
@@ -44,6 +44,14 @@ vi.mock('@/utils/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
 }))
 
+// These tests cover the connect STEPS, not the first-run primer (F1) — pin the
+// device as having already seen the intro so the BYO steps render immediately.
+// The primer's own gating has its own file (ConnectPage.intro.test.tsx).
+vi.mock('@/utils/connect-intro', () => ({
+  hasSeenConnectIntro: () => true,
+  markConnectIntroSeen: vi.fn(),
+}))
+
 // These tests cover the anonymous / companion-less flow, which must stay
 // byte-identical to the pre-companion-entry behaviour: pin the co-play gate to
 // `unavailable`. The companion default entry has its own test file

--- a/packages/game-bombsquad/src/pages/ConnectPage.tsx
+++ b/packages/game-bombsquad/src/pages/ConnectPage.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/bombsquad/Button'
 import { useDailyChallenge } from '@/hooks/useDailyChallenge'
 import { useCompanionPartner } from '@/hooks/useCompanionPartner'
 import { copyToClipboard } from '@/utils/clipboard'
+import { hasSeenConnectIntro, markConnectIntroSeen } from '@/utils/connect-intro'
 import { getAudioContext } from '@/audio/audio-context'
 import { useGame } from '@/store/game-context'
 import { clearPersistedState } from '@/store/persistence'
@@ -49,6 +50,30 @@ export default function ConnectPage() {
   const [step, setStep] = useState<1 | 2>(1)
   const [copied, setCopied] = useState(false)
   const [copyFailed, setCopyFailed] = useState(false)
+
+  // First-run primer (F1) — a brand-new anonymous player reaching the BYO flow
+  // gets one honest「怎么玩」screen ONCE per device (dismissible, never again
+  // after). It only fronts the BYO flow (practice / anonymous / companion-less);
+  // a signed-in companion owner who taps「自带 AI」(byoChosen) already knows the
+  // premise, so they never see it. `introSeen` is read once at mount (a live
+  // read would flip mid-session the moment we mark it).
+  const [introSeen] = useState(() => hasSeenConnectIntro())
+  const [introDismissed, setIntroDismissed] = useState(false)
+  const introEligible = mode === 'practice' || partner.status === 'unavailable'
+  const showIntro = introEligible && !introSeen && !introDismissed
+
+  const dismissIntro = () => {
+    markConnectIntroSeen()
+    setIntroDismissed(true)
+  }
+
+  // The no-AI path: the platform voice companion lives behind login on the
+  // separate platform SPA, so this is a full-page navigation, not a router push.
+  // Mark seen first so a return trip does not replay the primer.
+  const goToPlatformCompanion = () => {
+    markConnectIntroSeen()
+    window.location.assign('/login')
+  }
 
   useEffect(() => {
     saveEntryRecoveryState({
@@ -220,7 +245,61 @@ export default function ConnectPage() {
           </div>
         )}
 
-        {(mode === 'practice' || partner.status === 'unavailable' || byoChosen) && (
+        {/* First-run primer (F1) — bridges the unconventional「自带语音 AI +
+            人机分持信息」premise before the player hits「把手册发给 AI」. Shown
+            in place of the BYO steps on the first anonymous entry only; the
+            primary CTA dismisses it into the same steps (skippable, one tap). */}
+        {showIntro && (
+          <div className={`${styles.connect} ${styles.intro}`}>
+            <Eyebrow dot color="var(--y)">
+              开始之前
+            </Eyebrow>
+
+            <h2 className={styles.title}>
+              先弄清<span className={styles.titleAccent}>怎么玩</span>。
+            </h2>
+
+            <ol className={styles.introList}>
+              <li className={styles.introItem}>
+                <span className={styles.introNum} aria-hidden="true">
+                  1
+                </span>
+                <span className={styles.introText}>
+                  你和一个<strong>语音 AI 搭档</strong>一起拆弹：你看得到炸弹面板但查不了资料，AI
+                  拿着手册却看不到炸弹，全靠语音配合。
+                </span>
+              </li>
+              <li className={styles.introItem}>
+                <span className={styles.introNum} aria-hidden="true">
+                  2
+                </span>
+                <span className={styles.introText}>
+                  手边有能语音对话的 AI（Claude、ChatGPT、Gemini
+                  等）：把手册链接发给它，让它读完，就能开始。
+                </span>
+              </li>
+              <li className={styles.introItem}>
+                <span className={styles.introNum} aria-hidden="true">
+                  3
+                </span>
+                <span className={styles.introText}>
+                  没有现成的 AI？登录后可以让平台的语音伙伴用语音陪你拆，一样能玩。
+                </span>
+              </li>
+            </ol>
+
+            <div className={styles.cta}>
+              <Button variant="primary" full onClick={dismissIntro}>
+                知道了，开始对接 →
+              </Button>
+              <button type="button" className={styles.byoLink} onClick={goToPlatformCompanion}>
+                没有 AI？登录用平台伙伴 →
+              </button>
+            </div>
+          </div>
+        )}
+
+        {!showIntro && (mode === 'practice' || partner.status === 'unavailable' || byoChosen) && (
           <div className={styles.connect}>
             <Eyebrow dot color="var(--y)">
               第 {step}/2 步

--- a/packages/game-bombsquad/src/pages/ResultPage.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.tsx
@@ -112,7 +112,12 @@ export default function ResultPage() {
   // Distinguishes a server-side validation rejection from a network failure so
   // the failure copy can be honest. `null` while no failure is showing.
   const [submitFailKind, setSubmitFailKind] = useState<'network' | 'rejected' | null>(null)
-  const [submitFailMessage, setSubmitFailMessage] = useState<string | null>(null)
+  // The rejection's HTTP status drives a fully-localized Chinese reason (F2):
+  // 429 = rate limit, anything else (422 plausibility floor / structural) reads
+  // as「成绩未通过合理性校验」. The server's raw English `error` string is never
+  // shown — it would leak the exact 60s threshold to a would-be forger and mix
+  // English into the Chinese product. `null` while no failure is showing.
+  const [submitFailStatus, setSubmitFailStatus] = useState<number | null>(null)
   const [entryRecovery] = useState(() => readEntryRecoveryState())
   const [profileSaveState, setProfileSaveState] = useState<ProfileSaveState>('idle')
   const [dailyLoop, setDailyLoop] = useState<ArcadeDailyLoopSummary | null>(null)
@@ -285,7 +290,7 @@ export default function ResultPage() {
     hasFinishedDailyRun && (nickname === null || leaderboardMetadata === null)
   const [surveyReady, setSurveyReady] = useState(false)
   const [surveyRetired, setSurveyRetired] = useState(false)
-  // A server rejection notice (成绩校验未通过) is rendered inline in the rank card
+  // A server rejection notice (成绩未通过合理性校验) is rendered inline in the rank card
   // and must be readable before the once-per-device survey opens over it — the
   // same stacking guard as #209 deferring the survey behind the rank reveal
   // (F8). A network failure is deliberately NOT gated: it invites an immediate
@@ -383,7 +388,7 @@ export default function ResultPage() {
         submittedRef.current = 'done' // permanently lock — this run is on the board
         setSubmitFailed(false)
         setSubmitFailKind(null)
-        setSubmitFailMessage(null)
+        setSubmitFailStatus(null)
         setRankResult(result.data)
         // The board keeps one row per player — the day's best. Only seed an
         // optimistic entry when this run IS the personal best; a slower retry
@@ -404,7 +409,7 @@ export default function ResultPage() {
         submittedRef.current = 'idle' // release latch so the retry button can fire
         setSubmitFailed(true)
         setSubmitFailKind(result.kind)
-        setSubmitFailMessage(result.kind === 'rejected' ? (result.error ?? null) : null)
+        setSubmitFailStatus(result.kind === 'rejected' ? result.status : null)
       }
     },
     [recordOptimistic]
@@ -513,7 +518,7 @@ export default function ResultPage() {
     setRetried(true)
     setSubmitFailed(false)
     setSubmitFailKind(null)
-    setSubmitFailMessage(null)
+    setSubmitFailStatus(null)
     setSubmitting(true)
     // applySubmitResult resets submittedRef to 'idle' on failure, so
     // performSubmission will proceed here on the retry path.
@@ -763,16 +768,22 @@ export default function ResultPage() {
                         // Server reached and refused — not an offline state.
                         // Retry once for transient refusals (e.g. rate limit);
                         // a persistent rejection points the player at feedback.
+                        // Fully-localized honest copy (F2): a 429 is a pacing
+                        // limit that a later retry clears; anything else is the
+                        // plausibility校验. Neither leaks the server's raw
+                        // English string or the 60s threshold.
                         retried ? (
                           <>
-                            成绩未能通过校验，暂时无法上榜。
-                            {submitFailMessage ? `（${submitFailMessage}）` : ''}
+                            {submitFailStatus === 429
+                              ? '提交太频繁，请稍后再来重新提交。'
+                              : '成绩未通过合理性校验，暂时无法上榜。'}
                             可邮件反馈 byheaven0912@gmail.com
                           </>
                         ) : (
                           <>
-                            成绩校验未通过
-                            {submitFailMessage ? `（${submitFailMessage}）` : ''}
+                            {submitFailStatus === 429
+                              ? '提交太频繁，请稍后再试'
+                              : '成绩未通过合理性校验'}
                             <button className={styles.retryBtn} onClick={handleRetrySubmit}>
                               重试
                             </button>

--- a/packages/game-bombsquad/src/utils/connect-intro.test.ts
+++ b/packages/game-bombsquad/src/utils/connect-intro.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the connect-intro gating utility — the once-per-device flag
+ * that controls whether the first-run connect-AI primer renders (F1).
+ *
+ * Mirrors survey.test.ts: jsdom's localStorage is method-less here, so a small
+ * Map-backed fake is installed via vi.stubGlobal so the real util exercises its
+ * real branches; a throwing variant covers the storage-failure branches.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { hasSeenConnectIntro, markConnectIntroSeen } from './connect-intro'
+
+const KEY = 'bombsquad-connect-intro-seen'
+
+interface FakeLocalStorageOverrides {
+  getItem?: (key: string) => string | null
+  setItem?: (key: string, value: string) => void
+}
+
+function installFakeLocalStorage(overrides: FakeLocalStorageOverrides = {}) {
+  const store = new Map<string, string>()
+  const fake = {
+    getItem:
+      overrides.getItem ?? ((key: string) => (store.has(key) ? (store.get(key) as string) : null)),
+    setItem:
+      overrides.setItem ??
+      ((key: string, value: string) => {
+        store.set(key, String(value))
+      }),
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  }
+  vi.stubGlobal('localStorage', fake)
+  return { store, fake }
+}
+
+describe('hasSeenConnectIntro', () => {
+  beforeEach(() => {
+    installFakeLocalStorage()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns false when no flag is stored (first-run device)', () => {
+    expect(hasSeenConnectIntro()).toBe(false)
+  })
+
+  it('returns true when the flag is exactly "true"', () => {
+    localStorage.setItem(KEY, 'true')
+    expect(hasSeenConnectIntro()).toBe(true)
+  })
+
+  it('returns false for any stored value other than "true"', () => {
+    localStorage.setItem(KEY, 'seen')
+    expect(hasSeenConnectIntro()).toBe(false)
+  })
+
+  it('returns false when localStorage.getItem throws (errs toward showing once more)', () => {
+    installFakeLocalStorage({
+      getItem: () => {
+        throw new Error('storage disabled')
+      },
+    })
+    expect(hasSeenConnectIntro()).toBe(false)
+  })
+})
+
+describe('markConnectIntroSeen', () => {
+  beforeEach(() => {
+    installFakeLocalStorage()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('writes the flag so hasSeenConnectIntro reads back true', () => {
+    expect(hasSeenConnectIntro()).toBe(false)
+    markConnectIntroSeen()
+    expect(hasSeenConnectIntro()).toBe(true)
+    expect(localStorage.getItem(KEY)).toBe('true')
+  })
+
+  it('does not throw when localStorage.setItem throws (quota / private mode)', () => {
+    installFakeLocalStorage({
+      setItem: () => {
+        throw new Error('QuotaExceededError')
+      },
+    })
+    expect(() => markConnectIntroSeen()).not.toThrow()
+  })
+})

--- a/packages/game-bombsquad/src/utils/connect-intro.ts
+++ b/packages/game-bombsquad/src/utils/connect-intro.ts
@@ -1,0 +1,39 @@
+/**
+ * Per-device first-run gating for the connect-AI intro (F1).
+ *
+ * A brand-new anonymous player entering the BombSquad connect flow gets one
+ * honest primer explaining the unconventional premise (you + a voice AI partner
+ * splitting the bomb vs the manual), and — for players with no voice AI at hand
+ * — the platform-companion path. It shows ONCE per device: the first time the
+ * BYO connect flow is reached, and never again after it is dismissed. Mirrors
+ * the survey.ts per-device flag pattern.
+ */
+
+const CONNECT_INTRO_SEEN_KEY = 'bombsquad-connect-intro-seen'
+
+/**
+ * Returns true when this device has already seen (and dismissed) the connect
+ * intro. Returns false when the flag is absent or localStorage access throws
+ * (private mode / disabled) — a read failure errs toward showing the primer
+ * once more rather than silently suppressing it forever.
+ */
+export function hasSeenConnectIntro(): boolean {
+  try {
+    return localStorage.getItem(CONNECT_INTRO_SEEN_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Marks the connect intro as seen for this device. Storage failures (quota /
+ * private mode) are swallowed — the only consequence is the primer may show
+ * again on a later entry, which is acceptable.
+ */
+export function markConnectIntroSeen(): void {
+  try {
+    localStorage.setItem(CONNECT_INTRO_SEEN_KEY, 'true')
+  } catch {
+    /* storage full / disabled — intro simply shows again next time */
+  }
+}

--- a/packages/platform/src/components/home/DailyChecklist.test.tsx
+++ b/packages/platform/src/components/home/DailyChecklist.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ArcadeProfileSummary } from '@amiclaw/arcade-profile/types'
+import DailyChecklist from './DailyChecklist'
+
+/**
+ * DailyChecklist copy contracts:
+ *  - F3: a completed item reads「完成于 HH:MM」(the local wall-clock completion
+ *    time, a point in time), never「已完成 · HH:MM」that read as a game 用时
+ *    next to the result page / /me duration display (formatMs).
+ *  - F4: the「匿名状态只代表这台设备」caveat only belongs to device (anonymous)
+ *    scope; the 本账号 (signed-in) view must not leak it.
+ */
+
+function profile(overrides?: {
+  bombsquadCompletedAt?: string | null
+  bombsquadCompleted?: boolean
+}): ArcadeProfileSummary {
+  const daily_loop = {
+    date: '2026-07-08',
+    checklist: {
+      bombsquad_daily: {
+        completed: overrides?.bombsquadCompleted ?? true,
+        // Honor an explicit `null` (in-key check, since `null ?? default`
+        // would collapse back to the default timestamp).
+        completed_at:
+          overrides && 'bombsquadCompletedAt' in overrides
+            ? overrides.bombsquadCompletedAt
+            : '2026-07-08T20:44:00.000Z',
+      },
+      oracle_sign: { completed: false, completed_at: null },
+    },
+    streak: {
+      today_completed: true,
+      current_days: 3,
+      longest_days: 5,
+      last_active_date: '2026-07-08',
+    },
+  }
+  return { daily_loop } as unknown as ArcadeProfileSummary
+}
+
+describe('DailyChecklist — completion time label (F3)', () => {
+  it('renders a completed item as「完成于 HH:MM」, not「已完成 · HH:MM」', () => {
+    render(<DailyChecklist profile={profile()} scope="device" />)
+    expect(screen.getByText(/^完成于 \d{2}:\d{2}$/)).toBeInTheDocument()
+    expect(screen.queryByText(/^已完成 · /)).not.toBeInTheDocument()
+  })
+
+  it('falls back to「已完成」when no completion timestamp is present', () => {
+    render(<DailyChecklist profile={profile({ bombsquadCompletedAt: null })} scope="device" />)
+    expect(screen.getByText('已完成')).toBeInTheDocument()
+  })
+})
+
+describe('DailyChecklist — anonymous caveat scope (F4)', () => {
+  it('shows the 匿名状态 caveat in device scope', () => {
+    render(<DailyChecklist profile={profile()} scope="device" />)
+    expect(screen.getByText(/匿名状态只代表这台设备。/)).toBeInTheDocument()
+  })
+
+  it('omits the 匿名状态 caveat in account scope', () => {
+    render(<DailyChecklist profile={profile()} scope="account" />)
+    expect(screen.queryByText(/匿名状态只代表这台设备/)).not.toBeInTheDocument()
+    // The longest-streak line still renders in the account view.
+    expect(screen.getByText(/最长连续 5 天。/)).toBeInTheDocument()
+  })
+})

--- a/packages/platform/src/components/home/DailyChecklist.tsx
+++ b/packages/platform/src/components/home/DailyChecklist.tsx
@@ -57,8 +57,17 @@ export default function DailyChecklist({ profile, scope, loading = false }: Dail
             <span className={styles.itemBody}>
               <span className={styles.itemTitle}>{item.title}</span>
               <span className={styles.itemDetail}>
+                {/* The completed line shows WHEN the item was done today — the
+                    local wall-clock time of completion (完成于 HH:MM), not the
+                    game 用时. The result page and /me show the run DURATION
+                    (formatMs, e.g. 00:17); the bare「· 04:44」here used to read
+                    as a duration too and looked contradictory (F3). 「完成于」
+                    labels it as a point in time and reads the same for both the
+                    timed BombSquad run and the untimed Oracle sign. */}
                 {item.completed
-                  ? `已完成${item.completedAt ? ` · ${formatLocalClockTime(item.completedAt)}` : ''}`
+                  ? item.completedAt
+                    ? `完成于 ${formatLocalClockTime(item.completedAt)}`
+                    : '已完成'
                   : item.detail}
               </span>
             </span>
@@ -70,7 +79,10 @@ export default function DailyChecklist({ profile, scope, loading = false }: Dail
       <p className={styles.note}>
         {loading
           ? '正在读取账号记录；暂时显示这台设备上的状态。'
-          : `最长连续 ${loop.streak.longest_days} 天。匿名状态只代表这台设备。`}
+          : // The 匿名状态 caveat only belongs to device-scope (anonymous) records
+            // (F4). A signed-in visitor sees 本账号 scope, so leaking「匿名状态只
+            // 代表这台设备」into the account view is a scope mismatch — drop it there.
+            `最长连续 ${loop.streak.longest_days} 天。${scope === 'device' ? '匿名状态只代表这台设备。' : ''}`}
       </p>
       <p className={styles.hint}>{getDailyResetHint()}</p>
     </section>

--- a/packages/platform/src/pages/GamesPage.test.tsx
+++ b/packages/platform/src/pages/GamesPage.test.tsx
@@ -253,7 +253,9 @@ describe('GamesPage homepage', () => {
     // C3/F7: the completion time renders in the viewer's local timezone as HH:MM
     // and no longer carries a raw「… UTC」label. TZ-robust — assert the shape,
     // not a fixed clock (the exact local time depends on the runner timezone).
-    const completionLine = screen.getByText(/^已完成 · \d{2}:\d{2}$/)
+    // F3: the line reads「完成于 HH:MM」(a point in time), not the old ambiguous
+    // 「已完成 · HH:MM」that read as a game 用时 next to the result page's duration.
+    const completionLine = screen.getByText(/^完成于 \d{2}:\d{2}$/)
     expect(completionLine).toBeInTheDocument()
     expect(completionLine.textContent).not.toContain('UTC')
     expect(screen.getByText('连续天数 · 本设备')).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- 首跑引导时刻 (re-audit R3's S4, the closure plan's tier-1 gap): once-per-device skippable primer explaining the co-op model + the honest no-AI path (sign in → platform companion); 390/360 render-proofed
- Board integrity: plausibility floor applied at every read surface incl. submit-returned rank; anti-cheat copy fully Chinese; legacy junk hidden not deleted
- 「已完成 · 04:4x」 clock-time relabeled 完成于 — it was being misread as a duration
- Pre-existing deterministic e2e red (@survey-fresh) root-caused and fixed (2000ms wait vs real 4200ms celebration)

3-axis verify + fix round (rank-path filter gap closed).

## Test plan
- [x] api 216 / platform 207 / bombsquad 489 / yijing 271; typecheck; full lint; e2e audit 31↔31; @survey 3/3 now green
- [ ] CI full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w79dZWZzh7A7W6A7deN31