### PR TITLE
feat: playable Botanical Garden on probe branch (creation engine generality probe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Botanical Garden becomes a playable game on its own probe branch** - Internal
+change. The creation engine's botanical-garden case grows from a dev-harness
+data table into a real player-facing game (`packages/game-botanical`): a night
+garden scene with zone light bands and per-plant decay rings, verb-card care
+actions, an in-app AI botanist over the platform voice contract (voice primary,
+typed text fallback via a probe-only additive `text-turn` message), real-time
+neglect decay with a lose condition, and two machine-validated levels. The
+engine gains game-agnostic timed-emitter and lose-condition extensions with
+validator checks; sibling game fixtures are untouched. Not wired into the
+production arcade; playable via local dev only.
+
 **The Shadow Chase pursuer now obeys only visible world rules** — Fix. The
 pursuer no longer reads the private follow, split, or decoy command, any model
 lease, or a hidden shadow's live position. It sees the full unobstructed row and
@@ -53,7 +64,6 @@ to sign in — decline and the run simply stays off the board. The celebration a
 「再来一局」 lead the first screen, with the profile and module-breakdown cards
 below. The post-game survey no longer opens over your celebration or a near-miss:
 it waits as a quiet 「聊聊这一局」 link at the bottom once everything has settled.
-
 **Dual Shadow Chase now starts with a real tactical conversation** — Improvement.
 The new two-to-five-minute solo game now uses Chinese-first player copy and shows
 the complete frozen map before the chase. Tactical planning defaults to 20 seconds,
@@ -120,7 +130,6 @@ games now draw from one shared set of components and design tokens instead of
 per-screen copies. The visible result is a steadier, more finished feel; the
 Oracle's violet-gold and cinnabar-seal styling is now a registered part of that
 system rather than one-off colors.
-
 **A first-time player learns how BombSquad is played before the manual step** - Fix.
 An anonymous newcomer was dropped straight onto 「把手册发给你的 AI」 with no
 explanation of the unusual premise — you and a separate voice AI split the bomb

--- a/packages/creation/fixtures/botanical-garden/game-type.yaml
+++ b/packages/creation/fixtures/botanical-garden/game-type.yaml
@@ -11,7 +11,7 @@
 # target-language instantiation DATA; comments are English per repo policy.
 GameType:
   id: botanical-garden
-  version: '1.0.0'
+  version: '1.1.0' # v1.1.0: adds timed decay + lose condition + the dead health state
   display_name: 植物园养护
   description: 视觉多实体并行管理——一方看植物园场景，另一方持养护手册
 
@@ -49,9 +49,13 @@ GameType:
       states:
         # RESTRUCTURE: health ordered worst→best so advance_state = heal, and
         # so optimization_target's `at_least` ranks by declared order.
+        # v1.1.0: `dead` prepended as the worst end (timed-decay terminal). The
+        # prepend shifts every index +1 but advance_state (relative step) and
+        # optimization_target rank checks (indexOf on the same shifted order)
+        # are order-invariant, so existing win semantics are unchanged.
         - name: health
           type: enum
-          values: [critical, wilting, stable, thriving]
+          values: [dead, critical, wilting, stable, thriving]
           initial: stable
           verbal_template: '健康状态{health}'
         - name: growth_stage
@@ -180,8 +184,15 @@ GameType:
             effect: change_health
             params: [{ name: delta, type: string }]
           - relation: synergy
-            effect: change_health
-            params: [{ name: delta, type: string }]
+            # ACTIVE effect (standard-level play): synergy pairs heal each other
+            # one step (advance_state) on every apply_care. Safe on bg-demo-001:
+            # its matrix has no synergy pair present (the [fern, moss, synergy]
+            # row never matches — the tutorial has no moss), so this stays inert
+            # there. compatible/incompatible/neutral MUST stay change_health
+            # (no state_effect) — they are GameType-shared and a synergy-style
+            # heal on `compatible` would retroactively alter bg-demo-001.
+            effect: heal
+            params: []
           - relation: neutral
             effect: change_health
             params: [{ name: delta, type: string }]
@@ -190,7 +201,9 @@ GameType:
     - id: health_response
       type: state_transition
       transition_table_schema:
-        states: [critical, wilting, stable, thriving]
+        # v1.1.0: `dead` added so a decay row can reach it (the template's
+        # declared state list must include every value a transition row reaches).
+        states: [dead, critical, wilting, stable, thriving]
         events: [correct_care, wrong_care, neglect]
       communication_weight: 0.5
 
@@ -285,6 +298,23 @@ GameType:
   win_condition_type:
     type: optimization_target
     description: 所有植株健康达到 stable 或更高，且至少一株生长阶段达到 flowering
+
+  # v1.1.0: any plant reaching `dead` (枯死) ends the run as a loss.
+  lose_condition_type:
+    type: any_element_state_equals
+    description: 任一植株健康状态跌至 dead 即败局（枯死）
+
+  # v1.1.0: timed decay — `neglect` fires automatically on every plant as
+  # simulated time advances (host-injected via GameSession.advanceTime; the
+  # engine reads no wall-clock). Gentle tutorial pacing (60s base); per-plant
+  # staggering lives in the Level's initial_timers.
+  timed_emitters:
+    - id: decay
+      event: neglect
+      target_template: health_response
+      target: { kind: archetype, archetype: plant }
+      interval_ms: 60000
+      warning_lead_ms: 8000
 
   difficulty_budget:
     element_count:

--- a/packages/creation/fixtures/botanical-garden/level.bg-demo-001.yaml
+++ b/packages/creation/fixtures/botanical-garden/level.bg-demo-001.yaml
@@ -11,7 +11,7 @@ Level:
   metadata:
     id: bg-demo-001
     game_type: botanical-garden
-    game_type_version: '1.0.0'
+    game_type_version: '1.1.0' # lockstep with the v1.1.0 GameType (decay + dead + lose)
     title: 小花圃急救
     author: ai-author-002
     created_at: '2026-07-02T22:00:00+08:00'
@@ -47,6 +47,7 @@ Level:
         soil_type: peaty
       position: { slot: 1 }
       initial_states: { health: wilting, effective_light: partial_shade } # north zone: partial_shade
+      initial_timers: { decay: { offset_ms: 0 } } # staggered decay phase (fires last)
     - id: plant-2
       archetype: plant
       params:
@@ -55,6 +56,7 @@ Level:
         soil_type: sandy
       position: { slot: 5 }
       initial_states: { health: stable, effective_light: full_sun } # center zone: full_sun
+      initial_timers: { decay: { offset_ms: 20000 } } # staggered decay phase
     - id: plant-3
       archetype: plant
       params:
@@ -63,6 +65,7 @@ Level:
         soil_type: loamy
       position: { slot: 6 }
       initial_states: { health: wilting, effective_light: full_sun } # center zone: full_sun
+      initial_timers: { decay: { offset_ms: 40000 } } # staggered decay phase (fires first)
     - id: zone-north
       archetype: environment_zone
       params:
@@ -128,6 +131,9 @@ Level:
       target_elements: [plant-1, plant-2, plant-3]
     - id: rule-health
       template: health_response
+      # v1.1.0: covers ALL plants (the archetype-scoped decay emitter targets
+      # every plant, so each must carry a health_response rule) and the neglect
+      # ladder walks the whole way to `dead` so no decay ring lies.
       bindings:
         transitions:
           - [wilting, correct_care, stable]
@@ -138,7 +144,9 @@ Level:
           - [wilting, wrong_care, critical]
           - [thriving, neglect, stable]
           - [stable, neglect, wilting]
-      target_elements: [plant-1, plant-2]
+          - [wilting, neglect, critical]
+          - [critical, neglect, dead]
+      target_elements: [plant-1, plant-2, plant-3]
     - id: rule-growth
       template: growth_advancement
       bindings:
@@ -195,3 +203,8 @@ Level:
         - { state: health, value: stable } # every plant health >= stable (declared-order rank)
       count_states_equal:
         - { state: growth_stage, value: flowering, count: 1 } # >= 1 plant flowering
+
+  # v1.1.0: any plant reaching `dead` (via the neglect decay ladder) loses.
+  lose_condition:
+    type: any_element_state_equals
+    params: { state: health, value: dead }

--- a/packages/creation/fixtures/botanical-garden/level.bg-standard-001.yaml
+++ b/packages/creation/fixtures/botanical-garden/level.bg-standard-001.yaml
@@ -1,0 +1,276 @@
+# Botanical Garden standard Level (bg-standard-001). Bigger than the tutorial:
+# 5 plants (one per species — the GameType's shared_label_attributes: [species]
+# renders instance labels from species alone, so same-species plants would
+# collide on rendered_label_unique / instance_label_unique; 5 distinct species
+# is the feasible maximum under the current vocabulary — see r5-produce report
+# §Fork Point on the design's 6-8 target) across the 3 zones, exercising:
+#   - REACHABLE mis-care danger (the R5-fix): the harm a player can actually
+#     cause with the shipped verbs (water/shade/fertilize/repot/bloom) is
+#     REMOVING a heal via mis-shading — decay then does the killing (the only
+#     player-reachable health-decline; see r5-fix1 report for the engine
+#     boundary). Two distinct reachable traps:
+#       · orchid — starts full_sun, heals ONLY at partial_shade: care it BEFORE
+#         shading and nothing happens (wasted turns); shade it TWICE and it
+#         locks into full_shade where it can never heal again (irreversible —
+#         no verb raises light). "遮光后再养护，别遮过头."
+#       · fern — starts partial_shade (the right light), heals ONLY at
+#         partial_shade: shade it even ONCE and it drops to full_shade, locked
+#         out of healing. "蕨类已在正确光照，别再遮光."
+#   - synergy heal: moss + succulent are a synergy pair; caring for one heals
+#     BOTH one step (the GameType's synergy effect_schema advance_state) — a
+#     plant you did not touch gets healed. The matrix genuinely affects play.
+#   - timed decay + death: every plant decays (archetype-scoped emitter);
+#     initial_timers stagger the phase and put the orchid on a faster interval
+#     (the high-maintenance plant); any plant reaching `dead` loses.
+#   - growth to flowering: the orchid grows seedling→flowering.
+# Win: all plants health >= stable AND >= 1 flowering. Lose: any plant dead.
+Level:
+  metadata:
+    id: bg-standard-001
+    game_type: botanical-garden
+    game_type_version: '1.1.0'
+    title: 温室轮值
+    author: ai-author-002
+    created_at: '2026-07-10T21:00:00+08:00'
+
+  # partition_complexity is GameType-derived (same partition template as the
+  # tutorial) → 2.7. total_score = 8*0.8 + 7*1.2 + 2.7*2.0 = 6.4 + 8.4 + 5.4.
+  difficulty:
+    element_count: 8 # 5 plants + zone-north/center/south
+    rule_count: 7 # light + orchid-care + fern-care + health + health-shaded + growth + compatibility
+    partition_complexity: 2.7
+    total_score: 20.2
+
+  # round_trips = ceil(light 0.5 + orchid-care 2.0 + fern-care 2.0 + health 0.5
+  #             + health-shaded 0.5 + growth 1.0 + compatibility 0.5 = 7.0) = 7
+  communication_estimate:
+    round_trips: 7
+    estimated_seconds: 70
+    time_limit_seconds: 480
+    feasibility: feasible # 70 <= 480*0.75 = 360
+
+  elements:
+    - id: plant-orchid
+      archetype: plant
+      params:
+        species: orchid
+        pot_position: 4
+        soil_type: loamy
+      position: { slot: 4 }
+      initial_states: { health: wilting, effective_light: full_sun } # center zone; must shade ONCE to heal
+      initial_timers: { decay: { interval_ms: 40000, offset_ms: 0 } } # fragile: faster decay
+    - id: plant-fern
+      archetype: plant
+      params:
+        species: fern
+        pot_position: 1
+        soil_type: peaty
+      position: { slot: 1 }
+      initial_states: { health: wilting, effective_light: partial_shade } # north zone; already right light — do NOT shade
+      initial_timers: { decay: { offset_ms: 10000 } }
+    - id: plant-moss
+      archetype: plant
+      params:
+        species: moss
+        pot_position: 2
+        soil_type: peaty
+      position: { slot: 2 }
+      initial_states: { health: stable, effective_light: partial_shade } # north zone; synergy partner, water-healed
+      initial_timers: { decay: { offset_ms: 20000 } }
+    - id: plant-succulent
+      archetype: plant
+      params:
+        species: succulent
+        pot_position: 5
+        soil_type: sandy
+      position: { slot: 5 }
+      initial_states: { health: stable, effective_light: full_sun } # center zone; synergy partner, water-healed
+      initial_timers: { decay: { offset_ms: 30000 } }
+    - id: plant-vine
+      archetype: plant
+      params:
+        species: vine
+        pot_position: 7
+        soil_type: loamy
+      position: { slot: 7 }
+      initial_states: { health: thriving, effective_light: full_shade } # south zone; already healthy
+      initial_timers: { decay: { offset_ms: 45000 } }
+    - id: zone-north
+      archetype: environment_zone
+      params:
+        zone_id: north
+        light_level: partial_shade
+        temperature: cool
+        covers_positions: ['1', '2', '3']
+    - id: zone-center
+      archetype: environment_zone
+      params:
+        zone_id: center
+        light_level: full_sun
+        temperature: warm
+        covers_positions: ['4', '5', '6']
+    - id: zone-south
+      archetype: environment_zone
+      params:
+        zone_id: south
+        light_level: full_shade
+        temperature: moderate
+        covers_positions: ['7', '8', '9']
+
+  rules:
+    # rule-light precedes the care rules so one apply_care(shade) sets the new
+    # light THEN the needs-rule re-evaluates against it (the over-shade trap:
+    # once a plant drops to full_shade its heal rule stops firing, and no verb
+    # raises light again).
+    - id: rule-light
+      template: light_adjustment
+      bindings:
+        transitions:
+          - [full_sun, shade_applied, partial_shade]
+          - [partial_shade, shade_applied, full_shade]
+      target_elements: [plant-orchid, plant-fern]
+    - id: rule-orchid-care
+      template: needs_rule
+      # Orchid heals ONLY under partial_shade. Care it at full_sun → nothing
+      # (must shade first); shade twice → full_shade → this rule stops firing.
+      bindings:
+        predicates:
+          [
+            { name: species_is, species: orchid },
+            { name: light_is, effective_light: partial_shade },
+          ]
+        combinator: AND
+        action: { verb: heal }
+      target_elements: [plant-orchid]
+    - id: rule-fern-care
+      template: needs_rule
+      # Fern heals ONLY under partial_shade (its starting light). Shade it and
+      # it drops to full_shade → this rule stops firing → locked out of healing.
+      bindings:
+        predicates:
+          [{ name: species_is, species: fern }, { name: light_is, effective_light: partial_shade }]
+        combinator: AND
+        action: { verb: heal }
+      target_elements: [plant-fern]
+    - id: rule-health
+      template: health_response
+      # Water-healed plants (moss/succulent/vine): correct_care recovery
+      # (reachable via the `water` verb) + the neglect decay ladder to `dead`.
+      # No wrong_care rows: no shipped verb produces wrong_care, so every
+      # transition here is reachable in real play.
+      bindings:
+        transitions:
+          - [wilting, correct_care, stable]
+          - [stable, correct_care, thriving]
+          - [critical, correct_care, wilting]
+          - [thriving, neglect, stable]
+          - [stable, neglect, wilting]
+          - [wilting, neglect, critical]
+          - [critical, neglect, dead]
+      target_elements: [plant-moss, plant-succulent, plant-vine]
+    - id: rule-health-shaded
+      template: health_response
+      # The shade-healed plants (orchid + fern) heal ONLY through their
+      # needs-rules, so this rule carries just the neglect decay ladder to
+      # `dead` (the decay-coverage requirement); watering them is inert.
+      bindings:
+        transitions:
+          - [thriving, neglect, stable]
+          - [stable, neglect, wilting]
+          - [wilting, neglect, critical]
+          - [critical, neglect, dead]
+      target_elements: [plant-orchid, plant-fern]
+    - id: rule-growth
+      template: growth_advancement
+      # Only the orchid grows to flowering (the win's flowering candidate).
+      bindings:
+        transitions:
+          - [seedling, fertilize_correct, juvenile]
+          - [juvenile, repot_correct, mature]
+          - [mature, bloom_correct, flowering]
+      target_elements: [plant-orchid]
+    - id: rule-compatibility
+      template: compatibility_matrix
+      # moss + succulent = synergy (heals both, via the GameType's active
+      # synergy effect) — caring for either lifts the other. moss + vine and
+      # succulent + vine bind change_health (no state_effect) so they stay
+      # informational.
+      bindings:
+        matrix:
+          - [moss, succulent, synergy]
+          - [succulent, vine, compatible]
+          - [moss, vine, neutral]
+      target_elements: [plant-moss, plant-succulent, plant-vine]
+
+  information_partition:
+    role_assignments:
+      - role: gardener
+        element_views:
+          - {
+              element_id: plant-orchid,
+              visible_attributes: [species, pot_position],
+              visible_states: [health, growth_stage, effective_light],
+            }
+          - {
+              element_id: plant-fern,
+              visible_attributes: [species, pot_position],
+              visible_states: [health, growth_stage, effective_light],
+            }
+          - {
+              element_id: plant-moss,
+              visible_attributes: [species, pot_position],
+              visible_states: [health, growth_stage, effective_light],
+            }
+          - {
+              element_id: plant-succulent,
+              visible_attributes: [species, pot_position],
+              visible_states: [health, growth_stage, effective_light],
+            }
+          - {
+              element_id: plant-vine,
+              visible_attributes: [species, pot_position],
+              visible_states: [health, growth_stage, effective_light],
+            }
+          - {
+              element_id: zone-north,
+              visible_attributes: [zone_id, light_level, temperature, covers_positions],
+              visible_states: [],
+            }
+          - {
+              element_id: zone-center,
+              visible_attributes: [zone_id, light_level, temperature, covers_positions],
+              visible_states: [],
+            }
+          - {
+              element_id: zone-south,
+              visible_attributes: [zone_id, light_level, temperature, covers_positions],
+              visible_states: [],
+            }
+      - role: botanist
+        element_views:
+          - {
+              element_id: plant-orchid,
+              visible_attributes: [species, soil_type],
+              visible_states: [],
+            }
+          - { element_id: plant-fern, visible_attributes: [species, soil_type], visible_states: [] }
+          - { element_id: plant-moss, visible_attributes: [species, soil_type], visible_states: [] }
+          - {
+              element_id: plant-succulent,
+              visible_attributes: [species, soil_type],
+              visible_states: [],
+            }
+          - { element_id: plant-vine, visible_attributes: [species, soil_type], visible_states: [] }
+
+  win_condition:
+    type: optimization_target
+    params:
+      all_states_at_least:
+        - { state: health, value: stable } # every plant health >= stable
+      count_states_equal:
+        - { state: growth_stage, value: flowering, count: 1 } # >= 1 plant flowering
+
+  # Any plant reaching `dead` (via the neglect decay ladder) loses.
+  lose_condition:
+    type: any_element_state_equals
+    params: { state: health, value: dead }

--- a/packages/creation/package.json
+++ b/packages/creation/package.json
@@ -2,6 +2,11 @@
   "name": "@amiclaw/creation",
   "private": true,
   "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "dev": "vite --config dev/vite.config.ts",
     "typecheck": "tsc --noEmit",

--- a/packages/creation/src/engine/bg-standard.test.ts
+++ b/packages/creation/src/engine/bg-standard.test.ts
@@ -1,0 +1,141 @@
+/**
+ * bg-standard-001 engine play. The mis-care dangers are all triggered by REAL
+ * shipped verbs (water / shade / …) — never an injected exotic action_type —
+ * because the only player-reachable health-decline is via mis-shading that
+ * REMOVES a heal (decay then kills): `change_health` has no state_effect and
+ * `state_effect` only advances toward the best state, so no verb declines
+ * health directly (see r5-fix1 report for the engine boundary). Also covers
+ * the moss+succulent synergy heal, the load-bearing light skill, the intended
+ * winning playthrough, and the synergy edit staying inert on the tutorial.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../schema/load'
+import { GameSession } from './engine'
+
+const bgDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'botanical-garden'
+)
+const gameType = loadGameType(readFileSync(join(bgDir, 'game-type.yaml'), 'utf8'))
+const standard = loadLevel(readFileSync(join(bgDir, 'level.bg-standard-001.yaml'), 'utf8'))
+const tutorial = loadLevel(readFileSync(join(bgDir, 'level.bg-demo-001.yaml'), 'utf8'))
+
+const care = (session: GameSession, elementId: string, actionType: string) =>
+  session.performAction('gardener', 'apply_care', {
+    element_id: elementId,
+    action_type: actionType,
+  })
+const health = (session: GameSession, elementId: string) =>
+  session.getState().elements[elementId].health
+const light = (session: GameSession, elementId: string) =>
+  session.getState().elements[elementId].effective_light
+
+describe('bg-standard-001 — reachable mis-care dangers (real verbs only)', () => {
+  it('orchid must-shade: caring at full_sun is wasted; shade heals it', () => {
+    const session = new GameSession(gameType, standard)
+    expect(health(session, 'plant-orchid')).toBe('wilting')
+    expect(light(session, 'plant-orchid')).toBe('full_sun')
+
+    // Watering the orchid at full_sun does nothing — rule-orchid-care needs
+    // partial_shade, and rule-health-shaded has no correct_care row.
+    care(session, 'plant-orchid', 'water')
+    expect(health(session, 'plant-orchid')).toBe('wilting')
+
+    // Shade once → partial_shade → rule-orchid-care heals wilting → stable.
+    care(session, 'plant-orchid', 'shade')
+    expect(light(session, 'plant-orchid')).toBe('partial_shade')
+    expect(health(session, 'plant-orchid')).toBe('stable')
+  })
+
+  it('orchid over-shade lockout: shading twice drops it to full_shade where it can never heal', () => {
+    const session = new GameSession(gameType, standard)
+    care(session, 'plant-orchid', 'shade') // full_sun → partial_shade (heals wilting → stable)
+    care(session, 'plant-orchid', 'shade') // partial_shade → full_shade (irreversible)
+    expect(light(session, 'plant-orchid')).toBe('full_shade')
+    expect(health(session, 'plant-orchid')).toBe('stable')
+
+    // At full_shade, further care no longer heals — the heal is locked out (at
+    // partial_shade this same care would advance stable → thriving).
+    care(session, 'plant-orchid', 'fertilize')
+    expect(health(session, 'plant-orchid')).toBe('stable')
+  })
+
+  it('fern mis-shade: shading the fern (already in the right light) locks out its heal', () => {
+    const session = new GameSession(gameType, standard)
+    expect(light(session, 'plant-fern')).toBe('partial_shade')
+
+    // Control: at its starting partial_shade, caring heals the fern.
+    const control = new GameSession(gameType, standard)
+    care(control, 'plant-fern', 'water')
+    expect(health(control, 'plant-fern')).toBe('stable')
+
+    // Trap: shading the fern drops it to full_shade — no heal, and now locked.
+    care(session, 'plant-fern', 'shade')
+    expect(light(session, 'plant-fern')).toBe('full_shade')
+    expect(health(session, 'plant-fern')).toBe('wilting')
+    care(session, 'plant-fern', 'water')
+    expect(health(session, 'plant-fern')).toBe('wilting') // locked out of healing
+  })
+})
+
+describe('bg-standard-001 — synergy heal bonus (matrix affects play)', () => {
+  it('caring for one synergy plant heals its untouched partner', () => {
+    const session = new GameSession(gameType, standard)
+    expect(health(session, 'plant-moss')).toBe('stable')
+    expect(health(session, 'plant-succulent')).toBe('stable')
+
+    // Watering moss: correct_care lifts moss stable → thriving, and the
+    // moss+succulent synergy lifts the untouched succulent stable → thriving.
+    care(session, 'plant-moss', 'water')
+    expect(health(session, 'plant-moss')).toBe('thriving')
+    expect(health(session, 'plant-succulent')).toBe('thriving')
+  })
+})
+
+describe('bg-standard-001 — intended playthrough wins', () => {
+  it('shade the orchid, tend the fern, water moss (synergy), grow the orchid to flowering', () => {
+    const session = new GameSession(gameType, standard)
+    expect(session.isWon()).toBe(false)
+
+    care(session, 'plant-orchid', 'shade') // orchid heals wilting → stable
+    expect(health(session, 'plant-orchid')).toBe('stable')
+    care(session, 'plant-fern', 'water') // fern-care heals wilting → stable
+    expect(health(session, 'plant-fern')).toBe('stable')
+    care(session, 'plant-moss', 'water') // moss → thriving, succulent → thriving (synergy)
+    care(session, 'plant-orchid', 'fertilize') // seedling → juvenile (also heals at partial_shade)
+    care(session, 'plant-orchid', 'repot') // juvenile → mature
+    care(session, 'plant-orchid', 'bloom') // mature → flowering
+    expect(session.getState().elements['plant-orchid'].growth_stage).toBe('flowering')
+
+    expect(session.isWon()).toBe(true)
+    expect(session.getState().won).toBe(true)
+  })
+})
+
+describe('the synergy effect_schema edit is inert on the tutorial (bg-demo-001)', () => {
+  it('watering the tutorial fern heals only the correct_care step (no synergy pair)', () => {
+    const session = new GameSession(gameType, tutorial)
+    expect(health(session, 'plant-1')).toBe('wilting')
+    care(session, 'plant-1', 'water')
+    // Only correct_care fires: wilting → stable. NOT thriving — bg-demo-001 has
+    // no moss, so the [fern, moss, synergy] row never matches a real pair.
+    expect(health(session, 'plant-1')).toBe('stable')
+  })
+
+  it('the scripted tutorial care loop still wins', () => {
+    const session = new GameSession(gameType, tutorial)
+    care(session, 'plant-1', 'water')
+    care(session, 'plant-3', 'shade')
+    care(session, 'plant-3', 'fertilize')
+    care(session, 'plant-3', 'repot')
+    care(session, 'plant-3', 'bloom')
+    expect(session.isWon()).toBe(true)
+  })
+})

--- a/packages/creation/src/engine/botanical-decay.test.ts
+++ b/packages/creation/src/engine/botanical-decay.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Timed decay engine extension (§2): the host-injected advanceTime clock +
+ * per-(emitter, element) timerStatus, exercised on the botanical vocabulary
+ * through the SHARED state_transition core. All timers are synthetic clones of
+ * the golden (R1 keeps the shipped fixtures free of timed_emitters); the
+ * engine reads no wall-clock, so every assertion is deterministic.
+ *
+ * Covers test-design cases TC-01..TC-04, TC-18/TC-19 (manager-pinned throw),
+ * TC-20, TC-22, TC-24, TC-27, TC-30, TC-32.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../schema/load'
+import type { GameType, Level, TimedEmitter } from '../schema/types'
+import { GameSession } from './engine'
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'fixtures')
+const bgDir = join(fixturesDir, 'botanical-garden')
+const gameType = loadGameType(readFileSync(join(bgDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(bgDir, 'level.bg-demo-001.yaml'), 'utf8'))
+const rcDir = join(fixturesDir, 'radio-cipher')
+const rcGameType = loadGameType(readFileSync(join(rcDir, 'game-type.yaml'), 'utf8'))
+const rcLevel = loadLevel(readFileSync(join(rcDir, 'level.rc-demo-001.yaml'), 'utf8'))
+
+const INTERVAL = 1000
+
+function decayEmitter(overrides: Partial<TimedEmitter> = {}): TimedEmitter {
+  return {
+    id: 'decay',
+    event: 'neglect',
+    target_template: 'health_response',
+    target: { kind: 'all' },
+    interval_ms: INTERVAL,
+    warning_lead_ms: 200,
+    ...overrides,
+  }
+}
+
+/**
+ * Clone the golden with a single decay emitter, all three plants seeded
+ * thriving, and the fixture's initial_timers stagger CLEARED so each test
+ * controls timing against the emitter's interval (the shipped 60s offsets
+ * would otherwise overshoot a 1s test interval and fire on the first tick).
+ */
+function decayFixture(emitter: TimedEmitter = decayEmitter()): { gt: GameType; level: Level } {
+  const gt = structuredClone(gameType)
+  gt.timed_emitters = [emitter]
+  const lvl = structuredClone(level)
+  for (const id of ['plant-1', 'plant-2', 'plant-3']) {
+    const plant = lvl.elements.find((e) => e.id === id)
+    if (!plant) throw new Error(`fixture element ${id} missing`)
+    plant.initial_states = { ...plant.initial_states, health: 'thriving' }
+    delete plant.initial_timers
+  }
+  return { gt, level: lvl }
+}
+
+describe('advanceTime — no-op / boundary cases', () => {
+  it('TC-01: absent timed_emitters is a total no-op (radio-cipher)', () => {
+    const session = new GameSession(rcGameType, rcLevel)
+    const before = JSON.stringify(session.getState())
+    expect(session.advanceTime(10_000)).toEqual([])
+    expect(session.timerStatus()).toEqual([])
+    expect(JSON.stringify(session.getState())).toBe(before)
+  })
+
+  it('TC-02: empty timed_emitters:[] behaves identically to absent', () => {
+    const gt = structuredClone(gameType)
+    gt.timed_emitters = []
+    const session = new GameSession(gt, level)
+    expect(session.advanceTime(5000)).toEqual([])
+    expect(session.timerStatus()).toEqual([])
+  })
+
+  it('TC-04: an emitter targeting elements with no consuming rule fires nothing harmful', () => {
+    // Archetype-scoped onto environment_zone: real elements, but no
+    // health_response rule + empty state machine → every tick is inert.
+    const gt = structuredClone(gameType)
+    gt.timed_emitters = [
+      decayEmitter({ target: { kind: 'archetype', archetype: 'environment_zone' } }),
+    ]
+    const session = new GameSession(gt, level)
+    const before = JSON.stringify(session.getState())
+    let ticks: ReturnType<GameSession['advanceTime']> = []
+    expect(() => {
+      ticks = session.advanceTime(2 * INTERVAL)
+    }).not.toThrow()
+    expect(ticks.length).toBe(3) // zone-north/center/south
+    expect(ticks.every((t) => t.fired === false)).toBe(true)
+    expect(JSON.stringify(session.getState())).toBe(before)
+  })
+})
+
+describe('advanceTime — firing through the state_transition core', () => {
+  it('TC-03: the minimum positive interval (1ms) fires on the smallest tick', () => {
+    const { gt, level: lvl } = decayFixture(decayEmitter({ interval_ms: 1 }))
+    const session = new GameSession(gt, lvl)
+    const ticks = session.advanceTime(1)
+    const fired = ticks.filter((t) => t.fired)
+    expect(fired.length).toBe(3) // all three plants thriving → stable
+    expect(session.getState().elements['plant-1'].health).toBe('stable')
+    expect(ticks.every((t) => t.event === 'neglect')).toBe(true)
+  })
+
+  it('TC-24: a heal action counteracts a decay step through the same shared core', () => {
+    const { gt, level: lvl } = decayFixture()
+    const session = new GameSession(gt, lvl)
+    session.advanceTime(INTERVAL) // neglect: thriving → stable
+    expect(session.getState().elements['plant-1'].health).toBe('stable')
+    session.performAction('gardener', 'apply_care', { element_id: 'plant-1', action_type: 'water' })
+    expect(session.getState().elements['plant-1'].health).toBe('thriving') // correct_care heal
+    session.advanceTime(INTERVAL) // neglect again: thriving → stable
+    expect(session.getState().elements['plant-1'].health).toBe('stable')
+  })
+
+  it('TC-27: a big dt fires once (tick cap) — NOT associative with repeated small dt', () => {
+    const fa = decayFixture()
+    const a = new GameSession(fa.gt, fa.level)
+    a.advanceTime(3 * INTERVAL) // capped: one fire, thriving → stable
+    expect(a.getState().elements['plant-1'].health).toBe('stable')
+
+    const fb = decayFixture()
+    const b = new GameSession(fb.gt, fb.level)
+    b.advanceTime(INTERVAL) // thriving → stable
+    b.advanceTime(INTERVAL) // stable → wilting
+    b.advanceTime(INTERVAL) // wilting → critical (full v1.1.0 ladder), not yet dead
+    expect(b.getState().elements['plant-1'].health).toBe('critical')
+
+    expect(a.getState().elements['plant-1'].health).not.toBe(
+      b.getState().elements['plant-1'].health
+    )
+  })
+})
+
+describe('advanceTime — idempotency + adversarial dt (manager-pinned)', () => {
+  it('TC-22: advanceTime(0) is idempotent; sub-interval charge accumulates then fires once', () => {
+    const { gt, level: lvl } = decayFixture()
+    const session = new GameSession(gt, lvl)
+    const before = JSON.stringify(session.getState())
+    expect(session.advanceTime(0)).toEqual([])
+    expect(JSON.stringify(session.getState())).toBe(before)
+
+    expect(session.advanceTime(INTERVAL / 2).some((t) => t.fired)).toBe(false) // no cross yet
+    const second = session.advanceTime(INTERVAL / 2)
+    expect(second.filter((t) => t.fired).length).toBe(3) // crosses on the cumulative total
+    expect(session.getState().elements['plant-1'].health).toBe('stable')
+  })
+
+  it('TC-18/TC-19: non-finite or negative dt THROWS (host bug, fail loud); later valid call still fires', () => {
+    const { gt, level: lvl } = decayFixture()
+    const session = new GameSession(gt, lvl)
+    expect(() => session.advanceTime(-500)).toThrow()
+    expect(() => session.advanceTime(Number.NaN)).toThrow()
+    expect(() => session.advanceTime(Number.POSITIVE_INFINITY)).toThrow()
+    // The rejected calls mutate nothing, so charge is intact.
+    expect(session.advanceTime(INTERVAL).some((t) => t.fired)).toBe(true)
+  })
+})
+
+describe('advanceTime — game-over freeze + timerStatus', () => {
+  /** All plants thriving + plant-3 flowering → optimization_target already met. */
+  function wonFixture(): { gt: GameType; level: Level } {
+    const gt = structuredClone(gameType)
+    gt.timed_emitters = [decayEmitter()]
+    const lvl = structuredClone(level)
+    for (const id of ['plant-1', 'plant-2', 'plant-3']) {
+      const plant = lvl.elements.find((e) => e.id === id)
+      if (!plant) throw new Error(`fixture element ${id} missing`)
+      plant.initial_states = { ...plant.initial_states, health: 'thriving' }
+    }
+    const p3 = lvl.elements.find((e) => e.id === 'plant-3')
+    if (!p3) throw new Error('plant-3 missing')
+    p3.initial_states = { ...p3.initial_states, growth_stage: 'flowering' }
+    return { gt, level: lvl }
+  }
+
+  it('TC-20/TC-32: won at t=0 → advanceTime is a no-op freeze; timerStatus stays readable', () => {
+    const { gt, level: lvl } = wonFixture()
+    const session = new GameSession(gt, lvl)
+    expect(session.isWon()).toBe(true) // TC-32: initial snapshot is already over
+    const before = JSON.stringify(session.getState())
+    expect(session.advanceTime(5 * INTERVAL)).toEqual([]) // frozen: no plant decays
+    expect(JSON.stringify(session.getState())).toBe(before)
+    expect(session.timerStatus().length).toBeGreaterThan(0) // still readable
+  })
+
+  it('TC-30: timerStatus drives the per-pot ring — stagger, warning flip, pure read', () => {
+    const gt = structuredClone(gameType)
+    gt.timed_emitters = [decayEmitter({ warning_lead_ms: 300 })]
+    const lvl = structuredClone(level)
+    // Clear the shipped 60s stagger, then set test offsets against interval 1000.
+    const offsets: Record<string, number> = { 'plant-1': 0, 'plant-2': 400, 'plant-3': 0 }
+    for (const plant of lvl.elements) {
+      if (offsets[plant.id] === undefined) continue
+      plant.initial_states = { ...plant.initial_states, health: 'thriving' }
+      plant.initial_timers = { decay: { offset_ms: offsets[plant.id] } }
+    }
+    const session = new GameSession(gt, lvl)
+    session.advanceTime(500) // p1 charge 500, p2 charge 900 — neither crosses
+
+    const st1 = session
+      .timerStatus()
+      .find((t) => t.elementId === 'plant-1' && t.emitterId === 'decay')
+    const st2 = session
+      .timerStatus()
+      .find((t) => t.elementId === 'plant-2' && t.emitterId === 'decay')
+    expect(st1?.msUntilTick).toBe(500)
+    expect(st2?.msUntilTick).toBe(100) // staggered by offset 400
+    expect(st1?.warning).toBe(false) // 500 > 300
+    expect(st2?.warning).toBe(true) // 100 <= 300
+    expect(st1?.warning).toBe((st1?.msUntilTick ?? 0) <= 300)
+
+    // Pure read: no mutation, two consecutive reads identical.
+    const stateBefore = JSON.stringify(session.getState())
+    const readA = session.timerStatus()
+    const readB = session.timerStatus()
+    expect(readB).toEqual(readA)
+    expect(JSON.stringify(session.getState())).toBe(stateBefore)
+  })
+})

--- a/packages/creation/src/engine/botanical-lose.test.ts
+++ b/packages/creation/src/engine/botanical-lose.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Lose condition + death (§3): the full neglect ladder to `dead`, isLost(),
+ * the win/lose same-tick precedence (lose wins ties), the game-agnostic
+ * "dead is terminal — no resurrection" guard, and the enum-order invariance of
+ * prepending `dead`. Exercised on the v1.1.0 botanical fixtures.
+ *
+ * Covers test-design cases TC-25, TC-26, TC-28, TC-29, TC-31, and the engine
+ * half of TC-17 (the lie a lying decay ring would tell).
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../schema/load'
+import type { GameType, Level, TimedEmitter } from '../schema/types'
+import { GameSession } from './engine'
+
+const bgDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'botanical-garden'
+)
+const gameType = loadGameType(readFileSync(join(bgDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(bgDir, 'level.bg-demo-001.yaml'), 'utf8'))
+
+const INTERVAL = 1000
+
+function fastDecayEmitter(overrides: Partial<TimedEmitter> = {}): TimedEmitter {
+  return {
+    id: 'decay',
+    event: 'neglect',
+    target_template: 'health_response',
+    target: { kind: 'archetype', archetype: 'plant' },
+    interval_ms: INTERVAL,
+    ...overrides,
+  }
+}
+
+/** v1.1.0 clone: fast decay emitter, plant health seeded, stagger cleared. */
+function fixture(seedHealth: Record<string, string> = {}): { gt: GameType; level: Level } {
+  const gt = structuredClone(gameType)
+  gt.timed_emitters = [fastDecayEmitter()]
+  const lvl = structuredClone(level)
+  for (const plant of lvl.elements) {
+    if (plant.archetype !== 'plant') continue
+    delete plant.initial_timers
+    const health = seedHealth[plant.id]
+    if (health) plant.initial_states = { ...plant.initial_states, health }
+  }
+  return { gt, level: lvl }
+}
+
+describe('death via the full neglect ladder', () => {
+  it('TC-25: neglect walks thriving → dead and isLost() flips at dead', () => {
+    // All three plants seeded thriving with equal timing → they die in
+    // lockstep on the fourth tick, so no earlier death freezes the run before
+    // plant-1 completes its ladder.
+    const { gt, level: lvl } = fixture({
+      'plant-1': 'thriving',
+      'plant-2': 'thriving',
+      'plant-3': 'thriving',
+    })
+    const session = new GameSession(gt, lvl)
+    const seen: string[] = []
+    const lostAfter: boolean[] = []
+    let lastTicks: ReturnType<GameSession['advanceTime']> = []
+    for (let i = 0; i < 4; i++) {
+      lastTicks = session.advanceTime(INTERVAL)
+      seen.push(String(session.getState().elements['plant-1'].health))
+      lostAfter.push(session.isLost())
+    }
+    expect(seen).toEqual(['stable', 'wilting', 'critical', 'dead'])
+    expect(lostAfter).toEqual([false, false, false, true])
+    const p1Tick = lastTicks.find((t) => t.elementId === 'plant-1')
+    expect(p1Tick?.event).toBe('neglect')
+    expect(p1Tick?.fired).toBe(true)
+  })
+
+  it('TC-17 (engine): an emitter-targeted plant with no consuming rule never dies (the ring lies)', () => {
+    // Drop plant-3 from rule-health but keep it decay-targeted (archetype:plant)
+    // — its timer ticks yet the event is inert, so it can never reach dead.
+    const gt = structuredClone(gameType)
+    gt.timed_emitters = [fastDecayEmitter()]
+    const lvl = structuredClone(level)
+    for (const plant of lvl.elements) {
+      if (plant.archetype === 'plant') delete plant.initial_timers
+    }
+    const ruleHealth = lvl.rules.find((r) => r.id === 'rule-health')
+    if (!ruleHealth) throw new Error('fixture rule-health missing')
+    ruleHealth.target_elements = ruleHealth.target_elements.filter((id) => id !== 'plant-3')
+
+    const session = new GameSession(gt, lvl)
+    const ticks = session.advanceTime(INTERVAL)
+    const p3Tick = ticks.find((t) => t.elementId === 'plant-3')
+    expect(p3Tick).toBeTruthy() // the ring renders (plant-3 is targeted)
+    expect(p3Tick?.fired).toBe(false) // …but the event is inert
+    expect(session.getState().elements['plant-3'].health).toBe('wilting') // never decays
+  })
+})
+
+describe('win/lose precedence + terminal death', () => {
+  it('TC-26: win AND lose true in the same tick resolves to a LOSS (lose wins ties)', () => {
+    // Win = a flowering plant only (no health floor); Lose = any dead plant.
+    const gt = structuredClone(gameType)
+    const lvl = structuredClone(level)
+    lvl.win_condition = {
+      type: 'optimization_target',
+      params: { count_states_equal: [{ state: 'growth_stage', value: 'flowering', count: 1 }] },
+    }
+    const p1 = lvl.elements.find((e) => e.id === 'plant-1')
+    const p2 = lvl.elements.find((e) => e.id === 'plant-2')
+    if (!p1 || !p2) throw new Error('fixture plants missing')
+    p1.initial_states = { ...p1.initial_states, growth_stage: 'flowering' }
+    p2.initial_states = { ...p2.initial_states, health: 'dead' }
+
+    const session = new GameSession(gt, lvl)
+    // Raw predicates: both true.
+    expect(session.isWon()).toBe(true)
+    expect(session.isLost()).toBe(true)
+    // Resolved snapshot: lose wins the tie — never a win with a corpse.
+    expect(session.getState().won).toBe(false)
+    expect(session.getState().lost).toBe(true)
+  })
+
+  it('TC-28: care can never resurrect a dead plant (dead is terminal, game-agnostic)', () => {
+    // A dead orchid at partial_shade would satisfy rule-orchid-care's heal
+    // (advance_state) — the guard must block that revival.
+    const { gt, level: lvl } = fixture({ 'plant-3': 'dead' })
+    const p3 = lvl.elements.find((e) => e.id === 'plant-3')
+    if (!p3) throw new Error('plant-3 missing')
+    p3.initial_states = { ...p3.initial_states, health: 'dead', effective_light: 'partial_shade' }
+
+    const session = new GameSession(gt, lvl)
+    expect(session.isLost()).toBe(true)
+    const result = session.performAction('gardener', 'apply_care', {
+      element_id: 'plant-3',
+      action_type: 'water',
+    })
+    expect(result.ok).toBe(true) // the action is accepted…
+    expect(session.getState().elements['plant-3'].health).toBe('dead') // …but inert on the corpse
+  })
+
+  it('F3: a dead-exit transition row cannot resurrect via performAction (engine guard)', () => {
+    // Even if a level authored a `[dead, correct_care, wilting]` row, the
+    // state_transition guard blocks it (performAction is not frozen by isLost).
+    const { gt, level: lvl } = fixture({ 'plant-1': 'dead' })
+    const ruleHealth = lvl.rules.find((r) => r.id === 'rule-health')
+    if (!ruleHealth) throw new Error('fixture rule-health missing')
+    const rows = ruleHealth.bindings.transitions as unknown[]
+    ruleHealth.bindings = {
+      ...ruleHealth.bindings,
+      transitions: [...rows, ['dead', 'correct_care', 'wilting']],
+    }
+
+    const session = new GameSession(gt, lvl)
+    expect(session.isLost()).toBe(true)
+    const result = session.performAction('gardener', 'apply_care', {
+      element_id: 'plant-1',
+      action_type: 'water', // → correct_care, which the dead-exit row would consume
+    })
+    expect(result.ok).toBe(true)
+    expect(session.getState().elements['plant-1'].health).toBe('dead') // guard blocks revival
+  })
+
+  it('TC-31: an all-dead board is lost, timerStatus stays sane, advanceTime is frozen', () => {
+    const { gt, level: lvl } = fixture({ 'plant-1': 'dead', 'plant-2': 'dead', 'plant-3': 'dead' })
+    const session = new GameSession(gt, lvl)
+    expect(session.isLost()).toBe(true)
+    const status = session.timerStatus()
+    expect(status.length).toBe(3) // one per plant
+    expect(status.every((t) => t.msUntilTick >= 0)).toBe(true)
+    expect(session.advanceTime(INTERVAL)).toEqual([]) // frozen after game over
+  })
+})
+
+describe('TC-29: prepending dead preserves optimization_target rank semantics', () => {
+  it('all >= stable + one flowering still wins; a wilting plant still fails the floor', () => {
+    const won = structuredClone(level)
+    for (const plant of won.elements) {
+      if (plant.archetype === 'plant') {
+        plant.initial_states = { ...plant.initial_states, health: 'stable' }
+      }
+    }
+    const p3won = won.elements.find((e) => e.id === 'plant-3')
+    if (!p3won) throw new Error('plant-3 missing')
+    p3won.initial_states = { ...p3won.initial_states, growth_stage: 'flowering' }
+    expect(new GameSession(gameType, won).isWon()).toBe(true)
+
+    // One plant left at wilting ranks BELOW stable in the shifted order → no win.
+    const notWon = structuredClone(won)
+    const p1 = notWon.elements.find((e) => e.id === 'plant-1')
+    if (!p1) throw new Error('plant-1 missing')
+    p1.initial_states = { ...p1.initial_states, health: 'wilting' }
+    expect(new GameSession(gameType, notWon).isWon()).toBe(false)
+  })
+})

--- a/packages/creation/src/engine/decay-determinism.test.ts
+++ b/packages/creation/src/engine/decay-determinism.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Timed decay determinism property (§2, §6): advanceTime reads NO wall-clock,
+ * so the same interleaved (advanceTime, performAction) sequence over the same
+ * (GameType, Level) always yields the same state — the backbone the host's
+ * replay + solver-purity claims rest on. Also pins the documented once-per-
+ * advance tick cap as a deliberate non-associativity boundary (TC-27).
+ *
+ * Covers test-design case TC-23 (+ the TC-27 associativity boundary as a
+ * property).
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../schema/load'
+import type { GameType, Level } from '../schema/types'
+import { GameSession } from './engine'
+
+const bgDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'botanical-garden'
+)
+const gameType = loadGameType(readFileSync(join(bgDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(bgDir, 'level.bg-demo-001.yaml'), 'utf8'))
+
+const INTERVAL = 1000
+
+function decayFixture(): { gt: GameType; level: Level } {
+  const gt = structuredClone(gameType)
+  gt.timed_emitters = [
+    {
+      id: 'decay',
+      event: 'neglect',
+      target_template: 'health_response',
+      target: { kind: 'all' },
+      interval_ms: INTERVAL,
+      warning_lead_ms: 200,
+    },
+  ]
+  const lvl = structuredClone(level)
+  // Clear the shipped 60s stagger so the sequence's 1s-scale dt is meaningful;
+  // seed plant-1/plant-2 thriving and leave plant-3 wilting so it decays to
+  // death mid-sequence (this exercises decay + lose determinism together).
+  for (const plant of lvl.elements) {
+    if (plant.archetype !== 'plant') continue
+    delete plant.initial_timers
+    if (plant.id === 'plant-1' || plant.id === 'plant-2') {
+      plant.initial_states = { ...plant.initial_states, health: 'thriving' }
+    }
+  }
+  return { gt, level: lvl }
+}
+
+/** One interleaving of decay ticks and player care, exercising fire + heal + degrade. */
+function runSequence(session: GameSession): void {
+  session.advanceTime(300)
+  session.performAction('gardener', 'apply_care', { element_id: 'plant-1', action_type: 'water' })
+  session.advanceTime(1200) // crosses on plant-1
+  session.performAction('gardener', 'apply_care', {
+    element_id: 'plant-2',
+    action_type: 'overwater',
+  })
+  session.advanceTime(1500)
+  session.performAction('gardener', 'apply_care', { element_id: 'plant-1', action_type: 'water' })
+  session.advanceTime(700)
+}
+
+describe('advanceTime determinism / replay (TC-23)', () => {
+  it('two fresh sessions running the same sequence reach byte-identical state', () => {
+    const fa = decayFixture()
+    const a = new GameSession(fa.gt, fa.level)
+    const fb = decayFixture()
+    const b = new GameSession(fb.gt, fb.level)
+    runSequence(a)
+    runSequence(b)
+    expect(a.getState()).toEqual(b.getState())
+    expect(a.timerStatus()).toEqual(b.timerStatus())
+    // The sequence drives plant-3 to death — determinism spans decay + lose.
+    expect(a.isLost()).toBe(true)
+    expect(a.isLost()).toBe(b.isLost())
+  })
+
+  it('three independent replays are all mutually equal (no hidden clock state)', () => {
+    const states = [0, 1, 2].map(() => {
+      const f = decayFixture()
+      const s = new GameSession(f.gt, f.level)
+      runSequence(s)
+      return s.getState()
+    })
+    expect(states[1]).toEqual(states[0])
+    expect(states[2]).toEqual(states[0])
+  })
+
+  it('TC-27 property: summed dt is NOT associative across a tick boundary (documented cap)', () => {
+    const fa = decayFixture()
+    const bigStep = new GameSession(fa.gt, fa.level)
+    bigStep.advanceTime(3 * INTERVAL) // one fire (cap)
+
+    const fb = decayFixture()
+    const smallSteps = new GameSession(fb.gt, fb.level)
+    for (let i = 0; i < 3; i++) smallSteps.advanceTime(INTERVAL) // three fires
+
+    expect(bigStep.getState()).not.toEqual(smallSteps.getState())
+  })
+})

--- a/packages/creation/src/engine/engine.ts
+++ b/packages/creation/src/engine/engine.ts
@@ -20,8 +20,11 @@ import {
   applyConstruction,
   buildRuleContext,
   currentScore,
+  emitterTargetElementIds,
+  evaluateLose,
   evaluateWin,
   executeConditionAction,
+  isElementTerminallyLost,
   executeInteractionMatrix,
   executeStateTransition,
   executeTemporalStep,
@@ -31,7 +34,15 @@ import {
 
 export interface EngineSnapshot {
   elements: Record<string, Record<string, unknown>>
+  /**
+   * The RESOLVED win flag: true only when the win condition is met AND the run
+   * is not lost. Encodes the "lose wins ties" precedence (a corpse never shows
+   * a win), so a host can render this directly. The raw predicates isWon() /
+   * isLost() stay independent (both can be true in a tie).
+   */
   won: boolean
+  /** True when the lose condition is met (raw predicate). */
+  lost: boolean
 }
 
 export interface RoleElementView {
@@ -51,6 +62,45 @@ export interface RoleView {
 }
 
 export type ActionResult = { ok: true; effects: string[] } | { ok: false; reason: string }
+
+/**
+ * One (emitter, element) result of an advanceTime call — emitted only when the
+ * accumulated charge crossed the interval this advance. `fired` is whether a
+ * matching state_transition row actually changed state (false = the event was
+ * inert on the element, e.g. no consuming rule — the case the validator's
+ * emitter_target_reaches_terminal check prevents shipping).
+ */
+export interface TimedTick {
+  elementId: string
+  emitterId: string
+  event: string
+  fired: boolean
+}
+
+/** Per-(emitter, element) countdown for the pre-decay warning UI (pure read). */
+export interface TimerStatus {
+  elementId: string
+  emitterId: string
+  /** Milliseconds until the next tick (0 when due); never negative. */
+  msUntilTick: number
+  /** True once msUntilTick <= the emitter's warning_lead_ms. */
+  warning: boolean
+}
+
+/**
+ * One resolved (emitter, element) timer. `charge` is the only mutable field;
+ * `interval` folds in any per-instance initial_timers.interval_ms override,
+ * `warningLead` comes from the emitter (initial_timers carries no lead field).
+ */
+interface TimerEntry {
+  emitterId: string
+  event: string
+  targetTemplate: string
+  elementId: string
+  interval: number
+  warningLead: number
+  charge: number
+}
 
 export interface PerformActionArgs {
   element_id?: string
@@ -74,10 +124,41 @@ export class GameSession {
   private readonly ctx: RuleContext
   private readonly states: ElementStates
   private readonly stepsUsed = new Map<string, number>()
+  /** Resolved (emitter, element) timers; empty when no timed_emitters. */
+  private readonly timers: TimerEntry[]
 
   constructor(gameType: GameType, level: Level) {
     this.ctx = buildRuleContext(gameType, level)
     this.states = initialElementStates(gameType, level)
+    this.timers = this.buildTimers()
+  }
+
+  /**
+   * Resolve one TimerEntry per (emitter, targeted element), folding in
+   * per-instance initial_timers overrides. Initial charge = offset_ms (phase).
+   * Deterministic order (emitter order × resolved element order).
+   */
+  private buildTimers(): TimerEntry[] {
+    const timers: TimerEntry[] = []
+    for (const emitter of this.ctx.gameType.timed_emitters ?? []) {
+      const warningLead = emitter.warning_lead_ms ?? 0
+      for (const elementId of emitterTargetElementIds(this.ctx.level, emitter)) {
+        const override = this.ctx.elements.get(elementId)?.initial_timers?.[emitter.id]
+        const interval =
+          typeof override?.interval_ms === 'number' ? override.interval_ms : emitter.interval_ms
+        const offset = typeof override?.offset_ms === 'number' ? override.offset_ms : 0
+        timers.push({
+          emitterId: emitter.id,
+          event: emitter.event,
+          targetTemplate: emitter.target_template,
+          elementId,
+          interval,
+          warningLead,
+          charge: offset,
+        })
+      }
+    }
+    return timers
   }
 
   getState(): EngineSnapshot {
@@ -85,7 +166,9 @@ export class GameSession {
     for (const [elementId, machine] of this.states) {
       elements[elementId] = Object.fromEntries(machine)
     }
-    return { elements, won: this.isWon() }
+    const lost = this.isLost()
+    // Tie-break: lose wins ties — a dead plant never shows a win.
+    return { elements, won: this.isWon() && !lost, lost }
   }
 
   /**
@@ -222,6 +305,11 @@ export class GameSession {
     return evaluateWin(this.ctx, this.states)
   }
 
+  /** Failure-mode mirror of isWon (raw predicate; independent of isWon). */
+  isLost(): boolean {
+    return evaluateLose(this.ctx, this.states)
+  }
+
   /** Current score (score_threshold levels); undefined without a scoring rule. */
   score(): number | undefined {
     return currentScore(this.ctx, this.states)
@@ -230,6 +318,82 @@ export class GameSession {
   /** Spec remaining-steps metric; undefined without a construction/slot model. */
   remainingSteps(): number | undefined {
     return remainingSteps(this.ctx, this.states)
+  }
+
+  /**
+   * Advance simulated time by `dtMs`, firing any (emitter, element) whose
+   * accumulated charge crosses its interval. Deterministic: reads NO
+   * wall-clock, so the same call sequence yields the same result. Each
+   * (emitter, element) fires AT MOST ONCE per call — the documented
+   * once-per-advance tick cap (a large dt spanning many intervals still fires
+   * once and does NOT accumulate residual charge; charge is capped at
+   * interval). Returns one TimedTick per crossing for the host to render.
+   *
+   * Contracts (manager-pinned):
+   * - non-finite or negative dtMs → THROW (a host bug; fail loud).
+   * - dtMs === 0 → no-op (zero elapsed time changes nothing; idempotent).
+   * - after the run has ended (isWon OR isLost) → no-op freeze (timers stop;
+   *   timerStatus stays readable). The tick during which death occurs is fully
+   *   processed — isLost is false at its start — and only subsequent calls
+   *   freeze, so the run ends the instant a plant hits its terminal state.
+   */
+  advanceTime(dtMs: number): TimedTick[] {
+    if (!Number.isFinite(dtMs) || dtMs < 0) {
+      throw new RangeError(`advanceTime requires a finite dtMs >= 0, got ${dtMs}`)
+    }
+    if (dtMs === 0) return []
+    if (this.isWon() || this.isLost()) return []
+    const ticks: TimedTick[] = []
+    for (const timer of this.timers) {
+      timer.charge = Math.min(timer.charge + dtMs, timer.interval)
+      if (timer.charge < timer.interval) continue
+      const fired = this.fireEmitterEvent(timer.elementId, timer.targetTemplate, timer.event)
+      timer.charge = 0
+      ticks.push({
+        elementId: timer.elementId,
+        emitterId: timer.emitterId,
+        event: timer.event,
+        fired,
+      })
+    }
+    return ticks
+  }
+
+  /**
+   * Per-(emitter, element) countdown for the warning UI. Pure read: never
+   * advances charge, always readable (including after the run ends).
+   */
+  timerStatus(): TimerStatus[] {
+    return this.timers.map((timer) => {
+      const msUntilTick = Math.max(0, timer.interval - timer.charge)
+      return {
+        elementId: timer.elementId,
+        emitterId: timer.emitterId,
+        msUntilTick,
+        warning: msUntilTick <= timer.warningLead,
+      }
+    })
+  }
+
+  /**
+   * Fire one emitter event on every level rule of `targetTemplate` targeting
+   * the element, through the SAME executeStateTransition core a player-driven
+   * event uses. Returns whether any rule actually changed state.
+   */
+  private fireEmitterEvent(elementId: string, targetTemplate: string, event: string): boolean {
+    // A terminally-lost element never transitions out (mirrors the player-event
+    // guard); the advanceTime freeze makes this unreachable in practice, but it
+    // keeps the terminal-is-irreversible contract total across both callers.
+    if (isElementTerminallyLost(this.ctx, this.states, elementId)) return false
+    let changed = false
+    for (const rule of this.ctx.level.rules) {
+      if (rule.template !== targetTemplate) continue
+      if (!rule.target_elements.includes(elementId)) continue
+      const template = this.ctx.templates.get(rule.template)
+      if (!template || template.type !== 'state_transition') continue
+      if (executeStateTransition(rule, this.states, event, elementId)) changed = true
+    }
+    return changed
   }
 
   /**
@@ -252,7 +416,15 @@ export class GameSession {
       if (!template) continue
       if (template.type === 'state_transition') {
         const event = actionEvent(this.ctx.gameType, template.id, actionType)
-        if (event && executeStateTransition(rule, this.states, event, elementId)) {
+        // Dead is terminal on the transition path too: a lost element never
+        // transitions out (blocks a `[dead, correct_care, wilting]` revival via
+        // performAction, which isLost does not freeze). Mirrors the
+        // applyStateEffect resurrection guard.
+        if (
+          event &&
+          !isElementTerminallyLost(this.ctx, this.states, elementId) &&
+          executeStateTransition(rule, this.states, event, elementId)
+        ) {
           effects.push(`${rule.id}: event ${event}`)
         }
         continue

--- a/packages/creation/src/engine/rules.ts
+++ b/packages/creation/src/engine/rules.ts
@@ -58,6 +58,7 @@ import type {
   LevelRule,
   RuleTemplate,
   StateEffect,
+  TimedEmitter,
 } from '../schema/types'
 import { archetypesById, elementsById, isMappingValue, templatesById } from '../validate/helpers'
 
@@ -343,6 +344,56 @@ export function evaluateWin(ctx: RuleContext, states: ElementStates): boolean {
   return false
 }
 
+/**
+ * Lose evaluation over runtime states — the failure-mode mirror of
+ * evaluateWin. Implemented: any_element_state_equals (lost when ANY element
+ * has `state === value`) and score_below (lost when currentScore < target).
+ * No lose_condition → never lost (games without a failure path). Any
+ * unrecognized lose type is false here.
+ */
+export function evaluateLose(ctx: RuleContext, states: ElementStates): boolean {
+  const lose = ctx.level.lose_condition
+  if (!lose) return false
+  if (lose.type === 'any_element_state_equals') {
+    const stateName = lose.params.state
+    const value = lose.params.value
+    if (typeof stateName !== 'string' || typeof value !== 'string') return false
+    for (const machine of states.values()) {
+      if (machine.get(stateName) === value) return true
+    }
+    return false
+  }
+  if (lose.type === 'score_below') {
+    const target = lose.params.target_score
+    if (typeof target !== 'number') return false
+    const score = currentScore(ctx, states)
+    return score !== undefined && score < target
+  }
+  return false
+}
+
+/**
+ * Whether an element sits in a terminal LOST state per the level's
+ * lose_condition — a game-agnostic "frozen" predicate. For
+ * any_element_state_equals { state, value }, an element whose `state === value`
+ * is terminal (e.g. a dead plant): its state machine must not advance, so a
+ * later heal/advance_state cannot resurrect it. score_below is a global (not
+ * per-element) condition and freezes no individual element. No lose_condition
+ * → never frozen (sibling games are unaffected).
+ */
+export function isElementTerminallyLost(
+  ctx: RuleContext,
+  states: ElementStates,
+  elementId: string
+): boolean {
+  const lose = ctx.level.lose_condition
+  if (!lose || lose.type !== 'any_element_state_equals') return false
+  const stateName = lose.params.state
+  const value = lose.params.value
+  if (typeof stateName !== 'string' || typeof value !== 'string') return false
+  return states.get(elementId)?.get(stateName) === value
+}
+
 function evaluateOptimizationTarget(ctx: RuleContext, states: ElementStates): boolean {
   const params = ctx.level.win_condition.params
   const atLeast = Array.isArray(params.all_states_at_least) ? params.all_states_at_least : []
@@ -494,10 +545,33 @@ export function executeTemporalStep(
     const archetype = target ? ctx.archetypes.get(target.archetype) : undefined
     const machine = states.get(targetId)
     if (!target || !archetype || !machine) continue
+    if (isElementTerminallyLost(ctx, states, targetId)) continue // dead is terminal: no advance
     if (applyStateEffect(archetype, machine, stepAction?.state_effect)) changed = true
   }
   stepsUsed.set(rule.id, used + 1)
   return changed
+}
+
+/**
+ * Element instance ids a TimedEmitter ticks (game-agnostic; shared by the
+ * engine's timer construction and the validator's reachability check):
+ * - kind 'archetype' → every element of that archetype (whether or not it has
+ *   a consuming rule — the reason emitter_target_reaches_terminal exists).
+ * - kind 'all' → every element carried by a level rule of target_template.
+ * Order is deterministic (element declaration order / rule iteration order).
+ */
+export function emitterTargetElementIds(level: Level, emitter: TimedEmitter): string[] {
+  if (emitter.target?.kind === 'archetype') {
+    const archetype = emitter.target.archetype
+    return level.elements.filter((element) => element.archetype === archetype).map((e) => e.id)
+  }
+  const valid = new Set(level.elements.map((element) => element.id))
+  const ids = new Set<string>()
+  for (const rule of level.rules) {
+    if (rule.template !== emitter.target_template) continue
+    for (const id of rule.target_elements) if (valid.has(id)) ids.add(id)
+  }
+  return [...ids]
 }
 
 /** Fire a state_transition rule on one element under one event. */
@@ -543,6 +617,7 @@ export function executeConditionAction(
     const archetype = target ? ctx.archetypes.get(target.archetype) : undefined
     const machine = states.get(targetId)
     if (!target || !archetype || !machine) continue
+    if (isElementTerminallyLost(ctx, states, targetId)) continue // dead is terminal: no revive
     if (!evaluatePredicates(rule, archetype, target.params, machine)) continue
     if (applyStateEffect(archetype, machine, verbAction?.state_effect)) changed = true
   }
@@ -630,6 +705,7 @@ export function executeInteractionMatrix(
       const archetype = member ? ctx.archetypes.get(member.archetype) : undefined
       const machine = states.get(memberId)
       if (!member || !archetype || !machine) continue
+      if (isElementTerminallyLost(ctx, states, memberId)) continue // dead is terminal: no revive
       if (applyStateEffect(archetype, machine, effectAction?.state_effect)) changed = true
     }
   }

--- a/packages/creation/src/index.ts
+++ b/packages/creation/src/index.ts
@@ -1,0 +1,31 @@
+/*
+ * @amiclaw/creation — public API barrel for engine reuse by consuming apps
+ * (e.g. @amiclaw/game-botanical). Additive only; the dev/ harness and every
+ * internal module are untouched. Re-exports the schema types + loader, the
+ * runtime engine, the bounded solver, and the validator entry points.
+ */
+
+// Schema meta-model (types + the runtime co-play-form catalog constants).
+export * from './schema/types'
+
+// YAML loader.
+export { loadGameType, loadLevel, SchemaLoadError } from './schema/load'
+
+// Runtime engine session.
+export { GameSession } from './engine/engine'
+export type {
+  EngineSnapshot,
+  RoleView,
+  RoleElementView,
+  ActionResult,
+  PerformActionArgs,
+  TimedTick,
+  TimerStatus,
+} from './engine/engine'
+
+// Bounded solution search (solver).
+export { searchSolution, solutionDriversForTarget } from './engine/search'
+export type { SolutionSearchResult, SolutionDrivers } from './engine/search'
+
+// Validator entry points.
+export { validateLevel, validateGameType } from './validate/validate'

--- a/packages/creation/src/schema/types.ts
+++ b/packages/creation/src/schema/types.ts
@@ -406,6 +406,30 @@ export interface WinConditionType {
   description: string
 }
 
+/**
+ * Lose-condition type ids — the failure-mode mirror of WinConditionTypeId.
+ * Seed set, open like the win side; a game with no failure path omits it
+ * (radio-cipher / sound-garden).
+ */
+export type LoseConditionTypeId = 'any_element_state_equals' | 'score_below'
+
+export interface LoseConditionType {
+  type: LoseConditionTypeId
+  description: string
+}
+
+/**
+ * Level-side lose condition (mirrors WinCondition). Seed semantics:
+ * - any_element_state_equals — params { state, value } → lost when ANY element
+ *   has `state === value` (e.g. botanical { state: health, value: dead }).
+ * - score_below — params { target_score } → lost when currentScore < target.
+ */
+export interface LoseCondition {
+  /** References GameType.lose_condition_type. */
+  type: string
+  params: Record<string, unknown>
+}
+
 /** One entry of the GameType-global action verb registry. */
 export interface ActionDefinition {
   name: string
@@ -456,6 +480,41 @@ export interface CommunicationBudget {
  */
 export type ActionEventMappingEntry = { action_type: string } & Record<string, string>
 
+// ---------------------------------------------------------------------------
+// Timed event emitters (game-agnostic timed decay — engine extension)
+// ---------------------------------------------------------------------------
+
+/** Which elements one TimedEmitter ticks. */
+export type TimedEmitterTarget =
+  /** Every element carried by a level rule of the emitter's target_template. */
+  | { kind: 'all' }
+  /** Every element instance of one archetype. */
+  | { kind: 'archetype'; archetype: string }
+
+/**
+ * Declares a game event fired automatically as simulated time advances.
+ * Game-agnostic: a crossed emitter emits its `event` on the target element's
+ * rules of `target_template`, identical to a player action producing an event
+ * — only the source differs (the host-injected clock, not an action). The
+ * engine reads no wall-clock; the host drives elapsed time via
+ * GameSession.advanceTime. ABSENT `timed_emitters` = no timed events (games
+ * with neither field are byte-for-byte unaffected).
+ */
+export interface TimedEmitter {
+  /** Unique across the GameType's timed_emitters; keys initial_timers + diagnostics. */
+  id: string
+  /** Event name; MUST appear in target_template's transition_table_schema.events. */
+  event: string
+  /** MUST resolve to a registered state_transition RuleTemplate id. */
+  target_template: string
+  /** Which elements tick. */
+  target: TimedEmitterTarget
+  /** Base milliseconds between ticks per element; MUST be > 0. */
+  interval_ms: number
+  /** Optional pre-tick warning window for warning UI; 0 <= lead < interval_ms. */
+  warning_lead_ms?: number
+}
+
 export interface GameType {
   /** Unique id, kebab-case. */
   id: string
@@ -473,6 +532,12 @@ export interface GameType {
    */
   information_partition_template?: InformationPartitionTemplate
   win_condition_type: WinConditionType
+  /**
+   * Optional lose-condition type (mirror of win_condition_type). ABSENT = the
+   * game has no failure path (radio-cipher / sound-garden). A Level's
+   * lose_condition.type must match this when both are present.
+   */
+  lose_condition_type?: LoseConditionType
   difficulty_budget: DifficultyBudget
   action_registry: ActionDefinition[]
   /**
@@ -483,6 +548,12 @@ export interface GameType {
    * player action into the named event for each state_transition template.
    */
   action_event_mapping?: ActionEventMappingEntry[]
+  /**
+   * Optional game-agnostic timed event emitters (timed decay). ABSENT = no
+   * timed events; the engine has no time concept without it. Registration-time
+   * referential integrity is checked by validateGameType.
+   */
+  timed_emitters?: TimedEmitter[]
   communication_budget: CommunicationBudget
   /**
    * Solvability solver strategy id (e.g. "exhaustive_path_search", "csp").
@@ -567,6 +638,14 @@ export interface LevelElement {
    * initial.
    */
   initial_states?: Record<string, unknown>
+  /**
+   * Optional per-instance timer overrides, keyed by TimedEmitter.id (mirrors
+   * initial_states). `interval_ms` overrides the emitter's base interval for
+   * THIS element; `offset_ms` seeds the initial accumulated charge (a phase
+   * within one period — a larger offset ticks sooner), enabling staggered
+   * decay. Absent → base interval, phase 0. Validated by schema_conformance.
+   */
+  initial_timers?: Record<string, { interval_ms?: number; offset_ms?: number }>
   position?: ElementPosition
 }
 
@@ -636,6 +715,11 @@ export interface Level {
   rules: LevelRule[]
   information_partition: LevelInformationPartition
   win_condition: WinCondition
+  /**
+   * Optional lose condition (mirror of win_condition). ABSENT = no failure
+   * path. Its `type` must match GameType.lose_condition_type.type.
+   */
+  lose_condition?: LoseCondition
   /**
    * Optional — auto-generated for hidden_info_coop (surface generation
    * contract); shared-state forms may omit or generate symmetric surfaces.

--- a/packages/creation/src/validate/bg-standard.test.ts
+++ b/packages/creation/src/validate/bg-standard.test.ts
@@ -1,0 +1,65 @@
+/**
+ * bg-standard-001 validation gate (mirrors the bg-demo-001 golden gate): the
+ * bigger 5-plant standard level must reach overall pass + publish_ready with
+ * the solver finding a care path within budget, and the synergy DATA edit must
+ * leave bg-demo-001 still passing.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { searchSolution } from '../engine/search'
+import { loadGameType, loadLevel } from '../schema/load'
+import { validateLevel } from './validate'
+
+const bgDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'botanical-garden'
+)
+const gameType = loadGameType(readFileSync(join(bgDir, 'game-type.yaml'), 'utf8'))
+const standard = loadLevel(readFileSync(join(bgDir, 'level.bg-standard-001.yaml'), 'utf8'))
+const tutorial = loadLevel(readFileSync(join(bgDir, 'level.bg-demo-001.yaml'), 'utf8'))
+
+describe('bg-standard-001 golden gate', () => {
+  const report = validateLevel(gameType, standard)
+
+  it('reaches overall pass + publish_ready with every activated check passing', () => {
+    for (const check of report.checks) {
+      expect(`${String(check.check_type)}:${check.verdict}`).toBe(
+        `${String(check.check_type)}:pass`
+      )
+    }
+    expect(report.overall_verdict).toBe('pass')
+    expect(report.publish_ready).toBe(true)
+  })
+
+  it('activates the hidden_info_coop floors (same six checks as the tutorial)', () => {
+    expect(report.checks).toHaveLength(6)
+    const checkTypes = report.checks.map((c) => c.check_type)
+    expect(checkTypes).toContain('communication_completeness')
+    expect(checkTypes).toContain('verbal_distinguishability')
+  })
+
+  it('the solver finds a care path, and shade is load-bearing for the orchid', () => {
+    const result = searchSolution(gameType, standard)
+    expect(result.solvable).toBe(true)
+    expect(result.timedOut).toBe(false)
+    expect(result.path.length).toBeGreaterThan(0)
+    // The orchid heals ONLY via rule-light → rule-orchid-care (no correct_care
+    // row on rule-health-orchid), so the solution must shade it.
+    expect(result.path).toContain('rule-light')
+    expect(result.path).toContain('rule-orchid-care')
+  })
+})
+
+describe('bg-demo-001 is unaffected by the synergy effect_schema edit', () => {
+  it('still validates overall pass + publish_ready', () => {
+    const report = validateLevel(gameType, tutorial)
+    expect(report.overall_verdict).toBe('pass')
+    expect(report.publish_ready).toBe(true)
+  })
+})

--- a/packages/creation/src/validate/gametype-consistency.ts
+++ b/packages/creation/src/validate/gametype-consistency.ts
@@ -21,7 +21,14 @@ import type {
   Violation,
 } from '../schema/types'
 import { PARTITION_REQUIRED_CO_PLAY_FORMS } from '../schema/types'
-import { archetypesById, attributeNames, buildCheckResult, stateNames, WILDCARD } from './helpers'
+import {
+  archetypesById,
+  attributeNames,
+  buildCheckResult,
+  stateNames,
+  templatesById,
+  WILDCARD,
+} from './helpers'
 
 export function validateGameType(gameType: GameType): CheckResult {
   const violations: Violation[] = []
@@ -141,6 +148,137 @@ export function validateGameType(gameType: GameType): CheckResult {
         }
       })
     }
+  })
+
+  // timed_emitters: registration-time referential integrity (game-agnostic
+  // timed decay). Mirrors the trigger/state_effect guards. ABSENT → no checks,
+  // so games without the field are wholly unaffected.
+  const templatesMap = templatesById(gameType)
+  const emitterIds = new Map<string, number>()
+  ;(gameType.timed_emitters ?? []).forEach((emitter, i) => {
+    const base = `game_type.timed_emitters[${i}]`
+    const firstIndex = emitterIds.get(emitter.id)
+    if (firstIndex !== undefined) {
+      violations.push({
+        severity: 'error',
+        field_path: `${base}.id`,
+        constraint: 'emitter_id_unique',
+        expected: 'a GameType-unique timed_emitter id',
+        actual: `"${emitter.id}" already declared at game_type.timed_emitters[${firstIndex}]`,
+        suggestion:
+          'Rename one of the emitters — ids key initial_timers overrides and the runtime charge map, so collisions silently merge charge',
+      })
+    } else {
+      emitterIds.set(emitter.id, i)
+    }
+
+    const kind = templateKinds.get(emitter.target_template)
+    const target = templatesMap.get(emitter.target_template)
+    if (kind === undefined) {
+      violations.push({
+        severity: 'error',
+        field_path: `${base}.target_template`,
+        constraint: 'emitter_template_registered',
+        expected: `one of [${[...templateIds].join(', ')}]`,
+        actual: emitter.target_template,
+        suggestion: 'Reference a registered state_transition RuleTemplate id',
+      })
+    } else if (kind !== 'state_transition') {
+      violations.push({
+        severity: 'error',
+        field_path: `${base}.target_template`,
+        constraint: 'emitter_template_kind',
+        expected:
+          'a state_transition template (advanceTime fires the event through executeStateTransition)',
+        actual: `"${emitter.target_template}" is a ${kind} template`,
+        suggestion:
+          'Point the emitter at a state_transition template; only those consume timed events',
+      })
+    } else if (target?.type === 'state_transition') {
+      const events = target.transition_table_schema.events
+      if (!events.includes(emitter.event)) {
+        violations.push({
+          severity: 'error',
+          field_path: `${base}.event`,
+          constraint: 'emitter_event_in_table',
+          expected: `one of [${events.join(', ')}]`,
+          actual: emitter.event,
+          suggestion: `Use an event declared in "${emitter.target_template}".transition_table_schema.events, or add it there`,
+        })
+      }
+    }
+
+    if (emitter.target?.kind === 'archetype' && !archetypes.has(emitter.target.archetype)) {
+      violations.push({
+        severity: 'error',
+        field_path: `${base}.target.archetype`,
+        constraint: 'emitter_target_archetype',
+        expected: `one of [${[...archetypes.keys()].join(', ')}]`,
+        actual: emitter.target.archetype,
+        suggestion: 'Reference a registered ElementArchetype id',
+      })
+    }
+
+    const intervalValid =
+      typeof emitter.interval_ms === 'number' &&
+      Number.isFinite(emitter.interval_ms) &&
+      emitter.interval_ms > 0
+    if (!intervalValid) {
+      violations.push({
+        severity: 'error',
+        field_path: `${base}.interval_ms`,
+        constraint: 'emitter_interval_positive',
+        expected: 'a finite number > 0',
+        actual: String(emitter.interval_ms),
+        suggestion: 'Set interval_ms to a positive number of milliseconds between ticks',
+      })
+    }
+
+    if (emitter.warning_lead_ms !== undefined) {
+      const lead = emitter.warning_lead_ms
+      const leadValid =
+        typeof lead === 'number' &&
+        Number.isFinite(lead) &&
+        lead >= 0 &&
+        (!intervalValid || lead < emitter.interval_ms)
+      if (!leadValid) {
+        violations.push({
+          severity: 'error',
+          field_path: `${base}.warning_lead_ms`,
+          constraint: 'emitter_warning_lead_bounds',
+          expected: `0 <= warning_lead_ms < interval_ms (${emitter.interval_ms})`,
+          actual: String(lead),
+          suggestion: 'Set warning_lead_ms within [0, interval_ms)',
+        })
+      }
+    }
+  })
+
+  // state_values_unique (F2/TC-06): a duplicate value in a state enum silently
+  // corrupts every indexOf-based rank comparison (stateValueOrder,
+  // applyStateEffect, evaluateOptimizationTarget) — advance_state and the
+  // optimization_target ranking both read the FIRST index of a value. Mirrors
+  // the emitter_id_unique dedup idea.
+  gameType.element_archetypes.forEach((archetype, ai) => {
+    ;(archetype.states ?? []).forEach((state, si) => {
+      if (!state.values) return
+      const seen = new Map<string, number>()
+      state.values.forEach((value, vi) => {
+        const first = seen.get(value)
+        if (first !== undefined) {
+          violations.push({
+            severity: 'error',
+            field_path: `game_type.element_archetypes[${ai}].states[${si}].values[${vi}]`,
+            constraint: 'state_values_unique',
+            expected: `each value of state "${state.name}" declared at most once`,
+            actual: `"${value}" already declared at index ${first}`,
+            suggestion: `Remove the duplicate "${value}" — duplicate state values corrupt every indexOf-based rank comparison (advance_state, optimization_target)`,
+          })
+        } else {
+          seen.set(value, vi)
+        }
+      })
+    })
   })
 
   const template = gameType.information_partition_template

--- a/packages/creation/src/validate/lose-condition.test.ts
+++ b/packages/creation/src/validate/lose-condition.test.ts
@@ -1,0 +1,90 @@
+/**
+ * lose_condition validator checks (§3) + the v1.0.0→v1.1.0 version lockstep
+ * (TC-21). Negatives structuredClone the v1.1.0 golden and mutate one field.
+ *
+ * Covers test-design cases TC-15, TC-16, TC-21.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../schema/load'
+import type { CheckId, CheckResult, Level, ValidationReport } from '../schema/types'
+import { validateLevel } from './validate'
+
+const bgDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'botanical-garden'
+)
+const gameType = loadGameType(readFileSync(join(bgDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(bgDir, 'level.bg-demo-001.yaml'), 'utf8'))
+
+function checkOf(report: ValidationReport, checkType: CheckId): CheckResult {
+  const check = report.checks.find((c) => c.check_type === checkType)
+  if (!check) throw new Error(`check ${checkType} missing from report`)
+  return check
+}
+
+function cloneLevel(): Level {
+  return structuredClone(level)
+}
+
+describe('schema_conformance — lose_condition', () => {
+  it('the v1.1.0 golden lose_condition validates clean', () => {
+    const check = checkOf(validateLevel(gameType, level), 'schema_conformance')
+    expect(check.violations.some((v) => v.constraint.startsWith('lose_condition_'))).toBe(false)
+  })
+
+  it('TC-15: lose_condition.type mismatched against the GameType type', () => {
+    const bad = cloneLevel()
+    bad.lose_condition = { type: 'score_below', params: { target_score: 5 } }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    const v = check.violations.find((x) => x.constraint === 'lose_condition_type_match')
+    expect(v?.field_path).toBe('lose_condition.type')
+    expect(v?.expected).toBe('any_element_state_equals')
+  })
+
+  it('TC-16: any_element_state_equals referencing an undeclared state', () => {
+    const bad = cloneLevel()
+    bad.lose_condition = {
+      type: 'any_element_state_equals',
+      params: { state: 'vitality', value: 'dead' },
+    }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    const v = check.violations.find((x) => x.constraint === 'lose_condition_state_declared')
+    expect(v?.field_path).toBe('lose_condition.params.state')
+    expect(v?.actual).toBe('vitality')
+  })
+
+  it('TC-16: any_element_state_equals with a value outside the state enum', () => {
+    const bad = cloneLevel()
+    bad.lose_condition = {
+      type: 'any_element_state_equals',
+      params: { state: 'health', value: 'mummified' },
+    }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    const v = check.violations.find((x) => x.constraint === 'lose_condition_value_in_enum')
+    expect(v?.field_path).toBe('lose_condition.params.value')
+    expect(v?.expected).toContain('dead')
+  })
+})
+
+describe('TC-21 — v1.0.0 → v1.1.0 version lockstep', () => {
+  it('both golden fixtures are bumped to 1.1.0 together', () => {
+    expect(gameType.version).toBe('1.1.0')
+    expect(level.metadata.game_type_version).toBe('1.1.0')
+  })
+
+  it('a half-bumped level (GameType 1.1.0, level 1.0.0) fails version_binding', () => {
+    const bad = cloneLevel()
+    bad.metadata.game_type_version = '1.0.0'
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    const v = check.violations.find((x) => x.constraint === 'version_binding')
+    expect(v).toBeTruthy()
+    expect(v?.expected).toBe('1.1.0')
+  })
+})

--- a/packages/creation/src/validate/schema-conformance.ts
+++ b/packages/creation/src/validate/schema-conformance.ts
@@ -30,8 +30,11 @@ import type {
   RuleTemplate,
   StateDefinition,
   StateTransitionRuleTemplate,
+  TimedEmitter,
   Violation,
 } from '../schema/types'
+import type { ElementStates } from '../engine/rules'
+import { emitterTargetElementIds, initialElementStates } from '../engine/rules'
 import {
   archetypesById,
   attributeNames,
@@ -246,6 +249,7 @@ export function checkSchemaConformance(
   const archetypes = archetypesById(gameType)
   const templates = templatesById(gameType)
   const elements = elementsById(level)
+  const emitterIds = new Set((gameType.timed_emitters ?? []).map((emitter) => emitter.id))
 
   if (level.metadata.game_type !== gameType.id) {
     violations.push({
@@ -393,6 +397,64 @@ export function checkSchemaConformance(
       const stateViolation = checkStateValue(state, value, path)
       if (stateViolation) violations.push(stateViolation)
     }
+    // Per-instance initial_timers overrides (mirrors initial_states): each key
+    // must name a declared TimedEmitter id, and interval_ms / offset_ms stay in
+    // bounds (interval_ms > 0, offset_ms >= 0).
+    if (isMappingValue(element.initial_timers)) {
+      for (const [key, value] of Object.entries(element.initial_timers)) {
+        const path = `elements[${i}].initial_timers.${key}`
+        if (!emitterIds.has(key)) {
+          violations.push({
+            severity: 'error',
+            field_path: path,
+            constraint: 'timer_override_emitter_registered',
+            expected: `one of [${[...emitterIds].join(', ')}]`,
+            actual: key,
+            suggestion: `Remove "${key}" or key the override by a declared game_type.timed_emitters id`,
+          })
+          continue
+        }
+        if (!isMappingValue(value)) {
+          violations.push({
+            severity: 'error',
+            field_path: path,
+            constraint: 'timer_override_bounds',
+            expected: 'a mapping { interval_ms?, offset_ms? }',
+            actual: formatValue(value),
+            suggestion: 'Provide the override as { interval_ms?: number, offset_ms?: number }',
+          })
+          continue
+        }
+        const interval = value.interval_ms
+        if (
+          interval !== undefined &&
+          !(typeof interval === 'number' && Number.isFinite(interval) && interval > 0)
+        ) {
+          violations.push({
+            severity: 'error',
+            field_path: `${path}.interval_ms`,
+            constraint: 'timer_override_bounds',
+            expected: 'a finite number > 0',
+            actual: formatValue(interval),
+            suggestion: 'Set interval_ms to a positive number of milliseconds, or omit it',
+          })
+        }
+        const offset = value.offset_ms
+        if (
+          offset !== undefined &&
+          !(typeof offset === 'number' && Number.isFinite(offset) && offset >= 0)
+        ) {
+          violations.push({
+            severity: 'error',
+            field_path: `${path}.offset_ms`,
+            constraint: 'timer_override_bounds',
+            expected: 'a finite number >= 0',
+            actual: formatValue(offset),
+            suggestion: 'Set offset_ms to a non-negative number of milliseconds, or omit it',
+          })
+        }
+      }
+    }
   })
 
   level.rules.forEach((rule, i) => {
@@ -422,6 +484,116 @@ export function checkSchemaConformance(
       }
     })
   })
+
+  // emitter_target_reaches_terminal (§5 decay-coverage invariant): every
+  // element a timed emitter targets MUST be able to walk to the run's lose
+  // terminal via the emitter's event — otherwise the element renders a decay
+  // countdown that never reaches its terminal ("the ring lies"). When the
+  // level declares no matching lose terminal, it falls back to event
+  // consumability (the emitter's event must at least fire on the element).
+  // Skips emitters whose target_template is not a state_transition
+  // (validateGameType flags those).
+  if ((gameType.timed_emitters ?? []).length > 0) {
+    const initialStates = initialElementStates(gameType, level)
+    ;(gameType.timed_emitters ?? []).forEach((emitter, ei) => {
+      const template = templates.get(emitter.target_template)
+      if (!template || template.type !== 'state_transition') return
+      for (const elementId of emitterTargetElementIds(level, emitter)) {
+        const { hasEdges, reachable } = emitterTerminalReachability(
+          level,
+          template,
+          emitter,
+          elementId,
+          initialStates
+        )
+        if (reachable) continue
+        const detail = hasEdges
+          ? `cannot reach the lose terminal via "${emitter.event}" (the decay ladder is incomplete)`
+          : `has no rule consuming "${emitter.event}" (its decay timer would render but never fire)`
+        violations.push({
+          severity: 'error',
+          field_path: `game_type.timed_emitters[${ei}]`,
+          constraint: 'emitter_target_reaches_terminal',
+          expected: `element "${elementId}" can reach the emitter's terminal state via "${emitter.event}"`,
+          actual: `"${elementId}" ${detail}`,
+          suggestion: `Give "${elementId}" a ${emitter.target_template} rule whose "${emitter.event}" rows walk it to the terminal, or narrow the emitter's target`,
+          related_elements: [elementId],
+        })
+      }
+    })
+  }
+
+  // lose_condition (§3): its type matches the GameType's declared type, and
+  // any_element_state_equals params reference a declared state + a legal value.
+  if (level.lose_condition) {
+    const lose = level.lose_condition
+    const declaredType = gameType.lose_condition_type?.type
+    if (declaredType !== undefined && lose.type !== declaredType) {
+      violations.push({
+        severity: 'error',
+        field_path: 'lose_condition.type',
+        constraint: 'lose_condition_type_match',
+        expected: declaredType,
+        actual: String(lose.type),
+        suggestion: `Use the GameType's declared lose condition type "${declaredType}"`,
+      })
+    }
+    if (lose.type === 'any_element_state_equals') {
+      const stateName = lose.params.state
+      const stateDef = typeof stateName === 'string' ? findStateDef(gameType, stateName) : undefined
+      if (!stateDef) {
+        violations.push({
+          severity: 'error',
+          field_path: 'lose_condition.params.state',
+          constraint: 'lose_condition_state_declared',
+          expected: 'a state declared on some archetype',
+          actual: formatValue(stateName),
+          suggestion: 'Reference a declared state name (e.g. a plant health/growth state)',
+        })
+      } else if (stateDef.type === 'enum') {
+        const value = lose.params.value
+        const legal = stateDef.values ?? []
+        if (typeof value !== 'string' || !legal.includes(value)) {
+          violations.push({
+            severity: 'error',
+            field_path: 'lose_condition.params.value',
+            constraint: 'lose_condition_value_in_enum',
+            expected: `one of [${legal.join(', ')}]`,
+            actual: formatValue(value),
+            suggestion: `Set value to a declared value of state "${String(stateName)}"`,
+          })
+        }
+      }
+    }
+
+    // terminal_state_no_exit (F3): a lose-condition terminal state is
+    // irreversible, so NO state_transition row may transition OUT of it — a
+    // `[dead, correct_care, wilting]` row would resurrect a lost element via
+    // performAction (which isLost does not freeze). Static mirror of the engine
+    // isElementTerminallyLost guard: a transition INTO the terminal
+    // (`[critical, neglect, dead]`) is fine; only rows whose `from` is the
+    // terminal are rejected.
+    if (lose.type === 'any_element_state_equals' && typeof lose.params.value === 'string') {
+      const terminal = lose.params.value
+      level.rules.forEach((rule, ri) => {
+        if (templates.get(rule.template)?.type !== 'state_transition') return
+        const rows = Array.isArray(rule.bindings.transitions)
+          ? (rule.bindings.transitions as unknown[])
+          : []
+        rows.forEach((row, rowIndex) => {
+          if (!Array.isArray(row) || row.length !== 3 || row[0] !== terminal) return
+          violations.push({
+            severity: 'error',
+            field_path: `rules[${ri}].bindings.transitions[${rowIndex}]`,
+            constraint: 'terminal_state_no_exit',
+            expected: `no transition OUT of the lose terminal "${terminal}" (it is irreversible)`,
+            actual: `row transitions from "${terminal}" to "${String(row[2])}"`,
+            suggestion: `Remove this row — a lose-condition terminal state ("${terminal}") must have no outgoing transition, or a lost element could be resurrected`,
+          })
+        })
+      })
+    }
+  }
 
   const roles = new Set(
     (gameType.information_partition_template?.roles ?? []).map((role) => role.id)
@@ -486,6 +658,87 @@ export function checkSchemaConformance(
   }
 
   return buildCheckResult('schema_conformance', violations)
+}
+
+/** A declared state of any archetype by name (states are GameType-unique by convention). */
+function findStateDef(gameType: GameType, stateName: string): StateDefinition | undefined {
+  for (const archetype of gameType.element_archetypes) {
+    const state = (archetype.states ?? []).find((s) => s.name === stateName)
+    if (state) return state
+  }
+  return undefined
+}
+
+/**
+ * Whether a timed emitter's event can walk `elementId` to the run's lose
+ * terminal (§5 decay-coverage invariant). Builds the emitter-event transition
+ * graph from the element's target_template rules, then:
+ * - when the level's lose_condition names a terminal value in the template's
+ *   states, BFS from the element's initial governed-state value to that
+ *   terminal (the full ladder-completeness walk);
+ * - otherwise fall back to event consumability (at least one consuming row).
+ * `hasEdges` distinguishes "no consuming rule at all" from "ladder incomplete".
+ */
+function emitterTerminalReachability(
+  level: Level,
+  template: StateTransitionRuleTemplate,
+  emitter: TimedEmitter,
+  elementId: string,
+  initialStates: ElementStates
+): { hasEdges: boolean; reachable: boolean } {
+  const edges = new Map<string, Set<string>>()
+  for (const rule of level.rules) {
+    if (rule.template !== emitter.target_template) continue
+    if (!rule.target_elements.includes(elementId)) continue
+    const rows = Array.isArray(rule.bindings.transitions)
+      ? (rule.bindings.transitions as unknown[])
+      : []
+    for (const row of rows) {
+      if (!Array.isArray(row) || row.length !== 3 || row[1] !== emitter.event) continue
+      const from = String(row[0])
+      const to = String(row[2])
+      const set = edges.get(from) ?? new Set<string>()
+      set.add(to)
+      edges.set(from, set)
+    }
+  }
+  const hasEdges = edges.size > 0
+
+  const lose = level.lose_condition
+  const declaredStates = template.transition_table_schema.states
+  const terminal =
+    lose &&
+    lose.type === 'any_element_state_equals' &&
+    typeof lose.params.value === 'string' &&
+    declaredStates.includes(lose.params.value)
+      ? lose.params.value
+      : undefined
+  if (terminal === undefined) return { hasEdges, reachable: hasEdges } // R1 fallback: consumability
+
+  const machine = initialStates.get(elementId)
+  let start: string | undefined
+  for (const value of machine?.values() ?? []) {
+    if (typeof value === 'string' && declaredStates.includes(value)) {
+      start = value
+      break
+    }
+  }
+  if (start === undefined) return { hasEdges, reachable: false }
+  if (start === terminal) return { hasEdges, reachable: true }
+
+  const seen = new Set<string>([start])
+  const queue: string[] = [start]
+  while (queue.length > 0) {
+    const current = queue.shift() as string
+    for (const next of edges.get(current) ?? []) {
+      if (next === terminal) return { hasEdges, reachable: true }
+      if (!seen.has(next)) {
+        seen.add(next)
+        queue.push(next)
+      }
+    }
+  }
+  return { hasEdges, reachable: false }
 }
 
 function checkAttributeValue(

--- a/packages/creation/src/validate/state-terminal-integrity.test.ts
+++ b/packages/creation/src/validate/state-terminal-integrity.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Two structural-integrity guards closed in the R2 fix round:
+ * - F2/TC-06: duplicate values in a state enum (state_values_unique) — the
+ *   indexOf-rank hazard the test-design contract required an explicit decision on.
+ * - F3: a lose-condition terminal state must have no outgoing state_transition
+ *   row (terminal_state_no_exit) — the validator mirror of the engine's
+ *   "dead is terminal" guard, closing the transition-path resurrection gap.
+ *
+ * Negatives structuredClone the v1.1.0 golden and mutate one field.
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../schema/load'
+import type { CheckId, CheckResult, GameType, Level, ValidationReport } from '../schema/types'
+import { validateGameType, validateLevel } from './validate'
+
+const bgDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'botanical-garden'
+)
+const gameType = loadGameType(readFileSync(join(bgDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(bgDir, 'level.bg-demo-001.yaml'), 'utf8'))
+
+function checkOf(report: ValidationReport, checkType: CheckId): CheckResult {
+  const check = report.checks.find((c) => c.check_type === checkType)
+  if (!check) throw new Error(`check ${checkType} missing from report`)
+  return check
+}
+
+function cloneGameType(): GameType {
+  return structuredClone(gameType)
+}
+
+function cloneLevel(): Level {
+  return structuredClone(level)
+}
+
+describe('F2 / TC-06 — state_values_unique', () => {
+  it('flags a duplicate value in a state enum', () => {
+    const gt = cloneGameType()
+    const plant = gt.element_archetypes.find((a) => a.id === 'plant')
+    const health = plant?.states?.find((s) => s.name === 'health')
+    if (!health) throw new Error('fixture health state missing')
+    health.values = ['dead', 'dead', 'critical', 'wilting', 'stable', 'thriving']
+    const v = validateGameType(gt).violations.find((x) => x.constraint === 'state_values_unique')
+    expect(v).toBeTruthy()
+    expect(v?.field_path).toBe('game_type.element_archetypes[0].states[0].values[1]')
+    expect(v?.actual).toContain('dead')
+    expect(v?.suggestion).toBeTruthy()
+  })
+
+  it('the golden GameType has no duplicate state values', () => {
+    expect(
+      validateGameType(gameType).violations.some((v) => v.constraint === 'state_values_unique')
+    ).toBe(false)
+  })
+})
+
+describe('F3 — terminal_state_no_exit', () => {
+  it('flags a transition OUT of the lose terminal (dead-exit revival row)', () => {
+    const bad = cloneLevel()
+    const ruleHealth = bad.rules.find((r) => r.id === 'rule-health')
+    if (!ruleHealth) throw new Error('fixture rule-health missing')
+    const rows = ruleHealth.bindings.transitions as unknown[]
+    ruleHealth.bindings = {
+      ...ruleHealth.bindings,
+      transitions: [...rows, ['dead', 'correct_care', 'wilting']],
+    }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    const v = check.violations.find((x) => x.constraint === 'terminal_state_no_exit')
+    expect(v).toBeTruthy()
+    expect(v?.actual).toContain('dead')
+    expect(check.verdict).toBe('fail')
+  })
+
+  it('a transition INTO the terminal (neglect → dead) is fine; the golden passes', () => {
+    // The golden's [critical, neglect, dead] row transitions INTO dead, not out.
+    const check = checkOf(validateLevel(gameType, level), 'schema_conformance')
+    expect(check.violations.some((v) => v.constraint === 'terminal_state_no_exit')).toBe(false)
+  })
+})

--- a/packages/creation/src/validate/timed-emitter.test.ts
+++ b/packages/creation/src/validate/timed-emitter.test.ts
@@ -1,0 +1,285 @@
+/**
+ * timed_emitters + initial_timers validator checks (§2). Registration-time
+ * referential integrity lives in validateGameType (the 7 emitter checks);
+ * Level-side overrides + the decay-coverage reachability invariant live in
+ * schema_conformance. All negatives structuredClone the golden and mutate one
+ * field, mirroring the established cloneGameType()/cloneLevel() pattern.
+ *
+ * Covers test-design cases TC-05, TC-07..TC-14, the R1 form of TC-17
+ * (emitter_target_reaches_terminal), and TC-33 part 1 (fields genuinely
+ * optional — siblings carry neither).
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadGameType, loadLevel } from '../schema/load'
+import type {
+  CheckId,
+  CheckResult,
+  GameType,
+  Level,
+  TimedEmitter,
+  ValidationReport,
+} from '../schema/types'
+import { validateGameType, validateLevel } from './validate'
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'fixtures')
+const bgDir = join(fixturesDir, 'botanical-garden')
+const gameType = loadGameType(readFileSync(join(bgDir, 'game-type.yaml'), 'utf8'))
+const level = loadLevel(readFileSync(join(bgDir, 'level.bg-demo-001.yaml'), 'utf8'))
+const rcGameType = loadGameType(
+  readFileSync(join(fixturesDir, 'radio-cipher', 'game-type.yaml'), 'utf8')
+)
+const sgGameType = loadGameType(
+  readFileSync(join(fixturesDir, 'sound-garden', 'game-type.yaml'), 'utf8')
+)
+
+function checkOf(report: ValidationReport, checkType: CheckId): CheckResult {
+  const check = report.checks.find((c) => c.check_type === checkType)
+  if (!check) throw new Error(`check ${checkType} missing from report`)
+  return check
+}
+
+function cloneGameType(): GameType {
+  return structuredClone(gameType)
+}
+
+function cloneLevel(): Level {
+  return structuredClone(level)
+}
+
+/** A registration-valid decay emitter; `mut` mutates the single bad field. */
+function withEmitter(mut?: (emitter: TimedEmitter) => void): GameType {
+  const emitter: TimedEmitter = {
+    id: 'decay',
+    event: 'neglect',
+    target_template: 'health_response',
+    target: { kind: 'all' },
+    interval_ms: 60_000,
+    warning_lead_ms: 8000,
+  }
+  if (mut) mut(emitter)
+  const gt = cloneGameType()
+  gt.timed_emitters = [emitter]
+  return gt
+}
+
+describe('validateGameType — timed_emitter referential integrity', () => {
+  it('a well-formed emitter adds no emitter_* violations (positive baseline)', () => {
+    const violations = validateGameType(withEmitter()).violations
+    expect(violations.some((v) => v.constraint.startsWith('emitter_'))).toBe(false)
+  })
+
+  it('TC-07: target_template unregistered → emitter_template_registered', () => {
+    const v = validateGameType(
+      withEmitter((e) => {
+        e.target_template = 'no_such_template'
+      })
+    ).violations.find((x) => x.constraint === 'emitter_template_registered')
+    expect(v?.field_path).toBe('game_type.timed_emitters[0].target_template')
+    expect(v?.suggestion).toBeTruthy()
+  })
+
+  it('TC-08: target_template resolves but is not a state_transition → emitter_template_kind', () => {
+    for (const badTemplate of ['compatibility_matrix', 'needs_rule']) {
+      const v = validateGameType(
+        withEmitter((e) => {
+          e.target_template = badTemplate
+        })
+      ).violations.find((x) => x.constraint === 'emitter_template_kind')
+      expect(v, badTemplate).toBeTruthy()
+      expect(v?.field_path).toBe('game_type.timed_emitters[0].target_template')
+    }
+  })
+
+  it('TC-09: event not in the target template events → emitter_event_in_table', () => {
+    const v = validateGameType(
+      withEmitter((e) => {
+        e.event = 'photosynthesize'
+      })
+    ).violations.find((x) => x.constraint === 'emitter_event_in_table')
+    expect(v?.field_path).toBe('game_type.timed_emitters[0].event')
+    expect(v?.expected).toContain('neglect')
+  })
+
+  it('TC-10: non-positive / NaN interval_ms → emitter_interval_positive', () => {
+    for (const bad of [0, -5, Number.NaN]) {
+      const v = validateGameType(
+        withEmitter((e) => {
+          e.interval_ms = bad
+        })
+      ).violations.find((x) => x.constraint === 'emitter_interval_positive')
+      expect(v, `interval ${bad}`).toBeTruthy()
+      expect(v?.field_path).toBe('game_type.timed_emitters[0].interval_ms')
+    }
+  })
+
+  it('TC-05 / TC-11: warning_lead_ms half-open bound [0, interval)', () => {
+    const bounds = (lead: number) =>
+      validateGameType(
+        withEmitter((e) => {
+          e.interval_ms = 1000
+          e.warning_lead_ms = lead
+        })
+      ).violations.some((x) => x.constraint === 'emitter_warning_lead_bounds')
+    // Passing boundaries.
+    expect(bounds(0)).toBe(false)
+    expect(bounds(999)).toBe(false)
+    // Failing: lead >= interval.
+    expect(bounds(1000)).toBe(true)
+    expect(bounds(5000)).toBe(true)
+    const v = validateGameType(
+      withEmitter((e) => {
+        e.interval_ms = 1000
+        e.warning_lead_ms = 1000
+      })
+    ).violations.find((x) => x.constraint === 'emitter_warning_lead_bounds')
+    expect(v?.field_path).toBe('game_type.timed_emitters[0].warning_lead_ms')
+  })
+
+  it('TC-12: duplicate emitter id → emitter_id_unique on the second entry', () => {
+    const gt = cloneGameType()
+    gt.timed_emitters = [
+      {
+        id: 'decay',
+        event: 'neglect',
+        target_template: 'health_response',
+        target: { kind: 'all' },
+        interval_ms: 1000,
+      },
+      {
+        id: 'decay',
+        event: 'neglect',
+        target_template: 'health_response',
+        target: { kind: 'all' },
+        interval_ms: 2000,
+      },
+    ]
+    const v = validateGameType(gt).violations.find((x) => x.constraint === 'emitter_id_unique')
+    expect(v?.field_path).toBe('game_type.timed_emitters[1].id')
+  })
+
+  it('TC-13: archetype target unresolved → emitter_target_archetype', () => {
+    const v = validateGameType(
+      withEmitter((e) => {
+        e.target = { kind: 'archetype', archetype: 'shrub' }
+      })
+    ).violations.find((x) => x.constraint === 'emitter_target_archetype')
+    expect(v?.field_path).toBe('game_type.timed_emitters[0].target.archetype')
+  })
+})
+
+describe('schema_conformance — initial_timers overrides (TC-14)', () => {
+  function conformanceFor(timers: Record<string, unknown>): CheckResult {
+    const gt = withEmitter() // declares the "decay" emitter
+    const lvl = cloneLevel()
+    const plant = lvl.elements.find((e) => e.id === 'plant-1')
+    if (!plant) throw new Error('fixture element missing')
+    plant.initial_timers = timers as Level['elements'][number]['initial_timers']
+    return checkOf(validateLevel(gt, lvl), 'schema_conformance')
+  }
+
+  it('flags a non-positive interval_ms override → timer_override_bounds', () => {
+    const check = conformanceFor({ decay: { interval_ms: 0 } })
+    expect(
+      check.violations.some(
+        (v) =>
+          v.constraint === 'timer_override_bounds' &&
+          v.field_path === 'elements[0].initial_timers.decay.interval_ms'
+      )
+    ).toBe(true)
+  })
+
+  it('flags a negative offset_ms override → timer_override_bounds', () => {
+    const check = conformanceFor({ decay: { offset_ms: -100 } })
+    expect(
+      check.violations.some(
+        (v) =>
+          v.constraint === 'timer_override_bounds' &&
+          v.field_path === 'elements[0].initial_timers.decay.offset_ms'
+      )
+    ).toBe(true)
+  })
+
+  it('flags an override keyed by an unknown emitter id → timer_override_emitter_registered', () => {
+    const check = conformanceFor({ ghost_emitter: { interval_ms: 5 } })
+    const v = check.violations.find((x) => x.constraint === 'timer_override_emitter_registered')
+    expect(v?.field_path).toBe('elements[0].initial_timers.ghost_emitter')
+    expect(v?.actual).toBe('ghost_emitter')
+  })
+
+  it('accepts a well-formed override (no timer_override violation)', () => {
+    const check = conformanceFor({ decay: { interval_ms: 45_000, offset_ms: 10_000 } })
+    expect(check.violations.some((v) => v.constraint.startsWith('timer_override_'))).toBe(false)
+  })
+})
+
+describe('schema_conformance — emitter_target_reaches_terminal (decay-coverage invariant)', () => {
+  it('TC-17: flags an archetype-targeted element with no consuming rule (the ring would lie)', () => {
+    // The golden's archetype:plant decay emitter targets all 3 plants; drop
+    // plant-3 from rule-health so it becomes emitter-targeted with no
+    // health_response rule to carry the neglect event.
+    const bad = cloneLevel()
+    const ruleHealth = bad.rules.find((r) => r.id === 'rule-health')
+    if (!ruleHealth) throw new Error('fixture rule-health missing')
+    ruleHealth.target_elements = ruleHealth.target_elements.filter((id) => id !== 'plant-3')
+    const report = validateLevel(gameType, bad)
+    const check = checkOf(report, 'schema_conformance')
+    const v = check.violations.find((x) => x.constraint === 'emitter_target_reaches_terminal')
+    expect(v).toBeTruthy()
+    expect(v?.related_elements).toContain('plant-3')
+    expect(report.publish_ready).toBe(false)
+  })
+
+  it('TC-17: flags an incomplete decay ladder that never reaches the lose terminal', () => {
+    // Keep plant-3 covered but drop the [critical, neglect, dead] row so the
+    // ladder stalls at critical — the ring counts down but no plant can die.
+    const bad = cloneLevel()
+    const ruleHealth = bad.rules.find((r) => r.id === 'rule-health')
+    if (!ruleHealth) throw new Error('fixture rule-health missing')
+    ruleHealth.bindings = {
+      ...ruleHealth.bindings,
+      transitions: (ruleHealth.bindings.transitions as unknown[]).filter(
+        (row) => !(Array.isArray(row) && row[2] === 'dead')
+      ),
+    }
+    const check = checkOf(validateLevel(gameType, bad), 'schema_conformance')
+    expect(check.violations.some((v) => v.constraint === 'emitter_target_reaches_terminal')).toBe(
+      true
+    )
+  })
+
+  it('passes on the v1.1.0 golden — every plant walks its neglect ladder to dead', () => {
+    const check = checkOf(validateLevel(gameType, level), 'schema_conformance')
+    expect(check.violations.some((v) => v.constraint === 'emitter_target_reaches_terminal')).toBe(
+      false
+    )
+  })
+})
+
+describe('TC-33: the timed-decay fields are genuinely optional', () => {
+  it('sibling GameTypes carry neither field and gain no emitter checks', () => {
+    expect(rcGameType.timed_emitters).toBeUndefined()
+    expect(sgGameType.timed_emitters).toBeUndefined()
+    for (const gt of [rcGameType, sgGameType]) {
+      expect(validateGameType(gt).violations.some((v) => v.constraint.startsWith('emitter_'))).toBe(
+        false
+      )
+    }
+  })
+
+  it("the v1.1.0 golden's own decay emitter passes validateGameType clean", () => {
+    expect(gameType.timed_emitters).toBeDefined()
+    expect(
+      validateGameType(gameType).violations.some((v) => v.constraint.startsWith('emitter_'))
+    ).toBe(false)
+  })
+
+  it('TC-33: the v1.1.0 golden (decay + lose) reaches overall pass + publish_ready', () => {
+    const report = validateLevel(gameType, level)
+    expect(report.overall_verdict).toBe('pass')
+    expect(report.publish_ready).toBe(true)
+  })
+})

--- a/packages/game-botanical/.gitignore
+++ b/packages/game-botanical/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+test-results
+playwright-report
+.playwright

--- a/packages/game-botanical/README.md
+++ b/packages/game-botanical/README.md
@@ -1,0 +1,78 @@
+# @amiclaw/game-botanical — Botanical Garden (植物园养护)
+
+Player-facing app for the Botanical Garden co-op game: a 3×3 pot grid the
+gardener tends by voice/text guidance from an AI botanist. React + Vite SPA,
+served under `/botanical/`. The engine and level fixtures live in
+`@amiclaw/creation`; the voice/text botanist runs on `@amiclaw/platform-ai`.
+
+## Run it locally
+
+Two commands, two terminals. The game plays fully in terminal 1; add terminal 2
+to bring the AI botanist (voice + text) to life.
+
+### 1. Play the game
+
+```sh
+pnpm --filter @amiclaw/game-botanical dev
+```
+
+Then open:
+
+- `http://localhost:5173/botanical/` — the tutorial level (`bg-demo-001`)
+- `http://localhost:5173/botanical/?level=bg-standard-001` — the standard level
+
+Select a pot, tap a care verb (浇水 / 遮光 / 施肥 / 换盆 / 催花). A count-up
+stopwatch runs; plants decay in real time and a run ends on a win (养护成功) or a
+plant death (养护失败). "再玩一次" fully resets. This works with no second
+terminal — only the AI botanist needs one.
+
+### 2. Bring the AI botanist live (voice + text)
+
+In a **second terminal**, boot the local platform-ai Worker:
+
+```sh
+pnpm --filter @amiclaw/game-botanical ai:dev
+```
+
+This runs the real `@amiclaw/platform-ai` Worker via `dev/wrangler.local.toml`
+with the credential-free **`demo-mock`** provider and `DEV_AUTH_BYPASS`, bound to
+`:8787` — which the game dev server's `/ai-ws` proxy points at by default. Then,
+in the game:
+
+- Click **呼叫植物学家** to open the voice panel (hands-free — just speak; the
+  botanist greets first).
+- Or type a question in the **打字问植物学家** box (the text fallback) and hit
+  发送 — the reply streams back on the same session.
+
+`demo-mock` is a deterministic mock (canned replies, no real speech model), so it
+proves the whole pipeline — session create → manual injection → turn → reply →
+gamestate steering — credential-free.
+
+### 3. Inspect the botanist's manual
+
+```text
+http://localhost:5173/botanical/manual                       # tutorial
+http://localhost:5173/botanical/manual?level=bg-standard-001 # standard
+```
+
+The `/manual` route renders the manual the AI botanist is grounded on (species
+care, over-shade lockout warnings, compatibility/synergy, health & decay). It is
+a dev/inspection surface — in play the gardener does not read it.
+
+### Real botanist (`?ai=demo`) — creds required
+
+Append `?ai=demo` to play against the real LLM + speech stack instead of
+`demo-mock`. This needs a `.dev.vars` at the platform-ai package root
+(`DEEPSEEK_API_KEY` + `VOLC_API_KEY`) and a real-microphone ASR check — not set
+up here; pointer only. Do not probe production.
+
+## Scripts
+
+| Script              | What it does                                                   |
+| ------------------- | -------------------------------------------------------------- |
+| `dev`               | Vite dev server for the game (`:5173`, `/botanical/`)          |
+| `ai:dev`            | Local platform-ai Worker for the botanist (`:8787`, demo-mock) |
+| `build`             | Type-check + production build                                  |
+| `test` / `test:run` | Vitest unit/RTL suite                                          |
+| `test:e2e`          | Playwright WIN + LOSE runs (controlled clock)                  |
+| `typecheck`         | `tsc --noEmit`                                                 |

--- a/packages/game-botanical/dev/wrangler.local.toml
+++ b/packages/game-botanical/dev/wrangler.local.toml
@@ -1,0 +1,38 @@
+# Dev-only local Worker config for the Botanical Garden AI botanist.
+#
+# Runs the REAL @amiclaw/platform-ai Worker (../../platform-ai/src/worker.ts —
+# relative to THIS file) with demo-mock + DEV_AUTH_BYPASS so the voice + text
+# botanist work end-to-end with NO credentials.
+#
+# NO [assets] block on purpose: wrangler 4.x drives the platform-ai
+# demo/wrangler.dev.toml [assets] block into a file-watch reload loop that
+# drops the WebSocket mid-turn. The game serves its own app via `vite dev`, so
+# this Worker only needs to own `/ai-ws/*`.
+#
+# Boot with:  pnpm --filter @amiclaw/game-botanical ai:dev
+# It binds :8787 to match the game dev server's `/ai-ws` proxy default
+# (packages/game-botanical/vite.config.ts AI_WS_TARGET).
+name = "botanical-ai-local"
+main = "../../platform-ai/src/worker.ts"
+compatibility_date = "2026-06-08"
+# Required by the Agents SDK (VoiceSessionDO extends `Agent`, which imports
+# node:async_hooks) — matches the production + demo wrangler configs.
+compatibility_flags = ["nodejs_compat"]
+
+[dev]
+port = 8787
+
+# Per-session voice pipeline DO (same class as production).
+[[durable_objects.bindings]]
+name = "VOICE_SESSION"
+class_name = "VoiceSessionDO"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["VoiceSessionDO"]
+
+[vars]
+# Dev auth bypass ON for local play only — never set in production. The demo-mock
+# gameId (chosen client-side) selects the deterministic mock provider on all three
+# layers, so no DeepSeek / Volcengine keys are read or required.
+DEV_AUTH_BYPASS = "true"

--- a/packages/game-botanical/e2e/botanical.spec.ts
+++ b/packages/game-botanical/e2e/botanical.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * End-to-end WIN + LOSE runs of Botanical Garden (design §6), driving the REAL
+ * app + REAL engine over the bg-demo-001 tutorial. Time is CONTROLLED: the
+ * wall-clock decay loop is off (`?e2e=1`) and the test drives decay through the
+ * `window.__botanicalAdvance(dtMs)` seam — no real-time waits, fully repeatable.
+ */
+
+const pot = (page: Page, name: RegExp) => page.getByRole('button', { name })
+
+/** Drive simulated time deterministically through the controlled-clock seam. */
+async function advance(page: Page, dtMs: number): Promise<void> {
+  await page.evaluate((ms) => {
+    ;(window as unknown as { __botanicalAdvance: (n: number) => void }).__botanicalAdvance(ms)
+  }, dtMs)
+}
+
+test.describe('Botanical Garden — WIN', () => {
+  test('tutorial care path reaches 养护成功; Play Again resets to a fresh session', async ({
+    page,
+  }) => {
+    await page.goto('/botanical/?e2e=1')
+    await expect(page.getByRole('timer')).toHaveText('00:00')
+
+    // Heal the wilting fern (water), then heal + grow the orchid to flowering.
+    await pot(page, /蕨类/).click()
+    await page.getByRole('button', { name: '浇水' }).click()
+    await expect(pot(page, /蕨类/)).toHaveAccessibleName(/稳定/)
+
+    await pot(page, /兰花/).click()
+    await page.getByRole('button', { name: '遮光' }).click() // → partial_shade + heal
+    await page.getByRole('button', { name: '施肥' }).click() // seedling → juvenile
+    await page.getByRole('button', { name: '换盆' }).click() // juvenile → mature
+    await page.getByRole('button', { name: '催花' }).click() // mature → flowering → WIN
+
+    // Assertion 1: results overlay with 用时 + 操作数 present.
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toContainText('养护成功')
+    await expect(dialog).toContainText('用时')
+    await expect(dialog).toContainText('操作数')
+
+    // Assertion 2: Play Again resets to a fresh session.
+    await dialog.getByRole('button', { name: '再玩一次' }).click()
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+    await expect(page.getByRole('timer')).toHaveText('00:00')
+    await expect(pot(page, /蕨类/)).toHaveAccessibleName(/枯萎/) // back to the wilting start
+  })
+})
+
+test.describe('Botanical Garden — LOSE', () => {
+  test('decay warning shows before a tick; neglect to death reaches 养护失败', async ({ page }) => {
+    await page.goto('/botanical/?e2e=1')
+    await page.waitForFunction(() => '__botanicalAdvance' in window)
+
+    // Assertion 3: the decay ring WARNING is visible BEFORE any tick. The orchid
+    // (offset 40000, interval 60000) ticks at 20000ms; its 8000ms warning window
+    // opens at 12000ms, so at 15000ms it warns but has not yet ticked.
+    await advance(page, 15000)
+    await expect(pot(page, /兰花/)).toHaveAttribute('data-decay', 'warning')
+    await expect(page.getByRole('dialog')).toHaveCount(0) // no tick / no end yet
+
+    // Drive neglect to death: each advance fires one tick per plant.
+    await advance(page, 60000) // wilting → critical (no death yet)
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+    await advance(page, 60000) // critical → dead → LOSE
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toContainText('养护失败')
+    await expect(dialog).toContainText('用时')
+  })
+})

--- a/packages/game-botanical/index.html
+++ b/packages/game-botanical/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>植物园养护 — AMIO Arcade</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/game-botanical/package.json
+++ b/packages/game-botanical/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "ai:dev": "wrangler dev --config dev/wrangler.local.toml",
     "build": "tsc && vite build",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
@@ -31,6 +32,7 @@
     "jsdom": "^29.1.1",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.9",
+    "wrangler": "^4.103.0"
   }
 }

--- a/packages/game-botanical/package.json
+++ b/packages/game-botanical/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@amiclaw/game-botanical",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "@amiclaw/creation": "workspace:*",
+    "@amiclaw/ui": "workspace:*",
+    "js-yaml": "^4.2.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.18.0"
+  },
+  "devDependencies": {
+    "@amiclaw/platform-ai": "workspace:*",
+    "@playwright/test": "^1.61.0",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.5.0",
+    "@types/node": "^26.0.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "jsdom": "^29.1.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/game-botanical/playwright.config.ts
+++ b/packages/game-botanical/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Package-LOCAL Playwright config for the Botanical Garden probe (design §6 e2e).
+ *
+ * Deliberately standalone rather than wired into the repo-root e2e harness: that
+ * harness is BDD/gherkin bound to `e2e/flow-inventory.yaml` (a 1:1 scenario ⟷
+ * flow governance) and serves the ASSEMBLED platform build (packages/platform/dist),
+ * not this standalone game app. A probe should not touch that governance or CI, so
+ * this config drives the game-botanical Vite dev server directly. (Findings: if the
+ * game ships inside the platform post-merge, these win/lose runs can migrate into
+ * the root harness with a flow-inventory entry.)
+ *
+ * The runs use a CONTROLLED CLOCK: the app exposes `window.__botanicalAdvance(dtMs)`
+ * only when `import.meta.env.DEV && ?e2e=1` (compiled out of production), and the
+ * wall-clock decay loop is off in that mode — so decay is driven deterministically,
+ * with NO real-time waits.
+ */
+const PORT = 5199
+const BASE_URL = `http://localhost:${PORT}`
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: [['list']],
+  timeout: 30_000,
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    viewport: { width: 390, height: 844 }, // mobile-first target
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `pnpm exec vite --port ${PORT} --strictPort`,
+    url: `${BASE_URL}/botanical/`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+})

--- a/packages/game-botanical/src/App.tsx
+++ b/packages/game-botanical/src/App.tsx
@@ -1,0 +1,18 @@
+import { Routes, Route, Navigate } from 'react-router-dom'
+import { GamePage } from './pages/GamePage'
+import { ManualPage } from './pages/ManualPage'
+
+/* Botanical Garden shell (gardener-view playable probe).
+   `/` is the playable tutorial level (bg-demo-001); `/manual` is the
+   dev/inspection botanist-manual surface (not linked from the player screen).
+   Later rounds add the standard level (R5) and voice/text panels (R6/R7) as
+   sibling routes — the router is the seam kept clean for them. */
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<GamePage />} />
+      <Route path="/manual" element={<ManualPage />} />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  )
+}

--- a/packages/game-botanical/src/components/DecayRing.module.css
+++ b/packages/game-botanical/src/components/DecayRing.module.css
@@ -1,0 +1,43 @@
+/* Donut ring: conic fill proportional to --frac, masked to an annulus.
+   Color comes from data-tone. CSS-only (hard repo constraint). */
+.ring {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  width: 52px;
+  height: 52px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  --ring-color: var(--health-stable);
+  background: conic-gradient(
+    var(--ring-color) calc(var(--frac, 0) * 360deg),
+    rgba(255, 255, 255, 0.07) 0
+  );
+  -webkit-mask: radial-gradient(farthest-side, transparent 70%, #000 71%);
+  mask: radial-gradient(farthest-side, transparent 70%, #000 71%);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.ring[data-tone='warning'] {
+  --ring-color: var(--garden-warn);
+}
+
+.ring[data-tone='critical'] {
+  --ring-color: var(--health-critical);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .ring[data-tone='critical'] {
+    animation: ringPulse 1.1s ease-in-out infinite;
+  }
+}
+
+@keyframes ringPulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}

--- a/packages/game-botanical/src/components/DecayRing.tsx
+++ b/packages/game-botanical/src/components/DecayRing.tsx
@@ -1,0 +1,24 @@
+import styles from './DecayRing.module.css'
+
+export type DecayTone = 'ok' | 'warning' | 'critical'
+
+interface DecayRingProps {
+  /** 0 → just ticked, 1 → tick due. */
+  fraction: number
+  tone: DecayTone
+}
+
+/* Per-plant decay countdown as a donut ring filling toward the next neglect
+   tick. Green while safe, amber inside the warning window, red once the plant
+   is critical — the spike proved this materially sharpens triage feel.
+   Purely decorative (the pot button carries the accessible label). */
+export default function DecayRing({ fraction, tone }: DecayRingProps) {
+  return (
+    <div
+      className={styles.ring}
+      data-tone={tone}
+      style={{ ['--frac' as string]: String(Math.max(0, Math.min(1, fraction))) }}
+      aria-hidden="true"
+    />
+  )
+}

--- a/packages/game-botanical/src/components/GardenGrid.module.css
+++ b/packages/game-botanical/src/components/GardenGrid.module.css
@@ -1,0 +1,56 @@
+.board {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.zone {
+  border: 1px solid var(--garden-line);
+  border-radius: 12px;
+  padding: 8px 8px 10px;
+  background: var(--bg-garden-2);
+}
+
+/* ambient light tint per band */
+.zone[data-light='partial_shade'] {
+  background: linear-gradient(180deg, rgba(120, 180, 130, 0.09), rgba(120, 180, 130, 0.02));
+}
+.zone[data-light='full_sun'] {
+  background: linear-gradient(180deg, rgba(228, 205, 120, 0.12), rgba(228, 205, 120, 0.02));
+}
+.zone[data-light='full_shade'] {
+  background: linear-gradient(180deg, rgba(70, 110, 140, 0.1), rgba(20, 30, 40, 0.04));
+}
+
+.zoneLabel {
+  font-size: 11.5px;
+  color: var(--garden-ink-dim);
+  margin: 0 0 6px 2px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  letter-spacing: 0.5px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  background: var(--garden-ink-dim);
+}
+.zone[data-light='partial_shade'] .dot {
+  background: #9fd28a;
+}
+.zone[data-light='full_sun'] .dot {
+  background: #f0d874;
+}
+.zone[data-light='full_shade'] .dot {
+  background: #5f88a8;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}

--- a/packages/game-botanical/src/components/GardenGrid.tsx
+++ b/packages/game-botanical/src/components/GardenGrid.tsx
@@ -1,0 +1,44 @@
+import styles from './GardenGrid.module.css'
+import PotCell from './PotCell'
+import type { PlantView, ZoneView } from '@/game/useGardenSession'
+import { LIGHT_LABEL, ZONE_LABEL } from '@/game/visual-map'
+
+interface GardenGridProps {
+  plants: PlantView[]
+  zones: ZoneView[]
+  selectedId: string | null
+  onSelect: (elementId: string) => void
+}
+
+/* The 3×3 pot grid, drawn as three stacked zone bands (北/中/南). Each band is
+   tinted by its ambient light level and labels the light so the gardener can
+   describe what they see; pots sit at their covered positions. */
+export default function GardenGrid({ plants, zones, selectedId, onSelect }: GardenGridProps) {
+  const plantByPosition = new Map(plants.map((p) => [p.potPosition, p]))
+  const orderedZones = [...zones].sort((a, b) => (a.positions[0] ?? 0) - (b.positions[0] ?? 0))
+
+  return (
+    <div className={styles.board} role="group" aria-label="植物园">
+      {orderedZones.map((zone) => (
+        <section key={zone.id} className={styles.zone} data-light={zone.lightLevel}>
+          <header className={styles.zoneLabel}>
+            <i className={styles.dot} />
+            {ZONE_LABEL[zone.zoneId] ?? zone.zoneId} · 光照
+            {LIGHT_LABEL[zone.lightLevel] ?? zone.lightLevel}
+          </header>
+          <div className={styles.row}>
+            {zone.positions.map((position) => (
+              <PotCell
+                key={position}
+                position={position}
+                plant={plantByPosition.get(position) ?? null}
+                selected={plantByPosition.get(position)?.id === selectedId}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/packages/game-botanical/src/components/PlantSprite.module.css
+++ b/packages/game-botanical/src/components/PlantSprite.module.css
@@ -1,0 +1,76 @@
+.sprite {
+  position: relative;
+  z-index: 1;
+  font-size: 30px;
+  line-height: 1;
+  display: block;
+  transform-origin: 50% 90%;
+  transition:
+    transform 0.35s ease,
+    filter 0.35s ease,
+    opacity 0.35s ease;
+}
+
+/* growth_stage → size */
+.g_seedling {
+  font-size: 22px;
+}
+.g_juvenile {
+  font-size: 27px;
+}
+.g_mature {
+  font-size: 31px;
+}
+.g_flowering {
+  font-size: 33px;
+}
+
+/* health → tint + posture */
+.h_thriving {
+  filter: brightness(1.25) saturate(1.2) drop-shadow(0 0 6px rgba(143, 224, 138, 0.55));
+}
+.h_stable {
+  filter: none;
+}
+.h_wilting {
+  filter: grayscale(0.5) brightness(0.82);
+  transform: rotate(-8deg) translateY(2px);
+}
+.h_critical {
+  filter: grayscale(0.75) brightness(0.7) sepia(0.3) hue-rotate(-25deg);
+  transform: rotate(-16deg) translateY(4px);
+}
+.h_dead {
+  filter: grayscale(1) brightness(0.5);
+  transform: rotate(-22deg);
+  opacity: 0.6;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .h_thriving {
+    animation: sway 3.4s ease-in-out infinite;
+  }
+  .flowering {
+    animation: bloom 0.6s cubic-bezier(0.2, 1.5, 0.4, 1) both;
+  }
+}
+
+@keyframes sway {
+  0%,
+  100% {
+    transform: rotate(-3deg);
+  }
+  50% {
+    transform: rotate(3deg);
+  }
+}
+@keyframes bloom {
+  0% {
+    transform: scale(0.4) rotate(-30deg);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1) rotate(0);
+    opacity: 1;
+  }
+}

--- a/packages/game-botanical/src/components/PlantSprite.tsx
+++ b/packages/game-botanical/src/components/PlantSprite.tsx
@@ -1,0 +1,29 @@
+import styles from './PlantSprite.module.css'
+import { plantSprite } from '@/game/visual-map'
+
+interface PlantSpriteProps {
+  species: string
+  health: string
+  growthStage: string
+}
+
+/* The plant glyph. Health drives tint + wilt tilt (CSS classes), growth drives
+   size, and flowering / death swap the glyph. All motion is CSS-only and
+   gated behind prefers-reduced-motion. aria-hidden — the pot button owns the
+   accessible name. */
+export default function PlantSprite({ species, health, growthStage }: PlantSpriteProps) {
+  const glyph = plantSprite(species, health, growthStage)
+  const classes = [
+    styles.sprite,
+    styles[`h_${health}`],
+    styles[`g_${growthStage}`],
+    growthStage === 'flowering' ? styles.flowering : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+  return (
+    <span className={classes} aria-hidden="true">
+      {glyph}
+    </span>
+  )
+}

--- a/packages/game-botanical/src/components/PotCell.module.css
+++ b/packages/game-botanical/src/components/PotCell.module.css
@@ -1,0 +1,104 @@
+.pot {
+  position: relative;
+  min-height: 92px;
+  padding: 8px 6px 12px;
+  border: 1px solid var(--garden-line);
+  border-radius: 11px;
+  background: rgba(255, 255, 255, 0.02);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  text-align: center;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.08s ease;
+}
+
+.pot:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.empty {
+  color: var(--garden-ink-dim);
+  font-size: 11px;
+  opacity: 0.4;
+  border-style: dashed;
+  background: transparent;
+  min-height: 92px;
+}
+
+.selected {
+  border-color: var(--garden-accent);
+  box-shadow: 0 0 0 2px rgba(127, 212, 163, 0.35);
+}
+
+.speciesLabel {
+  position: relative;
+  z-index: 1;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.chips {
+  position: relative;
+  z-index: 1;
+  font-size: 10.5px;
+  color: var(--garden-ink-dim);
+}
+
+.bloom {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  font-size: 15px;
+  z-index: 2;
+}
+
+/* health-driven pot chrome */
+.h_wilting .speciesLabel {
+  color: var(--health-wilting);
+}
+.h_critical .speciesLabel {
+  color: var(--health-critical);
+}
+.h_thriving .speciesLabel {
+  color: var(--health-thriving);
+}
+.flowering .speciesLabel {
+  color: var(--health-thriving);
+}
+.h_dead .speciesLabel {
+  color: var(--health-dead);
+}
+
+.h_critical {
+  border-color: var(--health-critical);
+  box-shadow: inset 0 0 0 1px rgba(229, 86, 91, 0.5);
+}
+.h_dead {
+  border-color: #3a3a3a;
+  opacity: 0.85;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .h_critical {
+    animation: potPulse 1.1s ease-in-out infinite;
+  }
+}
+
+@keyframes potPulse {
+  0%,
+  100% {
+    box-shadow:
+      inset 0 0 0 1px rgba(229, 86, 91, 0.5),
+      0 0 0 rgba(229, 86, 91, 0);
+  }
+  50% {
+    box-shadow:
+      inset 0 0 0 1px rgba(229, 86, 91, 0.8),
+      0 0 14px rgba(229, 86, 91, 0.4);
+  }
+}

--- a/packages/game-botanical/src/components/PotCell.tsx
+++ b/packages/game-botanical/src/components/PotCell.tsx
@@ -1,0 +1,67 @@
+import styles from './PotCell.module.css'
+import DecayRing, { type DecayTone } from './DecayRing'
+import PlantSprite from './PlantSprite'
+import type { PlantView } from '@/game/useGardenSession'
+import { GROWTH_LABEL, HEALTH_LABEL, LIGHT_LABEL, speciesLabel } from '@/game/visual-map'
+
+interface PotCellProps {
+  position: number
+  plant: PlantView | null
+  selected: boolean
+  onSelect: (elementId: string) => void
+}
+
+function decayTone(plant: PlantView): DecayTone {
+  if (plant.health === 'critical') return 'critical'
+  if (plant.decayWarning) return 'warning'
+  return 'ok'
+}
+
+/* One 3×3 grid cell. Occupied → a tappable pot (min 44px) carrying the plant
+   sprite, decay ring, and a species/health/growth label; empty → a dashed
+   placeholder. The accessible name is the full plant state so voice/AT and
+   RTL tests can read it. */
+export default function PotCell({ position, plant, selected, onSelect }: PotCellProps) {
+  if (plant === null) {
+    return (
+      <div className={`${styles.pot} ${styles.empty}`} aria-hidden="true">
+        空盆
+      </div>
+    )
+  }
+
+  const isDead = plant.health === 'dead'
+  const label = isDead
+    ? `${speciesLabel(plant.species)} · 枯株`
+    : `${speciesLabel(plant.species)} · ${HEALTH_LABEL[plant.health]} · ${GROWTH_LABEL[plant.growthStage]} · 实际光照${LIGHT_LABEL[plant.effectiveLight]}`
+
+  const classes = [
+    styles.pot,
+    styles[`h_${plant.health}`],
+    selected ? styles.selected : '',
+    plant.growthStage === 'flowering' ? styles.flowering : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <button
+      type="button"
+      className={classes}
+      data-decay={isDead ? 'dead' : decayTone(plant)}
+      data-position={position}
+      aria-pressed={selected}
+      aria-label={label}
+      disabled={isDead}
+      onClick={() => onSelect(plant.id)}
+    >
+      {!isDead && <DecayRing fraction={plant.decayFraction} tone={decayTone(plant)} />}
+      {plant.growthStage === 'flowering' && <span className={styles.bloom}>✿</span>}
+      <PlantSprite species={plant.species} health={plant.health} growthStage={plant.growthStage} />
+      <span className={styles.speciesLabel}>{speciesLabel(plant.species)}</span>
+      <span className={styles.chips}>
+        {isDead ? '枯株' : `${HEALTH_LABEL[plant.health]} · ${GROWTH_LABEL[plant.growthStage]}`}
+      </span>
+    </button>
+  )
+}

--- a/packages/game-botanical/src/components/ResultsOverlay.module.css
+++ b/packages/game-botanical/src/components/ResultsOverlay.module.css
@@ -1,0 +1,72 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: rgba(6, 10, 8, 0.86);
+  z-index: 20;
+}
+
+.card {
+  width: 100%;
+  max-width: 360px;
+  padding: 22px 20px;
+  text-align: center;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0 0 4px;
+}
+.win {
+  color: var(--health-thriving);
+}
+.lose {
+  color: var(--health-critical);
+}
+
+.stats {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin: 14px 0;
+}
+.stat b {
+  display: block;
+  font-size: 22px;
+  font-variant-numeric: tabular-nums;
+  color: var(--garden-ink);
+}
+.stat span {
+  font-size: 11px;
+  color: var(--garden-ink-dim);
+}
+
+.final {
+  list-style: none;
+  margin: 8px 0 18px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: left;
+  font-size: 12.5px;
+}
+.final li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+.finalName {
+  color: var(--garden-ink-dim);
+}
+.finalState {
+  color: var(--garden-ink);
+}
+
+.replay {
+  width: 100%;
+}

--- a/packages/game-botanical/src/components/ResultsOverlay.tsx
+++ b/packages/game-botanical/src/components/ResultsOverlay.tsx
@@ -1,0 +1,62 @@
+import { Button, GlassCard } from '@amiclaw/ui'
+import styles from './ResultsOverlay.module.css'
+import type { PlantView, RunStatus } from '@/game/useGardenSession'
+import { formatClock } from '@/game/format'
+import { GROWTH_LABEL, HEALTH_LABEL, speciesLabel } from '@/game/visual-map'
+
+interface ResultsOverlayProps {
+  status: RunStatus
+  elapsedMs: number
+  ops: number
+  plants: PlantView[]
+  onReplay: () => void
+}
+
+/* Win/lose results, shown as an overlay over the frozen garden. Time + ops +
+   the final state of every plant, with a prominent full-reset 再玩一次. */
+export default function ResultsOverlay({
+  status,
+  elapsedMs,
+  ops,
+  plants,
+  onReplay,
+}: ResultsOverlayProps) {
+  if (status === 'playing') return null
+  const won = status === 'won'
+  return (
+    <div className={styles.overlay} role="dialog" aria-modal="true" aria-labelledby="result-title">
+      <GlassCard radius="2xl" className={styles.card}>
+        <h2 id="result-title" className={`${styles.title} ${won ? styles.win : styles.lose}`}>
+          {won ? '养护成功 🌸' : '养护失败 🥀'}
+        </h2>
+        <div className={styles.stats}>
+          <div className={styles.stat}>
+            <b>{formatClock(elapsedMs)}</b>
+            <span>用时</span>
+          </div>
+          <div className={styles.stat}>
+            <b>{ops}</b>
+            <span>操作数</span>
+          </div>
+        </div>
+        <ul className={styles.final}>
+          {[...plants]
+            .sort((a, b) => a.potPosition - b.potPosition)
+            .map((plant) => (
+              <li key={plant.id}>
+                <span className={styles.finalName}>{speciesLabel(plant.species)}</span>
+                <span className={styles.finalState}>
+                  {plant.health === 'dead'
+                    ? '枯株'
+                    : `${HEALTH_LABEL[plant.health]} · ${GROWTH_LABEL[plant.growthStage]}`}
+                </span>
+              </li>
+            ))}
+        </ul>
+        <Button variant="primary" className={styles.replay} onClick={onReplay}>
+          再玩一次
+        </Button>
+      </GlassCard>
+    </div>
+  )
+}

--- a/packages/game-botanical/src/components/Stopwatch.module.css
+++ b/packages/game-botanical/src/components/Stopwatch.module.css
@@ -1,0 +1,12 @@
+.timer {
+  font-variant-numeric: tabular-nums;
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: var(--garden-ink);
+  font-family: var(--font-numeric, 'Inter', system-ui, sans-serif);
+}
+
+.running {
+  color: var(--garden-ink);
+}

--- a/packages/game-botanical/src/components/Stopwatch.tsx
+++ b/packages/game-botanical/src/components/Stopwatch.tsx
@@ -1,0 +1,21 @@
+import styles from './Stopwatch.module.css'
+import { formatClock } from '@/game/format'
+
+interface StopwatchProps {
+  elapsedMs: number
+  running: boolean
+}
+
+/* Count-up stopwatch HUD (a score, not a deadline — faster ranks higher). */
+export default function Stopwatch({ elapsedMs, running }: StopwatchProps) {
+  const display = formatClock(elapsedMs)
+  return (
+    <div
+      className={`${styles.timer} ${running ? styles.running : ''}`}
+      role="timer"
+      aria-label={`用时：${display}`}
+    >
+      {display}
+    </div>
+  )
+}

--- a/packages/game-botanical/src/components/VerbCards.module.css
+++ b/packages/game-botanical/src/components/VerbCards.module.css
@@ -1,0 +1,36 @@
+.verbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.verb {
+  flex: 1 1 auto;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 8px 6px;
+  border: 1px solid var(--garden-line);
+  border-radius: 10px;
+  background: #12201a;
+  color: var(--garden-ink);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    transform 0.06s ease;
+}
+
+.verb:active:not(:disabled) {
+  transform: scale(0.96);
+  border-color: var(--garden-accent);
+}
+
+.verb:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/packages/game-botanical/src/components/VerbCards.tsx
+++ b/packages/game-botanical/src/components/VerbCards.tsx
@@ -1,0 +1,28 @@
+import styles from './VerbCards.module.css'
+import { CARE_VERBS } from '@/game/care-verbs'
+
+interface VerbCardsProps {
+  disabled: boolean
+  onVerb: (actionType: string) => void
+}
+
+/* Five care verb cards (浇水/遮光/施肥/换盆/催花). Select a pot, tap a verb →
+   the engine action. Disabled until a live plant is selected. Min 44px tap
+   targets for mobile. */
+export default function VerbCards({ disabled, onVerb }: VerbCardsProps) {
+  return (
+    <div className={styles.verbs} role="group" aria-label="养护动作">
+      {CARE_VERBS.map((verb) => (
+        <button
+          key={verb.actionType}
+          type="button"
+          className={styles.verb}
+          disabled={disabled}
+          onClick={() => onVerb(verb.actionType)}
+        >
+          {verb.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/packages/game-botanical/src/data/load.ts
+++ b/packages/game-botanical/src/data/load.ts
@@ -1,0 +1,47 @@
+/**
+ * Loads the botanical-garden GameType + every level from the canonical fixtures
+ * that live in @amiclaw/creation. The fixtures stay the SSOT there (so the
+ * engine + validator suites cover them); the player app reads the same YAML via
+ * Vite's `?raw` import and the creation loader.
+ *
+ * Levels are discovered data-driven from the fixtures directory (`import.meta.glob`)
+ * and keyed by their own `metadata.id`, so a new `level.*.yaml` becomes playable
+ * (and manual-renderable) with no code change here.
+ */
+import { loadGameType, loadLevel } from '@amiclaw/creation'
+import type { GameType, Level } from '@amiclaw/creation'
+import gameTypeYaml from '../../../creation/fixtures/botanical-garden/game-type.yaml?raw'
+
+export const botanicalGameType: GameType = loadGameType(gameTypeYaml)
+
+export interface LevelEntry {
+  id: string
+  title: string
+  level: Level
+}
+
+const levelYamls = import.meta.glob('../../../creation/fixtures/botanical-garden/level.*.yaml', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+/** All botanical levels, sorted by id (bg-demo-001 before bg-standard-001). */
+export const levels: LevelEntry[] = Object.values(levelYamls)
+  .map((raw) => {
+    const level = loadLevel(raw)
+    return { id: level.metadata.id, title: level.metadata.title, level }
+  })
+  .sort((a, b) => a.id.localeCompare(b.id))
+
+export const DEFAULT_LEVEL_ID = 'bg-demo-001'
+
+const tutorialEntry: LevelEntry = levels.find((entry) => entry.id === DEFAULT_LEVEL_ID) ?? levels[0]
+
+/** Resolve a level by id, falling back to the tutorial when the id is unknown. */
+export function levelById(id: string | null | undefined): LevelEntry {
+  return levels.find((entry) => entry.id === id) ?? tutorialEntry
+}
+
+/** The tutorial level (bg-demo-001) — the default run. */
+export const tutorialLevel: Level = tutorialEntry.level

--- a/packages/game-botanical/src/game/care-verbs.ts
+++ b/packages/game-botanical/src/game/care-verbs.ts
@@ -1,0 +1,20 @@
+/**
+ * The five gardener care verbs (PLAYER-LAYER data). Each maps a Chinese verb
+ * card to the engine `apply_care` action_type that drives the state-transition
+ * tables via action_event_mapping. Order matches the tutorial care loop:
+ * water / shade heal + adjust light; fertilize / repot / bloom advance growth.
+ */
+export interface CareVerb {
+  /** apply_care action_type — the engine-facing value. */
+  actionType: string
+  /** Chinese verb-card label. */
+  label: string
+}
+
+export const CARE_VERBS: CareVerb[] = [
+  { actionType: 'water', label: '浇水' },
+  { actionType: 'shade', label: '遮光' },
+  { actionType: 'fertilize', label: '施肥' },
+  { actionType: 'repot', label: '换盆' },
+  { actionType: 'bloom', label: '催花' },
+]

--- a/packages/game-botanical/src/game/format.ts
+++ b/packages/game-botanical/src/game/format.ts
@@ -1,0 +1,7 @@
+/** Format elapsed milliseconds as a MM:SS count-up stopwatch string. */
+export function formatClock(ms: number): string {
+  const totalSeconds = Math.floor(Math.max(0, ms) / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+}

--- a/packages/game-botanical/src/game/useGardenSession.test.ts
+++ b/packages/game-botanical/src/game/useGardenSession.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useGardenSession } from './useGardenSession'
+import { botanicalGameType, tutorialLevel } from '@/data/load'
+
+function mount() {
+  return renderHook(() => useGardenSession(botanicalGameType, tutorialLevel))
+}
+
+function plant(result: { current: ReturnType<typeof useGardenSession> }, id: string) {
+  const p = result.current.plants.find((x) => x.id === id)
+  if (!p) throw new Error(`plant ${id} not found`)
+  return p
+}
+
+describe('useGardenSession — care actions', () => {
+  it('heals a wilting plant on correct care (select → verb → state change)', () => {
+    const { result } = mount()
+    expect(plant(result, 'plant-1').health).toBe('wilting') // fern starts wilting
+
+    act(() => {
+      result.current.performCare('plant-1', 'water')
+    })
+
+    expect(plant(result, 'plant-1').health).toBe('stable')
+    expect(result.current.ops).toBe(1)
+  })
+
+  it('shading the orchid adjusts light AND heals it in one care', () => {
+    const { result } = mount()
+    act(() => {
+      result.current.performCare('plant-3', 'shade')
+    })
+    const orchid = plant(result, 'plant-3')
+    expect(orchid.effectiveLight).toBe('partial_shade')
+    expect(orchid.health).toBe('stable')
+  })
+
+  it('reaches the win state through the tutorial care path', () => {
+    const { result } = mount()
+    act(() => {
+      result.current.performCare('plant-1', 'water') // fern wilting → stable
+    })
+    act(() => {
+      result.current.performCare('plant-3', 'shade') // orchid → partial_shade + heal → stable
+    })
+    act(() => {
+      result.current.performCare('plant-3', 'fertilize') // seedling → juvenile
+    })
+    act(() => {
+      result.current.performCare('plant-3', 'repot') // juvenile → mature
+    })
+    act(() => {
+      result.current.performCare('plant-3', 'bloom') // mature → flowering
+    })
+
+    expect(result.current.status).toBe('won')
+    expect(plant(result, 'plant-3').growthStage).toBe('flowering')
+  })
+})
+
+describe('useGardenSession — timed decay', () => {
+  it('raises the decay warning as a plant nears its neglect tick', () => {
+    const { result } = mount()
+    // plant-3 has offset 40000 / interval 60000 → tick at 20000ms; warning
+    // window is the last 8000ms, so 15000ms elapsed is inside it.
+    act(() => {
+      result.current.advance(15000)
+    })
+    const orchid = plant(result, 'plant-3')
+    expect(orchid.decayWarning).toBe(true)
+    expect(orchid.health).toBe('wilting') // not yet ticked
+    expect(orchid.decayFraction).toBeGreaterThan(0.9)
+  })
+
+  it('lets an untended plant decay to death → lost (lose reachable)', () => {
+    const { result } = mount()
+
+    act(() => {
+      result.current.advance(20000) // plant-3 neglect: wilting → critical
+    })
+    expect(plant(result, 'plant-3').health).toBe('critical')
+    expect(result.current.status).toBe('playing')
+
+    act(() => {
+      result.current.advance(60000) // plant-3 neglect: critical → dead
+    })
+    expect(plant(result, 'plant-3').health).toBe('dead')
+    expect(result.current.status).toBe('lost')
+  })
+
+  it('freezes time once the run has ended', () => {
+    const { result } = mount()
+    act(() => {
+      result.current.advance(20000)
+    })
+    act(() => {
+      result.current.advance(60000) // → lost
+    })
+    const elapsedAtLoss = result.current.elapsedMs
+    act(() => {
+      result.current.advance(60000) // no-op after end
+    })
+    expect(result.current.elapsedMs).toBe(elapsedAtLoss)
+  })
+})
+
+describe('useGardenSession — reset', () => {
+  it('restores the initial board, clock, and op count', () => {
+    const { result } = mount()
+    act(() => {
+      result.current.performCare('plant-1', 'water')
+    })
+    act(() => {
+      result.current.advance(5000)
+    })
+    expect(result.current.ops).toBe(1)
+    expect(result.current.elapsedMs).toBe(5000)
+
+    act(() => {
+      result.current.reset()
+    })
+
+    expect(result.current.status).toBe('playing')
+    expect(result.current.ops).toBe(0)
+    expect(result.current.elapsedMs).toBe(0)
+    expect(plant(result, 'plant-1').health).toBe('wilting')
+  })
+})

--- a/packages/game-botanical/src/game/useGardenSession.ts
+++ b/packages/game-botanical/src/game/useGardenSession.ts
@@ -1,0 +1,234 @@
+/**
+ * React bridge over the engine GameSession (gardener-view only, Round 4).
+ *
+ * The engine is a persistent mutable object kept in a ref. Every mutation — a
+ * care action, a decay tick, or a reset — happens inside a callback, then
+ * re-derives an IMMUTABLE snapshot (plants / zones / decay rings / status /
+ * clock) and stores it in state. Render reads only that snapshot, never the
+ * ref, so the component stays a pure function of state. Wall-clock lives
+ * entirely in useDecayLoop, which calls `advance(dt)`; this hook injects no
+ * time of its own.
+ *
+ * Win/lose precedence is the engine's: getState().won already folds in
+ * "lose wins ties" (a dead plant never shows a win).
+ */
+import { useCallback, useRef, useState } from 'react'
+import { GameSession } from '@amiclaw/creation'
+import type { GameType, Level } from '@amiclaw/creation'
+import { GROWTH_LABEL, HEALTH_LABEL, LIGHT_LABEL, plantStateOrder, rankDelta } from './visual-map'
+
+const DECAY_EMITTER_ID = 'decay'
+
+// Runtime type is the engine's GameSession; aliased for readable signatures.
+type GameSession_ = InstanceType<typeof GameSession>
+
+export type RunStatus = 'playing' | 'won' | 'lost'
+
+export interface PlantView {
+  id: string
+  potPosition: number
+  species: string
+  health: string
+  growthStage: string
+  effectiveLight: string
+  /** 0 → just ticked, 1 → decay tick is due. Drives the DecayRing fill. */
+  decayFraction: number
+  /** True inside the emitter's warning window (amber ring). */
+  decayWarning: boolean
+}
+
+export interface ZoneView {
+  id: string
+  zoneId: string
+  lightLevel: string
+  temperature: string
+  positions: number[]
+}
+
+export interface CareOutcome {
+  ok: boolean
+  tone: 'good' | 'bad' | 'neutral'
+  message: string
+}
+
+interface GardenSnapshot {
+  plants: PlantView[]
+  zones: ZoneView[]
+  status: RunStatus
+  elapsedMs: number
+  ops: number
+}
+
+export interface GardenSession extends GardenSnapshot {
+  /** Perform one care verb on a plant; returns player-facing feedback. */
+  performCare: (elementId: string, actionType: string) => CareOutcome
+  /** Advance simulated time (called by the decay loop). No-op once ended. */
+  advance: (dtMs: number) => void
+  /** Full reset — a fresh session, zeroed clock + op count. */
+  reset: () => void
+}
+
+interface PlantSnapshot {
+  health: string
+  growthStage: string
+  effectiveLight: string
+}
+
+function clamp01(n: number): number {
+  return n < 0 ? 0 : n > 1 ? 1 : n
+}
+
+/** Resolved decay interval for one plant (base emitter, per-instance override). */
+function decayIntervalFor(gameType: GameType, level: Level, elementId: string): number {
+  const emitter = gameType.timed_emitters?.find((e) => e.id === DECAY_EMITTER_ID)
+  if (!emitter) return 0
+  const override = level.elements.find((e) => e.id === elementId)?.initial_timers?.[emitter.id]
+  return typeof override?.interval_ms === 'number' ? override.interval_ms : emitter.interval_ms
+}
+
+function plantSnapshot(session: GameSession_, elementId: string): PlantSnapshot {
+  const el = session.getState().elements[elementId] ?? {}
+  return {
+    health: String(el.health ?? ''),
+    growthStage: String(el.growth_stage ?? ''),
+    effectiveLight: String(el.effective_light ?? ''),
+  }
+}
+
+function careOutcome(
+  gameType: GameType,
+  ok: boolean,
+  before: PlantSnapshot,
+  after: PlantSnapshot
+): CareOutcome {
+  if (!ok) return { ok: false, tone: 'neutral', message: '无法执行该养护' }
+  const dHealth = rankDelta(plantStateOrder(gameType, 'health'), before.health, after.health)
+  const dGrowth = rankDelta(
+    plantStateOrder(gameType, 'growth_stage'),
+    before.growthStage,
+    after.growthStage
+  )
+  const lightChanged = before.effectiveLight !== after.effectiveLight
+  if (dGrowth > 0 && dHealth > 0)
+    return { ok: true, tone: 'good', message: `好转并生长 → ${GROWTH_LABEL[after.growthStage]}` }
+  if (dGrowth > 0)
+    return { ok: true, tone: 'good', message: `生长推进 → ${GROWTH_LABEL[after.growthStage]}` }
+  if (dHealth > 0)
+    return { ok: true, tone: 'good', message: `植株好转 → ${HEALTH_LABEL[after.health]}` }
+  if (dHealth < 0)
+    return { ok: true, tone: 'bad', message: `养护不当，受损 → ${HEALTH_LABEL[after.health]}` }
+  if (lightChanged)
+    return {
+      ok: true,
+      tone: 'neutral',
+      message: `已调整光照 → ${LIGHT_LABEL[after.effectiveLight]}`,
+    }
+  return { ok: true, tone: 'neutral', message: '本次养护没有变化' }
+}
+
+/** Re-derive the immutable render snapshot from the (just-mutated) session. */
+function deriveSnapshot(
+  session: GameSession_,
+  gameType: GameType,
+  level: Level,
+  elapsedMs: number,
+  ops: number
+): GardenSnapshot {
+  const state = session.getState()
+  const status: RunStatus = state.lost ? 'lost' : state.won ? 'won' : 'playing'
+
+  const view = session.getRoleView('gardener')
+  const timerByElement = new Map(
+    session
+      .timerStatus()
+      .filter((t) => t.emitterId === DECAY_EMITTER_ID)
+      .map((t) => [t.elementId, t])
+  )
+
+  const plants: PlantView[] = view.elements
+    .filter((el) => el.archetype === 'plant')
+    .map((el) => {
+      const interval = decayIntervalFor(gameType, level, el.element_id)
+      const timer = timerByElement.get(el.element_id)
+      const msUntilTick = timer?.msUntilTick ?? interval
+      return {
+        id: el.element_id,
+        potPosition: Number(el.visible_params.pot_position ?? 0),
+        species: String(el.visible_params.species ?? ''),
+        health: String(el.visible_states.health ?? ''),
+        growthStage: String(el.visible_states.growth_stage ?? ''),
+        effectiveLight: String(el.visible_states.effective_light ?? ''),
+        decayFraction: interval > 0 ? clamp01(1 - msUntilTick / interval) : 0,
+        decayWarning: timer?.warning ?? false,
+      }
+    })
+    .sort((a, b) => a.potPosition - b.potPosition)
+
+  const zones: ZoneView[] = view.elements
+    .filter((el) => el.archetype === 'environment_zone')
+    .map((el) => ({
+      id: el.element_id,
+      zoneId: String(el.visible_params.zone_id ?? ''),
+      lightLevel: String(el.visible_params.light_level ?? ''),
+      temperature: String(el.visible_params.temperature ?? ''),
+      positions: ((el.visible_params.covers_positions as string[]) ?? [])
+        .map(Number)
+        .sort((a, b) => a - b),
+    }))
+
+  return { plants, zones, status, elapsedMs, ops }
+}
+
+export function useGardenSession(gameType: GameType, level: Level): GardenSession {
+  const sessionRef = useRef<GameSession_ | null>(null)
+  if (sessionRef.current === null) sessionRef.current = new GameSession(gameType, level)
+  const elapsedRef = useRef(0)
+  const opsRef = useRef(0)
+
+  // The initial snapshot is a pure function of (gameType, level), so it is
+  // derived from a throwaway fresh session — reading the persistent ref during
+  // render is disallowed, and both sessions start byte-identical.
+  const [snapshot, setSnapshot] = useState<GardenSnapshot>(() =>
+    deriveSnapshot(new GameSession(gameType, level), gameType, level, 0, 0)
+  )
+
+  const performCare = useCallback(
+    (elementId: string, actionType: string): CareOutcome => {
+      const session = sessionRef.current!
+      const state = session.getState()
+      if (state.won || state.lost) return { ok: false, tone: 'neutral', message: '本局已结束' }
+      const before = plantSnapshot(session, elementId)
+      const result = session.performAction('gardener', 'apply_care', {
+        element_id: elementId,
+        action_type: actionType,
+      })
+      opsRef.current += 1
+      const after = plantSnapshot(session, elementId)
+      setSnapshot(deriveSnapshot(session, gameType, level, elapsedRef.current, opsRef.current))
+      return careOutcome(gameType, result.ok, before, after)
+    },
+    [gameType, level]
+  )
+
+  const advance = useCallback(
+    (dtMs: number) => {
+      const session = sessionRef.current!
+      const state = session.getState()
+      if (state.won || state.lost) return
+      elapsedRef.current += dtMs
+      session.advanceTime(dtMs)
+      setSnapshot(deriveSnapshot(session, gameType, level, elapsedRef.current, opsRef.current))
+    },
+    [gameType, level]
+  )
+
+  const reset = useCallback(() => {
+    const session = new GameSession(gameType, level)
+    sessionRef.current = session
+    elapsedRef.current = 0
+    opsRef.current = 0
+    setSnapshot(deriveSnapshot(session, gameType, level, 0, 0))
+  }, [gameType, level])
+
+  return { ...snapshot, performCare, advance, reset }
+}

--- a/packages/game-botanical/src/game/visual-map.test.ts
+++ b/packages/game-botanical/src/game/visual-map.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { plantSprite, plantStateOrder, rankDelta, speciesLabel } from './visual-map'
+import { botanicalGameType } from '@/data/load'
+
+describe('visual-map', () => {
+  it('swaps the glyph for death and flowering, else uses the species glyph', () => {
+    expect(plantSprite('orchid', 'stable', 'seedling')).toBe('🌷')
+    expect(plantSprite('orchid', 'dead', 'flowering')).toBe('🥀') // death wins over flowering
+    expect(plantSprite('fern', 'thriving', 'flowering')).toBe('🌸')
+  })
+
+  it('labels species in Chinese', () => {
+    expect(speciesLabel('succulent')).toBe('多肉')
+  })
+
+  it('reads the health order (worst → best) from the GameType, not a hardcode', () => {
+    expect(plantStateOrder(botanicalGameType, 'health')).toEqual([
+      'dead',
+      'critical',
+      'wilting',
+      'stable',
+      'thriving',
+    ])
+  })
+
+  it('computes a signed rank delta within an ordered enum', () => {
+    const order = plantStateOrder(botanicalGameType, 'health')
+    expect(rankDelta(order, 'wilting', 'stable')).toBeGreaterThan(0) // healed
+    expect(rankDelta(order, 'stable', 'critical')).toBeLessThan(0) // harmed
+    expect(rankDelta(order, 'stable', 'stable')).toBe(0)
+  })
+})

--- a/packages/game-botanical/src/game/visual-map.ts
+++ b/packages/game-botanical/src/game/visual-map.ts
@@ -1,0 +1,75 @@
+/**
+ * PLAYER-LAYER visual/display data (locked constraint §1). The engine stays a
+ * generic state machine keyed by ASCII enum values (`species: 'orchid'`,
+ * `health: 'wilting'`, …); this module is the ONLY place those enums become a
+ * sprite, a Chinese label, a tint, or a size. The engine never learns a sprite
+ * exists. Everything here is keyed by the engine's ASCII values and is safe to
+ * evolve without touching @amiclaw/creation.
+ */
+import type { GameType } from '@amiclaw/creation'
+
+/** species enum → glyph + Chinese label. */
+export const SPECIES_DISPLAY: Record<string, { label: string; sprite: string }> = {
+  fern: { label: '蕨类', sprite: '🌿' },
+  succulent: { label: '多肉', sprite: '🌵' },
+  orchid: { label: '兰花', sprite: '🌷' },
+  moss: { label: '苔藓', sprite: '🍀' },
+  vine: { label: '藤蔓', sprite: '🍃' },
+}
+
+/** health enum → Chinese label (worst → best). */
+export const HEALTH_LABEL: Record<string, string> = {
+  dead: '枯死',
+  critical: '垂危',
+  wilting: '枯萎',
+  stable: '稳定',
+  thriving: '茁壮',
+}
+
+/** growth_stage enum → Chinese label. */
+export const GROWTH_LABEL: Record<string, string> = {
+  seedling: '幼苗',
+  juvenile: '成株',
+  mature: '成熟',
+  flowering: '开花',
+}
+
+/** effective_light enum → Chinese label. */
+export const LIGHT_LABEL: Record<string, string> = {
+  full_sun: '全光',
+  partial_shade: '半荫',
+  full_shade: '全荫',
+}
+
+/** environment zone_id → Chinese label. */
+export const ZONE_LABEL: Record<string, string> = {
+  north: '北区',
+  center: '中区',
+  south: '南区',
+}
+
+export function speciesLabel(species: string): string {
+  return SPECIES_DISPLAY[species]?.label ?? species
+}
+
+/** The glyph a pot renders: death and flowering override the species glyph. */
+export function plantSprite(species: string, health: string, growthStage: string): string {
+  if (health === 'dead') return '🥀'
+  if (growthStage === 'flowering') return '🌸'
+  return SPECIES_DISPLAY[species]?.sprite ?? '🌱'
+}
+
+/**
+ * Ordered value list for a plant state, read from the loaded GameType archetype
+ * rather than hardcoded — so a rank comparison (did health improve?) tracks the
+ * engine's declared order (worst → best) instead of duplicating it here.
+ */
+export function plantStateOrder(gameType: GameType, stateName: string): string[] {
+  const plant = gameType.element_archetypes.find((a) => a.id === 'plant')
+  return plant?.states?.find((s) => s.name === stateName)?.values ?? []
+}
+
+/** Signed rank delta of `after` vs `before` within an ordered enum. */
+export function rankDelta(order: string[], before: string, after: string): number {
+  return order.indexOf(after) - order.indexOf(before)
+}

--- a/packages/game-botanical/src/hooks/useDecayLoop.test.tsx
+++ b/packages/game-botanical/src/hooks/useDecayLoop.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { act, render, cleanup } from '@testing-library/react'
+import { useDecayLoop } from './useDecayLoop'
+
+function Harness({ onTick, active }: { onTick: (dt: number) => void; active: boolean }) {
+  useDecayLoop(onTick, active)
+  return null
+}
+
+/** Controllable rAF: one pending callback, fired with an explicit timestamp. */
+function installFakeRaf() {
+  let pending: FrameRequestCallback | null = null
+  vi.stubGlobal('requestAnimationFrame', (fn: FrameRequestCallback) => {
+    pending = fn
+    return 1
+  })
+  vi.stubGlobal('cancelAnimationFrame', () => {
+    pending = null
+  })
+  return (timestamp: number) => {
+    const fn = pending
+    pending = null
+    act(() => fn?.(timestamp))
+  }
+}
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  setHidden(false)
+  cleanup()
+})
+
+describe('useDecayLoop', () => {
+  it('feeds the diffed frame delta to onTick (first frame primes the baseline)', () => {
+    const frame = installFakeRaf()
+    const seen: number[] = []
+    render(<Harness onTick={(dt) => seen.push(dt)} active />)
+
+    frame(1000) // primes last=1000, dt=0 → no tick
+    frame(1016) // dt=16
+    frame(1050) // dt=34
+    expect(seen).toEqual([16, 34])
+  })
+
+  it('clamps a large resume gap to the per-frame ceiling', () => {
+    const frame = installFakeRaf()
+    const seen: number[] = []
+    render(<Harness onTick={(dt) => seen.push(dt)} active />)
+
+    frame(1000) // prime
+    frame(6000) // dt=5000 → clamped to 1000
+    expect(seen).toEqual([1000])
+  })
+
+  it('pauses while the tab is hidden and never replays the gap', () => {
+    const frame = installFakeRaf()
+    const seen: number[] = []
+    render(<Harness onTick={(dt) => seen.push(dt)} active />)
+
+    frame(1000) // prime
+    frame(1016) // dt=16
+    setHidden(true)
+    frame(9000) // hidden → no tick, baseline reset
+    setHidden(false)
+    frame(9016) // re-prime after resume, dt=0
+    frame(9032) // dt=16
+    expect(seen).toEqual([16, 16])
+  })
+
+  it('does not schedule frames while inactive', () => {
+    const frame = installFakeRaf()
+    const seen: number[] = []
+    render(<Harness onTick={(dt) => seen.push(dt)} active={false} />)
+    frame(1000)
+    frame(2000)
+    expect(seen).toEqual([])
+  })
+})

--- a/packages/game-botanical/src/hooks/useDecayLoop.ts
+++ b/packages/game-botanical/src/hooks/useDecayLoop.ts
@@ -1,0 +1,51 @@
+/**
+ * The ONLY wall-clock in the botanical app. A single requestAnimationFrame
+ * loop measures elapsed real time and feeds it to `onTick(dtMs)` (the engine's
+ * host-injected time). It:
+ *   - pauses while the tab is hidden (no decay in a backgrounded tab), and
+ *     resets its baseline on `visibilitychange` so returning never replays a
+ *     huge jump;
+ *   - stops entirely when `active` is false (the run has ended).
+ *
+ * A per-frame safety clamp bounds any throttled-resume gap that dodges the
+ * visibility reset; normal frames are ~16ms so the clamp is otherwise inert.
+ */
+import { useEffect, useRef } from 'react'
+
+const MAX_FRAME_MS = 1000
+
+export function useDecayLoop(onTick: (dtMs: number) => void, active: boolean): void {
+  const onTickRef = useRef(onTick)
+  useEffect(() => {
+    onTickRef.current = onTick
+  }, [onTick])
+
+  useEffect(() => {
+    if (!active) return
+    let raf = 0
+    let last: number | null = null
+
+    const frame = (now: number) => {
+      if (document.hidden) {
+        last = null
+      } else {
+        if (last === null) last = now
+        const dt = now - last
+        last = now
+        if (dt > 0) onTickRef.current(Math.min(dt, MAX_FRAME_MS))
+      }
+      raf = requestAnimationFrame(frame)
+    }
+
+    const onVisibility = () => {
+      if (document.hidden) last = null
+    }
+
+    document.addEventListener('visibilitychange', onVisibility)
+    raf = requestAnimationFrame(frame)
+    return () => {
+      cancelAnimationFrame(raf)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [active])
+}

--- a/packages/game-botanical/src/main.tsx
+++ b/packages/game-botanical/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import '@amiclaw/ui/styles/tokens.css'
+import '@amiclaw/ui/styles/animations.css'
+import './styles/global.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter basename="/botanical">
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/packages/game-botanical/src/manual/ManualPanel.module.css
+++ b/packages/game-botanical/src/manual/ManualPanel.module.css
@@ -1,0 +1,51 @@
+.panel {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 16px 14px calc(24px + env(safe-area-inset-bottom, 0px));
+  color: var(--garden-ink);
+}
+
+.head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.version {
+  font-size: 12px;
+  color: var(--garden-ink-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.section {
+  border: 1px solid var(--garden-line);
+  border-radius: 12px;
+  padding: 10px 12px 12px;
+  background: var(--bg-garden-2);
+  margin-bottom: 8px;
+}
+
+.sectionTitle {
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--garden-accent);
+}
+
+.lines {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--garden-ink);
+}

--- a/packages/game-botanical/src/manual/ManualPanel.test.tsx
+++ b/packages/game-botanical/src/manual/ManualPanel.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import ManualPanel from './ManualPanel'
+import { renderBotanicalManual } from './render-manual'
+import { botanicalGameType, tutorialLevel } from '@/data/load'
+
+describe('ManualPanel', () => {
+  it('renders every manual section with its title and lines', () => {
+    const manual = renderBotanicalManual(botanicalGameType, tutorialLevel)
+    render(<ManualPanel manual={manual} />)
+
+    expect(screen.getByRole('heading', { level: 1, name: '养护手册' })).toBeInTheDocument()
+    // every section heading is present
+    for (const s of manual.sections) {
+      expect(screen.getByRole('heading', { level: 2, name: s.title })).toBeInTheDocument()
+    }
+    // section blocks are addressable by id in the DOM
+    const compatibility = document.querySelector('[data-section-id="compatibility"]')
+    expect(compatibility).not.toBeNull()
+    expect(within(compatibility as HTMLElement).getByText(/蕨类.*相克/)).toBeInTheDocument()
+  })
+})

--- a/packages/game-botanical/src/manual/ManualPanel.tsx
+++ b/packages/game-botanical/src/manual/ManualPanel.tsx
@@ -1,0 +1,30 @@
+import styles from './ManualPanel.module.css'
+import type { RenderedManual } from './render-manual'
+
+interface ManualPanelProps {
+  manual: RenderedManual
+}
+
+/* Dev-viewable botanist manual surface — renders the RenderedManual as HTML.
+   In hidden_info_coop the shipped player is the gardener and does NOT read
+   this; it is the botanist-side / inspection view (reachable at /manual). */
+export default function ManualPanel({ manual }: ManualPanelProps) {
+  return (
+    <article className={styles.panel} aria-label="养护手册">
+      <header className={styles.head}>
+        <h1 className={styles.title}>养护手册</h1>
+        <span className={styles.version}>v{manual.version}</span>
+      </header>
+      {manual.sections.map((section) => (
+        <section key={section.id} className={styles.section} data-section-id={section.id}>
+          <h2 className={styles.sectionTitle}>{section.title}</h2>
+          <ul className={styles.lines}>
+            {section.lines.map((line, i) => (
+              <li key={i}>{line}</li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </article>
+  )
+}

--- a/packages/game-botanical/src/manual/__snapshots__/render-manual.test.ts.snap
+++ b/packages/game-botanical/src/manual/__snapshots__/render-manual.test.ts.snap
@@ -1,0 +1,146 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderBotanicalManual — bg-demo-001 v1.1.0 > golden: full rendered manual is pinned for bg-demo-001 > bg-demo-001 1`] = `
+{
+  "sections": [
+    {
+      "id": "objective",
+      "lines": [
+        "达成目标：所有植株的健康至少达到「稳定（stable）」，且至少 1 株的生长阶段达到「开花（flowering）」。",
+        "败局：任一植株的健康跌至「枯死（dead）」即告失败；枯死无法挽回。",
+      ],
+      "title": "目标与败局",
+    },
+    {
+      "id": "species_care:orchid",
+      "lines": [
+        "当光照为半荫（partial_shade）时，养护兰花（orchid）可使其恢复健康。",
+      ],
+      "title": "兰花 · 养护要点",
+    },
+    {
+      "id": "danger:fern",
+      "lines": [
+        "当光照为全荫（full_shade）时，蕨类（fern）会受损，应当避免。",
+      ],
+      "title": "蕨类 · 风险提示",
+    },
+    {
+      "id": "compatibility",
+      "lines": [
+        "植株间的相性（本关卡为策略参考）：",
+        "蕨类（fern） 与 多肉（succulent）：相克（incompatible）",
+        "蕨类（fern） 与 兰花（orchid）：相容（compatible）",
+        "多肉（succulent） 与 兰花（orchid）：中性（neutral）",
+        "蕨类（fern） 与 苔藓（moss）：协同（synergy）",
+        "多肉（succulent） 与 藤蔓（vine）：相容（compatible）",
+      ],
+      "title": "相生相克",
+    },
+    {
+      "id": "light",
+      "lines": [
+        "调节光照可改变植株的实际光照：",
+        "全光经遮光变为半荫",
+        "半荫经遮光变为全荫",
+      ],
+      "title": "光照调节",
+    },
+    {
+      "id": "growth",
+      "lines": [
+        "养护得当可推进生长阶段：",
+        "幼苗经施肥变为成株",
+        "成株经换盆变为成熟",
+        "成熟经催花变为开花",
+      ],
+      "title": "生长阶段",
+    },
+    {
+      "id": "health_and_decay",
+      "lines": [
+        "健康档位由差到好：枯死（dead） < 垂危（critical） < 枯萎（wilting） < 稳定（stable） < 茁壮（thriving）。",
+        "浇水（correct_care）可提升健康：枯萎→稳定；稳定→茁壮；垂危→枯萎。",
+        "过量浇水（wrong_care）会降低健康：稳定→枯萎；茁壮→稳定；枯萎→垂危。",
+        "无人照料（neglect）会随时间衰退：茁壮→稳定；稳定→枯萎；枯萎→垂危；垂危→枯死。",
+        "无人照料每约 60 秒衰退一次，临近前 8 秒会预警。",
+        "植株一旦枯死即无法挽回，并会导致败局。",
+      ],
+      "title": "健康与衰败",
+    },
+  ],
+  "version": "1.1.0",
+}
+`;
+
+exports[`renderBotanicalManual — bg-standard-001 v1.1.0 > golden: full rendered manual is pinned for bg-standard-001 > bg-standard-001 1`] = `
+{
+  "sections": [
+    {
+      "id": "objective",
+      "lines": [
+        "达成目标：所有植株的健康至少达到「稳定（stable）」，且至少 1 株的生长阶段达到「开花（flowering）」。",
+        "败局：任一植株的健康跌至「枯死（dead）」即告失败；枯死无法挽回。",
+      ],
+      "title": "目标与败局",
+    },
+    {
+      "id": "species_care:orchid",
+      "lines": [
+        "兰花（orchid）只有在光照为半荫（partial_shade）时，养护才能使其恢复健康。",
+        "遮光只会让光照逐级变暗、无法回退；一旦兰花（orchid）被遮光到全荫（full_shade），就再也无法恢复健康，切勿遮光过头。",
+      ],
+      "title": "兰花 · 养护要点",
+    },
+    {
+      "id": "species_care:fern",
+      "lines": [
+        "蕨类（fern）只有在光照为半荫（partial_shade）时，养护才能使其恢复健康。",
+        "遮光只会让光照逐级变暗、无法回退；一旦蕨类（fern）被遮光到全荫（full_shade），就再也无法恢复健康，切勿遮光过头。",
+      ],
+      "title": "蕨类 · 养护要点",
+    },
+    {
+      "id": "compatibility",
+      "lines": [
+        "植株间的相性（本关卡为策略参考）：",
+        "苔藓（moss） 与 多肉（succulent）：协同（synergy）",
+        "多肉（succulent） 与 藤蔓（vine）：相容（compatible）",
+        "苔藓（moss） 与 藤蔓（vine）：中性（neutral）",
+      ],
+      "title": "相生相克",
+    },
+    {
+      "id": "light",
+      "lines": [
+        "调节光照可改变植株的实际光照：",
+        "全光经遮光变为半荫",
+        "半荫经遮光变为全荫",
+      ],
+      "title": "光照调节",
+    },
+    {
+      "id": "growth",
+      "lines": [
+        "养护得当可推进生长阶段：",
+        "幼苗经施肥变为成株",
+        "成株经换盆变为成熟",
+        "成熟经催花变为开花",
+      ],
+      "title": "生长阶段",
+    },
+    {
+      "id": "health_and_decay",
+      "lines": [
+        "健康档位由差到好：枯死（dead） < 垂危（critical） < 枯萎（wilting） < 稳定（stable） < 茁壮（thriving）。",
+        "浇水（correct_care）仅能提升 苔藓（moss）、多肉（succulent）、藤蔓（vine） 的健康：枯萎→稳定；稳定→茁壮；垂危→枯萎。兰花（orchid）、蕨类（fern）浇水无效，恢复方式见各自养护要点。",
+        "无人照料（neglect）会随时间衰退：茁壮→稳定；稳定→枯萎；枯萎→垂危；垂危→枯死。",
+        "无人照料每约 60 秒衰退一次，临近前 8 秒会预警。",
+        "植株一旦枯死即无法挽回，并会导致败局。",
+      ],
+      "title": "健康与衰败",
+    },
+  ],
+  "version": "1.1.0",
+}
+`;

--- a/packages/game-botanical/src/manual/__snapshots__/render-manual.test.ts.snap
+++ b/packages/game-botanical/src/manual/__snapshots__/render-manual.test.ts.snap
@@ -28,11 +28,11 @@ exports[`renderBotanicalManual — bg-demo-001 v1.1.0 > golden: full rendered ma
     {
       "id": "compatibility",
       "lines": [
-        "植株间的相性（本关卡为策略参考）：",
+        "植株间的相性（未注明机械效果的仅供策略参考）：",
         "蕨类（fern） 与 多肉（succulent）：相克（incompatible）",
         "蕨类（fern） 与 兰花（orchid）：相容（compatible）",
         "多肉（succulent） 与 兰花（orchid）：中性（neutral）",
-        "蕨类（fern） 与 苔藓（moss）：协同（synergy）",
+        "蕨类（fern） 与 苔藓（moss）：协同（synergy），养护任一株会同时治愈相邻的另一株。",
         "多肉（succulent） 与 藤蔓（vine）：相容（compatible）",
       ],
       "title": "相生相克",
@@ -61,7 +61,6 @@ exports[`renderBotanicalManual — bg-demo-001 v1.1.0 > golden: full rendered ma
       "lines": [
         "健康档位由差到好：枯死（dead） < 垂危（critical） < 枯萎（wilting） < 稳定（stable） < 茁壮（thriving）。",
         "浇水（correct_care）可提升健康：枯萎→稳定；稳定→茁壮；垂危→枯萎。",
-        "过量浇水（wrong_care）会降低健康：稳定→枯萎；茁壮→稳定；枯萎→垂危。",
         "无人照料（neglect）会随时间衰退：茁壮→稳定；稳定→枯萎；枯萎→垂危；垂危→枯死。",
         "无人照料每约 60 秒衰退一次，临近前 8 秒会预警。",
         "植株一旦枯死即无法挽回，并会导致败局。",
@@ -103,8 +102,8 @@ exports[`renderBotanicalManual — bg-standard-001 v1.1.0 > golden: full rendere
     {
       "id": "compatibility",
       "lines": [
-        "植株间的相性（本关卡为策略参考）：",
-        "苔藓（moss） 与 多肉（succulent）：协同（synergy）",
+        "植株间的相性（未注明机械效果的仅供策略参考）：",
+        "苔藓（moss） 与 多肉（succulent）：协同（synergy），养护任一株会同时治愈相邻的另一株。",
         "多肉（succulent） 与 藤蔓（vine）：相容（compatible）",
         "苔藓（moss） 与 藤蔓（vine）：中性（neutral）",
       ],
@@ -135,7 +134,7 @@ exports[`renderBotanicalManual — bg-standard-001 v1.1.0 > golden: full rendere
         "健康档位由差到好：枯死（dead） < 垂危（critical） < 枯萎（wilting） < 稳定（stable） < 茁壮（thriving）。",
         "浇水（correct_care）仅能提升 苔藓（moss）、多肉（succulent）、藤蔓（vine） 的健康：枯萎→稳定；稳定→茁壮；垂危→枯萎。兰花（orchid）、蕨类（fern）浇水无效，恢复方式见各自养护要点。",
         "无人照料（neglect）会随时间衰退：茁壮→稳定；稳定→枯萎；枯萎→垂危；垂危→枯死。",
-        "无人照料每约 60 秒衰退一次，临近前 8 秒会预警。",
+        "无人照料每约 40–60 秒衰退一次，其中兰花（orchid）最快（每约 40 秒），临近前 8 秒会预警。",
         "植株一旦枯死即无法挽回，并会导致败局。",
       ],
       "title": "健康与衰败",

--- a/packages/game-botanical/src/manual/manual-labels.ts
+++ b/packages/game-botanical/src/manual/manual-labels.ts
@@ -1,0 +1,52 @@
+/**
+ * PLAYER-LAYER display labels used only by the manual renderer, keyed by the
+ * engine's ASCII enum values. Species / health / growth / light glosses are
+ * reused from visual-map (the app's single label source); the maps here cover
+ * the manual-only vocabulary (relations, action verbs, soil, state + predicate
+ * field names). Every lookup falls back to the raw ASCII value, so an enum the
+ * fixture adds later never crashes the renderer — it just shows the raw value
+ * until a label is added.
+ */
+
+/** compatibility_matrix relation → Chinese label. */
+export const RELATION_LABEL: Record<string, string> = {
+  compatible: '相容',
+  incompatible: '相克',
+  synergy: '协同',
+  neutral: '中性',
+  modifies: '影响',
+}
+
+/** action_type → Chinese verb (the 5 care verbs + the mis-care overwater). */
+export const ACTION_LABEL: Record<string, string> = {
+  water: '浇水',
+  overwater: '过量浇水',
+  shade: '遮光',
+  fertilize: '施肥',
+  repot: '换盆',
+  bloom: '催花',
+}
+
+/** soil_type → Chinese label (not carried in the fixture display_labels). */
+export const SOIL_LABEL: Record<string, string> = {
+  sandy: '沙土',
+  loamy: '壤土',
+  peaty: '泥炭土',
+}
+
+/** plant state name → Chinese label (used in the objective + health sections). */
+export const STATE_NAME_LABEL: Record<string, string> = {
+  health: '健康',
+  growth_stage: '生长阶段',
+  effective_light: '实际光照',
+}
+
+/** predicate/attribute field name → Chinese label (used in preconditions). */
+export const FIELD_LABEL: Record<string, string> = {
+  species: '品种',
+  effective_light: '光照',
+  light_level: '光照',
+  growth_stage: '生长阶段',
+  soil_type: '土壤',
+  health: '健康',
+}

--- a/packages/game-botanical/src/manual/render-manual.test.ts
+++ b/packages/game-botanical/src/manual/render-manual.test.ts
@@ -49,12 +49,16 @@ describe('renderBotanicalManual — bg-demo-001 v1.1.0', () => {
     expect(s.lines[0]).toContain('受损')
   })
 
-  it('compatibility renders every matrix relation as strategic info', () => {
+  it('renders active synergy as a mechanical consequence; other relations as strategic reference', () => {
     const lines = section(manual, 'compatibility').lines
+    expect(lines[0]).toContain('未注明机械效果的仅供策略参考')
+    // synergy binds an active state_effect (heal) → spell out the consequence.
+    expect(lines).toContain(
+      '蕨类（fern） 与 苔藓（moss）：协同（synergy），养护任一株会同时治愈相邻的另一株。'
+    )
+    // relations without a state_effect stay bare (strategic reference).
     expect(lines).toContain('蕨类（fern） 与 多肉（succulent）：相克（incompatible）')
-    expect(lines).toContain('蕨类（fern） 与 苔藓（moss）：协同（synergy）')
-    // 1 lead line + 5 matrix rows
-    expect(lines).toHaveLength(6)
+    expect(lines).toHaveLength(6) // 1 lead line + 5 matrix rows
   })
 
   it('light renders the shade ladder with the player verb', () => {
@@ -70,16 +74,19 @@ describe('renderBotanicalManual — bg-demo-001 v1.1.0', () => {
     expect(lines).toContain('成熟经催花变为开花')
   })
 
-  it('health_and_decay renders the ladder, decay timing, and death', () => {
+  it('health_and_decay renders the ladder, decay timing, and death — but NOT unemittable harm', () => {
     const lines = section(manual, 'health_and_decay').lines.join('\n')
     expect(lines).toContain(
       '枯死（dead） < 垂危（critical） < 枯萎（wilting） < 稳定（stable） < 茁壮（thriving）'
     )
     expect(lines).toContain('浇水（correct_care）可提升健康')
-    expect(lines).toContain('过量浇水（wrong_care）会降低健康')
     expect(lines).toContain('无人照料（neglect）会随时间衰退')
-    expect(lines).toContain('每约 60 秒衰退一次，临近前 8 秒会预警')
+    expect(lines).toContain('每约 60 秒衰退一次，临近前 8 秒会预警') // uniform base interval
     expect(lines).toContain('枯死即无法挽回')
+    // Finding 2: overwater→wrong_care has no shipped verb, so the tutorial manual
+    // must NOT document that harm (it was mis-advising the botanist).
+    expect(lines).not.toContain('wrong_care')
+    expect(lines).not.toContain('过量浇水')
   })
 
   it('golden: full rendered manual is pinned for bg-demo-001', () => {
@@ -140,12 +147,21 @@ describe('renderBotanicalManual — bg-standard-001 v1.1.0', () => {
     expect(lines).not.toContain('浇水（correct_care）可提升健康：')
     // Decay stays universal (every plant decays).
     expect(lines).toContain('无人照料（neglect）会随时间衰退')
-    expect(lines).toContain('每约 60 秒衰退一次')
   })
 
-  it('compatibility renders the synergy pair and the informational relations', () => {
+  it('reports the EFFECTIVE per-instance decay pacing (orchid 40s override), matching the ring', () => {
+    // Finding 1: the orchid overrides interval_ms to 40s via initial_timers; the
+    // manual must report the effective range + fastest species, not the base 60s.
+    const lines = section(standard, 'health_and_decay').lines.join('\n')
+    expect(lines).toContain('每约 40–60 秒衰退一次，其中兰花（orchid）最快（每约 40 秒）')
+    expect(lines).not.toContain('每约 60 秒衰退一次') // the understated base value is gone
+  })
+
+  it('renders active synergy with its heal consequence; informational relations bare', () => {
     const lines = section(standard, 'compatibility').lines
-    expect(lines).toContain('苔藓（moss） 与 多肉（succulent）：协同（synergy）')
+    expect(lines).toContain(
+      '苔藓（moss） 与 多肉（succulent）：协同（synergy），养护任一株会同时治愈相邻的另一株。'
+    )
     expect(lines).toContain('多肉（succulent） 与 藤蔓（vine）：相容（compatible）')
     expect(lines).toContain('苔藓（moss） 与 藤蔓（vine）：中性（neutral）')
   })

--- a/packages/game-botanical/src/manual/render-manual.test.ts
+++ b/packages/game-botanical/src/manual/render-manual.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import { renderBotanicalManual, toManualData, type RenderedManual } from './render-manual'
+import { botanicalGameType, levelById, tutorialLevel } from '@/data/load'
+
+const manual = renderBotanicalManual(botanicalGameType, tutorialLevel)
+
+function section(m: RenderedManual, id: string) {
+  const s = m.sections.find((x) => x.id === id)
+  if (!s) throw new Error(`section ${id} missing`)
+  return s
+}
+
+describe('renderBotanicalManual — bg-demo-001 v1.1.0', () => {
+  it('emits the expected sections in a stable order (addressing)', () => {
+    expect(manual.version).toBe('1.1.0')
+    expect(manual.sections.map((s) => s.id)).toEqual([
+      'objective',
+      'species_care:orchid',
+      'danger:fern',
+      'compatibility',
+      'light',
+      'growth',
+      'health_and_decay',
+    ])
+    // section ids are unique
+    const ids = manual.sections.map((s) => s.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('objective renders win + lose from the level conditions', () => {
+    const lines = section(manual, 'objective').lines.join('\n')
+    expect(lines).toContain('稳定（stable）')
+    expect(lines).toContain('开花（flowering）')
+    expect(lines).toContain('枯死（dead）')
+    expect(lines).toContain('至少 1 株')
+  })
+
+  it('species_care reads the heal precondition from the needs rule', () => {
+    const s = section(manual, 'species_care:orchid')
+    expect(s.title).toBe('兰花 · 养护要点')
+    expect(s.lines[0]).toContain('半荫（partial_shade）')
+    expect(s.lines[0]).toContain('恢复健康')
+  })
+
+  it('danger reads the harm precondition from the needs rule', () => {
+    const s = section(manual, 'danger:fern')
+    expect(s.title).toBe('蕨类 · 风险提示')
+    expect(s.lines[0]).toContain('全荫（full_shade）')
+    expect(s.lines[0]).toContain('受损')
+  })
+
+  it('compatibility renders every matrix relation as strategic info', () => {
+    const lines = section(manual, 'compatibility').lines
+    expect(lines).toContain('蕨类（fern） 与 多肉（succulent）：相克（incompatible）')
+    expect(lines).toContain('蕨类（fern） 与 苔藓（moss）：协同（synergy）')
+    // 1 lead line + 5 matrix rows
+    expect(lines).toHaveLength(6)
+  })
+
+  it('light renders the shade ladder with the player verb', () => {
+    const lines = section(manual, 'light').lines.join('\n')
+    expect(lines).toContain('全光经遮光变为半荫')
+    expect(lines).toContain('半荫经遮光变为全荫')
+  })
+
+  it('growth renders the fertilize→repot→bloom sequence', () => {
+    const lines = section(manual, 'growth').lines
+    expect(lines).toContain('幼苗经施肥变为成株')
+    expect(lines).toContain('成株经换盆变为成熟')
+    expect(lines).toContain('成熟经催花变为开花')
+  })
+
+  it('health_and_decay renders the ladder, decay timing, and death', () => {
+    const lines = section(manual, 'health_and_decay').lines.join('\n')
+    expect(lines).toContain(
+      '枯死（dead） < 垂危（critical） < 枯萎（wilting） < 稳定（stable） < 茁壮（thriving）'
+    )
+    expect(lines).toContain('浇水（correct_care）可提升健康')
+    expect(lines).toContain('过量浇水（wrong_care）会降低健康')
+    expect(lines).toContain('无人照料（neglect）会随时间衰退')
+    expect(lines).toContain('每约 60 秒衰退一次，临近前 8 秒会预警')
+    expect(lines).toContain('枯死即无法挽回')
+  })
+
+  it('golden: full rendered manual is pinned for bg-demo-001', () => {
+    expect(manual).toMatchSnapshot('bg-demo-001')
+  })
+})
+
+describe('toManualData — platform-ai contract projection', () => {
+  it('keys sections by stable section id and carries the version', () => {
+    const data = toManualData(manual)
+    expect(data.version).toBe('1.1.0')
+    expect(Object.keys(data.sections).sort()).toEqual(manual.sections.map((s) => s.id).sort())
+    // each value is the addressable section (title + lines)
+    const objective = data.sections['objective'] as { title: string; lines: string[] }
+    expect(objective.title).toBe('目标与败局')
+    expect(Array.isArray(objective.lines)).toBe(true)
+  })
+})
+
+describe('renderBotanicalManual — bg-standard-001 v1.1.0', () => {
+  const standard = renderBotanicalManual(botanicalGameType, levelById('bg-standard-001').level)
+
+  it('emits a per-species care section for BOTH shade-healed plants (no danger section)', () => {
+    expect(standard.version).toBe('1.1.0')
+    expect(standard.sections.map((s) => s.id)).toEqual([
+      'objective',
+      'species_care:orchid',
+      'species_care:fern',
+      'compatibility',
+      'light',
+      'growth',
+      'health_and_decay',
+    ])
+  })
+
+  it('surfaces the irreversible over-shade LOCKOUT danger for orchid AND fern', () => {
+    // The load-bearing honesty requirement: a botanist consulting about the
+    // orchid/fern must be warned that over-shading to full_shade is irreversible
+    // (their heal rule never fires again, and no verb raises light).
+    for (const species of ['orchid', 'fern'] as const) {
+      const lines = section(standard, `species_care:${species}`).lines.join('\n')
+      expect(lines).toContain('只有在光照为半荫（partial_shade）时') // conditional heal
+      expect(lines).toContain('全荫（full_shade）') // where it locks out
+      expect(lines).toContain('再也无法恢复健康') // irreversible
+      expect(lines).toContain('切勿遮光过头') // the actionable warning
+    }
+  })
+
+  it('scopes the correct_care line HONESTLY: watering does NOT heal the shade-only plants', () => {
+    const lines = section(standard, 'health_and_decay').lines.join('\n')
+    // Watering heals only the three water-healed species...
+    expect(lines).toContain(
+      '浇水（correct_care）仅能提升 苔藓（moss）、多肉（succulent）、藤蔓（vine） 的健康'
+    )
+    // ...and the manual explicitly says it does NOT heal orchid/fern.
+    expect(lines).toContain('兰花（orchid）、蕨类（fern）浇水无效')
+    // The false universal claim must be gone.
+    expect(lines).not.toContain('浇水（correct_care）可提升健康：')
+    // Decay stays universal (every plant decays).
+    expect(lines).toContain('无人照料（neglect）会随时间衰退')
+    expect(lines).toContain('每约 60 秒衰退一次')
+  })
+
+  it('compatibility renders the synergy pair and the informational relations', () => {
+    const lines = section(standard, 'compatibility').lines
+    expect(lines).toContain('苔藓（moss） 与 多肉（succulent）：协同（synergy）')
+    expect(lines).toContain('多肉（succulent） 与 藤蔓（vine）：相容（compatible）')
+    expect(lines).toContain('苔藓（moss） 与 藤蔓（vine）：中性（neutral）')
+  })
+
+  it('golden: full rendered manual is pinned for bg-standard-001', () => {
+    expect(standard).toMatchSnapshot('bg-standard-001')
+  })
+})

--- a/packages/game-botanical/src/manual/render-manual.ts
+++ b/packages/game-botanical/src/manual/render-manual.ts
@@ -1,0 +1,512 @@
+/**
+ * Botanical manual RENDERER (L2 design §4a). A PURE function turning a Level's
+ * declarative rule bindings + the GameType vocabulary into ONE addressable,
+ * human-readable Chinese care manual — the single artifact projected two ways:
+ *   - toManualData() → the platform-ai contract's ManualData (AI botanist)
+ *   - ManualPanel     → a dev-viewable HTML surface (botanist-side inspection)
+ *
+ * Data-driven: every section's CONTENT (species, preconditions, transitions,
+ * matrix relations, timings, win/lose) is read from the bindings / vocabulary,
+ * never hardcoded prose. The renderer knows it is the *botanical* manual (it
+ * groups by this game's concepts), but it classifies rules by template KIND +
+ * which plant state a transition mutates — not by template id — so a renamed
+ * template or an added enum value keeps working. Golden tests pin the current
+ * fixture's exact output.
+ */
+import type { GameType, Level, LevelRule } from '@amiclaw/creation'
+import type { ManualData } from '@amiclaw/platform-ai/contract'
+import { GROWTH_LABEL, HEALTH_LABEL, LIGHT_LABEL } from '@/game/visual-map'
+import {
+  ACTION_LABEL,
+  FIELD_LABEL,
+  RELATION_LABEL,
+  SOIL_LABEL,
+  STATE_NAME_LABEL,
+} from './manual-labels'
+
+export interface RenderedManualSection {
+  id: string
+  title: string
+  lines: string[]
+}
+
+export interface RenderedManual {
+  version: string
+  sections: RenderedManualSection[]
+}
+
+// --- vocabulary helpers (all data-driven from the GameType) -----------------
+
+function plantArchetype(gameType: GameType) {
+  return gameType.element_archetypes.find((a) => a.id === 'plant')
+}
+
+function speciesLabel(gameType: GameType, species: string): string {
+  const attr = plantArchetype(gameType)?.attributes.find((a) => a.name === 'species')
+  return attr?.display_labels?.[species] ?? species
+}
+
+/** Chinese label for a state/attribute enum VALUE (label falls back to ASCII). */
+function valueLabel(gameType: GameType, field: string, value: string): string {
+  switch (field) {
+    case 'species':
+      return speciesLabel(gameType, value)
+    case 'effective_light':
+    case 'light_level':
+      return LIGHT_LABEL[value] ?? value
+    case 'growth_stage':
+      return GROWTH_LABEL[value] ?? value
+    case 'health':
+      return HEALTH_LABEL[value] ?? value
+    case 'soil_type':
+      return SOIL_LABEL[value] ?? value
+    default:
+      return value
+  }
+}
+
+/** `label（ascii）` — the Chinese gloss plus the engine value for AI grounding. */
+function gloss(gameType: GameType, field: string, value: string): string {
+  return `${valueLabel(gameType, field, value)}（${value}）`
+}
+
+/** state-value order (worst → best) for a plant state, read from the archetype. */
+function stateOrder(gameType: GameType, stateName: string): string[] {
+  return plantArchetype(gameType)?.states?.find((s) => s.name === stateName)?.values ?? []
+}
+
+/** event → action_type reverse map from action_event_mapping (`<tpl>_event` cols). */
+function eventToAction(gameType: GameType): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const row of gameType.action_event_mapping ?? []) {
+    for (const [key, value] of Object.entries(row)) {
+      if (key.endsWith('_event') && typeof value === 'string') map.set(value, row.action_type)
+    }
+  }
+  return map
+}
+
+/** The player verb (or "无人照料") that drives a transition event. */
+function eventVerbLabel(eventToActionMap: Map<string, string>, event: string): string {
+  const action = eventToActionMap.get(event)
+  if (action === undefined) return '无人照料'
+  return ACTION_LABEL[action] ?? action
+}
+
+// --- rule kind + binding narrowing ------------------------------------------
+
+type Transition = [string, string, string]
+type MatrixRow = [string, string, string]
+
+function templateKind(gameType: GameType, rule: LevelRule): string | undefined {
+  return gameType.rule_templates.find((t) => t.id === rule.template)?.type
+}
+
+function transitionsOf(rule: LevelRule): Transition[] {
+  const t = (rule.bindings as { transitions?: unknown }).transitions
+  return Array.isArray(t) ? (t as Transition[]) : []
+}
+
+function matrixOf(rule: LevelRule): MatrixRow[] {
+  const m = (rule.bindings as { matrix?: unknown }).matrix
+  return Array.isArray(m) ? (m as MatrixRow[]) : []
+}
+
+interface ParsedNeeds {
+  species: string | null
+  conditions: { field: string; value: string }[]
+  combinator: string
+  verb: string
+}
+
+function parseNeeds(rule: LevelRule): ParsedNeeds {
+  const b = rule.bindings as {
+    predicates?: Array<Record<string, string>>
+    combinator?: string
+    action?: { verb?: string }
+  }
+  let species: string | null = null
+  const conditions: { field: string; value: string }[] = []
+  for (const pred of b.predicates ?? []) {
+    const field = Object.keys(pred).find((k) => k !== 'name')
+    if (field === undefined) continue
+    const value = pred[field]
+    if (field === 'species') species = value
+    else conditions.push({ field, value })
+  }
+  return {
+    species,
+    conditions,
+    combinator: b.combinator ?? 'AND',
+    verb: b.action?.verb ?? '',
+  }
+}
+
+/** Which plant state a state_transition rule mutates (matched by from-values). */
+function transitionField(gameType: GameType, transitions: Transition[]): string | null {
+  const froms = transitions.map((t) => t[0])
+  if (froms.length === 0) return null
+  for (const state of plantArchetype(gameType)?.states ?? []) {
+    if (froms.every((f) => state.values?.includes(f))) return state.name
+  }
+  return null
+}
+
+// --- section builders -------------------------------------------------------
+
+function joinConditions(gameType: GameType, parsed: ParsedNeeds): string {
+  const parts = parsed.conditions.map(
+    (c) => `${FIELD_LABEL[c.field] ?? c.field}为${gloss(gameType, c.field, c.value)}`
+  )
+  const sep = parsed.combinator === 'OR' ? '或' : '且'
+  const joined = parts.join(sep)
+  return parsed.combinator === 'NOT' ? `非（${joined}）` : joined
+}
+
+function objectiveSection(gameType: GameType, level: Level): RenderedManualSection {
+  const lines: string[] = []
+  const win = level.win_condition.params as {
+    all_states_at_least?: { state: string; value: string }[]
+    count_states_equal?: { state: string; value: string; count: number }[]
+  }
+  const clauses: string[] = []
+  for (const c of win.all_states_at_least ?? [])
+    clauses.push(
+      `所有植株的${STATE_NAME_LABEL[c.state] ?? c.state}至少达到「${gloss(gameType, c.state, c.value)}」`
+    )
+  for (const c of win.count_states_equal ?? [])
+    clauses.push(
+      `至少 ${c.count} 株的${STATE_NAME_LABEL[c.state] ?? c.state}达到「${gloss(gameType, c.state, c.value)}」`
+    )
+  if (clauses.length > 0) lines.push(`达成目标：${clauses.join('，且')}。`)
+
+  const lose = level.lose_condition?.params as { state?: string; value?: string } | undefined
+  if (lose?.state && lose.value)
+    lines.push(
+      `败局：任一植株的${STATE_NAME_LABEL[lose.state] ?? lose.state}跌至「${gloss(gameType, lose.state, lose.value)}」即告失败；枯死无法挽回。`
+    )
+  return { id: 'objective', title: '目标与败局', lines }
+}
+
+function compatibilitySection(gameType: GameType, rows: MatrixRow[]): RenderedManualSection {
+  const lines = ['植株间的相性（本关卡为策略参考）：']
+  for (const [a, b, relation] of rows)
+    lines.push(
+      `${gloss(gameType, 'species', a)} 与 ${gloss(gameType, 'species', b)}：${RELATION_LABEL[relation] ?? relation}（${relation}）`
+    )
+  return { id: 'compatibility', title: '相生相克', lines }
+}
+
+function lightSection(
+  gameType: GameType,
+  transitions: Transition[],
+  e2a: Map<string, string>
+): RenderedManualSection {
+  const lines = ['调节光照可改变植株的实际光照：']
+  for (const [from, event, to] of transitions)
+    lines.push(
+      `${valueLabel(gameType, 'effective_light', from)}经${eventVerbLabel(e2a, event)}变为${valueLabel(gameType, 'effective_light', to)}`
+    )
+  return { id: 'light', title: '光照调节', lines }
+}
+
+function growthSection(
+  gameType: GameType,
+  transitions: Transition[],
+  e2a: Map<string, string>
+): RenderedManualSection {
+  const lines = ['养护得当可推进生长阶段：']
+  for (const [from, event, to] of transitions)
+    lines.push(
+      `${valueLabel(gameType, 'growth_stage', from)}经${eventVerbLabel(e2a, event)}变为${valueLabel(gameType, 'growth_stage', to)}`
+    )
+  return { id: 'growth', title: '生长阶段', lines }
+}
+
+/** One health_response rule with the species it targets (for honest scoping). */
+interface HealthRule {
+  species: string[]
+  transitions: Transition[]
+}
+
+/** Distinct species of a rule's target elements, first-seen order. */
+function speciesOfElements(level: Level, elementIds: string[]): string[] {
+  const out: string[] = []
+  for (const id of elementIds) {
+    const species = level.elements.find((e) => e.id === id)?.params.species
+    if (typeof species === 'string' && !out.includes(species)) out.push(species)
+  }
+  return out
+}
+
+/**
+ * A heal that is gated on a light level can become an IRREVERSIBLE LOCKOUT: if
+ * the light ladder lets you shade PAST the heal light (a transition moves light
+ * off the heal condition) and no transition returns to it, over-shading strands
+ * the plant where its heal rule never fires again — and no verb raises light.
+ * The botanist MUST warn about this. Returns the warning line, or null when the
+ * heal light cannot be over-shaded or the move is reversible.
+ */
+function lightLockoutWarning(
+  gameType: GameType,
+  parsed: ParsedNeeds,
+  lightTransitions: Transition[],
+  e2a: Map<string, string>
+): string | null {
+  const lightCond = parsed.conditions.find(
+    (c) => c.field === 'effective_light' || c.field === 'light_level'
+  )
+  if (parsed.species === null || lightCond === undefined) return null
+  const healLight = lightCond.value
+  const overShade = lightTransitions.filter(([from]) => from === healLight)
+  if (overShade.length === 0) return null // the heal light cannot be shaded past
+  const overTargets = overShade.map(([, , to]) => to)
+  const reversible = lightTransitions.some(
+    ([from, , to]) => to === healLight && overTargets.includes(from)
+  )
+  if (reversible) return null
+  const verb = eventVerbLabel(e2a, overShade[0][1])
+  const deepest = gloss(gameType, 'effective_light', overTargets[overTargets.length - 1])
+  const sp = gloss(gameType, 'species', parsed.species)
+  return `${verb}只会让光照逐级变暗、无法回退；一旦${sp}被${verb}到${deepest}，就再也无法恢复健康，切勿${verb}过头。`
+}
+
+/**
+ * A per-species care section for a heal needs-rule. When the species heals ONLY
+ * through this (light-)conditioned rule (no watering path), the condition is the
+ * ONLY way back to health, so it is stated as such and the irreversible-lockout
+ * warning is attached. When the species ALSO water-heals, the conditioned heal
+ * is one additional path and the milder phrasing is used (no lockout: watering
+ * still recovers it).
+ */
+function speciesCareSection(
+  gameType: GameType,
+  parsed: ParsedNeeds,
+  waterHeals: boolean,
+  lightTransitions: Transition[],
+  e2a: Map<string, string>
+): RenderedManualSection {
+  const species = parsed.species as string
+  const sp = gloss(gameType, 'species', species)
+  const conditions = joinConditions(gameType, parsed)
+  const lines: string[] = []
+  if (parsed.conditions.length === 0) {
+    lines.push(`养护${sp}可使其恢复健康。`)
+  } else if (waterHeals) {
+    lines.push(`当${conditions}时，养护${sp}可使其恢复健康。`)
+  } else {
+    lines.push(`${sp}只有在${conditions}时，养护才能使其恢复健康。`)
+    const warning = lightLockoutWarning(gameType, parsed, lightTransitions, e2a)
+    if (warning) lines.push(warning)
+  }
+  return {
+    id: `species_care:${species}`,
+    title: `${speciesLabel(gameType, species)} · 养护要点`,
+    lines,
+  }
+}
+
+function healthSection(
+  gameType: GameType,
+  rules: HealthRule[],
+  e2a: Map<string, string>
+): RenderedManualSection {
+  const order = stateOrder(gameType, 'health')
+  const rank = (v: string) => order.indexOf(v)
+  const lines: string[] = []
+  if (order.length > 0)
+    lines.push(`健康档位由差到好：${order.map((v) => gloss(gameType, 'health', v)).join(' < ')}。`)
+
+  // Every species any health rule covers (first-seen order) — the denominator
+  // for "does this event apply to ALL plants, or only some?".
+  const allSpecies: string[] = []
+  for (const r of rules) for (const s of r.species) if (!allSpecies.includes(s)) allSpecies.push(s)
+
+  // Per event (first-seen order): the species it affects + its deduped ladder.
+  const eventOrder: string[] = []
+  const eventSpecies = new Map<string, Set<string>>()
+  const eventLadder = new Map<string, Transition[]>()
+  for (const r of rules) {
+    for (const t of r.transitions) {
+      const ev = t[1]
+      if (!eventSpecies.has(ev)) {
+        eventOrder.push(ev)
+        eventSpecies.set(ev, new Set())
+        eventLadder.set(ev, [])
+      }
+      for (const s of r.species) eventSpecies.get(ev)!.add(s)
+      const ladder = eventLadder.get(ev)!
+      if (!ladder.some((x) => x.join('|') === t.join('|'))) ladder.push(t)
+    }
+  }
+
+  for (const ev of eventOrder) {
+    const speciesSet = eventSpecies.get(ev)!
+    const ladder = eventLadder.get(ev)!
+    const ladderStr = ladder
+      .map(
+        ([f, , t]) => `${valueLabel(gameType, 'health', f)}→${valueLabel(gameType, 'health', t)}`
+      )
+      .join('；')
+    const verb = eventVerbLabel(e2a, ev)
+    const reachesDead = ladder.some(([, , t]) => t === 'dead')
+    const deltas = ladder.map(([f, , t]) => rank(t) - rank(f))
+    const dir: 'decay' | 'up' | 'down' | 'mixed' = reachesDead
+      ? 'decay'
+      : deltas.every((d) => d > 0)
+        ? 'up'
+        : deltas.every((d) => d < 0)
+          ? 'down'
+          : 'mixed'
+    const universalEffect = {
+      decay: '会随时间衰退',
+      up: '可提升健康',
+      down: '会降低健康',
+      mixed: '会改变健康',
+    }[dir]
+
+    // Decay (reaches dead) is universal — every plant decays. An event that
+    // covers every health-tracked species is universal too. OTHERWISE scope it
+    // honestly to the species it affects and NAME the ones it does not (the fix
+    // for the false "watering heals every plant" claim: shade-only plants get no
+    // correct_care and must not be swept into a universal heal line).
+    const coversAll = allSpecies.every((s) => speciesSet.has(s))
+    if (dir === 'decay' || coversAll) {
+      lines.push(`${verb}（${ev}）${universalEffect}：${ladderStr}。`)
+    } else {
+      const applies = allSpecies.filter((s) => speciesSet.has(s))
+      const notApplies = allSpecies.filter((s) => !speciesSet.has(s))
+      const appliesStr = applies.map((s) => gloss(gameType, 'species', s)).join('、')
+      const scopedVerb = { up: '仅能提升', down: '仅会降低', mixed: '仅会改变' }[dir]
+      let line = `${verb}（${ev}）${scopedVerb} ${appliesStr} 的健康：${ladderStr}。`
+      if (notApplies.length > 0) {
+        const notStr = notApplies.map((s) => gloss(gameType, 'species', s)).join('、')
+        line += `${notStr}${verb}无效，恢复方式见各自养护要点。`
+      }
+      lines.push(line)
+    }
+  }
+
+  for (const emitter of gameType.timed_emitters ?? []) {
+    if (!eventSpecies.has(emitter.event)) continue
+    const intervalS = Math.round(emitter.interval_ms / 1000)
+    const warnS =
+      emitter.warning_lead_ms !== undefined ? Math.round(emitter.warning_lead_ms / 1000) : 0
+    lines.push(
+      warnS > 0
+        ? `无人照料每约 ${intervalS} 秒衰退一次，临近前 ${warnS} 秒会预警。`
+        : `无人照料每约 ${intervalS} 秒衰退一次。`
+    )
+  }
+  lines.push('植株一旦枯死即无法挽回，并会导致败局。')
+  return { id: 'health_and_decay', title: '健康与衰败', lines }
+}
+
+// --- top-level renderer -----------------------------------------------------
+
+/**
+ * Render the ONE botanical manual for a (GameType, Level) pair. Sections are
+ * emitted only when the level actually carries the corresponding rules, in a
+ * stable order: objective → per-species care → per-species danger →
+ * compatibility → light → growth → health & decay. Rules are collected first,
+ * then built, so a per-species care line can consult the light ladder (lockout)
+ * and the health section can honestly scope which plants each event affects.
+ */
+export function renderBotanicalManual(gameType: GameType, level: Level): RenderedManual {
+  const e2a = eventToAction(gameType)
+  const needsRules: ParsedNeeds[] = []
+  const matrixRows: MatrixRow[] = []
+  const lightTransitions: Transition[] = []
+  const growthTransitions: Transition[] = []
+  const healthRules: HealthRule[] = []
+  const seenLight = new Set<string>()
+  const seenGrowth = new Set<string>()
+
+  for (const rule of level.rules) {
+    const kind = templateKind(gameType, rule)
+    if (kind === 'condition_action') {
+      const parsed = parseNeeds(rule)
+      if (parsed.species !== null) needsRules.push(parsed)
+    } else if (kind === 'interaction_matrix') {
+      matrixRows.push(...matrixOf(rule))
+    } else if (kind === 'state_transition') {
+      const transitions = transitionsOf(rule)
+      const field = transitionField(gameType, transitions)
+      if (field === 'effective_light') {
+        for (const t of transitions) {
+          const k = t.join('|')
+          if (!seenLight.has(k)) {
+            seenLight.add(k)
+            lightTransitions.push(t)
+          }
+        }
+      } else if (field === 'growth_stage') {
+        for (const t of transitions) {
+          const k = t.join('|')
+          if (!seenGrowth.has(k)) {
+            seenGrowth.add(k)
+            growthTransitions.push(t)
+          }
+        }
+      } else if (field === 'health') {
+        healthRules.push({ species: speciesOfElements(level, rule.target_elements), transitions })
+      }
+    }
+  }
+
+  // Species that recover through WATERING (a health rule with a health-improving
+  // event). A species healing only through a conditioned needs-rule (not here)
+  // is the one an over-shade lockout can permanently strand.
+  const healthRank = (v: string) => stateOrder(gameType, 'health').indexOf(v)
+  const waterHealSpecies = new Set<string>()
+  for (const r of healthRules) {
+    if (r.transitions.some(([f, , t]) => healthRank(t) > healthRank(f))) {
+      for (const s of r.species) waterHealSpecies.add(s)
+    }
+  }
+
+  const care: RenderedManualSection[] = []
+  const danger: RenderedManualSection[] = []
+  for (const parsed of needsRules) {
+    if (parsed.verb === 'heal') {
+      care.push(
+        speciesCareSection(
+          gameType,
+          parsed,
+          waterHealSpecies.has(parsed.species as string),
+          lightTransitions,
+          e2a
+        )
+      )
+    } else {
+      const conditions = joinConditions(gameType, parsed)
+      danger.push({
+        id: `danger:${parsed.species}`,
+        title: `${speciesLabel(gameType, parsed.species as string)} · 风险提示`,
+        lines: [
+          `当${conditions}时，${gloss(gameType, 'species', parsed.species as string)}会受损，应当避免。`,
+        ],
+      })
+    }
+  }
+
+  const sections: RenderedManualSection[] = [objectiveSection(gameType, level), ...care, ...danger]
+  if (matrixRows.length > 0) sections.push(compatibilitySection(gameType, matrixRows))
+  if (lightTransitions.length > 0) sections.push(lightSection(gameType, lightTransitions, e2a))
+  if (growthTransitions.length > 0) sections.push(growthSection(gameType, growthTransitions, e2a))
+  if (healthRules.length > 0) sections.push(healthSection(gameType, healthRules, e2a))
+
+  return { version: gameType.version, sections }
+}
+
+/**
+ * Project the rendered manual into the platform-ai contract's ManualData:
+ * addressable sections keyed by stable section id (consume-only shape). The
+ * AI layer selects a subset of these keys by game state per turn.
+ */
+export function toManualData(rendered: RenderedManual): ManualData {
+  return {
+    version: rendered.version,
+    sections: Object.fromEntries(rendered.sections.map((s) => [s.id, s])),
+  }
+}

--- a/packages/game-botanical/src/manual/render-manual.ts
+++ b/packages/game-botanical/src/manual/render-manual.ts
@@ -13,8 +13,9 @@
  * template or an added enum value keeps working. Golden tests pin the current
  * fixture's exact output.
  */
-import type { GameType, Level, LevelRule } from '@amiclaw/creation'
+import type { GameType, Level, LevelElement, LevelRule, TimedEmitter } from '@amiclaw/creation'
 import type { ManualData } from '@amiclaw/platform-ai/contract'
+import { CARE_VERBS } from '@/game/care-verbs'
 import { GROWTH_LABEL, HEALTH_LABEL, LIGHT_LABEL } from '@/game/visual-map'
 import {
   ACTION_LABEL,
@@ -91,6 +92,82 @@ function eventVerbLabel(eventToActionMap: Map<string, string>, event: string): s
   const action = eventToActionMap.get(event)
   if (action === undefined) return '无人照料'
   return ACTION_LABEL[action] ?? action
+}
+
+/**
+ * Events the level can ACTUALLY emit — the only ones the manual should document.
+ * An event is emittable if a PLAYER-usable action_type reaches it via
+ * action_event_mapping (the shipped care verbs are the source of "player-usable";
+ * `overwater`→`wrong_care` is NOT among them, so tutorial harm the player can
+ * never cause is dropped), OR a timed emitter fires it (decay `neglect`).
+ */
+function emittableEvents(gameType: GameType): Set<string> {
+  const playerActionTypes = new Set(CARE_VERBS.map((v) => v.actionType))
+  const events = new Set<string>()
+  for (const row of gameType.action_event_mapping ?? []) {
+    if (!playerActionTypes.has(row.action_type)) continue
+    for (const [key, value] of Object.entries(row)) {
+      if (key.endsWith('_event') && typeof value === 'string') events.add(value)
+    }
+  }
+  for (const emitter of gameType.timed_emitters ?? []) events.add(emitter.event)
+  return events
+}
+
+/**
+ * True when a compatibility relation binds an effect that carries a `state_effect`
+ * (its effect verb ADVANCES a state) — i.e. the relation MECHANICALLY changes play
+ * (synergy→heal here) rather than being informational strategy-reference only.
+ */
+function relationIsActive(gameType: GameType, relation: string): boolean {
+  const template = gameType.rule_templates.find((t) => t.type === 'interaction_matrix') as
+    | { matrix_schema?: { effect_schema?: Array<{ relation: string; effect: string }> } }
+    | undefined
+  const effect = template?.matrix_schema?.effect_schema?.find((e) => e.relation === relation)
+  if (effect === undefined) return false
+  const action = gameType.action_registry.find((a) => a.name === effect.effect)
+  return action?.state_effect === 'advance_state' || action?.state_effect === 'complete_state'
+}
+
+/** Elements a timed emitter targets (archetype-scoped, or by target_template rule). */
+function emitterTargetElements(level: Level, emitter: TimedEmitter): LevelElement[] {
+  if (emitter.target.kind === 'archetype') {
+    const archetype = emitter.target.archetype
+    return level.elements.filter((e) => e.archetype === archetype)
+  }
+  const ids = new Set<string>()
+  for (const rule of level.rules) {
+    if (rule.template === emitter.target_template)
+      for (const id of rule.target_elements) ids.add(id)
+  }
+  return level.elements.filter((e) => ids.has(e.id))
+}
+
+/**
+ * Effective per-instance decay intervals across an emitter's targeted elements,
+ * folding in each element's `initial_timers[emitter.id].interval_ms` override (as
+ * the engine + the on-screen ring do). Returns the min/max (ms) and the species
+ * on the fastest interval, so the manual reports the real pacing — including
+ * bg-standard-001's orchid at 40s, not the base 60s.
+ */
+function effectiveDecayIntervals(
+  level: Level,
+  emitter: TimedEmitter
+): { minMs: number; maxMs: number; fastestSpecies: string[] } {
+  const entries = emitterTargetElements(level, emitter).map((el) => {
+    const override = el.initial_timers?.[emitter.id]?.interval_ms
+    return {
+      species: String(el.params.species ?? ''),
+      intervalMs: typeof override === 'number' ? override : emitter.interval_ms,
+    }
+  })
+  const intervals = entries.map((e) => e.intervalMs)
+  const minMs = Math.min(...intervals)
+  const maxMs = Math.max(...intervals)
+  const fastestSpecies = [
+    ...new Set(entries.filter((e) => e.intervalMs === minMs).map((e) => e.species)),
+  ]
+  return { minMs, maxMs, fastestSpecies }
 }
 
 // --- rule kind + binding narrowing ------------------------------------------
@@ -189,11 +266,16 @@ function objectiveSection(gameType: GameType, level: Level): RenderedManualSecti
 }
 
 function compatibilitySection(gameType: GameType, rows: MatrixRow[]): RenderedManualSection {
-  const lines = ['植株间的相性（本关卡为策略参考）：']
-  for (const [a, b, relation] of rows)
+  // A relation with an active state_effect (synergy→heal) gets its mechanical
+  // consequence spelled out; relations without one keep the strategic-reference
+  // framing carried by the lead line.
+  const lines = ['植株间的相性（未注明机械效果的仅供策略参考）：']
+  for (const [a, b, relation] of rows) {
+    const base = `${gloss(gameType, 'species', a)} 与 ${gloss(gameType, 'species', b)}：${RELATION_LABEL[relation] ?? relation}（${relation}）`
     lines.push(
-      `${gloss(gameType, 'species', a)} 与 ${gloss(gameType, 'species', b)}：${RELATION_LABEL[relation] ?? relation}（${relation}）`
+      relationIsActive(gameType, relation) ? `${base}，养护任一株会同时治愈相邻的另一株。` : base
     )
+  }
   return { id: 'compatibility', title: '相生相克', lines }
 }
 
@@ -308,6 +390,7 @@ function speciesCareSection(
 
 function healthSection(
   gameType: GameType,
+  level: Level,
   rules: HealthRule[],
   e2a: Map<string, string>
 ): RenderedManualSection {
@@ -389,14 +472,23 @@ function healthSection(
 
   for (const emitter of gameType.timed_emitters ?? []) {
     if (!eventSpecies.has(emitter.event)) continue
-    const intervalS = Math.round(emitter.interval_ms / 1000)
+    // Report the EFFECTIVE per-instance pacing (folding in initial_timers
+    // overrides) so the manual matches the on-screen decay ring — a uniform
+    // value, or a range that names the fastest-decaying species.
+    const { minMs, maxMs, fastestSpecies } = effectiveDecayIntervals(level, emitter)
+    const minS = Math.round(minMs / 1000)
+    const maxS = Math.round(maxMs / 1000)
     const warnS =
       emitter.warning_lead_ms !== undefined ? Math.round(emitter.warning_lead_ms / 1000) : 0
-    lines.push(
-      warnS > 0
-        ? `无人照料每约 ${intervalS} 秒衰退一次，临近前 ${warnS} 秒会预警。`
-        : `无人照料每约 ${intervalS} 秒衰退一次。`
-    )
+    const warnSuffix = warnS > 0 ? `，临近前 ${warnS} 秒会预警` : ''
+    if (minS === maxS) {
+      lines.push(`无人照料每约 ${minS} 秒衰退一次${warnSuffix}。`)
+    } else {
+      const fastestStr = fastestSpecies.map((s) => gloss(gameType, 'species', s)).join('、')
+      lines.push(
+        `无人照料每约 ${minS}–${maxS} 秒衰退一次，其中${fastestStr}最快（每约 ${minS} 秒）${warnSuffix}。`
+      )
+    }
   }
   lines.push('植株一旦枯死即无法挽回，并会导致败局。')
   return { id: 'health_and_decay', title: '健康与衰败', lines }
@@ -414,6 +506,10 @@ function healthSection(
  */
 export function renderBotanicalManual(gameType: GameType, level: Level): RenderedManual {
   const e2a = eventToAction(gameType)
+  // Only document transition rows whose event this level can actually emit — a
+  // manual that describes unreachable harm (tutorial `overwater`→`wrong_care`,
+  // which no shipped verb produces) mis-advises the botanist.
+  const emittable = emittableEvents(gameType)
   const needsRules: ParsedNeeds[] = []
   const matrixRows: MatrixRow[] = []
   const lightTransitions: Transition[] = []
@@ -430,7 +526,7 @@ export function renderBotanicalManual(gameType: GameType, level: Level): Rendere
     } else if (kind === 'interaction_matrix') {
       matrixRows.push(...matrixOf(rule))
     } else if (kind === 'state_transition') {
-      const transitions = transitionsOf(rule)
+      const transitions = transitionsOf(rule).filter(([, event]) => emittable.has(event))
       const field = transitionField(gameType, transitions)
       if (field === 'effective_light') {
         for (const t of transitions) {
@@ -494,7 +590,7 @@ export function renderBotanicalManual(gameType: GameType, level: Level): Rendere
   if (matrixRows.length > 0) sections.push(compatibilitySection(gameType, matrixRows))
   if (lightTransitions.length > 0) sections.push(lightSection(gameType, lightTransitions, e2a))
   if (growthTransitions.length > 0) sections.push(growthSection(gameType, growthTransitions, e2a))
-  if (healthRules.length > 0) sections.push(healthSection(gameType, healthRules, e2a))
+  if (healthRules.length > 0) sections.push(healthSection(gameType, level, healthRules, e2a))
 
   return { version: gameType.version, sections }
 }

--- a/packages/game-botanical/src/pages/GamePage.module.css
+++ b/packages/game-botanical/src/pages/GamePage.module.css
@@ -1,0 +1,100 @@
+.page {
+  position: relative;
+  display: block;
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 14px 12px calc(22px + env(safe-area-inset-bottom, 0px));
+  min-height: 100dvh;
+}
+
+.levelPicker {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 12px 12px 0;
+}
+
+.levelChip {
+  min-height: 34px;
+  padding: 6px 14px;
+  border: 1px solid var(--garden-line);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--garden-ink-dim);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+.levelChip[aria-current='true'] {
+  border-color: var(--garden-accent);
+  color: var(--garden-accent);
+  background: rgba(127, 212, 163, 0.08);
+}
+
+.voice {
+  margin: 12px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.voiceToggle {
+  align-self: flex-start;
+  min-height: 40px;
+  padding: 8px 16px;
+  border: 1px solid var(--garden-line);
+  border-radius: 10px;
+  background: #12201a;
+  color: var(--garden-accent);
+  font-size: 13px;
+  font-weight: 600;
+}
+.voiceToggle:active {
+  transform: scale(0.97);
+}
+
+.hud {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.goal {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--garden-ink-dim);
+  flex: 1 1 220px;
+  min-width: 180px;
+  line-height: 1.4;
+}
+
+.selInfo {
+  margin: 10px 2px 8px;
+  font-size: 12.5px;
+  color: var(--garden-ink-dim);
+  min-height: 18px;
+}
+.selInfo b {
+  color: var(--garden-ink);
+  font-weight: 600;
+}
+
+.toast {
+  margin: 9px 2px 0;
+  min-height: 20px;
+  font-size: 12.5px;
+  color: var(--garden-ink-dim);
+}
+.good {
+  color: var(--health-stable);
+}
+.bad {
+  color: var(--health-critical);
+}
+.neutral {
+  color: var(--garden-ink-dim);
+}

--- a/packages/game-botanical/src/pages/GamePage.test.tsx
+++ b/packages/game-botanical/src/pages/GamePage.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, render, screen, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { GamePage } from './GamePage'
+
+// GamePage reads ?level= via useSearchParams, so it must render under a router.
+function renderGame() {
+  return render(
+    <MemoryRouter>
+      <GamePage />
+    </MemoryRouter>
+  )
+}
+
+// Mock the wall-clock loop so decay is driven deterministically from the test
+// (frozen time — no real-time waits). The mock captures the latest onTick while
+// the run is active, mirroring the real freeze (active=false → no ticks).
+const hoisted = vi.hoisted(() => ({ tick: { current: null as ((dt: number) => void) | null } }))
+vi.mock('@/hooks/useDecayLoop', () => ({
+  useDecayLoop: (onTick: (dt: number) => void, active: boolean) => {
+    hoisted.tick.current = active ? onTick : null
+  },
+}))
+
+function step(dtMs: number) {
+  act(() => {
+    hoisted.tick.current?.(dtMs)
+  })
+}
+
+function pot(nameFragment: RegExp) {
+  return screen.getByRole('button', { name: nameFragment })
+}
+
+describe('GamePage', () => {
+  beforeEach(() => {
+    hoisted.tick.current = null
+  })
+
+  it('renders the garden scene and verb cards', () => {
+    renderGame()
+    expect(screen.getByRole('timer')).toHaveTextContent('00:00')
+    expect(screen.getByRole('button', { name: '浇水' })).toBeInTheDocument()
+    expect(pot(/蕨类/)).toBeInTheDocument()
+    expect(pot(/兰花/)).toBeInTheDocument()
+  })
+
+  it('select → verb → state change heals the plant', () => {
+    renderGame()
+    expect(pot(/蕨类/)).toHaveAccessibleName(/枯萎/)
+
+    fireEvent.click(pot(/蕨类/)) // select fern
+    fireEvent.click(screen.getByRole('button', { name: '浇水' })) // water
+
+    expect(pot(/蕨类/)).toHaveAccessibleName(/稳定/)
+    expect(screen.getByRole('status')).toHaveTextContent(/好转/)
+  })
+
+  it('prompts to pick a plant when a verb is tapped with no selection', () => {
+    renderGame()
+    fireEvent.click(screen.getByRole('button', { name: '浇水' }))
+    expect(screen.getByRole('status')).toHaveTextContent('请先选择一株植株')
+  })
+
+  it('shows the win overlay after the tutorial care path', () => {
+    renderGame()
+    fireEvent.click(pot(/蕨类/))
+    fireEvent.click(screen.getByRole('button', { name: '浇水' }))
+    fireEvent.click(pot(/兰花/))
+    fireEvent.click(screen.getByRole('button', { name: '遮光' }))
+    fireEvent.click(screen.getByRole('button', { name: '施肥' }))
+    fireEvent.click(screen.getByRole('button', { name: '换盆' }))
+    fireEvent.click(screen.getByRole('button', { name: '催花' }))
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText(/养护成功/)).toBeInTheDocument()
+    expect(within(dialog).getByRole('button', { name: '再玩一次' })).toBeInTheDocument()
+  })
+
+  it('shows the lose overlay when a plant decays to death', () => {
+    renderGame()
+    step(20000) // orchid: wilting → critical
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    step(60000) // orchid: critical → dead → lost
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText(/养护失败/)).toBeInTheDocument()
+  })
+
+  it('switches levels via the picker (data-driven from the fixtures)', () => {
+    renderGame()
+    // The tutorial (bg-demo-001) has no moss; the standard level (bg-standard-001) does.
+    expect(screen.queryByRole('button', { name: /苔藓/ })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '温室轮值' }))
+    expect(screen.getByRole('button', { name: /苔藓/ })).toBeInTheDocument()
+  })
+
+  it('re-playing fully resets the run', () => {
+    renderGame()
+    // Win quickly.
+    fireEvent.click(pot(/蕨类/))
+    fireEvent.click(screen.getByRole('button', { name: '浇水' }))
+    fireEvent.click(pot(/兰花/))
+    fireEvent.click(screen.getByRole('button', { name: '遮光' }))
+    fireEvent.click(screen.getByRole('button', { name: '施肥' }))
+    fireEvent.click(screen.getByRole('button', { name: '换盆' }))
+    fireEvent.click(screen.getByRole('button', { name: '催花' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '再玩一次' }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByRole('timer')).toHaveTextContent('00:00')
+    // fern is back to its wilting start state
+    expect(pot(/蕨类/)).toHaveAccessibleName(/枯萎/)
+  })
+})

--- a/packages/game-botanical/src/pages/GamePage.tsx
+++ b/packages/game-botanical/src/pages/GamePage.tsx
@@ -1,0 +1,47 @@
+import { useSearchParams } from 'react-router-dom'
+import styles from './GamePage.module.css'
+import { levels, levelById } from '@/data/load'
+import { GardenRun } from './GardenRun'
+
+/**
+ * Level-select shell. Reads `?level=<id>` (default bg-demo-001) and `?ai=<gameId>`
+ * (default demo-mock inside the voice hook), renders a minimal level picker when
+ * more than one level exists, and mounts GardenRun keyed on the level id so a
+ * level switch is a clean reset.
+ */
+export function GamePage() {
+  const [params, setParams] = useSearchParams()
+  const entry = levelById(params.get('level'))
+  const aiParam = params.get('ai') ?? undefined
+  // Controlled-clock test seam — dev-only (compiled out of production: DEV is
+  // false in the prod build, so this is always false there regardless of the URL).
+  const e2e = import.meta.env.DEV && params.get('e2e') === '1'
+
+  const pickLevel = (id: string) => {
+    const next: Record<string, string> = { level: id }
+    if (aiParam) next.ai = aiParam
+    if (params.get('e2e') === '1') next.e2e = '1'
+    setParams(next)
+  }
+
+  return (
+    <>
+      {levels.length > 1 && (
+        <nav className={styles.levelPicker} aria-label="关卡选择">
+          {levels.map((lvl) => (
+            <button
+              key={lvl.id}
+              type="button"
+              className={styles.levelChip}
+              aria-current={lvl.id === entry.id}
+              onClick={() => pickLevel(lvl.id)}
+            >
+              {lvl.title}
+            </button>
+          ))}
+        </nav>
+      )}
+      <GardenRun key={entry.id} level={entry.level} gameId={aiParam} e2e={e2e} />
+    </>
+  )
+}

--- a/packages/game-botanical/src/pages/GardenRun.tsx
+++ b/packages/game-botanical/src/pages/GardenRun.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { Level } from '@amiclaw/creation'
+import type { GameState } from '@amiclaw/platform-ai/contract'
+import styles from './GamePage.module.css'
+import { botanicalGameType } from '@/data/load'
+import { useGardenSession, type CareOutcome } from '@/game/useGardenSession'
+import { useDecayLoop } from '@/hooks/useDecayLoop'
+import {
+  GROWTH_LABEL,
+  HEALTH_LABEL,
+  LIGHT_LABEL,
+  ZONE_LABEL,
+  speciesLabel,
+} from '@/game/visual-map'
+import Stopwatch from '@/components/Stopwatch'
+import GardenGrid from '@/components/GardenGrid'
+import VerbCards from '@/components/VerbCards'
+import ResultsOverlay from '@/components/ResultsOverlay'
+import VoicePanel from '@/voice/VoicePanel'
+import { buildBotanicalManualData } from '@/voice/manual-data'
+import { gardenStateToRelevantSections } from '@/voice/relevant-sections'
+
+const GOAL_TEXT = '目标 · 所有存活植株≥稳定，且至少一株开花'
+
+interface GardenRunProps {
+  level: Level
+  /** Platform game id for the voice botanist. Defaults to the mock probe path. */
+  gameId?: string
+  /**
+   * Controlled-clock test seam (e2e only). When true, the wall-clock decay loop
+   * is turned OFF and `window.__botanicalAdvance(dtMs)` is exposed so a test can
+   * drive decay deterministically (no real-time waits). GamePage only sets this
+   * when `import.meta.env.DEV && ?e2e=1`, so it is compiled OUT of the production
+   * build (DEV is false there) — production behaviour is provably unaffected.
+   */
+  e2e?: boolean
+}
+
+/**
+ * One playable botanical run over a single level. Owns the engine session, the
+ * decay clock, and (opt-in) the AI botanist voice channel. Remounted per level
+ * (keyed on level id by the GamePage shell), so switching levels is a clean reset.
+ */
+export function GardenRun({ level, gameId, e2e = false }: GardenRunProps) {
+  const session = useGardenSession(botanicalGameType, level)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [toast, setToast] = useState<CareOutcome | null>(null)
+  const [voiceOpen, setVoiceOpen] = useState(false)
+
+  // The single wall-clock: advance simulated time while the run is live. In the
+  // e2e seam the loop is OFF so ONLY the test's explicit advance drives decay.
+  useDecayLoop(session.advance, session.status === 'playing' && !e2e)
+
+  // Controlled-clock seam: expose advance to the e2e driver (dev + ?e2e=1 only).
+  // The body sits inside `if (import.meta.env.DEV)` so the whole seam — the
+  // `window.__botanicalAdvance` write included — is DEAD-CODE-ELIMINATED from the
+  // production bundle (Vite replaces DEV with `false`); it cannot exist in prod.
+  useEffect(() => {
+    if (!e2e) return
+    if (import.meta.env.DEV) {
+      const w = window as unknown as { __botanicalAdvance?: (dtMs: number) => void }
+      w.__botanicalAdvance = session.advance
+      return () => {
+        delete w.__botanicalAdvance
+      }
+    }
+  }, [e2e, session.advance])
+
+  const selectedPlant = session.plants.find((p) => p.id === selectedId) ?? null
+  const selectedZone = selectedPlant
+    ? session.zones.find((z) => z.positions.includes(selectedPlant.potPosition))
+    : undefined
+
+  // --- AI botanist wiring: manual + live section steering ---
+  const manualData = useMemo(() => buildBotanicalManualData(botanicalGameType, level), [level])
+  const availableSectionIds = useMemo(() => Object.keys(manualData.sections), [manualData])
+  // The relevant-section selection only changes when a plant's health or the
+  // focus changes (NOT per decay frame — decayFraction is not an input), so the
+  // joined key is stable across frames. Memoize gameState on that key so the
+  // memoized VoicePanel (and its live session) re-render / steer only on a real
+  // change; the key round-trips through split(',') since section ids carry no comma.
+  const sectionsKey = gardenStateToRelevantSections({
+    plants: session.plants.map((p) => ({ id: p.id, species: p.species, health: p.health })),
+    focusedId: selectedId,
+    availableSectionIds,
+  }).join(',')
+  const gameState = useMemo<GameState>(
+    () => ({ relevantSections: sectionsKey === '' ? [] : sectionsKey.split(',') }),
+    [sectionsKey]
+  )
+
+  const handleSelect = (elementId: string) => {
+    setSelectedId(elementId)
+    setToast(null)
+  }
+
+  const handleVerb = (actionType: string) => {
+    if (selectedPlant === null) {
+      setToast({ ok: false, tone: 'neutral', message: '请先选择一株植株' })
+      return
+    }
+    setToast(session.performCare(selectedPlant.id, actionType))
+  }
+
+  const handleReplay = () => {
+    session.reset()
+    setSelectedId(null)
+    setToast(null)
+  }
+
+  return (
+    <main className={styles.page}>
+      <header className={styles.hud}>
+        <Stopwatch elapsedMs={session.elapsedMs} running={session.status === 'playing'} />
+        <p className={styles.goal}>{GOAL_TEXT}</p>
+      </header>
+
+      <GardenGrid
+        plants={session.plants}
+        zones={session.zones}
+        selectedId={selectedId}
+        onSelect={handleSelect}
+      />
+
+      <p className={styles.selInfo}>
+        {selectedPlant === null ? (
+          '选择一株植株，再点下方养护动作。'
+        ) : (
+          <>
+            已选 <b>{speciesLabel(selectedPlant.species)}</b>
+            {selectedZone
+              ? `（${ZONE_LABEL[selectedZone.zoneId] ?? selectedZone.zoneId}）`
+              : ''} · {HEALTH_LABEL[selectedPlant.health]} ·{' '}
+            {GROWTH_LABEL[selectedPlant.growthStage]} · 实际光照
+            {LIGHT_LABEL[selectedPlant.effectiveLight]}
+          </>
+        )}
+      </p>
+
+      <VerbCards disabled={session.status !== 'playing'} onVerb={handleVerb} />
+
+      <p
+        className={`${styles.toast} ${toast ? styles[toast.tone] : ''}`}
+        role="status"
+        aria-live="polite"
+      >
+        {toast?.message ?? ' '}
+      </p>
+
+      <div className={styles.voice}>
+        <button
+          type="button"
+          className={styles.voiceToggle}
+          aria-pressed={voiceOpen}
+          onClick={() => setVoiceOpen((open) => !open)}
+        >
+          {voiceOpen ? '关闭语音' : '呼叫植物学家'}
+        </button>
+        {voiceOpen && <VoicePanel manualData={manualData} gameState={gameState} gameId={gameId} />}
+      </div>
+
+      <ResultsOverlay
+        status={session.status}
+        elapsedMs={session.elapsedMs}
+        ops={session.ops}
+        plants={session.plants}
+        onReplay={handleReplay}
+      />
+    </main>
+  )
+}

--- a/packages/game-botanical/src/pages/ManualPage.tsx
+++ b/packages/game-botanical/src/pages/ManualPage.tsx
@@ -1,0 +1,15 @@
+import { useSearchParams } from 'react-router-dom'
+import { botanicalGameType, levelById } from '@/data/load'
+import { renderBotanicalManual } from '@/manual/render-manual'
+import ManualPanel from '@/manual/ManualPanel'
+
+/* Dev/inspection route (/manual): the botanist-side manual for the selected
+   level (`?level=<id>`, default bg-demo-001). Not linked from the player screen —
+   the shipped player is the gardener; the AI botanist consumes toManualData().
+   Reachable by URL for inspection. */
+export function ManualPage() {
+  const [params] = useSearchParams()
+  const level = levelById(params.get('level')).level
+  const manual = renderBotanicalManual(botanicalGameType, level)
+  return <ManualPanel manual={manual} />
+}

--- a/packages/game-botanical/src/styles/global.css
+++ b/packages/game-botanical/src/styles/global.css
@@ -1,0 +1,47 @@
+/* Botanical Garden — global base. Dark-only by product mandate; no light mode.
+   Garden-tinted surface tokens layered on top of the shared @amiclaw/ui tokens
+   so the player app reads as a living greenhouse, not the platform chrome. */
+:root {
+  --bg-garden: #0b120d;
+  --bg-garden-2: #0e1712;
+  --garden-line: #24382a;
+  --garden-ink: #dfe9df;
+  --garden-ink-dim: #8ba393;
+  --garden-accent: #7fd4a3;
+  --garden-warn: #e8a13c;
+  --health-dead: #6b6b6b;
+  --health-critical: #e5565b;
+  --health-wilting: #c7a24b;
+  --health-stable: #5fb267;
+  --health-thriving: #8fe08a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100dvh;
+  color: var(--garden-ink);
+  font-family: var(--font-body, 'Noto Sans SC', system-ui, sans-serif);
+  background:
+    radial-gradient(120% 90% at 50% 0%, rgba(16, 32, 23, 0) 0%, #0b120d 70%), var(--bg-garden);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+#root {
+  min-height: 100dvh;
+}
+
+button {
+  font-family: inherit;
+  color: inherit;
+  cursor: pointer;
+}

--- a/packages/game-botanical/src/test-setup.ts
+++ b/packages/game-botanical/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/packages/game-botanical/src/voice/TextPanel.module.css
+++ b/packages/game-botanical/src/voice/TextPanel.module.css
@@ -1,0 +1,47 @@
+.panel {
+  display: flex;
+  gap: 7px;
+  align-items: stretch;
+}
+
+.input {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 40px;
+  padding: 8px 12px;
+  border: 1px solid var(--garden-line);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--garden-ink);
+  font-size: 13px;
+  font-family: inherit;
+}
+.input::placeholder {
+  color: var(--garden-ink-dim);
+}
+.input:focus {
+  outline: none;
+  border-color: var(--garden-accent);
+}
+.input:disabled {
+  opacity: 0.5;
+}
+
+.send {
+  min-height: 40px;
+  min-width: 56px;
+  padding: 8px 14px;
+  border: 1px solid var(--garden-line);
+  border-radius: 9px;
+  background: #12201a;
+  color: var(--garden-accent);
+  font-size: 13px;
+  font-weight: 600;
+}
+.send:active:not(:disabled) {
+  transform: scale(0.97);
+}
+.send:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/packages/game-botanical/src/voice/TextPanel.test.tsx
+++ b/packages/game-botanical/src/voice/TextPanel.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import TextPanel from './TextPanel'
+
+describe('TextPanel', () => {
+  it('sends the typed question and clears the input', () => {
+    const onSend = vi.fn()
+    render(<TextPanel onSend={onSend} disabled={false} />)
+    const input = screen.getByLabelText('给植物学家的问题') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '兰花能浇水吗' } })
+    fireEvent.click(screen.getByRole('button', { name: '发送' }))
+    expect(onSend).toHaveBeenCalledWith('兰花能浇水吗')
+    expect(input.value).toBe('')
+  })
+
+  it('does not send an empty / whitespace question', () => {
+    const onSend = vi.fn()
+    render(<TextPanel onSend={onSend} disabled={false} />)
+    const input = screen.getByLabelText('给植物学家的问题')
+    fireEvent.change(input, { target: { value: '   ' } })
+    expect(screen.getByRole('button', { name: '发送' })).toBeDisabled()
+    fireEvent.submit(input.closest('form') as HTMLFormElement)
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('is disabled until the session is live', () => {
+    render(<TextPanel onSend={vi.fn()} disabled />)
+    expect(screen.getByLabelText('给植物学家的问题')).toBeDisabled()
+    expect(screen.getByRole('button', { name: '发送' })).toBeDisabled()
+  })
+})

--- a/packages/game-botanical/src/voice/TextPanel.test.tsx
+++ b/packages/game-botanical/src/voice/TextPanel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
-import TextPanel from './TextPanel'
+import TextPanel, { MAX_QUESTION_CHARS } from './TextPanel'
 
 describe('TextPanel', () => {
   it('sends the typed question and clears the input', () => {
@@ -27,5 +27,13 @@ describe('TextPanel', () => {
     render(<TextPanel onSend={vi.fn()} disabled />)
     expect(screen.getByLabelText('给植物学家的问题')).toBeDisabled()
     expect(screen.getByRole('button', { name: '发送' })).toBeDisabled()
+  })
+
+  it('caps the typed question length client-side (visible maxLength)', () => {
+    render(<TextPanel onSend={vi.fn()} disabled={false} />)
+    expect(screen.getByLabelText('给植物学家的问题')).toHaveAttribute(
+      'maxLength',
+      String(MAX_QUESTION_CHARS)
+    )
   })
 })

--- a/packages/game-botanical/src/voice/TextPanel.tsx
+++ b/packages/game-botanical/src/voice/TextPanel.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import styles from './TextPanel.module.css'
+
+interface TextPanelProps {
+  /** Send the typed question as a text-turn on the live session. */
+  onSend: (text: string) => void
+  /** Disabled until the session is live. */
+  disabled: boolean
+}
+
+/* The typed-input fallback (FP1 A): 环境不便说话时打字问植物学家. Wired through the
+   SAME botanist session as VoicePanel — the typed question rides a `text-turn`
+   and the reply streams back on the shared socket. Presentation only. */
+export default function TextPanel({ onSend, disabled }: TextPanelProps) {
+  const [text, setText] = useState('')
+
+  const submit = () => {
+    const trimmed = text.trim()
+    if (trimmed === '' || disabled) return
+    onSend(trimmed)
+    setText('')
+  }
+
+  return (
+    <form
+      className={styles.panel}
+      aria-label="打字问植物学家"
+      onSubmit={(e) => {
+        e.preventDefault()
+        submit()
+      }}
+    >
+      <input
+        className={styles.input}
+        type="text"
+        value={text}
+        disabled={disabled}
+        placeholder="环境不便说话？打字问植物学家…"
+        aria-label="给植物学家的问题"
+        onChange={(e) => setText(e.target.value)}
+      />
+      <button type="submit" className={styles.send} disabled={disabled || text.trim() === ''}>
+        发送
+      </button>
+    </form>
+  )
+}

--- a/packages/game-botanical/src/voice/TextPanel.tsx
+++ b/packages/game-botanical/src/voice/TextPanel.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react'
 import styles from './TextPanel.module.css'
 
+/** Client-side cap on a typed question — a botanist question is a short prompt,
+ *  not an essay; the server enforces its own (larger) bound too. */
+export const MAX_QUESTION_CHARS = 500
+
 interface TextPanelProps {
   /** Send the typed question as a text-turn on the live session. */
   onSend: (text: string) => void
@@ -35,6 +39,7 @@ export default function TextPanel({ onSend, disabled }: TextPanelProps) {
         type="text"
         value={text}
         disabled={disabled}
+        maxLength={MAX_QUESTION_CHARS}
         placeholder="环境不便说话？打字问植物学家…"
         aria-label="给植物学家的问题"
         onChange={(e) => setText(e.target.value)}

--- a/packages/game-botanical/src/voice/VoicePanel.module.css
+++ b/packages/game-botanical/src/voice/VoicePanel.module.css
@@ -1,0 +1,159 @@
+.panel {
+  border: 1px solid var(--garden-line);
+  border-radius: 12px;
+  padding: 12px 12px 10px;
+  background: var(--bg-garden-2);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.statusDot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--garden-ink-dim);
+}
+.statusDot[data-status='ready'] {
+  background: var(--garden-accent);
+}
+.statusDot[data-status='error'] {
+  background: var(--health-critical);
+}
+.statusDot[data-phase='speaking'] {
+  background: var(--health-thriving);
+}
+.statusDot[data-phase='thinking'] {
+  background: var(--garden-warn);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .statusDot[data-status='connecting'],
+  .statusDot[data-phase='thinking'] {
+    animation: pulse 1.1s ease-in-out infinite;
+  }
+}
+
+.statusText {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--garden-ink);
+}
+
+.speaking {
+  display: inline-flex;
+}
+.speakingDots {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 14px;
+}
+.speakingDots i {
+  width: 3px;
+  height: 6px;
+  border-radius: 2px;
+  background: var(--health-thriving);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .speakingDots i {
+    animation: bar 0.9s ease-in-out infinite;
+  }
+  .speakingDots i:nth-child(2) {
+    animation-delay: 0.15s;
+  }
+  .speakingDots i:nth-child(3) {
+    animation-delay: 0.3s;
+  }
+}
+
+.playerTranscript {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--garden-ink-dim);
+  line-height: 1.4;
+}
+
+.reply {
+  min-height: 20px;
+}
+.replyText {
+  margin: 0;
+  font-size: 13px;
+  color: var(--garden-ink);
+  line-height: 1.5;
+}
+.replyPlaceholder {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--garden-ink-dim);
+}
+.transcriptLabel {
+  color: var(--garden-accent);
+  font-weight: 600;
+}
+
+.error {
+  margin: 0;
+  font-size: 12px;
+  color: var(--health-critical);
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.hint {
+  margin: 0;
+  font-size: 11px;
+  color: var(--garden-ink-dim);
+  flex: 1 1 auto;
+}
+.endButton {
+  min-height: 36px;
+  padding: 6px 14px;
+  border: 1px solid var(--garden-line);
+  border-radius: 9px;
+  background: transparent;
+  color: var(--garden-ink-dim);
+  font-size: 12px;
+  font-weight: 600;
+}
+.endButton:active {
+  transform: scale(0.97);
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes bar {
+  0%,
+  100% {
+    height: 5px;
+  }
+  50% {
+    height: 13px;
+  }
+}

--- a/packages/game-botanical/src/voice/VoicePanel.test.tsx
+++ b/packages/game-botanical/src/voice/VoicePanel.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
+import type { UseVoiceSessionResult } from './useVoiceSession'
+import VoicePanel from './VoicePanel'
+
+// Mock the hook so the panel can be driven through every status / phase without a
+// real WebSocket, mic, or AudioContext (those are the browser-only play-green).
+vi.mock('./useVoiceSession', () => ({ useVoiceSession: vi.fn() }))
+import { useVoiceSession } from './useVoiceSession'
+const mockHook = vi.mocked(useVoiceSession)
+
+const endSession = vi.fn()
+const sendText = vi.fn()
+
+function hookState(partial: Partial<UseVoiceSessionResult> = {}): UseVoiceSessionResult {
+  return {
+    status: 'ready',
+    conversationPhase: 'listening',
+    playerSpeaking: false,
+    aiText: '',
+    playerTranscript: '',
+    isAiSpeaking: false,
+    error: null,
+    summary: null,
+    endSession,
+    sendText,
+    ...partial,
+  }
+}
+
+const manualData: ManualData = { version: '1.1.0', sections: { objective: { lines: [] } } }
+const gameState: GameState = { relevantSections: ['objective'] }
+
+function renderPanel(partial: Partial<UseVoiceSessionResult> = {}) {
+  mockHook.mockReturnValue(hookState(partial))
+  return render(<VoicePanel manualData={manualData} gameState={gameState} />)
+}
+
+beforeEach(() => {
+  mockHook.mockReset()
+  endSession.mockReset()
+  sendText.mockReset()
+})
+
+describe('VoicePanel — status + 3-state phase', () => {
+  it('shows the connecting status before live', () => {
+    renderPanel({ status: 'connecting' })
+    expect(screen.getByText('连接中')).toBeInTheDocument()
+  })
+
+  it('shows 聆听中 / 思考中 / 说话中 while live', () => {
+    renderPanel({ status: 'ready', conversationPhase: 'listening' })
+    expect(screen.getByText('聆听中')).toBeInTheDocument()
+    renderPanel({ status: 'ready', conversationPhase: 'thinking' })
+    expect(screen.getByText('思考中')).toBeInTheDocument()
+    renderPanel({ status: 'ready', conversationPhase: 'speaking', isAiSpeaking: true })
+    expect(screen.getByText('说话中')).toBeInTheDocument()
+  })
+})
+
+describe('VoicePanel — botanist framing + content', () => {
+  it('renders the AI reply labeled 植物学家：', () => {
+    renderPanel({
+      aiText: '先给兰花遮一次光，再浇水。',
+      conversationPhase: 'speaking',
+      isAiSpeaking: true,
+    })
+    const reply = screen.getByLabelText('植物学家说的话')
+    expect(reply).toHaveTextContent('植物学家：先给兰花遮一次光，再浇水。')
+  })
+
+  it('renders the player subtitle labeled 你：', () => {
+    renderPanel({ playerTranscript: '这株多肉能浇水吗' })
+    expect(screen.getByLabelText('你说的话')).toHaveTextContent('你：这株多肉能浇水吗')
+  })
+
+  it('shows the speaking cue while the botanist is speaking', () => {
+    const { container } = renderPanel({ conversationPhase: 'speaking', isAiSpeaking: true })
+    expect(container.querySelector('[aria-label="植物学家正在说话"]')).toBeInTheDocument()
+  })
+
+  it('surfaces a bounded error as an alert', () => {
+    renderPanel({ error: 'microphone permission denied' })
+    expect(screen.getByRole('alert')).toHaveTextContent('microphone permission denied')
+  })
+
+  it('ends the session from the end-call control', () => {
+    renderPanel({ status: 'ready' })
+    fireEvent.click(screen.getByRole('button', { name: '结束对话' }))
+    expect(endSession).toHaveBeenCalledOnce()
+  })
+
+  it('shows the hands-free botanist hint', () => {
+    renderPanel({ status: 'ready' })
+    expect(screen.getByText(/免提对话已开启/)).toBeInTheDocument()
+  })
+
+  it('wires the text fallback: a typed question calls sendText', () => {
+    renderPanel({ status: 'ready' })
+    const input = screen.getByLabelText('给植物学家的问题')
+    fireEvent.change(input, { target: { value: '打字问一句' } })
+    fireEvent.click(screen.getByRole('button', { name: '发送' }))
+    expect(sendText).toHaveBeenCalledWith('打字问一句')
+  })
+})

--- a/packages/game-botanical/src/voice/VoicePanel.tsx
+++ b/packages/game-botanical/src/voice/VoicePanel.tsx
@@ -1,0 +1,133 @@
+import { memo } from 'react'
+import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
+import { useVoiceSession } from './useVoiceSession'
+import type { ConversationPhase, VoiceStatus } from './voice-session-protocol'
+import TextPanel from './TextPanel'
+import styles from './VoicePanel.module.css'
+
+interface VoicePanelProps {
+  /** Per-run manual payload (`null` while the manual is still loading). */
+  manualData: ManualData | null
+  /** Live game state driving the manual-subset selection for this turn. */
+  gameState: GameState
+  /** Platform game id; defaults to `'demo-mock'` inside the hook. */
+  gameId?: string
+}
+
+/** Connection-status copy for the non-live states. Chinese. */
+const STATUS_LABEL: Record<Exclude<VoiceStatus, 'ready'>, string> = {
+  idle: '准备中',
+  connecting: '连接中',
+  error: '连接出错',
+  closed: '已结束',
+}
+
+/** The 3-state conversation phase copy (shown while the session is live). */
+const PHASE_LABEL: Record<ConversationPhase, string> = {
+  listening: '聆听中',
+  thinking: '思考中',
+  speaking: '说话中',
+}
+
+function placeholderFor(status: VoiceStatus, phase: ConversationPhase): string {
+  if (status === 'ready') {
+    if (phase === 'thinking') return '植物学家正在思考…'
+    if (phase === 'speaking') return '植物学家正在回应…'
+    return '开口说话，植物学家会即时回应'
+  }
+  if (status === 'closed') return '语音对话已结束'
+  if (status === 'error') return '语音连接已断开'
+  return '正在接通植物学家…'
+}
+
+/**
+ * In-game voice panel for the Botanical run, hands-free. Renders the
+ * `useVoiceSession` surface: a prominent 3-state conversation indicator
+ * (聆听中 / 思考中 / 说话中) once the session is live, the connection status before
+ * that, the player's own recognized-speech subtitle (你：…), the AI botanist's
+ * streamed reply (植物学家：…), a bounded error line, and an end-call control.
+ * There is NO push-to-talk — the mic streams continuously and the botanist
+ * greets first; the player just talks. Dark-only, CSS-only animation.
+ */
+function VoicePanelImpl({ manualData, gameState, gameId }: VoicePanelProps) {
+  const {
+    status,
+    conversationPhase,
+    aiText,
+    playerTranscript,
+    isAiSpeaking,
+    error,
+    endSession,
+    sendText,
+  } = useVoiceSession({ manualData, gameState, gameId })
+
+  const isLive = status === 'ready'
+  const indicatorLabel = isLive ? PHASE_LABEL[conversationPhase] : STATUS_LABEL[status]
+
+  return (
+    <section className={styles.panel} aria-label="AI 植物学家语音">
+      <div className={styles.header}>
+        <span className={styles.status}>
+          <span
+            className={styles.statusDot}
+            data-status={status}
+            data-phase={isLive ? conversationPhase : undefined}
+            aria-hidden="true"
+          />
+          <span className={styles.statusText} role="status">
+            {indicatorLabel}
+          </span>
+        </span>
+        {isLive && isAiSpeaking && (
+          <span className={styles.speaking} role="status" aria-label="植物学家正在说话">
+            <span className={styles.speakingDots} aria-hidden="true">
+              <i />
+              <i />
+              <i />
+            </span>
+          </span>
+        )}
+      </div>
+
+      {playerTranscript && (
+        <p className={styles.playerTranscript} aria-label="你说的话">
+          <span className={styles.transcriptLabel}>你：</span>
+          {playerTranscript}
+        </p>
+      )}
+
+      <div className={styles.reply} role="status" aria-live="polite">
+        {aiText ? (
+          <p className={styles.replyText} aria-label="植物学家说的话">
+            <span className={styles.transcriptLabel}>植物学家：</span>
+            {aiText}
+          </p>
+        ) : (
+          <p className={styles.replyPlaceholder}>{placeholderFor(status, conversationPhase)}</p>
+        )}
+      </div>
+
+      {error && (
+        <p className={styles.error} role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* Text fallback (FP1 A): type instead of speak — same botanist session. */}
+      <TextPanel onSend={sendText} disabled={!isLive} />
+
+      <div className={styles.footer}>
+        <p className={styles.hint}>免提对话已开启，直接对植物学家说话即可，无需按键。</p>
+        {isLive && (
+          <button type="button" className={styles.endButton} onClick={endSession}>
+            结束对话
+          </button>
+        )}
+      </div>
+    </section>
+  )
+}
+
+/** Memoized so the ~60fps GamePage timer re-render does not re-render the panel. */
+const VoicePanel = memo(VoicePanelImpl)
+export default VoicePanel

--- a/packages/game-botanical/src/voice/audio-pcm.ts
+++ b/packages/game-botanical/src/voice/audio-pcm.ts
@@ -1,0 +1,6 @@
+/**
+ * Re-export shim: the pure audio-format helpers live in the game-agnostic
+ * `@shared/voice/audio-pcm`. This path is the Botanical-local import surface;
+ * the implementation is shared with every voice consumer.
+ */
+export * from '@shared/voice/audio-pcm'

--- a/packages/game-botanical/src/voice/manual-data.test.ts
+++ b/packages/game-botanical/src/voice/manual-data.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { buildBotanicalManualData } from './manual-data'
+import { botanicalGameType, levelById } from '@/data/load'
+
+describe('buildBotanicalManualData', () => {
+  it('projects the rendered manual into the platform-ai ManualData shape', () => {
+    const data = buildBotanicalManualData(botanicalGameType, levelById('bg-demo-001').level)
+    expect(data.version).toBe('1.1.0')
+    // Addressable sections keyed by stable section id.
+    expect(Object.keys(data.sections)).toContain('objective')
+    expect(Object.keys(data.sections)).toContain('species_care:orchid')
+    const objective = data.sections['objective'] as { title: string; lines: string[] }
+    expect(objective.title).toBe('目标与败局')
+    expect(Array.isArray(objective.lines)).toBe(true)
+  })
+
+  it('keys sections for the standard level too (data-driven)', () => {
+    const data = buildBotanicalManualData(botanicalGameType, levelById('bg-standard-001').level)
+    expect(Object.keys(data.sections)).toContain('compatibility')
+    expect(Object.keys(data.sections)).toContain('species_care:orchid')
+    // The standard level has no needs-rule danger section (mis-care is wrong_care).
+    expect(Object.keys(data.sections)).not.toContain('danger:fern')
+  })
+})

--- a/packages/game-botanical/src/voice/manual-data.ts
+++ b/packages/game-botanical/src/voice/manual-data.ts
@@ -1,0 +1,14 @@
+/**
+ * Botanical bridge into the platform-ai voice-session contract's `ManualData`:
+ * render the manual (R3) and project it to the addressable-sections shape the
+ * AI botanist is grounded on. Pure — no I/O, no React — so the voice hook/UI
+ * build on a unit-tested seam.
+ */
+import type { GameType, Level } from '@amiclaw/creation'
+import type { ManualData } from '@amiclaw/platform-ai/contract'
+import { renderBotanicalManual, toManualData } from '@/manual/render-manual'
+
+/** Build the per-level `ManualData` the botanist session is created with. */
+export function buildBotanicalManualData(gameType: GameType, level: Level): ManualData {
+  return toManualData(renderBotanicalManual(gameType, level))
+}

--- a/packages/game-botanical/src/voice/relevant-sections.test.ts
+++ b/packages/game-botanical/src/voice/relevant-sections.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { gardenStateToRelevantSections } from './relevant-sections'
+
+const AVAILABLE = [
+  'objective',
+  'species_care:orchid',
+  'danger:fern',
+  'compatibility',
+  'light',
+  'growth',
+  'health_and_decay',
+]
+
+const plant = (id: string, species: string, health: string) => ({ id, species, health })
+
+describe('gardenStateToRelevantSections', () => {
+  it('injects only the always-on sections when nothing needs attention', () => {
+    const sections = gardenStateToRelevantSections({
+      plants: [plant('p1', 'fern', 'stable'), plant('p2', 'orchid', 'thriving')],
+      focusedId: null,
+      availableSectionIds: AVAILABLE,
+    })
+    expect(sections).toEqual(['objective', 'compatibility', 'light', 'health_and_decay'])
+  })
+
+  it('adds the focused plant’s species care + growth', () => {
+    const sections = gardenStateToRelevantSections({
+      plants: [plant('p1', 'fern', 'stable'), plant('p2', 'orchid', 'stable')],
+      focusedId: 'p2',
+      availableSectionIds: AVAILABLE,
+    })
+    expect(sections).toContain('species_care:orchid')
+    expect(sections).toContain('growth')
+    // danger:orchid does not exist in this manual → filtered out.
+    expect(sections).not.toContain('danger:orchid')
+  })
+
+  it('adds danger for a wilting/critical plant even without focus', () => {
+    const sections = gardenStateToRelevantSections({
+      plants: [plant('p1', 'fern', 'wilting'), plant('p2', 'orchid', 'stable')],
+      focusedId: null,
+      availableSectionIds: AVAILABLE,
+    })
+    expect(sections).toContain('danger:fern')
+    // species_care:fern is not present in the manual → filtered out.
+    expect(sections).not.toContain('species_care:fern')
+    expect(sections).toContain('growth')
+  })
+
+  it('steers as the garden evolves: the section set changes with focus', () => {
+    const plants = [plant('p1', 'fern', 'stable'), plant('p2', 'orchid', 'stable')]
+    const focusFern = gardenStateToRelevantSections({
+      plants,
+      focusedId: 'p1',
+      availableSectionIds: AVAILABLE,
+    })
+    const focusOrchid = gardenStateToRelevantSections({
+      plants,
+      focusedId: 'p2',
+      availableSectionIds: AVAILABLE,
+    })
+    expect(focusFern).toContain('danger:fern')
+    expect(focusFern).not.toContain('species_care:orchid')
+    expect(focusOrchid).toContain('species_care:orchid')
+    expect(focusFern.join(',')).not.toBe(focusOrchid.join(','))
+  })
+
+  it('never names a section the manual does not contain', () => {
+    const sections = gardenStateToRelevantSections({
+      plants: [plant('p1', 'vine', 'critical')],
+      focusedId: 'p1',
+      availableSectionIds: ['objective', 'health_and_decay'], // sparse manual
+    })
+    expect(sections).toEqual(['objective', 'health_and_decay'])
+  })
+})

--- a/packages/game-botanical/src/voice/relevant-sections.ts
+++ b/packages/game-botanical/src/voice/relevant-sections.ts
@@ -1,0 +1,57 @@
+/**
+ * Map the live garden state to the manual section ids the platform should
+ * inject for the botanist's next turn (`GameState.relevantSections`). Pure — no
+ * React, no I/O — so it is a unit-tested seam and can be signature-diffed by the
+ * voice hook to steer the live session only on real change.
+ *
+ * Selection:
+ *  - always: `objective`, `compatibility`, `light`, `health_and_decay`.
+ *  - for each ACTIVE plant (health wilting/critical, OR the focused plant):
+ *    its `species_care:<species>` + `danger:<species>`, plus `growth` once.
+ * The result is filtered to the manual's actually-present section ids, so a
+ * plant with no species-care rule (or a level with no growth section) never
+ * names a non-existent section.
+ */
+
+const ALWAYS_ON = ['objective', 'compatibility', 'light', 'health_and_decay'] as const
+const ACTIVE_HEALTH = new Set(['wilting', 'critical'])
+
+export interface GardenSectionState {
+  /** Live plants (ordered — pot order preserved for deterministic output). */
+  plants: { id: string; species: string; health: string }[]
+  /** The currently selected plant id, or null. */
+  focusedId: string | null
+  /** Section ids the rendered manual actually contains (`manualData.sections`). */
+  availableSectionIds: string[]
+}
+
+export function gardenStateToRelevantSections(state: GardenSectionState): string[] {
+  const available = new Set(state.availableSectionIds)
+  const active = state.plants.filter((p) => ACTIVE_HEALTH.has(p.health) || p.id === state.focusedId)
+
+  const ordered: string[] = ['objective']
+  for (const plant of active) {
+    ordered.push(`species_care:${plant.species}`, `danger:${plant.species}`)
+  }
+  ordered.push('compatibility', 'light')
+  if (active.length > 0) ordered.push('growth')
+  ordered.push('health_and_decay')
+
+  // Keep ALWAYS_ON ids that exist even if the ordering above dropped one, filter
+  // to present sections, and dedupe preserving first-seen order.
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const id of ordered) {
+    if (!available.has(id) || seen.has(id)) continue
+    seen.add(id)
+    result.push(id)
+  }
+  // Safety: guarantee the always-on ids that exist are present.
+  for (const id of ALWAYS_ON) {
+    if (available.has(id) && !seen.has(id)) {
+      seen.add(id)
+      result.push(id)
+    }
+  }
+  return result
+}

--- a/packages/game-botanical/src/voice/useVoiceSession.test.ts
+++ b/packages/game-botanical/src/voice/useVoiceSession.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { GameState, ManualData, SessionSummary } from '@amiclaw/platform-ai/contract'
+import { useVoiceSession } from './useVoiceSession'
+
+// --- Mocks: WebSocket / AudioContext / getUserMedia (browser-only play-green) ---
+
+type Listener = ((arg?: unknown) => void) | null
+
+class MockWebSocket {
+  static OPEN = 1
+  static CLOSED = 3
+  static instances: MockWebSocket[] = []
+
+  url: string
+  readyState = 0
+  sent: Array<string | ArrayBuffer> = []
+  onopen: Listener = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onerror: Listener = null
+  onclose: ((event: { code: number; reason?: string }) => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+  send(data: string | ArrayBuffer): void {
+    this.sent.push(data)
+  }
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.({ code: 1000, reason: '' })
+  }
+  fireOpen(): void {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+  fireMessage(obj: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(obj) })
+  }
+  fireClose(code: number, reason = ''): void {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.({ code, reason })
+  }
+  controlMessages(): Array<Record<string, unknown>> {
+    return this.sent
+      .filter((m): m is string => typeof m === 'string')
+      .map((m) => JSON.parse(m) as Record<string, unknown>)
+  }
+  binaryFrameCount(): number {
+    return this.sent.filter((m) => typeof m !== 'string').length
+  }
+}
+
+class MockBufferSource {
+  buffer: unknown = null
+  onended: Listener = null
+  stopped = false
+  connect(): void {}
+  disconnect(): void {}
+  start(): void {}
+  stop(): void {
+    this.stopped = true
+  }
+}
+
+class MockScriptProcessor {
+  onaudioprocess: ((e: { inputBuffer: { getChannelData: () => Float32Array } }) => void) | null =
+    null
+  connect(): void {}
+  disconnect(): void {}
+}
+
+class MockAudioContext {
+  static instances: MockAudioContext[] = []
+  currentTime = 0
+  destination = {}
+  sampleRate: number
+  processor: MockScriptProcessor | null = null
+  sources: MockBufferSource[] = []
+  constructor(opts?: { sampleRate?: number }) {
+    this.sampleRate = opts?.sampleRate ?? 48000
+    MockAudioContext.instances.push(this)
+  }
+  resume(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+  createBuffer(_ch: number, len: number, rate: number) {
+    return { duration: len / rate, getChannelData: () => new Float32Array(len) }
+  }
+  createBufferSource(): MockBufferSource {
+    const s = new MockBufferSource()
+    this.sources.push(s)
+    return s
+  }
+  createMediaStreamSource() {
+    return { connect() {}, disconnect() {} }
+  }
+  createScriptProcessor(): MockScriptProcessor {
+    const p = new MockScriptProcessor()
+    this.processor = p
+    return p
+  }
+}
+
+const getUserMedia = vi.fn(async () => ({ getTracks: () => [{ stop() {} }] }))
+
+function manualData(): ManualData {
+  return { version: '1.1.0', sections: { objective: { title: '目标', lines: [] } } }
+}
+function gameState(sections: string[] = ['objective', 'compatibility']): GameState {
+  return { relevantSections: sections }
+}
+function summary(): SessionSummary {
+  return {
+    sessionId: 's1',
+    gameId: 'demo-mock',
+    userId: 'dev-user',
+    turnCount: 1,
+    usage: { llmInputTokens: 0, llmOutputTokens: 0, sttInputSeconds: 0, ttsOutputSeconds: 0 },
+  }
+}
+
+function captureProcessor(): MockScriptProcessor {
+  const ctx = MockAudioContext.instances.find((c) => c.processor)
+  if (!ctx?.processor) throw new Error('no capture processor yet')
+  return ctx.processor
+}
+
+const SAMPLES = 4096
+function fireFrame(amplitude: number): void {
+  const data = new Float32Array(SAMPLES).fill(amplitude)
+  captureProcessor().onaudioprocess?.({ inputBuffer: { getChannelData: () => data } })
+}
+const audioB64 = btoa(String.fromCharCode(0, 0, 1, 0))
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  MockAudioContext.instances = []
+  getUserMedia.mockClear()
+  getUserMedia.mockImplementation(async () => ({ getTracks: () => [{ stop() {} }] }))
+  vi.stubGlobal('WebSocket', MockWebSocket)
+  vi.stubGlobal('AudioContext', MockAudioContext)
+  Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+    value: { getUserMedia },
+    configurable: true,
+  })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+function lastSocket(): MockWebSocket {
+  const ws = MockWebSocket.instances.at(-1)
+  if (!ws) throw new Error('no WebSocket constructed')
+  return ws
+}
+
+async function ready() {
+  const rendered = renderHook(() =>
+    useVoiceSession({ manualData: manualData(), gameState: gameState() })
+  )
+  const ws = lastSocket()
+  act(() => ws.fireOpen())
+  await act(async () => {
+    ws.fireMessage({ type: 'created', sessionId: 'sess-1' })
+  })
+  await waitFor(() => captureProcessor())
+  return { ...rendered, ws }
+}
+
+describe('useVoiceSession — connection', () => {
+  it('stays idle until a manual is provided', () => {
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: null, gameState: gameState() })
+    )
+    expect(result.current.status).toBe('idle')
+    expect(MockWebSocket.instances.length).toBe(0)
+  })
+
+  it('connects same-origin as botanical- and sends create with demo-mock, no userId', () => {
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    expect(result.current.status).toBe('connecting')
+    const ws = lastSocket()
+    expect(ws.url).toMatch(/^ws:\/\/[^/]+\/ai-ws\/botanical-/)
+
+    act(() => ws.fireOpen())
+    const create = ws.controlMessages()[0]
+    expect(create).toMatchObject({
+      type: 'create',
+      gameId: 'demo-mock',
+      manualData: { version: '1.1.0' },
+      gameState: { relevantSections: ['objective', 'compatibility'] },
+    })
+    expect(create).not.toHaveProperty('userId')
+    expect(create).not.toHaveProperty('systemPrompt')
+  })
+
+  it('honors a custom gameId (the real demo path)', () => {
+    renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState(), gameId: 'demo' })
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    expect(ws.controlMessages()[0]).toMatchObject({ gameId: 'demo' })
+  })
+
+  it('an unexpected socket close becomes a bounded transport error', () => {
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    act(() => ws.fireMessage({ type: 'created', sessionId: 'sess-1' }))
+    act(() => ws.fireClose(1006))
+    expect(result.current.status).toBe('error')
+    expect(result.current.error).toContain('1006')
+  })
+
+  it('closes the socket on unmount (lifecycle hygiene)', () => {
+    const { unmount } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    expect(ws.readyState).toBe(MockWebSocket.OPEN)
+    unmount()
+    expect(ws.readyState).toBe(MockWebSocket.CLOSED)
+  })
+})
+
+describe('useVoiceSession — hands-free lifecycle', () => {
+  it('reaches ready and auto-opens the mic on created (no push-to-talk)', async () => {
+    const { result, ws } = await ready()
+    expect(result.current.status).toBe('ready')
+    expect(getUserMedia).toHaveBeenCalledOnce()
+    act(() => fireFrame(0.0))
+    expect(ws.binaryFrameCount()).toBeGreaterThan(0)
+  })
+
+  it('renders the AI-first opening turn with no player input (thinking -> speaking)', async () => {
+    const { result, ws } = await ready()
+    expect(result.current.conversationPhase).toBe('thinking')
+    act(() => {
+      ws.fireMessage({ type: 'chunk', kind: 'text', text: '你好，', done: false })
+      ws.fireMessage({ type: 'chunk', kind: 'text', text: '我是植物学家。', done: false })
+      ws.fireMessage({ type: 'chunk', kind: 'audio', audio: audioB64, done: true })
+    })
+    expect(result.current.aiText).toBe('你好，我是植物学家。')
+    expect(result.current.isAiSpeaking).toBe(true)
+    expect(result.current.conversationPhase).toBe('speaking')
+  })
+
+  it('exposes the player transcript from a transcript frame', async () => {
+    const { result, ws } = await ready()
+    act(() => ws.fireMessage({ type: 'transcript', text: '这株兰花叶子发黄' }))
+    expect(result.current.playerTranscript).toBe('这株兰花叶子发黄')
+  })
+
+  it('endSession sends end and lands closed with the summary', async () => {
+    const { result, ws } = await ready()
+    act(() => result.current.endSession())
+    expect(ws.controlMessages().some((m) => m.type === 'end')).toBe(true)
+    act(() => ws.fireMessage({ type: 'summary', summary: summary() }))
+    act(() => ws.fireClose(1000))
+    expect(result.current.status).toBe('closed')
+    expect(result.current.summary).toMatchObject({ turnCount: 1 })
+  })
+
+  it('endSession sends end exactly once even when called twice', async () => {
+    const { result, ws } = await ready()
+    act(() => result.current.endSession())
+    act(() => result.current.endSession())
+    expect(ws.controlMessages().filter((m) => m.type === 'end')).toHaveLength(1)
+  })
+
+  it('treats a turn_in_flight server error as a benign no-op', async () => {
+    const { result, ws } = await ready()
+    act(() => ws.fireMessage({ type: 'error', code: 'turn_in_flight', message: 'busy' }))
+    expect(result.current.error).toBeNull()
+    expect(result.current.status).toBe('ready')
+  })
+})
+
+function finishGreeting(ws: MockWebSocket): void {
+  act(() => ws.fireMessage({ type: 'chunk', kind: 'audio', audio: audioB64, done: true }))
+  const ctx = MockAudioContext.instances.find((c) => !c.processor && c.sources.length > 0)
+  act(() => ctx?.sources.at(-1)?.onended?.())
+}
+
+describe('useVoiceSession — client VAD', () => {
+  it('sends speech-start then turn, in order, for a real player utterance', async () => {
+    const { ws } = await ready()
+    finishGreeting(ws)
+    act(() => {
+      fireFrame(0.5)
+      fireFrame(0.5)
+    })
+    expect(ws.controlMessages().filter((m) => m.type === 'speech-start')).toHaveLength(1)
+    expect(ws.controlMessages().some((m) => m.type === 'turn')).toBe(false)
+    act(() => {
+      for (let i = 0; i < 10; i += 1) fireFrame(0.0)
+    })
+    const types = ws.controlMessages().map((m) => m.type)
+    expect(types.filter((t) => t === 'speech-start')).toHaveLength(1)
+    expect(types.filter((t) => t === 'turn')).toHaveLength(1)
+    expect(types.indexOf('turn')).toBeGreaterThan(types.indexOf('speech-start'))
+  })
+
+  it('does not send speech-start while the opening greeting is in flight', async () => {
+    const { ws } = await ready()
+    act(() => {
+      fireFrame(0.5)
+      fireFrame(0.5)
+      fireFrame(0.0)
+      fireFrame(0.0)
+    })
+    expect(ws.controlMessages().some((m) => m.type === 'speech-start')).toBe(false)
+  })
+})
+
+describe('useVoiceSession — garden-state steering', () => {
+  async function readyWithGameState(initial: GameState) {
+    const rendered = renderHook(
+      ({ gs }: { gs: GameState }) => useVoiceSession({ manualData: manualData(), gameState: gs }),
+      { initialProps: { gs: initial } }
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    await act(async () => {
+      ws.fireMessage({ type: 'created', sessionId: 'sess-1' })
+    })
+    await waitFor(() => captureProcessor())
+    return { ...rendered, ws }
+  }
+
+  it('sends the first selection via create and never an update for it', async () => {
+    const { ws } = await readyWithGameState(gameState(['objective', 'light']))
+    expect(ws.controlMessages().find((m) => m.type === 'create')).toMatchObject({
+      gameState: { relevantSections: ['objective', 'light'] },
+    })
+    expect(ws.controlMessages().some((m) => m.type === 'update-gamestate')).toBe(false)
+  })
+
+  it('steers ONE update-gamestate on the SAME socket when the sections change', async () => {
+    const { ws, rerender } = await readyWithGameState(gameState(['objective', 'light']))
+    const socketsBefore = MockWebSocket.instances.length
+    act(() => rerender({ gs: gameState(['objective', 'species_care:orchid', 'growth']) }))
+    const updates = ws.controlMessages().filter((m) => m.type === 'update-gamestate')
+    expect(updates).toHaveLength(1)
+    expect(updates[0]).toMatchObject({
+      gameState: { relevantSections: ['objective', 'species_care:orchid', 'growth'] },
+    })
+    expect(MockWebSocket.instances.length).toBe(socketsBefore)
+    expect(ws.controlMessages().filter((m) => m.type === 'create')).toHaveLength(1)
+  })
+
+  it('does not steer when a re-render leaves the sections unchanged', async () => {
+    const { ws, rerender } = await readyWithGameState(gameState(['objective', 'light']))
+    act(() => rerender({ gs: gameState(['objective', 'light']) }))
+    expect(ws.controlMessages().some((m) => m.type === 'update-gamestate')).toBe(false)
+  })
+
+  it('does not steer before the session is created', async () => {
+    const rendered = renderHook(
+      ({ gs }: { gs: GameState }) => useVoiceSession({ manualData: manualData(), gameState: gs }),
+      { initialProps: { gs: gameState(['objective']) } }
+    )
+    const ws = lastSocket()
+    act(() => ws.fireOpen())
+    act(() => rendered.rerender({ gs: gameState(['objective', 'light']) }))
+    expect(ws.controlMessages().some((m) => m.type === 'update-gamestate')).toBe(false)
+    await act(async () => {
+      ws.fireMessage({ type: 'created', sessionId: 'sess-1' })
+    })
+    expect(ws.controlMessages().filter((m) => m.type === 'update-gamestate')).toHaveLength(1)
+  })
+})
+
+describe('useVoiceSession — text fallback', () => {
+  it('sends a typed question as a text-turn on the live socket', async () => {
+    const { result, ws } = await ready()
+    act(() => result.current.sendText('这株兰花怎么救'))
+    expect(ws.controlMessages()).toContainEqual({ type: 'text-turn', text: '这株兰花怎么救' })
+  })
+
+  it('trims and ignores an empty typed question', async () => {
+    const { result, ws } = await ready()
+    act(() => result.current.sendText('   '))
+    expect(ws.controlMessages().some((m) => m.type === 'text-turn')).toBe(false)
+  })
+
+  it('does not send a text-turn before the session is live', () => {
+    const { result } = renderHook(() =>
+      useVoiceSession({ manualData: manualData(), gameState: gameState() })
+    )
+    const ws = lastSocket() // connecting: socket not OPEN yet
+    act(() => result.current.sendText('在吗'))
+    expect(ws.controlMessages().some((m) => m.type === 'text-turn')).toBe(false)
+  })
+})
+
+describe('useVoiceSession — barge-in', () => {
+  it('stops playback and drops the interrupted turn when the player talks over it', async () => {
+    const { result, ws } = await ready()
+    act(() => {
+      ws.fireMessage({ type: 'chunk', kind: 'text', text: '这一条很长的建议', done: false })
+      ws.fireMessage({ type: 'chunk', kind: 'audio', audio: audioB64, done: false })
+    })
+    expect(result.current.isAiSpeaking).toBe(true)
+    const before = ws.controlMessages().filter((m) => m.type === 'speech-start').length
+    act(() => {
+      fireFrame(0.5)
+      fireFrame(0.5)
+    })
+    expect(result.current.isAiSpeaking).toBe(false)
+    expect(result.current.aiText).toBe('')
+    expect(ws.controlMessages().filter((m) => m.type === 'speech-start').length).toBe(before + 1)
+  })
+})

--- a/packages/game-botanical/src/voice/useVoiceSession.ts
+++ b/packages/game-botanical/src/voice/useVoiceSession.ts
@@ -1,0 +1,425 @@
+/**
+ * `useVoiceSession` — the Botanical client for one platform-ai voice session,
+ * hands-free full-duplex. Adapted from game-bombsquad's hook (the load-bearing
+ * turn model / VAD / barge-in / mic / playback machinery is copied verbatim);
+ * the bombsquad-only surface (closing-recap, account streak, score-settlement
+ * gameRunId) is dropped — the botanical probe needs only the core contract:
+ * create → speech-start → audio → turn → chunk → update-gamestate → end.
+ *
+ * Runs the whole conversation against the deployed `@amiclaw/platform-ai` Worker
+ * over the same-origin `/ai-ws/*` WebSocket: connect → create session → open the
+ * mic ONCE and stream PCM16 16 kHz frames continuously → the AI botanist greets
+ * first and answers each utterance → render the AI's streamed text + play its TTS
+ * audio → end session. There is NO push-to-talk; the player just talks.
+ *
+ * Turn model (important): the CLIENT runs the VAD. On `create` the server fires
+ * the AI-first opening greeting (no client input). Thereafter the hook streams
+ * the mic continuously; the client-side VAD detects utterance START and sends
+ * `{type:'speech-start'}` (opens the recognizer to transcribe LIVE), then
+ * end-of-utterance and sends `{type:'turn'}` (finalizes STT→LLM→TTS over the
+ * audio buffered since the last turn). Turns are SERIAL server-side, so BOTH
+ * sends fire only when the AI is idle — otherwise the open mic picking up the
+ * AI's own greeting would open a spurious utterance / fire a rejected turn. The
+ * one mid-stream exception is a genuine barge-in.
+ *
+ * Security invariant (load-bearing): connects ONLY to the same-origin Worker WS
+ * and sends ONLY `{gameId, manualData, gameState}` plus binary audio. NO provider
+ * key, NO system prompt, NO userId — the session cookie / DEV_AUTH_BYPASS
+ * authenticates same-origin and the server holds every secret.
+ */
+
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
+import type { GameState, ManualData } from '@amiclaw/platform-ai/contract'
+import { base64ToBytes } from './audio-pcm'
+import {
+  buildSessionUrl,
+  deriveConversationPhase,
+  initialVoiceState,
+  randomSessionName,
+  voiceReducer,
+  type ConversationPhase,
+  type ServerFrame,
+  type VoiceStatus,
+} from './voice-session-protocol'
+import { createPcmCapture, type PcmCapture } from '@shared/voice/audio-capture'
+import { createPcmPlayback, type PcmPlayback } from '@shared/voice/audio-playback'
+
+/** Volcengine TTS output sample rate (`volcengine.ts` `DEFAULT_SAMPLE_RATE`). */
+const TTS_OUTPUT_SAMPLE_RATE = 16000
+/** Mic capture rate — the STT adapter's exact wire rate (PCM16 16 kHz mono). */
+const CAPTURE_SAMPLE_RATE = 16000
+/** ScriptProcessor buffer size (frames). Matches the demo. */
+const CAPTURE_BUFFER_SIZE = 4096
+/** Fallback out of `thinking` if a (no-speech / spurious-VAD) turn gets no reply. */
+const NO_RESPONSE_TIMEOUT_MS = 12000
+
+/** Stable signature of the manual-subset selection, for change detection. */
+function sectionsSignature(gameState: GameState): string {
+  return JSON.stringify(gameState.relevantSections ?? [])
+}
+
+export interface UseVoiceSessionOptions {
+  /**
+   * The per-run manual payload (built via `buildBotanicalManualData`). `null`
+   * while the manual is still loading — the hook stays `idle` and connects once
+   * a non-null value is provided.
+   */
+  manualData: ManualData | null
+  /**
+   * The game state driving manual-subset selection (`relevantSections` via
+   * `gardenStateToRelevantSections`). The FIRST value rides the `create`
+   * message; a later change is steered on the live socket with a single
+   * `update-gamestate` (no reconnect, no re-greet).
+   */
+  gameState: GameState
+  /** Platform game id. Defaults to `'demo-mock'` (the credential-free probe path). */
+  gameId?: string
+}
+
+export interface UseVoiceSessionResult {
+  /** Connection lifecycle status for the panel (socket state). */
+  status: VoiceStatus
+  /** In-conversation 3-state phase for a live session (listening / thinking / speaking). */
+  conversationPhase: ConversationPhase
+  /** True while the client VAD reports the player is speaking. */
+  playerSpeaking: boolean
+  /** Accumulated AI text for the current turn. */
+  aiText: string
+  /** The player's live recognized speech, streamed as recognition builds. */
+  playerTranscript: string
+  /** True while TTS audio is scheduled/playing. */
+  isAiSpeaking: boolean
+  /** Last bounded error message, or null. */
+  error: string | null
+  /** Session summary, set once the session ends cleanly. */
+  summary: import('@amiclaw/platform-ai/contract').SessionSummary | null
+  /** End the session: send `end`, await the summary, and tear down. */
+  endSession: () => void
+  /**
+   * Text fallback (FP1 A): send a typed question as a `text-turn` on the live
+   * socket — the AI botanist replies over the same session, skipping STT. A
+   * no-op if empty or not connected. The reply streams back through the same
+   * `chunk`/`transcript` path a voice turn uses.
+   */
+  sendText: (text: string) => void
+}
+
+export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessionResult {
+  const { manualData, gameState, gameId = 'demo-mock' } = options
+
+  const [state, dispatch] = useReducer(voiceReducer, initialVoiceState)
+  const [isAiSpeaking, setIsAiSpeaking] = useState(false)
+  const [playerSpeaking, setPlayerSpeaking] = useState(false)
+  const [awaitingResponse, setAwaitingResponse] = useState(false)
+  const awaitingResponseRef = useRef(false)
+  const awaitingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Latest inputs, captured at connect/create time without re-running connect.
+  const manualDataRef = useRef<ManualData | null>(manualData)
+  const gameStateRef = useRef<GameState>(gameState)
+  const gameIdRef = useRef<string>(gameId)
+  useEffect(() => {
+    manualDataRef.current = manualData
+    gameStateRef.current = gameState
+    gameIdRef.current = gameId
+  })
+
+  // Side-effect handles (never trigger re-render).
+  const wsRef = useRef<WebSocket | null>(null)
+  const endedRef = useRef(false)
+  const mountedRef = useRef(true)
+  const sentSectionsRef = useRef<string | null>(null)
+  const turnStreamingRef = useRef(false)
+  const suppressTurnRef = useRef(false)
+
+  const safeDispatch = useCallback((action: Parameters<typeof dispatch>[0]) => {
+    if (mountedRef.current) dispatch(action)
+  }, [])
+
+  const setAwaiting = useCallback((v: boolean) => {
+    awaitingResponseRef.current = v
+    if (mountedRef.current) setAwaitingResponse(v)
+    if (awaitingTimeoutRef.current) {
+      clearTimeout(awaitingTimeoutRef.current)
+      awaitingTimeoutRef.current = null
+    }
+    if (v) {
+      awaitingTimeoutRef.current = setTimeout(() => {
+        awaitingTimeoutRef.current = null
+        awaitingResponseRef.current = false
+        if (mountedRef.current) setAwaitingResponse(false)
+      }, NO_RESPONSE_TIMEOUT_MS)
+    }
+  }, [])
+
+  // --- Imperative audio shells (TTS playback + mic capture) ---
+  const [playback] = useState<PcmPlayback>(() => createPcmPlayback(TTS_OUTPUT_SAMPLE_RATE))
+  const [capture] = useState<PcmCapture>(() =>
+    createPcmCapture(CAPTURE_SAMPLE_RATE, CAPTURE_BUFFER_SIZE)
+  )
+
+  const onSpeakingChange = useCallback((speaking: boolean) => {
+    if (speaking) setIsAiSpeaking(true)
+    else if (mountedRef.current) setIsAiSpeaking(false)
+  }, [])
+
+  /** A VAD `utterance-end`: the player went silent after speaking. */
+  const onUtteranceEnd = useCallback(() => {
+    setPlayerSpeaking(false)
+    // Only hand the floor to the server when the AI is idle (serial turns).
+    const aiHoldsFloor =
+      playback.isPlaying() ||
+      awaitingResponseRef.current ||
+      (turnStreamingRef.current && !suppressTurnRef.current)
+    if (aiHoldsFloor) return
+    setAwaiting(true)
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      try {
+        ws.send(JSON.stringify({ type: 'turn' }))
+      } catch {
+        /* non-fatal — a dropped turn just means this utterance isn't answered */
+      }
+    }
+  }, [setAwaiting, playback])
+
+  /** A VAD `speech-start`: the player began an utterance (incl. barge-in). */
+  const onSpeechStart = useCallback(() => {
+    const bargeIn = playback.isPlaying()
+    if (bargeIn) {
+      playback.interrupt(onSpeakingChange)
+      if (turnStreamingRef.current) suppressTurnRef.current = true
+      safeDispatch({ type: 'barge-in' })
+    }
+    // Guard the SAME way the `turn` send is guarded — only signal a REAL utterance.
+    const aiHoldsFloor =
+      !bargeIn &&
+      (awaitingResponseRef.current || (turnStreamingRef.current && !suppressTurnRef.current))
+    if (aiHoldsFloor) return
+    setPlayerSpeaking(true)
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      try {
+        ws.send(JSON.stringify({ type: 'speech-start' }))
+      } catch {
+        /* non-fatal — a dropped speech-start just defers live transcription to the turn */
+      }
+    }
+  }, [playback, safeDispatch, onSpeakingChange])
+
+  // --- WebSocket lifecycle ---
+
+  const closeSocket = useCallback((detachHandlers: boolean) => {
+    const ws = wsRef.current
+    wsRef.current = null
+    if (!ws) return
+    if (detachHandlers) {
+      ws.onopen = null
+      ws.onmessage = null
+      ws.onerror = null
+      ws.onclose = null
+    }
+    try {
+      ws.close()
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
+  const connect = useCallback(() => {
+    if (wsRef.current) return
+    const data = manualDataRef.current
+    if (!data) return
+    endedRef.current = false
+    sentSectionsRef.current = null
+    safeDispatch({ type: 'connecting' })
+
+    let ws: WebSocket
+    try {
+      ws = new WebSocket(buildSessionUrl(window.location, randomSessionName()))
+    } catch {
+      safeDispatch({ type: 'transport-error', message: 'failed to open voice connection' })
+      return
+    }
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      const create = {
+        type: 'create' as const,
+        gameId: gameIdRef.current,
+        manualData: manualDataRef.current,
+        gameState: gameStateRef.current,
+      }
+      try {
+        ws.send(JSON.stringify(create))
+        sentSectionsRef.current = sectionsSignature(gameStateRef.current)
+      } catch {
+        safeDispatch({ type: 'transport-error', message: 'failed to create voice session' })
+      }
+    }
+
+    ws.onmessage = (event) => {
+      if (typeof event.data !== 'string') return
+      let frame: ServerFrame
+      try {
+        frame = JSON.parse(event.data) as ServerFrame
+      } catch {
+        return
+      }
+      if (frame.type === 'created') {
+        // The AI greets first: open the mic now and mark the greeting pending.
+        setAwaiting(true)
+        capture.start({
+          onSpeechStart,
+          onUtteranceEnd,
+          onError: (message) => safeDispatch({ type: 'mic-error', message }),
+          isMounted: () => mountedRef.current,
+          getSocket: () => wsRef.current,
+        })
+        safeDispatch({ type: 'frame', frame })
+        return
+      }
+      if (frame.type === 'chunk') {
+        // Drop the tail of a turn the player barged in on, until its `done`.
+        if (suppressTurnRef.current) {
+          if (frame.done) {
+            suppressTurnRef.current = false
+            turnStreamingRef.current = false
+          }
+          return
+        }
+        turnStreamingRef.current = !frame.done
+        if (awaitingResponseRef.current) setAwaiting(false)
+        if (frame.kind === 'audio' && frame.audio) {
+          playback.play(base64ToBytes(frame.audio), onSpeakingChange)
+        }
+        safeDispatch({ type: 'frame', frame })
+        return
+      }
+      if (frame.type === 'error') {
+        if (frame.code === 'turn_in_flight' && awaitingResponseRef.current) setAwaiting(false)
+        safeDispatch({ type: 'frame', frame })
+        return
+      }
+      safeDispatch({ type: 'frame', frame })
+    }
+
+    ws.onerror = () => {
+      safeDispatch({ type: 'transport-error', message: 'voice connection error' })
+    }
+
+    ws.onclose = (event) => {
+      wsRef.current = null
+      if (endedRef.current || event.code === 1000) {
+        safeDispatch({ type: 'closed' })
+      } else {
+        const reason = event.reason ? `: ${event.reason}` : ''
+        safeDispatch({
+          type: 'transport-error',
+          message: `voice connection closed (${event.code}${reason})`,
+        })
+      }
+    }
+  }, [
+    capture,
+    playback,
+    onSpeechStart,
+    onUtteranceEnd,
+    onSpeakingChange,
+    safeDispatch,
+    setAwaiting,
+  ])
+
+  // --- Public actions ---
+
+  const endSession = useCallback(() => {
+    // Exactly-once: a duplicate `{type:'end'}` would double the server's
+    // memory-capture hand-off. `endedRef` guards the second call.
+    if (endedRef.current) return
+    capture.stop()
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      endedRef.current = true
+      try {
+        ws.send(JSON.stringify({ type: 'end' }))
+      } catch {
+        closeSocket(true)
+        safeDispatch({ type: 'closed' })
+      }
+    } else {
+      closeSocket(true)
+      safeDispatch({ type: 'closed' })
+    }
+  }, [capture, closeSocket, safeDispatch])
+
+  /** Send a typed question as a `text-turn` (the text fallback). */
+  const sendText = useCallback(
+    (text: string) => {
+      const trimmed = text.trim()
+      if (trimmed === '') return
+      const ws = wsRef.current
+      if (!ws || ws.readyState !== WebSocket.OPEN) return
+      try {
+        ws.send(JSON.stringify({ type: 'text-turn', text: trimmed }))
+        // A typed question awaits a reply → drive the `thinking` phase; the first
+        // reply chunk (or a turn_in_flight rejection, or the watchdog) clears it.
+        setAwaiting(true)
+      } catch {
+        /* non-fatal — a dropped text-turn just goes unanswered */
+      }
+    },
+    [setAwaiting]
+  )
+
+  // --- Connect on mount (once the manual is ready); full teardown on unmount ---
+
+  const hasManual = manualData !== null
+  useEffect(() => {
+    if (!hasManual) return
+    mountedRef.current = true
+    connect()
+    return () => {
+      mountedRef.current = false
+      if (awaitingTimeoutRef.current) {
+        clearTimeout(awaitingTimeoutRef.current)
+        awaitingTimeoutRef.current = null
+      }
+      capture.stop()
+      playback.teardown(onSpeakingChange)
+      closeSocket(true)
+    }
+  }, [hasManual, connect, capture, playback, onSpeakingChange, closeSocket])
+
+  // --- Garden state advance within one run: steer the live session, no reconnect ---
+  const liveSectionsSignature = sectionsSignature(gameState)
+  useEffect(() => {
+    if (state.status !== 'ready') return
+    if (sentSectionsRef.current === liveSectionsSignature) return
+    const ws = wsRef.current
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+    sentSectionsRef.current = liveSectionsSignature
+    try {
+      ws.send(JSON.stringify({ type: 'update-gamestate', gameState: gameStateRef.current }))
+    } catch {
+      /* non-fatal — a dropped steer just leaves the next turn on the old sections */
+    }
+  }, [liveSectionsSignature, state.status])
+
+  const conversationPhase = useMemo(
+    () => deriveConversationPhase({ isAiSpeaking, playerSpeaking, awaitingResponse }),
+    [isAiSpeaking, playerSpeaking, awaitingResponse]
+  )
+
+  return {
+    status: state.status,
+    conversationPhase,
+    playerSpeaking,
+    aiText: state.aiText,
+    playerTranscript: state.playerTranscript,
+    isAiSpeaking,
+    error: state.error,
+    summary: state.summary as import('@amiclaw/platform-ai/contract').SessionSummary | null,
+    endSession,
+    sendText,
+  }
+}

--- a/packages/game-botanical/src/voice/voice-session-protocol.ts
+++ b/packages/game-botanical/src/voice/voice-session-protocol.ts
@@ -1,0 +1,16 @@
+/**
+ * Re-export shim: the game-agnostic voice-session protocol (wire envelope types,
+ * exposed-state reducer, URL builder) lives in `@shared/voice/voice-session-protocol`.
+ * This path is the Botanical-local import surface; the implementation is shared
+ * with every voice consumer (bombsquad, lobby).
+ *
+ * The one Botanical-local addition is `randomSessionName`: each consumer mints
+ * its own self-identifying WS session name (here `botanical-…`), so the
+ * generator lives with its consumer, not in the shared module.
+ */
+export * from '@shared/voice/voice-session-protocol'
+
+/** Generate a random, collision-unlikely Botanical session name for the WS path. */
+export function randomSessionName(): string {
+  return `botanical-${Math.random().toString(36).slice(2, 10)}`
+}

--- a/packages/game-botanical/tsconfig.json
+++ b/packages/game-botanical/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["../../shared/*"]
+    },
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "../../shared"]
+}

--- a/packages/game-botanical/vite.config.ts
+++ b/packages/game-botanical/vite.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from 'vite'
+import { configDefaults } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
+
+// Local wrangler-dev target for the voice WebSocket. game-bombsquad needs no
+// proxy (served same-origin behind the platform Worker in prod); the botanical
+// dev server is standalone, so it proxies /ai-ws/* to a locally-running
+// platform-ai `wrangler dev`. Override the port to match your wrangler dev via
+// AI_WS_TARGET (e.g. AI_WS_TARGET=http://127.0.0.1:8799 pnpm dev).
+const AI_WS_TARGET = process.env.AI_WS_TARGET ?? 'http://127.0.0.1:8787'
+
+export default defineConfig({
+  // Served from /botanical/ on Cloudflare Pages (merged into the platform dist).
+  // Vite needs the deploy sub-path so built asset URLs become /botanical/assets/...
+  // BrowserRouter is used, so `base` only affects built asset paths, not route
+  // matching — the /botanical/* routes stay literal.
+  base: '/botanical/',
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+      '@shared': resolve(__dirname, '../../shared'),
+    },
+  },
+  server: {
+    proxy: {
+      '/ai-ws': { target: AI_WS_TARGET, ws: true, changeOrigin: true },
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
+    globals: true,
+    // Playwright e2e specs live in e2e/ and are run by `playwright test`, not
+    // vitest — keep vitest from collecting them (they import @playwright/test).
+    exclude: [...configDefaults.exclude, 'e2e/**'],
+  },
+})

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -186,6 +186,22 @@ interface TurnMessage {
   type: 'turn'
 }
 
+/**
+ * The player typed a question instead of speaking — the text fallback (FP1
+ * option A, probe-branch only). Feeds `text` DIRECTLY to the LLM as the turn's
+ * transcript, skipping STT entirely, then runs the SAME LLM+TTS reply path a
+ * voice `turn` uses (`runReply`) — including the terminal transcript frame (the
+ * typed text echoed) and usage accounting (STT cost is zero: no audio).
+ * Game-agnostic and additive: it needs no prior `speech-start` and does not
+ * touch the live-utterance / ASR path. Serial with voice turns (rejected with
+ * `turn_in_flight` mid-reply); an empty/whitespace `text` is a benign no-op; a
+ * `text-turn` with no live session fail-louds exactly like `turn`.
+ */
+interface TextTurnMessage {
+  type: 'text-turn'
+  text: string
+}
+
 interface EndSessionMessage {
   type: 'end'
 }
@@ -222,6 +238,7 @@ type ControlMessage =
   | CreateSessionMessage
   | SpeechStartMessage
   | TurnMessage
+  | TextTurnMessage
   | EndSessionMessage
   | UpdateGameStateMessage
   | ClosingSessionMessage
@@ -1382,6 +1399,38 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
         // (see its docstring), so a mid-reply `end`/owner close cancels cleanly and
         // a stale `finally` cannot clobber a newer session's guard.
         const turn = runReply(this.providers, this.sessionState, result)[Symbol.asyncIterator]()
+        await this.streamTurn(ws, turn)
+        return
+      }
+      case 'text-turn': {
+        // The text fallback (FP1 A): typed input bypasses STT. Same gates as a
+        // voice `turn` (owner + live session), the same serial in-flight guard,
+        // and the same reply path — only the transcript source differs (the
+        // typed text, not ASR). Additive: it neither requires nor disturbs the
+        // live-utterance / ASR path, so it works with no prior `speech-start`.
+        const sessionId = this.sessionId
+        if (!this.sessionState || !socketUserId || sessionId === undefined || !this.providers) {
+          ws.close(1008, safeCloseReason('text-turn before create'))
+          return
+        }
+        this.assertOwner(sessionId, socketUserId)
+        if (this.turnInFlight) {
+          this.sendError(ws, 'turn_in_flight', 'a turn is already in progress')
+          return
+        }
+        const text = typeof msg.text === 'string' ? msg.text.trim() : ''
+        if (text.length === 0) {
+          // Empty/whitespace typed input: benign no-op (the typed analog of a
+          // no-speech turn) — no reply, no state, no turn counted.
+          return
+        }
+        traceTurn('turn', 'text-start', { sessionId })
+        // Feed the typed text as the turn's transcript directly (audioBytes: 0,
+        // so STT usage is zero), reusing the voice reply path wholesale.
+        const turn = runReply(this.providers, this.sessionState, {
+          transcript: text,
+          audioBytes: 0,
+        })[Symbol.asyncIterator]()
         await this.streamTurn(ws, turn)
         return
       }

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -234,6 +234,15 @@ interface ClosingSessionMessage {
   outcome?: RecapOutcome
 }
 
+/**
+ * Server-side cap on a `text-turn`'s typed text. A botanist question is a short
+ * prompt; a client caps it too, but the DO must not trust the client — an
+ * over-long payload is TRUNCATED (not rejected) so a benign over-run still gets
+ * answered, and a hostile one cannot bloat the LLM context. Generous vs the
+ * client bound so normal input is never clipped.
+ */
+const MAX_TEXT_TURN_CHARS = 2000
+
 type ControlMessage =
   | CreateSessionMessage
   | SpeechStartMessage
@@ -1418,7 +1427,9 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
           this.sendError(ws, 'turn_in_flight', 'a turn is already in progress')
           return
         }
-        const text = typeof msg.text === 'string' ? msg.text.trim() : ''
+        // Truncate defensively: never trust the client's length cap.
+        const text =
+          typeof msg.text === 'string' ? msg.text.trim().slice(0, MAX_TEXT_TURN_CHARS) : ''
         if (text.length === 0) {
           // Empty/whitespace typed input: benign no-op (the typed analog of a
           // no-speech turn) — no reply, no state, no turn counted.

--- a/packages/platform-ai/src/session-text-turn.test.ts
+++ b/packages/platform-ai/src/session-text-turn.test.ts
@@ -84,6 +84,21 @@ describe('real VoiceSessionDO — text-turn (FP1 text fallback)', () => {
     expect(sawDoneChunk(socket)).toBe(true)
   })
 
+  it('truncates over-long typed text to the server cap (2000 chars)', async () => {
+    providerControl.override = makeInspectingProviders().providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    socket.send(textTurn('兰'.repeat(5000))) // way over the cap
+    await waitFor(() => sawDoneChunk(socket), 'reply done')
+
+    // The echoed transcript is the TRUNCATED text (exactly the 2000-char cap),
+    // proving the DO did not trust the client and did not feed the LLM 5000 chars.
+    const finalTranscript = messagesOfType(socket, 'transcript').find((t) => t.final === true)
+    expect((finalTranscript?.text as string).length).toBe(2000)
+  })
+
   it('empty / whitespace text is a benign no-op (no reply, no turn counted)', async () => {
     providerControl.override = makeInspectingProviders().providers
     const session = makeSessionDo()

--- a/packages/platform-ai/src/session-text-turn.test.ts
+++ b/packages/platform-ai/src/session-text-turn.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Tests for the additive `text-turn` message (FP1 text fallback, probe branch),
+ * driving the REAL `VoiceSessionDO` under workerd (`@cloudflare/vitest-pool-workers`).
+ * A `text-turn` feeds typed text directly to the LLM (skipping STT) and reuses the
+ * voice reply path (`runReply`) — so it must: echo the typed text as the terminal
+ * transcript, stream a reply, count exactly one turn, and cost zero STT; no-op on
+ * empty text; work with no prior `speech-start`; fail loud with no live session;
+ * and reject mid-flight (serial). Existing message flows are untouched.
+ */
+
+const providerControl = vi.hoisted(() => ({
+  override: undefined as import('./turn-pipeline').TurnProviders | undefined,
+}))
+
+vi.mock('./providers/factory', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./providers/factory')>()
+  return {
+    ...actual,
+    createProviders: (...args: Parameters<typeof actual.createProviders>) =>
+      providerControl.override ?? actual.createProviders(...args),
+  }
+})
+
+import {
+  createSessionOverWs,
+  driveUtteranceToLlm,
+  makeGatedProviders,
+  makeInspectingProviders,
+  makeSessionDo,
+  messagesOfType,
+  openSocket,
+  sawDoneChunk,
+  settle,
+  waitFor,
+  waitForMessage,
+} from './session-do-test-kit'
+
+beforeEach(() => {
+  providerControl.override = undefined
+})
+
+const textTurn = (text: string) => JSON.stringify({ type: 'text-turn', text })
+const END = JSON.stringify({ type: 'end' })
+
+describe('real VoiceSessionDO — text-turn (FP1 text fallback)', () => {
+  it('feeds typed text directly to the LLM (skips STT), echoes it, and replies', async () => {
+    providerControl.override = makeInspectingProviders().providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    socket.send(textTurn('兰花怎么养护'))
+    await waitFor(() => sawDoneChunk(socket), 'reply done')
+
+    // The typed text is echoed as the terminal transcript (final: true).
+    const transcripts = messagesOfType(socket, 'transcript')
+    expect(transcripts.some((t) => t.text === '兰花怎么养护' && t.final === true)).toBe(true)
+    // A real AI reply streamed.
+    const textChunks = messagesOfType(socket, 'chunk').filter((c) => c.kind === 'text')
+    expect(textChunks.length).toBeGreaterThan(0)
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    const summary = messagesOfType(socket, 'summary')[0].summary as {
+      turnCount: number
+      usage: { sttInputSeconds: number }
+    }
+    // Exactly one turn, and STT cost is zero (STT was skipped entirely).
+    expect(summary.turnCount).toBe(1)
+    expect(summary.usage.sttInputSeconds).toBe(0)
+  })
+
+  it('needs no prior speech-start (typed input bypasses the utterance path)', async () => {
+    providerControl.override = makeInspectingProviders().providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    // No speech-start; a text-turn still produces a reply.
+    socket.send(textTurn('遮光一次可以吗'))
+    await waitFor(() => sawDoneChunk(socket), 'reply done without speech-start')
+    expect(sawDoneChunk(socket)).toBe(true)
+  })
+
+  it('empty / whitespace text is a benign no-op (no reply, no turn counted)', async () => {
+    providerControl.override = makeInspectingProviders().providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    socket.send(textTurn('   '))
+    await settle()
+    expect(sawDoneChunk(socket)).toBe(false)
+    expect(messagesOfType(socket, 'chunk')).toEqual([])
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    const summary = messagesOfType(socket, 'summary')[0].summary as { turnCount: number }
+    expect(summary.turnCount).toBe(0)
+  })
+
+  it('text-turn before create fail-louds with 1008 (no live session)', async () => {
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    // No create.
+    socket.send(textTurn('在吗'))
+    await waitFor(() => socket.closeEvents.some((c) => c.code === 1008), '1008 close')
+    expect(socket.closeEvents.some((c) => c.code === 1008)).toBe(true)
+  })
+
+  it('text-turn after end is impossible: session torn down, socket closed', async () => {
+    providerControl.override = makeInspectingProviders().providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+    await waitFor(() => socket.closeEvents.some((c) => c.code === 1000), 'clean close')
+
+    // The socket is closed on end, so a text-turn cannot be delivered — the
+    // transport rejects the send. No reply can be produced post-end.
+    expect(() => socket.send(textTurn('还在吗'))).toThrow()
+    await settle()
+    expect(messagesOfType(socket, 'summary')).toHaveLength(1)
+  })
+
+  it('a text-turn while a turn is in flight is rejected (serial turns)', async () => {
+    const kit = makeGatedProviders()
+    providerControl.override = kit.providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket)
+
+    // A voice turn parks at the gated LLM.
+    await driveUtteranceToLlm(socket, kit, 1)
+    // A text-turn arrives mid-reply.
+    socket.send(textTurn('插一句'))
+    await waitForMessage(socket, 'error')
+    expect(messagesOfType(socket, 'error')).toContainEqual({
+      type: 'error',
+      code: 'turn_in_flight',
+      message: 'a turn is already in progress',
+    })
+
+    // The first turn still completes normally.
+    await session.run(() => kit.llmTurns[0].finishStream())
+    await waitFor(() => sawDoneChunk(socket), 'first turn done')
+    expect(sawDoneChunk(socket)).toBe(true)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      wrangler:
+        specifier: ^4.103.0
+        version: 4.105.0(@cloudflare/workers-types@4.20260621.1)
 
   packages/game-shadow-chase:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,67 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/game-botanical:
+    dependencies:
+      '@amiclaw/creation':
+        specifier: workspace:*
+        version: link:../creation
+      '@amiclaw/ui':
+        specifier: workspace:*
+        version: link:../ui
+      js-yaml:
+        specifier: ^4.2.0
+        version: 4.2.0
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-router-dom:
+        specifier: ^7.18.0
+        version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    devDependencies:
+      '@amiclaw/platform-ai':
+        specifier: workspace:*
+        version: link:../platform-ai
+      '@playwright/test':
+        specifier: ^1.61.0
+        version: 1.61.0
+      '@testing-library/jest-dom':
+        specifier: ^6.4.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.5.0
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^26.0.1
+        version: 26.0.1
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/game-shadow-chase:
     dependencies:
       '@amiclaw/ui':


### PR DESCRIPTION
## Summary

- Makes the Botanical Garden case game genuinely playable: new `packages/game-botanical` player app (night-garden scene, verb-card care, real-time decay + lose, results + Play Again), in-app AI botanist over the platform-ai contract (voice primary via demo-mock, typed text fallback), two machine-validated levels
- Game-agnostic creation-engine extensions: public API barrel, `timed_emitters`/`advanceTime` decay, `lose_condition`/`dead` terminal state — all with validator checks; radio-cipher / sound-garden fixtures byte-untouched
- Probe-only additive platform-ai `text-turn` message (user-approved carve-out; verified against local wrangler dev only)

**⚠️ Probe branch — do NOT merge yet.** Production arcade integration was explicitly deferred by the task's locked scope; the merge decision is taken at the task's completion gate. PR exists for CI, codex review, and diff visibility.

## Test plan

- [x] creation 216 / game-botanical 78 / platform-ai 383 unit+RTL+workerd tests green post-rebase
- [x] Package-local Playwright e2e: controlled-clock WIN and LOSE runs (3× no flakes); DEV-only clock seam dead-code-eliminated from prod bundle
- [x] Live demo-mock voice round-trip + text-turn round-trip against local wrangler dev (node driver + in-browser)
- [x] Both levels validate overall pass + publish_ready (solver 17-65ms)
- [ ] User play-green (task completion gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WntfCVAhNbSYvVXtm4Fxz8