### PR TITLE
fix(shadow-chase): make pursuer rules observable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**The Shadow Chase pursuer now obeys only visible world rules** — Fix. The
+pursuer no longer reads the private follow, split, or decoy command, any model
+lease, or a hidden shadow's live position. It sees the full unobstructed row and
+column, chases the nearest visible uncaptured shadow, keeps its current actor on
+an equal-distance tie, and returns toward the moon gate when nobody is visible.
+Difficulty changes only movement cadence and rescue time. Decoy now works by
+moving the companion into a nearer visible lane, so the same rule explains why
+the pursuer changes course.
+
+Setup and tactical planning show the exact pursuer rule that is injected into
+the AI companion manual. The board also renders low-contrast cardinal sight
+lanes and one truthful current-destination marker without taking pointer input.
+This makes pursuit, wall cover, decoy timing, capture by same-cell contact or
+opposite-edge crossing, and moon-gate return planable from shared information.
+
 **Dual Shadow Chase now starts with a real tactical conversation** — Improvement.
 The new two-to-five-minute solo game now uses Chinese-first player copy and shows
 the complete frozen map before the chase. Tactical planning defaults to 20 seconds,

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ solo real-time grid chase for one human and the existing AI companion.
 - Inspect the complete frozen map during a 20-second tactical-planning phase;
   adjust it from 5 to 60 seconds in five-second steps or start early
 - Collect three cores and reach the exit while a pursuer searches the map
+- Plan against one public pursuer rule: unobstructed row/column sight, nearest
+  visible uncaptured shadow, stable equal-distance ties, and moon-gate return
+  when neither shadow is visible
 - Command the companion to follow, split, or decoy; swap positions when ready
 - Rescue a captured shadow before its deadline
 - Queue rapid movement inputs FIFO, tap a persistent destination path, and see
@@ -45,6 +48,10 @@ Voice reuses the platform's existing companion identity, voice, provider adapter
 and memory boundary. It is opt-in and bounded; neither voice nor model work can
 pause planning or frame-level play. The deterministic engine owns movement and
 outcomes, and the Chinese strategy buttons remain authoritative fallback controls.
+The pursuer cannot read those strategy buttons or model output. Decoy changes
+only companion movement and succeeds when that movement makes the companion the
+nearer visible shadow. Difficulty changes pursuer cadence and rescue time, not
+visibility or target selection.
 
 On the Arcade homepage, BombSquad remains the sole featured game. Dual Shadow
 Chase and the Yijing Oracle appear together in the playable peer grid. Arcade

--- a/e2e/shadow-chase.gherkin
+++ b/e2e/shadow-chase.gherkin
@@ -34,4 +34,5 @@ Feature: Dual Shadow Chase deterministic solo play
     When I click "查看地图并制定策略"
     And I click "立即出发"
     Then Shadow Chase phone controls are at least 44 pixels and do not cover the board
+    And Shadow Chase shows nonblocking pursuer sight and target
     And Shadow Chase accepts a path target through an overlay

--- a/e2e/steps/shadow-chase.steps.ts
+++ b/e2e/steps/shadow-chase.steps.ts
@@ -17,6 +17,13 @@ Then('the Shadow Chase opening rule is complete', async ({ page }) => {
   expect(copy).toContain('02:00 开启')
   expect(copy).toContain('完成救援')
   expect(copy).toContain('一起撤离')
+  expect(copy).toContain(
+    '追兵能看见整条没有墙遮挡的横竖直线：它追最近且未被捕获的可见影子，距离相同时不换目标；谁都看不见就返回月门。同格或迎面交叉会被捕获。诱敌只改变伙伴走位，难度只改变追兵速度和救援时间。'
+  )
+  const pursuerRule = await page.getByRole('region', { name: '追兵规则' }).locator('p').innerText()
+  await page.locator('html').evaluate((element, rule) => {
+    ;(element as HTMLElement).dataset.shadowPursuerRule = rule
+  }, pursuerRule)
 })
 
 Then('the Shadow Chase planning map is visible and frozen', async ({ page }) => {
@@ -27,6 +34,12 @@ Then('the Shadow Chase planning map is visible and frozen', async ({ page }) => 
     'aria-disabled',
     'true'
   )
+  const setupRule = await page.locator('html').getAttribute('data-shadow-pursuer-rule')
+  const planningRule = await page.getByRole('region', { name: '追兵规则' }).locator('p').innerText()
+  expect(planningRule).toBe(setupRule)
+  const board = page.getByRole('application', { name: '双影追逃地图' })
+  await expect(board).toHaveAccessibleDescription('追兵当前目标：月门')
+  expect(await page.locator('.sight-lane').count()).toBe(4)
 })
 
 Then('the Shadow Chase board and essential controls are visible', async ({ page }) => {
@@ -87,4 +100,19 @@ Then('Shadow Chase accepts a path target through an overlay', async ({ page, wor
   await page.mouse.click(core!.x + core!.width / 2, core!.y + core!.height / 2)
   await world.advance(300)
   await expect(page.locator('.path-target')).toBeVisible()
+})
+
+Then('Shadow Chase shows nonblocking pursuer sight and target', async ({ page }) => {
+  const lanes = page.locator('.sight-lane')
+  expect(await lanes.count()).toBe(4)
+  const indicator = page.locator('.pursuer-destination-indicator')
+  await expect(indicator).toHaveCount(1)
+  await expect(indicator).toBeVisible()
+  await expect(page.getByRole('application', { name: '双影追逃地图' })).toHaveAccessibleDescription(
+    /追兵当前目标：(你|AI 伙伴|月门)/
+  )
+  for (const overlay of [lanes.first(), indicator]) {
+    await expect(overlay).toHaveCSS('pointer-events', 'none')
+    await expect(overlay).toHaveAttribute('aria-hidden', 'true')
+  }
 })

--- a/packages/game-bombsquad/src/engine/manual-engine-equivalence.test.ts
+++ b/packages/game-bombsquad/src/engine/manual-engine-equivalence.test.ts
@@ -411,7 +411,7 @@ describe('manual↔engine: wire — engine accepts exactly what the manual, read
       }
     }
     expect(checks).toBeGreaterThan(0)
-  }, 60000)
+  }, 90000)
 })
 
 const BUTTON_COLORS = ['red', 'blue', 'yellow', 'white']

--- a/packages/game-shadow-chase/src/App.test.tsx
+++ b/packages/game-shadow-chase/src/App.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import { App } from './App'
+import { PURSUER_RULE_COPY } from './engine/pursuer-rules'
 import type { ShadowVoiceSource } from './voice/useShadowChaseVoice'
 
 const BUTTON_ONLY_VOICE: ShadowVoiceSource = {
@@ -15,9 +16,13 @@ describe('playable shell semantics', () => {
     render(<App voiceSource={BUTTON_ONLY_VOICE} />)
     expect(screen.getByRole('heading', { name: '双影追逃' })).toBeTruthy()
     expect(screen.getByText(/收集三枚光核/)).toBeTruthy()
+    expect(screen.getByText(PURSUER_RULE_COPY)).toBeTruthy()
+    expect(screen.getByRole('region', { name: '追兵规则' })).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: '查看地图并制定策略' }))
     expect(screen.getByRole('application', { name: '双影追逃地图' })).toBeTruthy()
     expect(screen.getByText('战术准备')).toBeTruthy()
+    expect(screen.getByText(PURSUER_RULE_COPY)).toBeTruthy()
+    expect(screen.getByRole('region', { name: '追兵规则' })).toBeTruthy()
     expect(screen.getAllByText('20')).toHaveLength(2)
     expect(screen.getByRole('button', { name: '立即出发' })).toBeTruthy()
   })

--- a/packages/game-shadow-chase/src/components/GameBoard.test.tsx
+++ b/packages/game-shadow-chase/src/components/GameBoard.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
+import { advance } from '../engine/reducer'
 import { createRunningState } from '../engine/rules'
 import { GameBoard } from './GameBoard'
 
@@ -32,5 +33,66 @@ describe('whole-board target ownership', () => {
     fireEvent.pointerDown(board, { pointerId: 1, clientX: 24, clientY: 24 })
     fireEvent.pointerUp(board, { pointerId: 1, clientX: 24, clientY: 24 })
     expect(onTarget).not.toHaveBeenCalled()
+  })
+
+  it('renders non-intercepting sight lanes and a visible current target indicator', () => {
+    const state = createRunningState('courtyard', 'standard', 7)
+    state.tick = 1
+    state.actors.pursuer.position = { x: 0, y: 0 }
+    state.actors.pursuer.target = 'player'
+    state.actors.pursuer.destination = 'companion'
+    const onTarget = vi.fn()
+    const view = render(<GameBoard state={state} onTarget={onTarget} />)
+
+    const lanes = document.querySelectorAll('.sight-lane.board-overlay')
+    expect(lanes).toHaveLength(4)
+    expect(document.querySelector('[data-direction="up"]')?.getAttribute('y2')).toBe('24')
+    expect(document.querySelector('[data-direction="right"]')?.getAttribute('x2')).toBe('312')
+    const target = document.querySelector('.pursuer-destination-indicator')!
+    expect(document.querySelectorAll('.pursuer-destination-indicator')).toHaveLength(1)
+    expect(target.classList.contains('board-overlay')).toBe(true)
+    expect(target.getAttribute('aria-hidden')).toBe('true')
+    const board = screen.getByRole('application', { name: '双影追逃地图' })
+    const description = document.getElementById(board.getAttribute('aria-describedby')!)
+    expect(description?.textContent).toBe('追兵当前目标：AI 伙伴')
+    Object.defineProperty(board, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 336, height: 336 }),
+    })
+    fireEvent.pointerDown(target, { pointerId: 2, clientX: 120, clientY: 72 })
+    fireEvent.pointerUp(target, { pointerId: 2, clientX: 120, clientY: 72 })
+    expect(onTarget).toHaveBeenCalledWith({ x: 2, y: 1 })
+
+    state.actors.pursuer.destination = 'moon-gate'
+    view.rerender(<GameBoard state={state} onTarget={onTarget} />)
+    expect(document.querySelectorAll('.pursuer-destination-indicator')).toHaveLength(1)
+    expect(description?.textContent).toBe('追兵当前目标：月门')
+  })
+
+  it('derives a truthful planning destination before the first policy tick', () => {
+    const state = createRunningState('crossroads', 'standard', 7)
+    state.actors.pursuer.position = { x: 4, y: 0 }
+    state.actors.player.position = { x: 2, y: 0 }
+    state.actors.companion.position = { x: 1, y: 2 }
+    state.actors.pursuer.destination = 'moon-gate'
+
+    render(<GameBoard state={state} interactive={false} onTarget={vi.fn()} />)
+
+    const board = screen.getByRole('application', { name: '双影追逃地图' })
+    const description = document.getElementById(board.getAttribute('aria-describedby')!)
+    expect(description?.textContent).toBe('追兵当前目标：你')
+  })
+
+  it('describes the reconciled destination immediately after capture', () => {
+    const state = createRunningState('courtyard', 'intense', 7)
+    state.actors.pursuer.position = { x: 2, y: 1 }
+    state.actors.player.position = { x: 1, y: 1 }
+    state.actors.companion.position = { x: 6, y: 6 }
+    const contacted = advance(state, [])
+
+    render(<GameBoard state={contacted} onTarget={vi.fn()} />)
+
+    const board = screen.getByRole('application', { name: '双影追逃地图' })
+    const description = document.getElementById(board.getAttribute('aria-describedby')!)
+    expect(description?.textContent).toBe('追兵当前目标：月门')
   })
 })

--- a/packages/game-shadow-chase/src/components/GameBoard.tsx
+++ b/packages/game-shadow-chase/src/components/GameBoard.tsx
@@ -1,6 +1,12 @@
 import { useRef } from 'react'
 
 import { getMap } from '../engine/maps'
+import { sightLanes } from '../engine/line-of-sight'
+import {
+  buildPursuerObservation,
+  selectPursuerDecision,
+  type PursuerDestination,
+} from '../engine/pursuer-policy'
 import type { Coordinate, SimulationState } from '../engine/types'
 
 const CELL = 48
@@ -48,6 +54,24 @@ export function GameBoard({
   onTarget(target: Coordinate): void
 }) {
   const map = getMap(state.mapId)
+  const pursuer = state.actors.pursuer
+  const lanes = sightLanes(map, pursuer.position)
+  const displayedDestination: PursuerDestination =
+    !interactive || state.tick === 0
+      ? selectPursuerDecision(buildPursuerObservation(state)).destination
+      : pursuer.destination
+  const destinationPosition =
+    displayedDestination === 'moon-gate'
+      ? state.exit.position
+      : state.actors[displayedDestination].position
+  const destinationName =
+    displayedDestination === 'moon-gate'
+      ? '月门'
+      : displayedDestination === 'player'
+        ? '你'
+        : 'AI 伙伴'
+  const destinationDescriptionId = `pursuer-destination-${state.runId}`
+  const arrowheadId = `pursuer-arrowhead-${state.runId}`
   const gesture = useRef<{ pointerId: number; start: Coordinate } | null>(null)
   const cells = Array.from({ length: map.width * map.height }, (_, index) => ({
     x: index % map.width,
@@ -63,6 +87,7 @@ export function GameBoard({
       className={interactive ? 'game-board interactive' : 'game-board planning-board'}
       role="application"
       aria-label="双影追逃地图"
+      aria-describedby={destinationDescriptionId}
       aria-disabled={!interactive}
       viewBox={`0 0 ${map.width * CELL} ${map.height * CELL}`}
       onPointerDown={(event) => {
@@ -101,6 +126,22 @@ export function GameBoard({
       onLostPointerCapture={clearGesture}
     >
       <title>{map.name}</title>
+      <desc id={destinationDescriptionId}>追兵当前目标：{destinationName}</desc>
+      <defs>
+        <marker
+          className="pursuer-arrowhead"
+          id={arrowheadId}
+          markerWidth="6"
+          markerHeight="6"
+          refX="5"
+          refY="3"
+          orient="auto"
+          markerUnits="userSpaceOnUse"
+          aria-hidden="true"
+        >
+          <path d="M0 0 6 3 0 6Z" />
+        </marker>
+      </defs>
       {cells.map((cell) => {
         const wall = map.walls.some((candidate) => sameCoordinate(candidate, cell))
         return (
@@ -116,6 +157,32 @@ export function GameBoard({
           />
         )
       })}
+      {lanes.map((lane) => (
+        <line
+          key={lane.id}
+          className="sight-lane board-overlay"
+          data-direction={lane.id}
+          x1={pursuer.position.x * CELL + CELL / 2}
+          y1={pursuer.position.y * CELL + CELL / 2}
+          x2={lane.end.x * CELL + CELL / 2}
+          y2={lane.end.y * CELL + CELL / 2}
+          aria-hidden="true"
+        />
+      ))}
+      <g className="pursuer-destination-indicator board-overlay" aria-hidden="true">
+        <line
+          x1={pursuer.position.x * CELL + CELL / 2}
+          y1={pursuer.position.y * CELL + CELL / 2}
+          x2={destinationPosition.x * CELL + CELL / 2}
+          y2={destinationPosition.y * CELL + CELL / 2}
+          markerEnd={`url(#${arrowheadId})`}
+        />
+        <circle
+          cx={destinationPosition.x * CELL + CELL / 2}
+          cy={destinationPosition.y * CELL + CELL / 2}
+          r="20"
+        />
+      </g>
       {state.playerNavigation && (
         <rect
           className="path-target board-overlay"

--- a/packages/game-shadow-chase/src/components/PlanningScreen.tsx
+++ b/packages/game-shadow-chase/src/components/PlanningScreen.tsx
@@ -1,5 +1,6 @@
 import type { PlanningSnapshot } from '../planning/planning-controller'
 import { PlanningDurationControl } from './PlanningDurationControl'
+import { PursuerRule } from './PursuerRule'
 
 export function PlanningScreen({
   planning,
@@ -16,6 +17,7 @@ export function PlanningScreen({
         <p className="eyebrow">战术准备</p>
         <h1>先看地图，再决定伙伴策略</h1>
         <p>追逃尚未开始。地图与角色保持冻结，语音连接失败也不会延长倒计时。</p>
+        <PursuerRule />
       </div>
       <div className="planning-countdown" aria-label="战术准备倒计时">
         <span className="planning-countdown-label">剩余</span>

--- a/packages/game-shadow-chase/src/components/PursuerRule.tsx
+++ b/packages/game-shadow-chase/src/components/PursuerRule.tsx
@@ -1,0 +1,10 @@
+import { PURSUER_RULE_COPY } from '../engine/pursuer-rules'
+
+export function PursuerRule() {
+  return (
+    <section className="pursuer-rule" aria-label="追兵规则">
+      <strong>追兵规则</strong>
+      <p>{PURSUER_RULE_COPY}</p>
+    </section>
+  )
+}

--- a/packages/game-shadow-chase/src/components/StartScreen.tsx
+++ b/packages/game-shadow-chase/src/components/StartScreen.tsx
@@ -1,5 +1,6 @@
 import type { Difficulty } from '../engine/types'
 import { PlanningDurationControl } from './PlanningDurationControl'
+import { PursuerRule } from './PursuerRule'
 
 interface StartScreenProps {
   difficulty: Difficulty
@@ -21,6 +22,7 @@ export function StartScreen(props: StartScreenProps) {
         收集三枚光核，坚持到月门在 02:00
         开启，与伙伴一起撤离。战术准备结束后追兵立即行动；任何一方被捕获，都要在倒计时结束前完成救援。
       </p>
+      <PursuerRule />
       <div className="start-options" aria-label="本局设置">
         <label>
           难度

--- a/packages/game-shadow-chase/src/engine/companion-policy.test.ts
+++ b/packages/game-shadow-chase/src/engine/companion-policy.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { companionNextStep } from './companion-policy'
+import { hasLineOfSight, visibleSightCells } from './line-of-sight'
+import { getMap } from './maps'
+import { pathDistance } from './pathfinding'
+import { createRunningState } from './rules'
+import { buildPursuerObservation, selectPursuerDecision } from './pursuer-policy'
+
+describe('deterministic companion decoy policy', () => {
+  it('moves toward a sight-lane cell that would become nearer than the player', () => {
+    const state = createRunningState('courtyard', 'standard', 23)
+    state.actors.pursuer.position = { x: 6, y: 6 }
+    state.actors.player.position = { x: 6, y: 0 }
+    state.actors.companion.position = { x: 0, y: 0 }
+    state.actors.pursuer.target = 'player'
+    state.command = { intent: 'decoy' }
+    const map = getMap(state.mapId)
+    const playerDistance = pathDistance(
+      map,
+      state.actors.pursuer.position,
+      state.actors.player.position
+    )
+    const nearerSightCells = visibleSightCells(map, state.actors.pursuer.position).filter(
+      (candidate) =>
+        pathDistance(map, state.actors.pursuer.position, candidate) < playerDistance &&
+        (candidate.x !== state.actors.player.position.x ||
+          candidate.y !== state.actors.player.position.y)
+    )
+    const distanceToLane = (position: { x: number; y: number }) =>
+      Math.min(...nearerSightCells.map((candidate) => pathDistance(map, position, candidate)))
+
+    const next = companionNextStep(state)
+
+    expect(distanceToLane(next)).toBeLessThan(distanceToLane(state.actors.companion.position))
+    expect(state.actors.pursuer.target).toBe('player')
+  })
+
+  it('switches pursuit only after decoy movement creates visible nearer geometry', () => {
+    const state = createRunningState('courtyard', 'standard', 23)
+    state.actors.pursuer.position = { x: 6, y: 6 }
+    state.actors.player.position = { x: 6, y: 0 }
+    state.actors.companion.position = { x: 0, y: 0 }
+    state.command = { intent: 'decoy' }
+    const map = getMap(state.mapId)
+    let switched = false
+    let switchTick = -1
+
+    for (let step = 0; step < 20; step += 1) {
+      const decision = selectPursuerDecision(buildPursuerObservation(state))
+      const visible = hasLineOfSight(
+        map,
+        state.actors.pursuer.position,
+        state.actors.companion.position
+      )
+      const strictlyNearer =
+        pathDistance(map, state.actors.pursuer.position, state.actors.companion.position) <
+        pathDistance(map, state.actors.pursuer.position, state.actors.player.position)
+      if (decision.destination === 'companion') {
+        expect(visible).toBe(true)
+        expect(strictlyNearer).toBe(true)
+        switched = true
+        switchTick = step
+        break
+      }
+      expect(visible && strictlyNearer).toBe(false)
+      expect(decision.destination).toBe('player')
+      state.actors.companion.position = companionNextStep(state)
+    }
+
+    expect(switched).toBe(true)
+    expect(switchTick).toBeGreaterThan(0)
+  })
+})

--- a/packages/game-shadow-chase/src/engine/companion-policy.ts
+++ b/packages/game-shadow-chase/src/engine/companion-policy.ts
@@ -1,6 +1,6 @@
 import { getMap } from './maps'
+import { visibleSightCells } from './line-of-sight'
 import { neighbors, nextStepOnShortestPath, pathDistance } from './pathfinding'
-import { coordinatesEqual } from './rules'
 import type { Coordinate, SimulationState } from './types'
 
 function nearestObjective(state: SimulationState): Coordinate | null {
@@ -26,6 +26,39 @@ function evade(state: SimulationState): Coordinate | null {
     return distanceDelta || left.y - right.y || left.x - right.x
   })
   return options[0] ?? null
+}
+
+function decoyStep(state: SimulationState): Coordinate {
+  const map = getMap(state.mapId)
+  const companion = state.actors.companion.position
+  const pursuer = state.actors.pursuer.position
+  const player = state.actors.player.position
+  const playerDistance = pathDistance(map, pursuer, player)
+  const candidates = visibleSightCells(map, pursuer)
+    .filter(
+      (candidate) =>
+        (candidate.x !== player.x || candidate.y !== player.y) &&
+        (candidate.x !== pursuer.x || candidate.y !== pursuer.y)
+    )
+    .map((candidate) => ({
+      candidate,
+      companionDistance: pathDistance(map, companion, candidate),
+      pursuerDistance: pathDistance(map, pursuer, candidate),
+    }))
+    .filter((candidate) => Number.isFinite(candidate.companionDistance))
+  candidates.sort((left, right) => {
+    const leftNearer = left.pursuerDistance < playerDistance ? 0 : 1
+    const rightNearer = right.pursuerDistance < playerDistance ? 0 : 1
+    return (
+      leftNearer - rightNearer ||
+      left.companionDistance - right.companionDistance ||
+      left.pursuerDistance - right.pursuerDistance ||
+      left.candidate.y - right.candidate.y ||
+      left.candidate.x - right.candidate.x
+    )
+  })
+  const target = candidates[0]?.candidate
+  return target ? (nextStepOnShortestPath(map, companion, target) ?? companion) : companion
 }
 
 export function companionNextStep(state: SimulationState): Coordinate {
@@ -55,19 +88,7 @@ export function companionNextStep(state: SimulationState): Coordinate {
       : actor.position
   }
   if (intent.intent === 'decoy') {
-    const options = neighbors(map, actor.position).filter(
-      (candidate) => !coordinatesEqual(candidate, state.actors.player.position)
-    )
-    options.sort((left, right) => {
-      const fromPlayer =
-        pathDistance(map, right, state.actors.player.position) -
-        pathDistance(map, left, state.actors.player.position)
-      const toPursuer =
-        pathDistance(map, left, state.actors.pursuer.position) -
-        pathDistance(map, right, state.actors.pursuer.position)
-      return fromPlayer || toPursuer || left.y - right.y || left.x - right.x
-    })
-    return options[0] ?? actor.position
+    return decoyStep(state)
   }
   const uncollected = nearestObjective(state)
   if (

--- a/packages/game-shadow-chase/src/engine/config.ts
+++ b/packages/game-shadow-chase/src/engine/config.ts
@@ -24,7 +24,7 @@ export function isSafeTick(value: unknown, max = RUN_CAP_TICKS): value is number
 }
 
 export const DIFFICULTY_CONFIG = Object.freeze({
-  relaxed: Object.freeze({ pursuerCadence: 3, rescueTicks: 32, visionRange: 6 }),
-  standard: Object.freeze({ pursuerCadence: 2, rescueTicks: 24, visionRange: 8 }),
-  intense: Object.freeze({ pursuerCadence: 1, rescueTicks: 20, visionRange: 10 }),
+  relaxed: Object.freeze({ pursuerCadence: 3, rescueTicks: 32 }),
+  standard: Object.freeze({ pursuerCadence: 2, rescueTicks: 24 }),
+  intense: Object.freeze({ pursuerCadence: 1, rescueTicks: 20 }),
 })

--- a/packages/game-shadow-chase/src/engine/contracts.test.ts
+++ b/packages/game-shadow-chase/src/engine/contracts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  DIFFICULTY_CONFIG,
   OBJECTIVE_COUNT,
   MIN_RUN_TICKS,
   RUN_CAP_TICKS,
@@ -10,7 +11,7 @@ import {
 } from './config'
 import { AUTHORED_MAPS, validateMap } from './maps'
 import { nextStepOnShortestPath } from './pathfinding'
-import { hasLineOfSight } from './line-of-sight'
+import { hasLineOfSight, sightLanes } from './line-of-sight'
 
 describe('frozen engine contracts', () => {
   it('freezes the five-minute fixed-step contract', () => {
@@ -51,10 +52,29 @@ describe('frozen engine contracts', () => {
     expect(validateMap(unsafeSpawn)).toEqual({ ok: false, reason: 'pursuer-spawn-distance' })
   })
 
-  it('blocks sight through walls and beyond the difficulty range', () => {
+  it('uses unlimited unobstructed cardinal sight and no difficulty vision range', () => {
     const map = AUTHORED_MAPS[0]
-    expect(hasLineOfSight(map, { x: 3, y: 1 }, { x: 3, y: 5 }, 8)).toBe(false)
-    expect(hasLineOfSight(map, { x: 0, y: 0 }, { x: 6, y: 0 }, 5)).toBe(false)
-    expect(hasLineOfSight(map, { x: 0, y: 0 }, { x: 6, y: 0 }, 6)).toBe(true)
+    expect(hasLineOfSight(map, { x: 3, y: 1 }, { x: 3, y: 5 })).toBe(false)
+    expect(hasLineOfSight({ ...map, width: 15, walls: [] }, { x: 0, y: 0 }, { x: 14, y: 0 })).toBe(
+      true
+    )
+    expect(hasLineOfSight(map, { x: 0, y: 0 }, { x: 6, y: 6 })).toBe(false)
+    expect(
+      hasLineOfSight({ ...map, width: 5, walls: [{ x: 4, y: 0 }] }, { x: 0, y: 0 }, { x: 3, y: 0 })
+    ).toBe(true)
+    for (const config of Object.values(DIFFICULTY_CONFIG)) {
+      expect(Object.keys(config).sort()).toEqual(['pursuerCadence', 'rescueTicks'])
+    }
+  })
+
+  it('returns four deterministic sight lanes clipped by walls and boundaries', () => {
+    const lanes = sightLanes({ width: 4, height: 4, walls: [{ x: 2, y: 0 }] }, { x: 0, y: 0 })
+
+    expect(lanes).toEqual([
+      { id: 'up', end: { x: 0, y: 0 } },
+      { id: 'left', end: { x: 0, y: 0 } },
+      { id: 'right', end: { x: 1, y: 0 } },
+      { id: 'down', end: { x: 0, y: 3 } },
+    ])
   })
 })

--- a/packages/game-shadow-chase/src/engine/line-of-sight.ts
+++ b/packages/game-shadow-chase/src/engine/line-of-sight.ts
@@ -1,17 +1,56 @@
-import type { Coordinate, MapDefinition } from './types'
+import type { WalkableMap } from './rules'
+import type { Coordinate } from './types'
 
-export function hasLineOfSight(
-  map: MapDefinition,
-  from: Coordinate,
-  to: Coordinate,
-  maxRange: number
-): boolean {
-  const distance = Math.abs(from.x - to.x) + Math.abs(from.y - to.y)
-  if (distance > maxRange || (from.x !== to.x && from.y !== to.y)) return false
+const CARDINAL_DIRECTIONS = [
+  { id: 'up', x: 0, y: -1 },
+  { id: 'left', x: -1, y: 0 },
+  { id: 'right', x: 1, y: 0 },
+  { id: 'down', x: 0, y: 1 },
+] as const
+
+function inside(map: WalkableMap, position: Coordinate): boolean {
+  return position.x >= 0 && position.y >= 0 && position.x < map.width && position.y < map.height
+}
+
+function isWall(map: WalkableMap, position: Coordinate): boolean {
+  return map.walls.some((wall) => wall.x === position.x && wall.y === position.y)
+}
+
+export function hasLineOfSight(map: WalkableMap, from: Coordinate, to: Coordinate): boolean {
+  if (from.x !== to.x && from.y !== to.y) return false
   const dx = Math.sign(to.x - from.x)
   const dy = Math.sign(to.y - from.y)
   for (let x = from.x + dx, y = from.y + dy; x !== to.x || y !== to.y; x += dx, y += dy) {
-    if (map.walls.some((wall) => wall.x === x && wall.y === y)) return false
+    if (isWall(map, { x, y })) return false
   }
   return true
+}
+
+export interface SightLane {
+  id: (typeof CARDINAL_DIRECTIONS)[number]['id']
+  end: Coordinate
+}
+
+export function sightLanes(map: WalkableMap, origin: Coordinate): SightLane[] {
+  return CARDINAL_DIRECTIONS.map((direction) => {
+    let cursor = { x: origin.x + direction.x, y: origin.y + direction.y }
+    let end: Coordinate | null = null
+    while (inside(map, cursor) && !isWall(map, cursor)) {
+      end = cursor
+      cursor = { x: cursor.x + direction.x, y: cursor.y + direction.y }
+    }
+    return { id: direction.id, end: end ?? origin }
+  })
+}
+
+export function visibleSightCells(map: WalkableMap, origin: Coordinate): Coordinate[] {
+  return CARDINAL_DIRECTIONS.flatMap((direction) => {
+    const cells: Coordinate[] = []
+    let cursor = { x: origin.x + direction.x, y: origin.y + direction.y }
+    while (inside(map, cursor) && !isWall(map, cursor)) {
+      cells.push(cursor)
+      cursor = { x: cursor.x + direction.x, y: cursor.y + direction.y }
+    }
+    return cells
+  })
 }

--- a/packages/game-shadow-chase/src/engine/pathfinding.ts
+++ b/packages/game-shadow-chase/src/engine/pathfinding.ts
@@ -1,5 +1,5 @@
-import { coordinatesEqual, isWalkable } from './rules'
-import type { Coordinate, MapDefinition } from './types'
+import { coordinatesEqual, isWalkable, type WalkableMap } from './rules'
+import type { Coordinate } from './types'
 
 const OFFSETS: Coordinate[] = [
   { x: 0, y: -1 },
@@ -12,14 +12,14 @@ export function coordinateKey(value: Coordinate): string {
   return `${value.x}:${value.y}`
 }
 
-export function neighbors(map: MapDefinition, position: Coordinate): Coordinate[] {
+export function neighbors(map: WalkableMap, position: Coordinate): Coordinate[] {
   return OFFSETS.map((offset) => ({ x: position.x + offset.x, y: position.y + offset.y })).filter(
     (candidate) => isWalkable(map, candidate)
   )
 }
 
 export function shortestPath(
-  map: MapDefinition,
+  map: WalkableMap,
   start: Coordinate,
   target: Coordinate
 ): Coordinate[] | null {
@@ -49,7 +49,7 @@ export function shortestPath(
 }
 
 export function nextStepOnShortestPath(
-  map: MapDefinition,
+  map: WalkableMap,
   start: Coordinate,
   target: Coordinate
 ): Coordinate | null {
@@ -57,7 +57,7 @@ export function nextStepOnShortestPath(
   return path && path.length > 1 ? path[1] : (path?.[0] ?? null)
 }
 
-export function pathDistance(map: MapDefinition, start: Coordinate, target: Coordinate): number {
+export function pathDistance(map: WalkableMap, start: Coordinate, target: Coordinate): number {
   const path = shortestPath(map, start, target)
   return path ? path.length - 1 : Number.POSITIVE_INFINITY
 }

--- a/packages/game-shadow-chase/src/engine/properties.test.ts
+++ b/packages/game-shadow-chase/src/engine/properties.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { RUN_CAP_TICKS } from './config'
+import { hasLineOfSight } from './line-of-sight'
 import { getMap } from './maps'
 import { advance } from './reducer'
 import { isWalkable } from './rules'
@@ -33,12 +34,25 @@ describe('seeded engine properties', () => {
           },
         ]
         const previousTick = state.tick
+        const previousPursuer = { ...state.actors.pursuer.position }
         state = advance(state, actions)
         expect(state.tick).toBe(previousTick + 1)
         const map = getMap(state.mapId)
         expect(isWalkable(map, state.actors.player.position)).toBe(true)
         expect(isWalkable(map, state.actors.companion.position)).toBe(true)
         expect(isWalkable(map, state.actors.pursuer.position)).toBe(true)
+        expect(
+          Math.abs(previousPursuer.x - state.actors.pursuer.position.x) +
+            Math.abs(previousPursuer.y - state.actors.pursuer.position.y)
+        ).toBeLessThanOrEqual(1)
+        expect(['player', 'companion', 'moon-gate']).toContain(state.actors.pursuer.destination)
+        if (state.actors.pursuer.destination !== 'moon-gate') {
+          const destination = state.actors[state.actors.pursuer.destination]
+          expect(destination.status).toBe('free')
+          expect(hasLineOfSight(map, state.actors.pursuer.position, destination.position)).toBe(
+            true
+          )
+        }
         const nextCollected = state.objectives.filter((objective) => objective.collected).length
         expect(nextCollected).toBeGreaterThanOrEqual(collected)
         collected = nextCollected
@@ -46,5 +60,5 @@ describe('seeded engine properties', () => {
       }
       expect(['win', 'loss', 'timeout']).toContain(state.phase)
     }
-  })
+  }, 30_000)
 })

--- a/packages/game-shadow-chase/src/engine/properties.test.ts
+++ b/packages/game-shadow-chase/src/engine/properties.test.ts
@@ -9,6 +9,7 @@ import { createRunningState } from './rules'
 import type { Direction, QueuedAction } from './types'
 
 const DIRECTIONS: Direction[] = ['up', 'left', 'right', 'down']
+const RANDOM_TRACE_TICKS = 240
 
 function lcg(seed: number): () => number {
   let state = seed >>> 0
@@ -24,7 +25,7 @@ describe('seeded engine properties', () => {
       const random = lcg(seed)
       let state = createRunningState('courtyard', 'relaxed', seed)
       let collected = 0
-      while (state.phase === 'running') {
+      while (state.phase === 'running' && state.tick < RANDOM_TRACE_TICKS) {
         const direction = DIRECTIONS[random() % DIRECTIONS.length]
         const actions: QueuedAction[] = [
           {
@@ -57,6 +58,10 @@ describe('seeded engine properties', () => {
         expect(nextCollected).toBeGreaterThanOrEqual(collected)
         collected = nextCollected
         expect(state.tick).toBeLessThanOrEqual(RUN_CAP_TICKS)
+      }
+      if (state.phase === 'running') {
+        state.tick = RUN_CAP_TICKS - 1
+        state = advance(state, [])
       }
       expect(['win', 'loss', 'timeout']).toContain(state.phase)
     }

--- a/packages/game-shadow-chase/src/engine/pursuer-policy.test.ts
+++ b/packages/game-shadow-chase/src/engine/pursuer-policy.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest'
+
+import { getMap } from './maps'
+import { nextStepOnShortestPath } from './pathfinding'
+import {
+  buildPursuerObservation,
+  nextPursuerStep,
+  pursuerNextStep,
+  selectPursuerDecision,
+  type PursuerObservation,
+} from './pursuer-policy'
+import { createRunningState } from './rules'
+
+describe('pursuer observation policy', () => {
+  it('ignores command and model intent while retaining an equally near visible target', () => {
+    const state = createRunningState('crossroads', 'intense', 17)
+    state.actors.pursuer.position = { x: 4, y: 0 }
+    state.actors.player.position = { x: 2, y: 0 }
+    state.actors.companion.position = { x: 6, y: 0 }
+    state.actors.pursuer.target = 'player'
+    state.command = { intent: 'decoy' }
+    state.activeModelLease = {
+      requestId: '00000000-0000-4000-8000-000000000001',
+      acceptedTick: 0,
+      expiryTick: 10,
+      intent: 'decoy',
+    }
+
+    const baseline = structuredClone(state)
+    baseline.command = { intent: 'follow' }
+    baseline.activeModelLease = undefined
+
+    expect(pursuerNextStep(state, 1)).toEqual({ x: 3, y: 0 })
+    expect(pursuerNextStep(baseline, 1)).toEqual({ x: 3, y: 0 })
+    expect(state.actors.pursuer.target).toBe('player')
+    expect(state.actors.pursuer.destination).toBe('player')
+    expect(baseline.actors.pursuer).toEqual(state.actors.pursuer)
+
+    const companionTargeted = structuredClone(state)
+    companionTargeted.actors.pursuer.target = 'companion'
+    expect(pursuerNextStep(companionTargeted, 1)).toEqual({ x: 5, y: 0 })
+    expect(companionTargeted.actors.pursuer.target).toBe('companion')
+    expect(companionTargeted.actors.pursuer.destination).toBe('companion')
+  })
+
+  it('chooses the nearest visible shadow by path distance', () => {
+    const state = createRunningState('crossroads', 'intense', 17)
+    state.actors.pursuer.position = { x: 4, y: 0 }
+    state.actors.player.position = { x: 0, y: 0 }
+    state.actors.companion.position = { x: 6, y: 0 }
+    state.actors.pursuer.target = 'player'
+
+    expect(pursuerNextStep(state, 1)).toEqual({ x: 5, y: 0 })
+    expect(state.actors.pursuer.target).toBe('companion')
+    expect(state.actors.pursuer.destination).toBe('companion')
+  })
+
+  it('falls back to the player when tie memory is absent or ineligible', () => {
+    const state = createRunningState('crossroads', 'intense', 17)
+    state.actors.pursuer.position = { x: 4, y: 0 }
+    state.actors.player.position = { x: 2, y: 0 }
+    state.actors.companion.position = { x: 6, y: 0 }
+    const observation = buildPursuerObservation(state)
+
+    expect(
+      selectPursuerDecision({
+        ...observation,
+        previousTarget: null,
+      }).destination
+    ).toBe('player')
+
+    expect(
+      selectPursuerDecision({
+        ...observation,
+        shadows: observation.shadows.map((shadow) =>
+          shadow.id === 'companion' ? { ...shadow, status: 'captured' as const } : shadow
+        ),
+        previousTarget: 'companion',
+      }).destination
+    ).toBe('player')
+  })
+
+  it('searches toward the moon gate instead of a stale hidden target', () => {
+    const state = createRunningState('crossroads', 'intense', 17)
+    state.actors.pursuer.target = 'companion'
+    const expected = nextStepOnShortestPath(
+      getMap(state.mapId),
+      state.actors.pursuer.position,
+      state.exit.position
+    )
+
+    expect(pursuerNextStep(state, 1)).toEqual(expected)
+    expect(state.actors.pursuer.destination).toBe('moon-gate')
+    expect(state.actors.pursuer.target).toBe('companion')
+  })
+
+  it('excludes a captured shadow from visible pursuit candidates', () => {
+    const state = createRunningState('crossroads', 'intense', 17)
+    state.actors.pursuer.position = { x: 4, y: 0 }
+    state.actors.player.position = { x: 0, y: 0 }
+    state.actors.companion.position = { x: 5, y: 0 }
+    state.actors.companion.status = 'captured'
+    state.actors.pursuer.target = 'companion'
+
+    expect(pursuerNextStep(state, 1)).toEqual({ x: 3, y: 0 })
+    expect(state.actors.pursuer.destination).toBe('player')
+    expect(state.actors.pursuer.target).toBe('player')
+  })
+
+  it('observes and selects every tick while cadence gates movement only', () => {
+    const state = createRunningState('crossroads', 'relaxed', 17)
+    state.actors.pursuer.position = { x: 4, y: 0 }
+    state.actors.player.position = { x: 0, y: 0 }
+    state.actors.companion.position = { x: 5, y: 0 }
+    state.actors.pursuer.target = 'player'
+
+    expect(pursuerNextStep(state, 1)).toEqual({ x: 4, y: 0 })
+    expect(state.actors.pursuer.destination).toBe('companion')
+    expect(state.actors.pursuer.target).toBe('companion')
+  })
+
+  it('drops a newly hidden destination off cadence while preserving tie memory', () => {
+    const state = createRunningState('crossroads', 'relaxed', 17)
+    state.actors.pursuer.position = { x: 4, y: 0 }
+    state.actors.player.position = { x: 0, y: 1 }
+    state.actors.companion.position = { x: 5, y: 0 }
+    state.actors.pursuer.target = 'companion'
+    pursuerNextStep(state, 1)
+    state.actors.companion.position = { x: 5, y: 1 }
+
+    expect(pursuerNextStep(state, 2)).toEqual({ x: 4, y: 0 })
+    expect(state.actors.pursuer.destination).toBe('moon-gate')
+    expect(state.actors.pursuer.target).toBe('companion')
+  })
+
+  it('stays at the moon gate when no free shadow is visible', () => {
+    const state = createRunningState('crossroads', 'intense', 17)
+    state.actors.pursuer.position = { ...state.exit.position }
+
+    expect(pursuerNextStep(state, 1)).toEqual(state.exit.position)
+    expect(state.actors.pursuer.destination).toBe('moon-gate')
+  })
+
+  it('makes the same observation and step across difficulties on a shared cadence tick', () => {
+    const decisions = (['relaxed', 'standard', 'intense'] as const).map((difficulty) => {
+      const state = createRunningState('crossroads', difficulty, 17)
+      state.actors.pursuer.position = { x: 4, y: 0 }
+      state.actors.player.position = { x: 0, y: 0 }
+      state.actors.companion.position = { x: 5, y: 0 }
+      const step = pursuerNextStep(state, 6)
+      return {
+        step,
+        target: state.actors.pursuer.target,
+        destination: state.actors.pursuer.destination,
+      }
+    })
+
+    expect(decisions[1]).toEqual(decisions[0])
+    expect(decisions[2]).toEqual(decisions[0])
+  })
+
+  it('builds a narrow observation without reading forbidden simulation fields', () => {
+    const state = createRunningState('crossroads', 'standard', 17)
+    for (const field of [
+      'command',
+      'activeModelLease',
+      'difficulty',
+      'objectives',
+      'exit',
+      'decisionEpoch',
+      'eventLog',
+      'playerNavigation',
+      'rngState',
+    ] as const) {
+      Object.defineProperty(state, field, {
+        configurable: true,
+        get: () => {
+          throw new Error(`forbidden read: ${field}`)
+        },
+      })
+    }
+
+    expect(() => buildPursuerObservation(state)).not.toThrow()
+  })
+
+  it('keeps the pure selector isolated from poisoned private fields', () => {
+    const observation = buildPursuerObservation(createRunningState('crossroads', 'standard', 17))
+    const poisoned = { ...observation } as PursuerObservation & Record<string, unknown>
+    for (const field of [
+      'command',
+      'modelLease',
+      'difficulty',
+      'objectives',
+      'voice',
+      'subtitle',
+    ]) {
+      Object.defineProperty(poisoned, field, {
+        get: () => {
+          throw new Error(`forbidden read: ${field}`)
+        },
+      })
+    }
+
+    const baseline = selectPursuerDecision(observation)
+    const poisonedDecision = selectPursuerDecision(poisoned)
+    expect(poisonedDecision).toEqual(baseline)
+    expect(nextPursuerStep(poisoned, poisonedDecision)).toEqual(
+      nextPursuerStep(observation, baseline)
+    )
+  })
+
+  it('does not let hidden actor movement change the moon-gate route', () => {
+    const first = createRunningState('crossroads', 'standard', 17)
+    first.actors.pursuer.target = 'companion'
+    const movedHidden = structuredClone(first)
+    movedHidden.actors.companion.position = { x: 8, y: 0 }
+
+    expect(selectPursuerDecision(buildPursuerObservation(movedHidden))).toEqual(
+      selectPursuerDecision(buildPursuerObservation(first))
+    )
+  })
+})

--- a/packages/game-shadow-chase/src/engine/pursuer-policy.ts
+++ b/packages/game-shadow-chase/src/engine/pursuer-policy.ts
@@ -1,40 +1,129 @@
 import { DIFFICULTY_CONFIG } from './config'
 import { hasLineOfSight } from './line-of-sight'
 import { getMap } from './maps'
-import { nextStepOnShortestPath, pathDistance } from './pathfinding'
-import type { Coordinate, SimulationState } from './types'
+import { nextStepOnShortestPath } from './pathfinding'
+import type { WalkableMap } from './rules'
+import type { Coordinate, ShadowActor, SimulationState } from './types'
+
+export type PursuerShadowId = ShadowActor['id']
+export type PursuerDestination = PursuerShadowId | 'moon-gate'
+
+export interface PursuerObservation {
+  readonly map: WalkableMap & { readonly moonGate: Coordinate }
+  readonly pursuer: Coordinate
+  readonly shadows: readonly {
+    readonly id: PursuerShadowId
+    readonly position: Coordinate
+    readonly status: ShadowActor['status']
+  }[]
+  readonly previousTarget: PursuerShadowId | null
+}
+
+export interface PursuerDecision {
+  readonly visibleCandidates: readonly PursuerShadowId[]
+  readonly destination: PursuerDestination
+  readonly targetMemory: PursuerShadowId | null
+}
+
+function immutableCoordinate(position: Coordinate): Coordinate {
+  return Object.freeze({ x: position.x, y: position.y })
+}
+
+const OBSERVATION_MAPS = new WeakMap<object, PursuerObservation['map']>()
+
+function immutableObservationMap(map: ReturnType<typeof getMap>): PursuerObservation['map'] {
+  const cached = OBSERVATION_MAPS.get(map)
+  if (cached) return cached
+  const observationMap = Object.freeze({
+    width: map.width,
+    height: map.height,
+    walls: Object.freeze(map.walls.map(immutableCoordinate)),
+    moonGate: immutableCoordinate(map.exit),
+  })
+  OBSERVATION_MAPS.set(map, observationMap)
+  return observationMap
+}
+
+export function buildPursuerObservation(state: SimulationState): PursuerObservation {
+  const map = getMap(state.mapId)
+  return Object.freeze({
+    map: immutableObservationMap(map),
+    pursuer: immutableCoordinate(state.actors.pursuer.position),
+    shadows: Object.freeze(
+      (['player', 'companion'] as const).map((id) =>
+        Object.freeze({
+          id,
+          position: immutableCoordinate(state.actors[id].position),
+          status: state.actors[id].status,
+        })
+      )
+    ),
+    previousTarget: state.actors.pursuer.target,
+  })
+}
+
+export function selectPursuerDecision(observation: PursuerObservation): PursuerDecision {
+  const visibleCandidates = observation.shadows.filter(
+    (actor) =>
+      actor.status === 'free' &&
+      hasLineOfSight(observation.map, observation.pursuer, actor.position)
+  )
+  let destination: PursuerDestination = 'moon-gate'
+  let targetMemory = observation.previousTarget
+  if (visibleCandidates.length > 0) {
+    const distances = visibleCandidates.map((actor) => ({
+      actor,
+      // A visible actor shares an unobstructed row or column with the pursuer,
+      // so this direct segment is also the map's shortest walkable path.
+      distance:
+        Math.abs(observation.pursuer.x - actor.position.x) +
+        Math.abs(observation.pursuer.y - actor.position.y),
+    }))
+    const nearestDistance = Math.min(...distances.map((candidate) => candidate.distance))
+    const nearest = distances
+      .filter((candidate) => candidate.distance === nearestDistance)
+      .map((candidate) => candidate.actor.id)
+    destination =
+      targetMemory !== null && nearest.includes(targetMemory) ? targetMemory : nearest[0]
+    targetMemory = destination
+  }
+  return Object.freeze({
+    visibleCandidates: Object.freeze(visibleCandidates.map((actor) => actor.id)),
+    destination,
+    targetMemory,
+  })
+}
+
+export function nextPursuerStep(
+  observation: PursuerObservation,
+  decision: PursuerDecision
+): Coordinate {
+  const destinationPosition =
+    decision.destination === 'moon-gate'
+      ? observation.map.moonGate
+      : observation.shadows.find((actor) => actor.id === decision.destination)!.position
+  return (
+    nextStepOnShortestPath(observation.map, observation.pursuer, destinationPosition) ??
+    observation.pursuer
+  )
+}
+
+function applyPursuerDecision(state: SimulationState, decision: PursuerDecision): void {
+  state.actors.pursuer.destination = decision.destination
+  if (decision.targetMemory !== null) state.actors.pursuer.target = decision.targetMemory
+}
+
+export function refreshPursuerDecision(state: SimulationState): PursuerDecision {
+  const decision = selectPursuerDecision(buildPursuerObservation(state))
+  applyPursuerDecision(state, decision)
+  return decision
+}
 
 export function pursuerNextStep(state: SimulationState, nextTick: number): Coordinate {
-  const pursuer = state.actors.pursuer
-  const config = DIFFICULTY_CONFIG[state.difficulty]
-  if (nextTick % config.pursuerCadence !== 0) return pursuer.position
-  const map = getMap(state.mapId)
-  const commandIntent = state.command.intent
-  const leaseIntent =
-    state.activeModelLease && state.activeModelLease.expiryTick >= nextTick
-      ? state.activeModelLease.intent
-      : undefined
-  let target: 'player' | 'companion'
-  if (commandIntent === 'decoy' || leaseIntent === 'decoy') {
-    target = 'companion'
-  } else {
-    const visible = (['player', 'companion'] as const).filter((actorId) =>
-      hasLineOfSight(map, pursuer.position, state.actors[actorId].position, config.visionRange)
-    )
-    if (visible.length === 0) {
-      target = pursuer.target
-    } else {
-      visible.sort((left, right) => {
-        const distance =
-          pathDistance(map, pursuer.position, state.actors[left].position) -
-          pathDistance(map, pursuer.position, state.actors[right].position)
-        return distance || (left === 'player' ? -1 : 1)
-      })
-      target = visible[0]
-    }
-  }
-  state.actors.pursuer.target = target
-  return (
-    nextStepOnShortestPath(map, pursuer.position, state.actors[target].position) ?? pursuer.position
-  )
+  const observation = buildPursuerObservation(state)
+  const decision = selectPursuerDecision(observation)
+  applyPursuerDecision(state, decision)
+  return nextTick % DIFFICULTY_CONFIG[state.difficulty].pursuerCadence === 0
+    ? nextPursuerStep(observation, decision)
+    : state.actors.pursuer.position
 }

--- a/packages/game-shadow-chase/src/engine/pursuer-rules.ts
+++ b/packages/game-shadow-chase/src/engine/pursuer-rules.ts
@@ -1,0 +1,20 @@
+export const PURSUER_RULE_COPY =
+  '追兵能看见整条没有墙遮挡的横竖直线：它追最近且未被捕获的可见影子，距离相同时不换目标；谁都看不见就返回月门。同格或迎面交叉会被捕获。诱敌只改变伙伴走位，难度只改变追兵速度和救援时间。'
+
+export const PURSUER_RULE_CONTRACT = Object.freeze({
+  eligibility: 'free-visible-shadows',
+  vision: Object.freeze({
+    alignment: 'same-row-or-column',
+    blocker: 'wall-between',
+    range: 'full-map',
+  }),
+  selection: Object.freeze({
+    metric: 'shortest-path-distance',
+    tie: 'retain-last-eligible-actor-target',
+    initialFallback: 'player',
+  }),
+  noVisibleDestination: 'moon-gate',
+  capture: Object.freeze(['same-cell', 'opposite-edge-crossing']),
+  difficultyEffects: Object.freeze(['movement-cadence', 'rescue-time']),
+  decoyAuthority: 'companion-movement-only',
+})

--- a/packages/game-shadow-chase/src/engine/reducer.test.ts
+++ b/packages/game-shadow-chase/src/engine/reducer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { MIN_RUN_TICKS, RUN_CAP_TICKS } from './config'
+import { pursuerNextStep } from './pursuer-policy'
 import { createRunningState } from './rules'
 import { advance } from './reducer'
 import type { QueuedAction, SimulationState } from './types'
@@ -36,12 +37,81 @@ describe('ten-phase reducer contract', () => {
     expect(next.cooldowns.swapReadyTick).toBeGreaterThan(next.tick)
   })
 
-  it('increments the decision epoch when a command retargets the pursuer', () => {
+  it('accepts a decoy command without granting the pursuer command knowledge', () => {
     const state = createRunningState('courtyard', 'standard', 7)
     state.tick = 1
     const next = advance(state, [action(state, 1, { type: 'companion-command', command: 'decoy' })])
-    expect(next.actors.pursuer.target).toBe('companion')
-    expect(next.decisionEpoch).toBe(2)
+    expect(next.command.intent).toBe('decoy')
+    expect(next.actors.pursuer.target).not.toBe('companion')
+    expect(next.actors.pursuer.destination).toBe('moon-gate')
+    expect(next.decisionEpoch).toBe(1)
+  })
+
+  it('resolves contact even when pursuer cadence holds movement', () => {
+    const state = createRunningState('courtyard', 'relaxed', 7)
+    state.actors.player.position = { ...state.actors.pursuer.position }
+
+    const contacted = advance(state, [])
+
+    expect(contacted.actors.pursuer.position).toEqual(state.actors.pursuer.position)
+    expect(contacted.actors.player.status).toBe('captured')
+    expect(contacted.actors.pursuer.destination).toBe('moon-gate')
+    expect(contacted.actors.pursuer.target).toBe('player')
+  })
+
+  it('reconciles destination after same-cell capture while retaining actor tie memory', () => {
+    const state = createRunningState('courtyard', 'intense', 7)
+    state.actors.pursuer.position = { x: 2, y: 1 }
+    state.actors.player.position = { x: 1, y: 1 }
+    state.actors.companion.position = { x: 6, y: 6 }
+
+    const contacted = advance(state, [])
+
+    expect(contacted.actors.pursuer.position).toEqual({ x: 1, y: 1 })
+    expect(contacted.actors.player.status).toBe('captured')
+    expect(contacted.actors.pursuer.destination).toBe('moon-gate')
+    expect(contacted.actors.pursuer.target).toBe('player')
+  })
+
+  it('captures opposite-edge crossing', () => {
+    const state = createRunningState('courtyard', 'intense', 7)
+    state.actors.player.position = { x: 1, y: 1 }
+    state.actors.companion.position = { x: 6, y: 6 }
+    state.actors.pursuer.position = { x: 2, y: 1 }
+    state.actors.pursuer.destination = 'player'
+
+    const crossed = advance(
+      state,
+      [action(state, 1, { type: 'player-move', direction: 'right' })],
+      {
+        companion: (current) => current.actors.companion.position,
+        pursuer: () => ({ x: 1, y: 1 }),
+      }
+    )
+
+    expect(crossed.actors.player.status).toBe('captured')
+    expect(crossed.actors.pursuer.destination).toBe('moon-gate')
+    expect(crossed.actors.pursuer.target).toBe('player')
+  })
+
+  it('captures contact while returning to the moon gate', () => {
+    const state = createRunningState('courtyard', 'intense', 7)
+    state.actors.pursuer.position = { x: 1, y: 6 }
+    state.actors.player.position = { x: 0, y: 5 }
+    state.actors.companion.position = { x: 6, y: 0 }
+
+    const contacted = advance(
+      state,
+      [action(state, 1, { type: 'player-move', direction: 'down' })],
+      {
+        companion: (current) => current.actors.companion.position,
+        pursuer: pursuerNextStep,
+      }
+    )
+
+    expect(contacted.actors.pursuer.destination).toBe('moon-gate')
+    expect(contacted.actors.pursuer.position).toEqual(state.exit.position)
+    expect(contacted.actors.player.status).toBe('captured')
   })
 
   it('moves the pursuer and resolves contact on the first chase tick', () => {

--- a/packages/game-shadow-chase/src/engine/reducer.ts
+++ b/packages/game-shadow-chase/src/engine/reducer.ts
@@ -9,7 +9,7 @@ import { companionNextStep } from './companion-policy'
 import { validateModelProposal } from './intent-legality'
 import { getMap } from './maps'
 import { nextStepOnShortestPath, shortestPath } from './pathfinding'
-import { pursuerNextStep } from './pursuer-policy'
+import { pursuerNextStep, refreshPursuerDecision } from './pursuer-policy'
 import { coordinatesEqual, isInsideMap, isWalkable, moved } from './rules'
 import type {
   Coordinate,
@@ -276,6 +276,12 @@ export function advance(
       next.decisionEpoch += 1
       tickEvents.push({ tick: nextTick, type: 'rescue', actorId: capturedId })
     }
+  }
+
+  const targetBeforeCommitRefresh = next.actors.pursuer.target
+  refreshPursuerDecision(next)
+  if (next.actors.pursuer.target !== targetBeforeCommitRefresh) {
+    next.decisionEpoch += 1
   }
 
   const deadlineLoss = (['player', 'companion'] as const).some((actorId) => {

--- a/packages/game-shadow-chase/src/engine/rules.ts
+++ b/packages/game-shadow-chase/src/engine/rules.ts
@@ -1,6 +1,12 @@
 import { DIFFICULTY_CONFIG } from './config'
 import { getMap, validateMap } from './maps'
-import type { Coordinate, Difficulty, Direction, MapDefinition, SimulationState } from './types'
+import type { Coordinate, Difficulty, Direction, SimulationState } from './types'
+
+export interface WalkableMap {
+  readonly width: number
+  readonly height: number
+  readonly walls: readonly Coordinate[]
+}
 
 export function coordinatesEqual(left: Coordinate, right: Coordinate): boolean {
   return left.x === right.x && left.y === right.y
@@ -12,11 +18,11 @@ export function isCoordinate(value: unknown): value is Coordinate {
   return Number.isSafeInteger(coordinate.x) && Number.isSafeInteger(coordinate.y)
 }
 
-export function isInsideMap(map: MapDefinition, position: Coordinate): boolean {
+export function isInsideMap(map: WalkableMap, position: Coordinate): boolean {
   return position.x >= 0 && position.y >= 0 && position.x < map.width && position.y < map.height
 }
 
-export function isWalkable(map: MapDefinition, position: Coordinate): boolean {
+export function isWalkable(map: WalkableMap, position: Coordinate): boolean {
   return isInsideMap(map, position) && !map.walls.some((wall) => coordinatesEqual(wall, position))
 }
 
@@ -65,7 +71,12 @@ export function createRunningState(
     actors: {
       player: { id: 'player', position: { ...map.playerSpawn }, status: 'free' },
       companion: { id: 'companion', position: { ...map.companionSpawn }, status: 'free' },
-      pursuer: { id: 'pursuer', position: { ...map.pursuerSpawn }, target: 'player' },
+      pursuer: {
+        id: 'pursuer',
+        position: { ...map.pursuerSpawn },
+        target: 'player',
+        destination: 'moon-gate',
+      },
     },
     objectives: map.objectives.map((objective) => ({
       ...objective,

--- a/packages/game-shadow-chase/src/engine/types.ts
+++ b/packages/game-shadow-chase/src/engine/types.ts
@@ -43,7 +43,10 @@ export interface ShadowActor {
 export interface PursuerActor {
   id: 'pursuer'
   position: Coordinate
+  /** Last observed shadow, used only to keep equal-distance ties stable. */
   target: 'player' | 'companion'
+  /** Actual movement destination selected by the latest observation. */
+  destination: 'player' | 'companion' | 'moon-gate'
 }
 
 export interface ObjectiveState extends ObjectiveDefinition {

--- a/packages/game-shadow-chase/src/styles/global.css
+++ b/packages/game-shadow-chase/src/styles/global.css
@@ -92,6 +92,27 @@ h1 {
   line-height: 1.65;
 }
 
+.pursuer-rule {
+  max-width: 580px;
+  margin: 0 auto 18px;
+  padding: 9px 11px;
+  border: 1px solid var(--border-hairline, rgba(255, 255, 255, 0.06));
+  border-radius: var(--radius-md, 10px);
+  color: var(--text-3, rgba(255, 255, 255, 0.55));
+  background: rgba(0, 0, 0, 0.14);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.pursuer-rule strong {
+  color: var(--text-2, rgba(255, 255, 255, 0.7));
+}
+
+.pursuer-rule p {
+  margin: 3px 0 0;
+}
+
 .start-options {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -303,6 +324,25 @@ select {
 
 .board-overlay {
   pointer-events: none;
+}
+
+.sight-lane {
+  stroke: rgba(255, 107, 157, 0.2);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-dasharray: 3 8;
+}
+
+.pursuer-destination-indicator line,
+.pursuer-destination-indicator circle {
+  fill: none;
+  stroke: rgba(255, 229, 62, 0.42);
+  stroke-width: 1.5;
+  stroke-dasharray: 4 6;
+}
+
+.pursuer-arrowhead path {
+  fill: rgba(255, 229, 62, 0.58);
 }
 
 .path-target {

--- a/packages/game-shadow-chase/src/voice/shadow-chase-context.test.ts
+++ b/packages/game-shadow-chase/src/voice/shadow-chase-context.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { PURSUER_RULE_CONTRACT, PURSUER_RULE_COPY } from '../engine/pursuer-rules'
 import { createRunningState } from '../engine/rules'
 import {
   buildShadowChaseVoiceContext,
@@ -7,6 +8,8 @@ import {
   MAX_SHADOW_CHASE_MANUAL_BYTES,
   serializedVoiceManualBytes,
   shadowChaseVoiceStateSignature,
+  SHADOW_CHASE_RULES_SECTION,
+  SHADOW_CHASE_VOICE_MANUAL,
 } from './shadow-chase-context'
 
 describe('Shadow Chase voice context', () => {
@@ -43,6 +46,38 @@ describe('Shadow Chase voice context', () => {
     expect(context.objectives).toHaveLength(3)
     expect(context.map.walls.length).toBeLessThanOrEqual(64)
     expect(serializedVoiceManualBytes()).toBeLessThanOrEqual(MAX_SHADOW_CHASE_MANUAL_BYTES)
+    expect(
+      (
+        SHADOW_CHASE_VOICE_MANUAL.sections[SHADOW_CHASE_RULES_SECTION] as {
+          pursuerRule: string
+          pursuerContract: unknown
+        }
+      ).pursuerRule
+    ).toBe(PURSUER_RULE_COPY)
+    expect(
+      (
+        SHADOW_CHASE_VOICE_MANUAL.sections[SHADOW_CHASE_RULES_SECTION] as {
+          pursuerContract: unknown
+        }
+      ).pursuerContract
+    ).toEqual(PURSUER_RULE_CONTRACT)
+    expect(PURSUER_RULE_CONTRACT).toEqual({
+      eligibility: 'free-visible-shadows',
+      vision: {
+        alignment: 'same-row-or-column',
+        blocker: 'wall-between',
+        range: 'full-map',
+      },
+      selection: {
+        metric: 'shortest-path-distance',
+        tie: 'retain-last-eligible-actor-target',
+        initialFallback: 'player',
+      },
+      noVisibleDestination: 'moon-gate',
+      capture: ['same-cell', 'opposite-edge-crossing'],
+      difficultyEffects: ['movement-cadence', 'rescue-time'],
+      decoyAuthority: 'companion-movement-only',
+    })
   })
 
   it('ignores frame-only movement while tracking material game changes', () => {

--- a/packages/game-shadow-chase/src/voice/shadow-chase-context.ts
+++ b/packages/game-shadow-chase/src/voice/shadow-chase-context.ts
@@ -1,6 +1,7 @@
 import type { GameVoiceManualData, GameVoiceState } from '@shared/voice/use-game-voice-session'
 
 import { getMap } from '../engine/maps'
+import { PURSUER_RULE_CONTRACT, PURSUER_RULE_COPY } from '../engine/pursuer-rules'
 import type { CompanionIntent, Coordinate, SimulationState } from '../engine/types'
 
 export const SHADOW_CHASE_RULES_SECTION = 'shadow-chase-rules'
@@ -25,10 +26,13 @@ export const SHADOW_CHASE_VOICE_MANUAL: GameVoiceManualData = {
       goal: 'Collect all three light cores, survive until the moon gate opens, and exit together.',
       authority:
         'The deterministic engine owns movement, collision, pursuit, rescue, cooldowns, and outcomes.',
+      pursuerRule: PURSUER_RULE_COPY,
+      pursuerContract: PURSUER_RULE_CONTRACT,
       strategies: {
         follow: 'Stay near the player and prioritize rescue and joint exit.',
         split: 'Take a separate objective route while deterministic safety rules remain active.',
-        decoy: 'Draw pursuer pressure away from the player when legal.',
+        decoy:
+          'Move the deterministic companion toward a visible lane where it can become the nearer free shadow. The command itself gives the pursuer no knowledge.',
       },
       voiceCommands:
         'Only an explicit final player utterance may request follow, split, or decoy. Assistant prose is informational.',


### PR DESCRIPTION
## Summary

- Replace private strategy and model-intent pursuit reads with immutable observable-world decisions: full wall-blocked cardinal sight, nearest visible free-shadow targeting, stable ties, and moon-gate fallback.
- Make decoy affect deterministic companion movement only, then share one pursuer rule with setup, planning, the Platform AI voice manual, sight lanes, and a truthful destination marker.
- Reconcile pursuit after capture and rescue commits so the visible destination never points at a captured shadow.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Manual and automated evidence:

- `pnpm test:run` across all 11 workspaces, including Shadow Chase 20 files / 110 tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm e2e:audit`
- `pnpm test:e2e` — Chromium 40 / 40
- In-app Browser desktop and 390x844 play: canonical setup/planning copy, four wall-clipped sight lanes, one pointer-transparent live destination, 44px controls, and no horizontal overflow
- Independent adversarial verification: PASS with no open P0/P1/P2

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

## Breaking changes

None.

## Attribution

Codex implementation with independent Codex verifier review. No Claude Code contribution in this correction batch.