### PR TITLE
feat(shadow-chase): rework pursuit around earned swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ engine gains game-agnostic timed-emitter and lose-condition extensions with
 validator checks; sibling game fixtures are untouched. Not wired into the
 production arcade; playable via local dev only.
 
+**Shadow Chase now revolves around earned position swaps** — Changed. The
+pursuer locks onto the human-controlled shadow only, moves every tick, and takes
+a predictable difficulty-based bonus step so equal-speed infinite kiting is no
+longer possible. It can still capture the AI companion through incidental
+same-cell contact or opposite-edge crossing. Each collected core grants one
+consumable position swap, replacing the unlimited cooldown-based swap.
+
+Companion strategies are now Support, Scout, and Anchor. The companion can stand
+near a core but only the player can collect it, preventing an idle player from
+outsourcing the objective. The strategies trade rescue distance, route setup,
+and swap distance without giving the pursuer any private strategy knowledge.
+Rescue coverage now includes a live pursuer returning to the moon gate instead
+of relying on a frozen-pursuer fixture. Chinese setup, HUD, buttons, voice
+commands, and the Platform AI contract share the new rules.
+
 **The Shadow Chase pursuer now obeys only visible world rules** — Fix. The
 pursuer no longer reads the private follow, split, or decoy command, any model
 lease, or a hidden shadow's live position. It sees the full unobstructed row and

--- a/README.md
+++ b/README.md
@@ -33,25 +33,27 @@ solo real-time grid chase for one human and the existing AI companion.
 - Inspect the complete frozen map during a 20-second tactical-planning phase;
   adjust it from 5 to 60 seconds in five-second steps or start early
 - Collect three cores and reach the exit while a pursuer searches the map
-- Plan against one public pursuer rule: unobstructed row/column sight, nearest
-  visible uncaptured shadow, stable equal-distance ties, and moon-gate return
-  when neither shadow is visible
-- Command the companion to follow, split, or decoy; swap positions when ready
+- Plan against one public pursuer rule: unobstructed row/column sight, the
+  player as the only pursuit target, and moon-gate return when the player is hidden
+- Command the companion to support, scout the next core, or establish a distant anchor
+- Earn one position swap for every collected core
 - Rescue a captured shadow before its deadline
 - Queue rapid movement inputs FIFO, tap a persistent destination path, and see
   why a blocked move was rejected
 - Optionally discuss strategy by voice with the authenticated account companion;
-  only an explicit final player command can select follow, split, or decoy
+  only an explicit final player command can select support, scout, or anchor
 - Keep playing through anonymous, microphone, provider, model, or network failure
 
 Voice reuses the platform's existing companion identity, voice, provider adapters,
 and memory boundary. It is opt-in and bounded; neither voice nor model work can
 pause planning or frame-level play. The deterministic engine owns movement and
 outcomes, and the Chinese strategy buttons remain authoritative fallback controls.
-The pursuer cannot read those strategy buttons or model output. Decoy changes
-only companion movement and succeeds when that movement makes the companion the
-nearer visible shadow. Difficulty changes pursuer cadence and rescue time, not
-visibility or target selection.
+The pursuer cannot read those strategy buttons, model output, or the companion's
+position when selecting a destination. It moves every tick and takes a public,
+difficulty-dependent bonus step often enough to stay slightly faster than both
+shadows. The companion is never targeted, but same-cell contact and opposite-edge
+crossing still capture it. Difficulty changes the bonus-step interval and rescue
+time, not visibility or target selection.
 
 On the Arcade homepage, BombSquad remains the sole featured game. Dual Shadow
 Chase and the Yijing Oracle appear together in the playable peer grid. Arcade

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -461,11 +461,11 @@ flows:
     name: Dual Shadow Chase deterministic solo play
     description: >-
       A visitor opens the Shadow Chase SPA, reads the five-second head-start
-      rule, starts a solo run, and activates a companion Decoy command while
+      rule, starts a solo run, and activates a companion Anchor command while
       optional model handoffs return unavailable. The deterministic loop stays
       live and exposes no multi-human room, matchmaking, PvP, or voice-room
       affordance.
-    steps: [shadow-chase-start, opening-grace, companion-decoy, fallback-live]
+    steps: [shadow-chase-start, opening-grace, companion-anchor, fallback-live]
     status: active
 
   - id: shadow-chase-mobile-controls

--- a/e2e/shadow-chase.gherkin
+++ b/e2e/shadow-chase.gherkin
@@ -22,8 +22,8 @@ Feature: Dual Shadow Chase deterministic solo play
     And Shadow Chase exposes no multiplayer affordance
     And Shadow Chase pursuit is active when the chase starts
 
-    When I click "诱敌"
-    Then the Shadow Chase command "诱敌" is active
+    When I click "架点"
+    Then the Shadow Chase command "架点" is active
 
   # Source: shadow-chase-mobile-controls
   @playwright

--- a/e2e/steps/shadow-chase.steps.ts
+++ b/e2e/steps/shadow-chase.steps.ts
@@ -18,7 +18,7 @@ Then('the Shadow Chase opening rule is complete', async ({ page }) => {
   expect(copy).toContain('完成救援')
   expect(copy).toContain('一起撤离')
   expect(copy).toContain(
-    '追兵能看见整条没有墙遮挡的横竖直线：它追最近且未被捕获的可见影子，距离相同时不换目标；谁都看不见就返回月门。同格或迎面交叉会被捕获。诱敌只改变伙伴走位，难度只改变追兵速度和救援时间。'
+    '追兵只锁定你：横竖直线没有墙遮挡时追向你，看不见你就返回月门。它始终比你和伙伴略快；接触或迎面交叉仍会捕获任何一方。每收集一枚光核获得一次换位。'
   )
   const pursuerRule = await page.getByRole('region', { name: '追兵规则' }).locator('p').innerText()
   await page.locator('html').evaluate((element, rule) => {
@@ -46,7 +46,7 @@ Then('the Shadow Chase board and essential controls are visible', async ({ page 
   await expect(page.getByRole('application', { name: '双影追逃地图' })).toBeVisible()
   await expect(page.getByText('光核', { exact: true })).toBeVisible()
   await expect(page.getByText('救援', { exact: true })).toBeVisible()
-  await expect(page.getByRole('button', { name: '交换位置' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '交换位置 · 0' })).toBeVisible()
   await expect(page.getByRole('button', { name: '向上移动' })).toBeVisible()
 })
 

--- a/packages/game-shadow-chase/src/App.test.tsx
+++ b/packages/game-shadow-chase/src/App.test.tsx
@@ -30,11 +30,11 @@ describe('playable shell semantics', () => {
   it('keeps deterministic Chinese strategy buttons available during planning and play', () => {
     render(<App voiceSource={BUTTON_ONLY_VOICE} />)
     fireEvent.click(screen.getByRole('button', { name: '查看地图并制定策略' }))
-    for (const name of ['跟随', '分头', '诱敌']) {
+    for (const name of ['接应', '探路', '架点']) {
       expect(screen.getByRole('button', { name }).getAttribute('aria-pressed')).not.toBeNull()
     }
     fireEvent.click(screen.getByRole('button', { name: '立即出发' }))
-    expect(screen.getByRole('button', { name: '交换位置' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '交换位置 · 0' })).toBeTruthy()
   })
 
   it('adjusts the same planning duration before and during the frozen phase', () => {

--- a/packages/game-shadow-chase/src/App.tsx
+++ b/packages/game-shadow-chase/src/App.tsx
@@ -31,8 +31,8 @@ export function App({ voiceSource }: { voiceSource?: ShadowVoiceSource | null })
   const [planning] = useState(() => createPlanningController())
   const planningState = usePlanningController(planning)
   const state = useGameStore(store)
-  const [pendingStrategy, setPendingStrategy] = useState<CompanionIntent>('follow')
-  const pendingStrategyRef = useRef<CompanionIntent>('follow')
+  const [pendingStrategy, setPendingStrategy] = useState<CompanionIntent>('support')
+  const pendingStrategyRef = useRef<CompanionIntent>('support')
   const settledRuns = useRef(new Set<string>())
 
   const selectStrategy = useCallback(
@@ -52,8 +52,8 @@ export function App({ voiceSource }: { voiceSource?: ShadowVoiceSource | null })
 
   const beginPlanning = useCallback(
     (runStore: GameStore) => {
-      pendingStrategyRef.current = 'follow'
-      setPendingStrategy('follow')
+      pendingStrategyRef.current = 'support'
+      setPendingStrategy('support')
       setSessionPhase('planning')
       planning.begin(() => {
         runStore.dispatch({

--- a/packages/game-shadow-chase/src/components/GameBoard.test.tsx
+++ b/packages/game-shadow-chase/src/components/GameBoard.test.tsx
@@ -40,7 +40,7 @@ describe('whole-board target ownership', () => {
     state.tick = 1
     state.actors.pursuer.position = { x: 0, y: 0 }
     state.actors.pursuer.target = 'player'
-    state.actors.pursuer.destination = 'companion'
+    state.actors.pursuer.destination = 'player'
     const onTarget = vi.fn()
     const view = render(<GameBoard state={state} onTarget={onTarget} />)
 
@@ -54,7 +54,7 @@ describe('whole-board target ownership', () => {
     expect(target.getAttribute('aria-hidden')).toBe('true')
     const board = screen.getByRole('application', { name: '双影追逃地图' })
     const description = document.getElementById(board.getAttribute('aria-describedby')!)
-    expect(description?.textContent).toBe('追兵当前目标：AI 伙伴')
+    expect(description?.textContent).toBe('追兵当前目标：你')
     Object.defineProperty(board, 'getBoundingClientRect', {
       value: () => ({ left: 0, top: 0, width: 336, height: 336 }),
     })

--- a/packages/game-shadow-chase/src/components/GameBoard.tsx
+++ b/packages/game-shadow-chase/src/components/GameBoard.tsx
@@ -64,12 +64,7 @@ export function GameBoard({
     displayedDestination === 'moon-gate'
       ? state.exit.position
       : state.actors[displayedDestination].position
-  const destinationName =
-    displayedDestination === 'moon-gate'
-      ? '月门'
-      : displayedDestination === 'player'
-        ? '你'
-        : 'AI 伙伴'
+  const destinationName = displayedDestination === 'moon-gate' ? '月门' : '你'
   const destinationDescriptionId = `pursuer-destination-${state.runId}`
   const arrowheadId = `pursuer-arrowhead-${state.runId}`
   const gesture = useRef<{ pointerId: number; start: Coordinate } | null>(null)

--- a/packages/game-shadow-chase/src/components/Hud.test.tsx
+++ b/packages/game-shadow-chase/src/components/Hud.test.tsx
@@ -5,6 +5,17 @@ import { createRunningState } from '../engine/rules'
 import { Hud } from './Hud'
 
 describe('pacing feedback', () => {
+  it('shows the remaining core count and available swap charges', () => {
+    const state = createRunningState('courtyard', 'standard', 7)
+    state.objectives[0].collected = true
+    state.swapCharges = 1
+
+    render(<Hud state={state} />)
+
+    expect(screen.getByText('还需收集 2 枚光核')).toBeTruthy()
+    expect(screen.getByText('1 次')).toBeTruthy()
+  })
+
   it('shows the deterministic moon-gate countdown after all cores are collected early', () => {
     const state = createRunningState('courtyard', 'relaxed', 7)
     state.tick = 100
@@ -14,5 +25,17 @@ describe('pacing feedback', () => {
     state.exit.enabled = false
     render(<Hud state={state} />)
     expect(screen.getByText('01:35 后开启')).toBeTruthy()
+  })
+
+  it('makes a rescue and immediate recapture visible', () => {
+    const state = createRunningState('courtyard', 'standard', 7)
+    state.tick = 10
+    state.actors.player.status = 'captured'
+    state.actors.player.rescueDeadlineTick = 30
+    state.eventLog.push({ tick: 8, type: 'rescue', actorId: 'player' })
+
+    render(<Hud state={state} />)
+
+    expect(screen.getByText('你再次被捕 · 5 秒')).toBeTruthy()
   })
 })

--- a/packages/game-shadow-chase/src/components/Hud.tsx
+++ b/packages/game-shadow-chase/src/components/Hud.tsx
@@ -13,11 +13,14 @@ export function Hud({ state }: { state: SimulationState }) {
   const captured = (['player', 'companion'] as const)
     .map((id) => ({ id, ticks: rescueTicksRemaining(state.actors[id], state.tick) }))
     .find((entry) => entry.ticks !== null)
+  const recentRescue = [...state.eventLog]
+    .reverse()
+    .find((event) => event.type === 'rescue' && state.tick - event.tick <= 8)
   const gateStatus = state.exit.enabled
     ? '已开启'
     : allCoresCollected
       ? `${formatTime(Math.max(0, MIN_RUN_TICKS - state.tick))} 后开启`
-      : '还需收集 3 枚光核'
+      : `还需收集 ${state.objectives.length - collected} 枚光核`
   return (
     <header className="hud" aria-label="追逃状态">
       <div>
@@ -33,12 +36,20 @@ export function Hud({ state }: { state: SimulationState }) {
         <span className="hud-label">月门</span>
         <strong className="hud-value">{gateStatus}</strong>
       </div>
+      <div>
+        <span className="hud-label">换位</span>
+        <strong className="hud-value">{state.swapCharges} 次</strong>
+      </div>
       <div className={captured ? 'rescue-alert' : ''}>
         <span className="hud-label">救援</span>
         <strong className="hud-value">
           {captured
-            ? `${captured.id === 'player' ? '你' : '伙伴'} · ${((captured.ticks ?? 0) * TICK_MS) / 1000} 秒`
-            : '双方安全'}
+            ? `${recentRescue?.actorId === captured.id ? (captured.id === 'player' ? '你再次被捕' : '伙伴再次被捕') : captured.id === 'player' ? '你' : '伙伴'} · ${((captured.ticks ?? 0) * TICK_MS) / 1000} 秒`
+            : recentRescue
+              ? recentRescue.actorId === 'player'
+                ? '伙伴刚救下你'
+                : '你刚救下伙伴'
+              : '双方安全'}
         </strong>
       </div>
     </header>

--- a/packages/game-shadow-chase/src/components/ResultScreen.tsx
+++ b/packages/game-shadow-chase/src/components/ResultScreen.tsx
@@ -6,7 +6,7 @@ function causalBeat(state: SimulationState): string {
     .find((candidate) => ['rescue', 'swap', 'core-collected'].includes(candidate.type))
   if (!event) return '即使模型没有连接，确定性伙伴也始终在行动。'
   if (event.type === 'rescue') return '这次救援让两道影子都留在了追逃中。'
-  if (event.type === 'swap') return '交换位置改变了追兵施压的目标。'
+  if (event.type === 'swap') return '有限换位把你送到了伙伴预先建立的落点。'
   return '两条路线配合收集了最后一枚光核。'
 }
 

--- a/packages/game-shadow-chase/src/components/StartScreen.tsx
+++ b/packages/game-shadow-chase/src/components/StartScreen.tsx
@@ -30,9 +30,9 @@ export function StartScreen(props: StartScreenProps) {
             value={props.difficulty}
             onChange={(event) => props.onDifficultyChange(event.target.value as Difficulty)}
           >
-            <option value="relaxed">轻松</option>
-            <option value="standard">标准</option>
-            <option value="intense">紧张</option>
+            <option value="relaxed">轻松 · 每 2 秒多走 1 格</option>
+            <option value="standard">标准 · 每 1.5 秒多走 1 格</option>
+            <option value="intense">紧张 · 每 1 秒多走 1 格</option>
           </select>
         </label>
         <label>

--- a/packages/game-shadow-chase/src/components/StrategyPanel.test.tsx
+++ b/packages/game-shadow-chase/src/components/StrategyPanel.test.tsx
@@ -19,7 +19,7 @@ function panel(activeVoice: ShadowVoiceView) {
   return (
     <StrategyPanel
       state={createRunningState('courtyard', 'standard', 7)}
-      activeIntent="follow"
+      activeIntent="support"
       planning={false}
       voice={activeVoice}
       onStrategy={vi.fn()}
@@ -39,7 +39,7 @@ describe('StrategyPanel voice controls', () => {
       expect(button.className).toContain('voice-control')
       fireEvent.click(button)
       expect(stop).toHaveBeenCalledTimes(1)
-      for (const label of ['跟随', '分头', '诱敌']) {
+      for (const label of ['接应', '探路', '架点']) {
         expect(screen.getByRole('button', { name: label })).toBeTruthy()
       }
     }

--- a/packages/game-shadow-chase/src/components/StrategyPanel.tsx
+++ b/packages/game-shadow-chase/src/components/StrategyPanel.tsx
@@ -2,9 +2,9 @@ import type { CompanionIntent, SimulationState } from '../engine/types'
 import type { ShadowVoiceView } from '../voice/useShadowChaseVoice'
 
 const STRATEGIES: Array<{ intent: CompanionIntent; label: string; effect: string }> = [
-  { intent: 'follow', label: '跟随', effect: '伙伴保持在你附近，优先协助救援和共同撤离。' },
-  { intent: 'split', label: '分头', effect: '伙伴选择另一条路线收集光核，扩大行动范围。' },
-  { intent: 'decoy', label: '诱敌', effect: '伙伴主动吸引追兵，为你腾出移动空间。' },
+  { intent: 'support', label: '接应', effect: '伙伴保持在你附近，缩短被捕后的救援路线。' },
+  { intent: 'scout', label: '探路', effect: '伙伴前往下一枚光核附近，为你的收集路线预先站位。' },
+  { intent: 'anchor', label: '架点', effect: '伙伴远离你建立换位落点，但救援赶路更久。' },
 ]
 
 const VOICE_STATUS: Record<ShadowVoiceView['status'], string> = {
@@ -43,10 +43,9 @@ export function StrategyPanel({
   const recommendation = state.activeModelLease
     ? strategy(state.activeModelLease.intent).label
     : '确定性伙伴会根据追兵与救援状态自行判断'
-  const swapTicks = Math.max(0, state.cooldowns.swapReadyTick - state.tick)
   const swapDisabled =
     planning ||
-    swapTicks > 0 ||
+    state.swapCharges === 0 ||
     state.actors.player.status === 'captured' ||
     state.actors.companion.status === 'captured'
 
@@ -87,14 +86,14 @@ export function StrategyPanel({
         ) : null}
         <p>
           <strong>你说的话：</strong>
-          {voice.playerTranscript || '可使用“跟着我”“分头行动”“去诱敌”明确下令。'}
+          {voice.playerTranscript || '可使用“过来接应”“去光核探路”“去远处架点”明确下令。'}
         </p>
         <p>
           <strong>伙伴字幕：</strong>
           {voice.companionText || '语音不可用时，策略按钮仍然完整可用。'}
         </p>
         {voice.commandResult?.kind === 'clarify' && (
-          <p className="voice-clarify">请只说一种明确策略：跟随、分头或诱敌。</p>
+          <p className="voice-clarify">请只说一种明确策略：接应、探路或架点。</p>
         )}
         {voice.statusMessage && <p className="voice-status-message">{voice.statusMessage}</p>}
       </div>
@@ -105,16 +104,16 @@ export function StrategyPanel({
         aria-describedby="swap-reason"
         onClick={onSwap}
       >
-        交换位置
+        交换位置 · {state.swapCharges}
       </button>
       <span id="swap-reason" className="control-reason">
         {planning
           ? '追逃开始后才能交换。'
-          : swapTicks > 0
-            ? `交换冷却还剩 ${(swapTicks / 4).toFixed(1)} 秒。`
+          : state.swapCharges === 0
+            ? '每收集一枚光核获得一次交换。'
             : swapDisabled
               ? '双方都未被捕获时才能交换。'
-              : '现在可以交换位置。'}
+              : `现在可交换 ${state.swapCharges} 次。`}
       </span>
     </section>
   )

--- a/packages/game-shadow-chase/src/engine/companion-policy.test.ts
+++ b/packages/game-shadow-chase/src/engine/companion-policy.test.ts
@@ -1,74 +1,59 @@
 import { describe, expect, it } from 'vitest'
 
 import { companionNextStep } from './companion-policy'
-import { hasLineOfSight, visibleSightCells } from './line-of-sight'
 import { getMap } from './maps'
 import { pathDistance } from './pathfinding'
 import { createRunningState } from './rules'
-import { buildPursuerObservation, selectPursuerDecision } from './pursuer-policy'
 
-describe('deterministic companion decoy policy', () => {
-  it('moves toward a sight-lane cell that would become nearer than the player', () => {
+describe('deterministic companion positioning policy', () => {
+  it('moves into the player trail in support mode', () => {
     const state = createRunningState('courtyard', 'standard', 23)
-    state.actors.pursuer.position = { x: 6, y: 6 }
-    state.actors.player.position = { x: 6, y: 0 }
-    state.actors.companion.position = { x: 0, y: 0 }
-    state.actors.pursuer.target = 'player'
-    state.command = { intent: 'decoy' }
-    const map = getMap(state.mapId)
-    const playerDistance = pathDistance(
-      map,
-      state.actors.pursuer.position,
-      state.actors.player.position
-    )
-    const nearerSightCells = visibleSightCells(map, state.actors.pursuer.position).filter(
-      (candidate) =>
-        pathDistance(map, state.actors.pursuer.position, candidate) < playerDistance &&
-        (candidate.x !== state.actors.player.position.x ||
-          candidate.y !== state.actors.player.position.y)
-    )
-    const distanceToLane = (position: { x: number; y: number }) =>
-      Math.min(...nearerSightCells.map((candidate) => pathDistance(map, position, candidate)))
+    state.command = { intent: 'support' }
 
-    const next = companionNextStep(state)
-
-    expect(distanceToLane(next)).toBeLessThan(distanceToLane(state.actors.companion.position))
-    expect(state.actors.pursuer.target).toBe('player')
+    expect(companionNextStep(state)).toEqual(state.actors.player.position)
   })
 
-  it('switches pursuit only after decoy movement creates visible nearer geometry', () => {
+  it('moves closer to an uncollected core in scout mode', () => {
     const state = createRunningState('courtyard', 'standard', 23)
-    state.actors.pursuer.position = { x: 6, y: 6 }
-    state.actors.player.position = { x: 6, y: 0 }
-    state.actors.companion.position = { x: 0, y: 0 }
-    state.command = { intent: 'decoy' }
+    state.command = { intent: 'scout', targetObjectiveId: 'core-aurora' }
     const map = getMap(state.mapId)
-    let switched = false
-    let switchTick = -1
+    const target = state.objectives[0].position
 
-    for (let step = 0; step < 20; step += 1) {
-      const decision = selectPursuerDecision(buildPursuerObservation(state))
-      const visible = hasLineOfSight(
-        map,
-        state.actors.pursuer.position,
-        state.actors.companion.position
-      )
-      const strictlyNearer =
-        pathDistance(map, state.actors.pursuer.position, state.actors.companion.position) <
-        pathDistance(map, state.actors.pursuer.position, state.actors.player.position)
-      if (decision.destination === 'companion') {
-        expect(visible).toBe(true)
-        expect(strictlyNearer).toBe(true)
-        switched = true
-        switchTick = step
-        break
-      }
-      expect(visible && strictlyNearer).toBe(false)
-      expect(decision.destination).toBe('player')
-      state.actors.companion.position = companionNextStep(state)
-    }
+    expect(pathDistance(map, companionNextStep(state), target)).toBeLessThan(
+      pathDistance(map, state.actors.companion.position, target)
+    )
+  })
 
-    expect(switched).toBe(true)
-    expect(switchTick).toBeGreaterThan(0)
+  it('moves off the player route when scouting beside a core', () => {
+    const state = createRunningState('courtyard', 'standard', 23)
+    state.actors.player.position = { x: 4, y: 0 }
+    state.actors.companion.position = { x: 5, y: 0 }
+    state.command = { intent: 'scout', targetObjectiveId: 'core-aurora' }
+
+    expect(companionNextStep(state)).toEqual({ x: 6, y: 0 })
+  })
+
+  it('increases player separation in anchor mode', () => {
+    const state = createRunningState('courtyard', 'standard', 23)
+    state.actors.companion.position = { x: 2, y: 2 }
+    state.command = { intent: 'anchor' }
+    const map = getMap(state.mapId)
+
+    expect(
+      pathDistance(map, companionNextStep(state), state.actors.player.position)
+    ).toBeGreaterThan(
+      pathDistance(map, state.actors.companion.position, state.actors.player.position)
+    )
+  })
+
+  it('waits or evades while the pursuer occupies the captured player', () => {
+    const state = createRunningState('courtyard', 'standard', 23)
+    state.actors.player.status = 'captured'
+    state.actors.player.rescueDeadlineTick = 24
+    state.actors.player.position = { x: 2, y: 1 }
+    state.actors.pursuer.position = { x: 2, y: 1 }
+    state.actors.companion.position = { x: 1, y: 1 }
+
+    expect(companionNextStep(state)).not.toEqual(state.actors.player.position)
   })
 })

--- a/packages/game-shadow-chase/src/engine/companion-policy.ts
+++ b/packages/game-shadow-chase/src/engine/companion-policy.ts
@@ -1,6 +1,13 @@
+import { DIFFICULTY_CONFIG } from './config'
 import { getMap } from './maps'
-import { visibleSightCells } from './line-of-sight'
-import { neighbors, nextStepOnShortestPath, pathDistance } from './pathfinding'
+import {
+  coordinateKey,
+  neighbors,
+  nextStepOnShortestPath,
+  pathDistance,
+  shortestPath,
+} from './pathfinding'
+import { coordinatesEqual, isWalkable, type WalkableMap } from './rules'
 import type { Coordinate, SimulationState } from './types'
 
 function nearestObjective(state: SimulationState): Coordinate | null {
@@ -13,6 +20,24 @@ function nearestObjective(state: SimulationState): Coordinate | null {
     return distance || left.id.localeCompare(right.id)
   })
   return available[0]?.position ?? null
+}
+
+function objectiveApproach(state: SimulationState, objective: Coordinate): Coordinate {
+  const map = getMap(state.mapId)
+  const companion = state.actors.companion.position
+  const candidates = neighbors(map, objective)
+  const playerRoute = shortestPath(map, state.actors.player.position, objective) ?? []
+  const playerRouteKeys = new Set(playerRoute.map(coordinateKey))
+  const offRoute = candidates.filter((candidate) => !playerRouteKeys.has(coordinateKey(candidate)))
+  const available = offRoute.length > 0 ? offRoute : candidates
+  available.sort((left, right) => {
+    const travelDistance = pathDistance(map, companion, left) - pathDistance(map, companion, right)
+    const pursuerDistance =
+      pathDistance(map, right, state.actors.pursuer.position) -
+      pathDistance(map, left, state.actors.pursuer.position)
+    return travelDistance || pursuerDistance || left.y - right.y || left.x - right.x
+  })
+  return available[0] ?? companion
 }
 
 function evade(state: SimulationState): Coordinate | null {
@@ -28,48 +53,62 @@ function evade(state: SimulationState): Coordinate | null {
   return options[0] ?? null
 }
 
-function decoyStep(state: SimulationState): Coordinate {
+function mapAvoiding(map: WalkableMap, blocked: readonly Coordinate[]): WalkableMap {
+  return {
+    width: map.width,
+    height: map.height,
+    walls: [...map.walls, ...blocked],
+  }
+}
+
+function rescueStep(state: SimulationState): Coordinate {
   const map = getMap(state.mapId)
   const companion = state.actors.companion.position
-  const pursuer = state.actors.pursuer.position
   const player = state.actors.player.position
-  const playerDistance = pathDistance(map, pursuer, player)
-  const candidates = visibleSightCells(map, pursuer)
-    .filter(
-      (candidate) =>
-        (candidate.x !== player.x || candidate.y !== player.y) &&
-        (candidate.x !== pursuer.x || candidate.y !== pursuer.y)
-    )
-    .map((candidate) => ({
-      candidate,
-      companionDistance: pathDistance(map, companion, candidate),
-      pursuerDistance: pathDistance(map, pursuer, candidate),
-    }))
-    .filter((candidate) => Number.isFinite(candidate.companionDistance))
+  const pursuer = state.actors.pursuer.position
+  const pursuerFirst = nextStepOnShortestPath(map, pursuer, state.exit.position) ?? pursuer
+  const pursuerPath = [pursuer, pursuerFirst]
+  const bonusInterval = DIFFICULTY_CONFIG[state.difficulty].pursuerBonusStepInterval
+  if ((state.tick + 1) % bonusInterval === 0) {
+    pursuerPath.push(nextStepOnShortestPath(map, pursuerFirst, state.exit.position) ?? pursuerFirst)
+  }
+  if (pursuerPath.some((position) => coordinatesEqual(player, position))) {
+    return evade(state) ?? companion
+  }
+  const safeMap = mapAvoiding(map, pursuerPath)
+  return nextStepOnShortestPath(safeMap, companion, player) ?? evade(state) ?? companion
+}
+
+function farAnchor(state: SimulationState): Coordinate {
+  const map = getMap(state.mapId)
+  const companion = state.actors.companion.position
+  const candidates: Coordinate[] = []
+  for (let y = 0; y < map.height; y += 1) {
+    for (let x = 0; x < map.width; x += 1) {
+      const candidate = { x, y }
+      if (isWalkable(map, candidate)) candidates.push(candidate)
+    }
+  }
   candidates.sort((left, right) => {
-    const leftNearer = left.pursuerDistance < playerDistance ? 0 : 1
-    const rightNearer = right.pursuerDistance < playerDistance ? 0 : 1
+    const playerDistance =
+      pathDistance(map, right, state.actors.player.position) -
+      pathDistance(map, left, state.actors.player.position)
+    const pursuerDistance =
+      pathDistance(map, right, state.actors.pursuer.position) -
+      pathDistance(map, left, state.actors.pursuer.position)
+    const travelDistance = pathDistance(map, companion, left) - pathDistance(map, companion, right)
     return (
-      leftNearer - rightNearer ||
-      left.companionDistance - right.companionDistance ||
-      left.pursuerDistance - right.pursuerDistance ||
-      left.candidate.y - right.candidate.y ||
-      left.candidate.x - right.candidate.x
+      playerDistance || pursuerDistance || travelDistance || left.y - right.y || left.x - right.x
     )
   })
-  const target = candidates[0]?.candidate
-  return target ? (nextStepOnShortestPath(map, companion, target) ?? companion) : companion
+  return candidates[0] ?? companion
 }
 
 export function companionNextStep(state: SimulationState): Coordinate {
   const actor = state.actors.companion
   if (actor.status === 'captured' || state.phase !== 'running') return actor.position
   const map = getMap(state.mapId)
-  if (state.actors.player.status === 'captured') {
-    return (
-      nextStepOnShortestPath(map, actor.position, state.actors.player.position) ?? actor.position
-    )
-  }
+  if (state.actors.player.status === 'captured') return rescueStep(state)
   const evasive = evade(state)
   if (evasive) return evasive
   if (state.exit.enabled) {
@@ -77,26 +116,20 @@ export function companionNextStep(state: SimulationState): Coordinate {
   }
   const lease = state.activeModelLease
   const leasedIntent = lease && lease.expiryTick >= state.tick + 1 ? lease : undefined
-  const intent = state.command.intent !== 'follow' ? state.command : (leasedIntent ?? state.command)
-  if (intent.intent === 'split') {
+  const intent =
+    state.command.intent !== 'support' ? state.command : (leasedIntent ?? state.command)
+  if (intent.intent === 'scout') {
     const objective = state.objectives.find(
       (candidate) => candidate.id === intent.targetObjectiveId && !candidate.collected
     )
-    const target = objective?.position ?? nearestObjective(state)
+    const objectivePosition = objective?.position ?? nearestObjective(state)
+    const target = objectivePosition ? objectiveApproach(state, objectivePosition) : null
     return target
       ? (nextStepOnShortestPath(map, actor.position, target) ?? actor.position)
       : actor.position
   }
-  if (intent.intent === 'decoy') {
-    return decoyStep(state)
-  }
-  const uncollected = nearestObjective(state)
-  if (
-    uncollected &&
-    pathDistance(map, actor.position, uncollected) + 2 <
-      pathDistance(map, actor.position, state.actors.player.position)
-  ) {
-    return nextStepOnShortestPath(map, actor.position, uncollected) ?? actor.position
+  if (intent.intent === 'anchor') {
+    return nextStepOnShortestPath(map, actor.position, farAnchor(state)) ?? actor.position
   }
   return nextStepOnShortestPath(map, actor.position, state.actors.player.position) ?? actor.position
 }

--- a/packages/game-shadow-chase/src/engine/config.ts
+++ b/packages/game-shadow-chase/src/engine/config.ts
@@ -5,8 +5,6 @@ export const OBJECTIVE_COUNT = 3
 export const MAP_MIN_SIZE = 7
 export const MAP_MAX_SIZE = 15
 export const MIN_PURSUER_SPAWN_DISTANCE = 6
-export const SWAP_COOLDOWN_TICKS = 20
-
 export const STABLE_ID_PATTERN = /^[a-z][a-z0-9-]{0,31}$/
 export const CANONICAL_UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -24,7 +22,7 @@ export function isSafeTick(value: unknown, max = RUN_CAP_TICKS): value is number
 }
 
 export const DIFFICULTY_CONFIG = Object.freeze({
-  relaxed: Object.freeze({ pursuerCadence: 3, rescueTicks: 32 }),
-  standard: Object.freeze({ pursuerCadence: 2, rescueTicks: 24 }),
-  intense: Object.freeze({ pursuerCadence: 1, rescueTicks: 20 }),
+  relaxed: Object.freeze({ pursuerBonusStepInterval: 8, rescueTicks: 32 }),
+  standard: Object.freeze({ pursuerBonusStepInterval: 6, rescueTicks: 24 }),
+  intense: Object.freeze({ pursuerBonusStepInterval: 4, rescueTicks: 20 }),
 })

--- a/packages/game-shadow-chase/src/engine/contracts.test.ts
+++ b/packages/game-shadow-chase/src/engine/contracts.test.ts
@@ -63,7 +63,7 @@ describe('frozen engine contracts', () => {
       hasLineOfSight({ ...map, width: 5, walls: [{ x: 4, y: 0 }] }, { x: 0, y: 0 }, { x: 3, y: 0 })
     ).toBe(true)
     for (const config of Object.values(DIFFICULTY_CONFIG)) {
-      expect(Object.keys(config).sort()).toEqual(['pursuerCadence', 'rescueTicks'])
+      expect(Object.keys(config).sort()).toEqual(['pursuerBonusStepInterval', 'rescueTicks'])
     }
   })
 

--- a/packages/game-shadow-chase/src/engine/intent-legality.ts
+++ b/packages/game-shadow-chase/src/engine/intent-legality.ts
@@ -29,10 +29,10 @@ export function validateModelProposal(
     return { ok: false, reason: 'lease' }
   }
   const { proposal } = input
-  if (!['follow', 'split', 'decoy'].includes(proposal.intent)) {
+  if (!['support', 'scout', 'anchor'].includes(proposal.intent)) {
     return { ok: false, reason: 'intent' }
   }
-  if (proposal.intent === 'follow' || proposal.intent === 'decoy') {
+  if (proposal.intent === 'support' || proposal.intent === 'anchor') {
     return proposal.targetObjectiveId ? { ok: false, reason: 'unexpected-target' } : { ok: true }
   }
   const objective = state.objectives.find(

--- a/packages/game-shadow-chase/src/engine/properties.test.ts
+++ b/packages/game-shadow-chase/src/engine/properties.test.ts
@@ -45,8 +45,8 @@ describe('seeded engine properties', () => {
         expect(
           Math.abs(previousPursuer.x - state.actors.pursuer.position.x) +
             Math.abs(previousPursuer.y - state.actors.pursuer.position.y)
-        ).toBeLessThanOrEqual(1)
-        expect(['player', 'companion', 'moon-gate']).toContain(state.actors.pursuer.destination)
+        ).toBeLessThanOrEqual(2)
+        expect(['player', 'moon-gate']).toContain(state.actors.pursuer.destination)
         if (state.actors.pursuer.destination !== 'moon-gate') {
           const destination = state.actors[state.actors.pursuer.destination]
           expect(destination.status).toBe('free')

--- a/packages/game-shadow-chase/src/engine/pursuer-policy.test.ts
+++ b/packages/game-shadow-chase/src/engine/pursuer-policy.test.ts
@@ -5,172 +5,88 @@ import { nextStepOnShortestPath } from './pathfinding'
 import {
   buildPursuerObservation,
   nextPursuerStep,
-  pursuerNextStep,
+  pursuerStepPath,
   selectPursuerDecision,
   type PursuerObservation,
 } from './pursuer-policy'
 import { createRunningState } from './rules'
 
-describe('pursuer observation policy', () => {
-  it('ignores command and model intent while retaining an equally near visible target', () => {
-    const state = createRunningState('crossroads', 'intense', 17)
+describe('player-only pursuer policy', () => {
+  it('targets a visible player and ignores a nearer companion and private intent', () => {
+    const state = createRunningState('crossroads', 'standard', 17)
     state.actors.pursuer.position = { x: 4, y: 0 }
-    state.actors.player.position = { x: 2, y: 0 }
-    state.actors.companion.position = { x: 6, y: 0 }
-    state.actors.pursuer.target = 'player'
-    state.command = { intent: 'decoy' }
+    state.actors.player.position = { x: 0, y: 0 }
+    state.actors.companion.position = { x: 5, y: 0 }
+    state.command = { intent: 'anchor' }
     state.activeModelLease = {
       requestId: '00000000-0000-4000-8000-000000000001',
       acceptedTick: 0,
       expiryTick: 10,
-      intent: 'decoy',
+      intent: 'anchor',
     }
 
-    const baseline = structuredClone(state)
-    baseline.command = { intent: 'follow' }
-    baseline.activeModelLease = undefined
+    const decision = selectPursuerDecision(buildPursuerObservation(state))
 
-    expect(pursuerNextStep(state, 1)).toEqual({ x: 3, y: 0 })
-    expect(pursuerNextStep(baseline, 1)).toEqual({ x: 3, y: 0 })
-    expect(state.actors.pursuer.target).toBe('player')
-    expect(state.actors.pursuer.destination).toBe('player')
-    expect(baseline.actors.pursuer).toEqual(state.actors.pursuer)
-
-    const companionTargeted = structuredClone(state)
-    companionTargeted.actors.pursuer.target = 'companion'
-    expect(pursuerNextStep(companionTargeted, 1)).toEqual({ x: 5, y: 0 })
-    expect(companionTargeted.actors.pursuer.target).toBe('companion')
-    expect(companionTargeted.actors.pursuer.destination).toBe('companion')
+    expect(decision).toEqual({ visibleCandidates: ['player'], destination: 'player' })
+    expect(nextPursuerStep(buildPursuerObservation(state), decision)).toEqual({ x: 3, y: 0 })
   })
 
-  it('chooses the nearest visible shadow by path distance', () => {
-    const state = createRunningState('crossroads', 'intense', 17)
-    state.actors.pursuer.position = { x: 4, y: 0 }
-    state.actors.player.position = { x: 0, y: 0 }
-    state.actors.companion.position = { x: 6, y: 0 }
-    state.actors.pursuer.target = 'player'
-
-    expect(pursuerNextStep(state, 1)).toEqual({ x: 5, y: 0 })
-    expect(state.actors.pursuer.target).toBe('companion')
-    expect(state.actors.pursuer.destination).toBe('companion')
-  })
-
-  it('falls back to the player when tie memory is absent or ineligible', () => {
-    const state = createRunningState('crossroads', 'intense', 17)
-    state.actors.pursuer.position = { x: 4, y: 0 }
-    state.actors.player.position = { x: 2, y: 0 }
-    state.actors.companion.position = { x: 6, y: 0 }
-    const observation = buildPursuerObservation(state)
-
-    expect(
-      selectPursuerDecision({
-        ...observation,
-        previousTarget: null,
-      }).destination
-    ).toBe('player')
-
-    expect(
-      selectPursuerDecision({
-        ...observation,
-        shadows: observation.shadows.map((shadow) =>
-          shadow.id === 'companion' ? { ...shadow, status: 'captured' as const } : shadow
-        ),
-        previousTarget: 'companion',
-      }).destination
-    ).toBe('player')
-  })
-
-  it('searches toward the moon gate instead of a stale hidden target', () => {
-    const state = createRunningState('crossroads', 'intense', 17)
-    state.actors.pursuer.target = 'companion'
+  it('returns to the moon gate when the player is hidden even if the companion is visible', () => {
+    const state = createRunningState('crossroads', 'standard', 17)
+    state.actors.companion.position = { x: 7, y: 4 }
     const expected = nextStepOnShortestPath(
       getMap(state.mapId),
       state.actors.pursuer.position,
       state.exit.position
     )
 
-    expect(pursuerNextStep(state, 1)).toEqual(expected)
-    expect(state.actors.pursuer.destination).toBe('moon-gate')
-    expect(state.actors.pursuer.target).toBe('companion')
-  })
-
-  it('excludes a captured shadow from visible pursuit candidates', () => {
-    const state = createRunningState('crossroads', 'intense', 17)
-    state.actors.pursuer.position = { x: 4, y: 0 }
-    state.actors.player.position = { x: 0, y: 0 }
-    state.actors.companion.position = { x: 5, y: 0 }
-    state.actors.companion.status = 'captured'
-    state.actors.pursuer.target = 'companion'
-
-    expect(pursuerNextStep(state, 1)).toEqual({ x: 3, y: 0 })
-    expect(state.actors.pursuer.destination).toBe('player')
-    expect(state.actors.pursuer.target).toBe('player')
-  })
-
-  it('observes and selects every tick while cadence gates movement only', () => {
-    const state = createRunningState('crossroads', 'relaxed', 17)
-    state.actors.pursuer.position = { x: 4, y: 0 }
-    state.actors.player.position = { x: 0, y: 0 }
-    state.actors.companion.position = { x: 5, y: 0 }
-    state.actors.pursuer.target = 'player'
-
-    expect(pursuerNextStep(state, 1)).toEqual({ x: 4, y: 0 })
-    expect(state.actors.pursuer.destination).toBe('companion')
-    expect(state.actors.pursuer.target).toBe('companion')
-  })
-
-  it('drops a newly hidden destination off cadence while preserving tie memory', () => {
-    const state = createRunningState('crossroads', 'relaxed', 17)
-    state.actors.pursuer.position = { x: 4, y: 0 }
-    state.actors.player.position = { x: 0, y: 1 }
-    state.actors.companion.position = { x: 5, y: 0 }
-    state.actors.pursuer.target = 'companion'
-    pursuerNextStep(state, 1)
-    state.actors.companion.position = { x: 5, y: 1 }
-
-    expect(pursuerNextStep(state, 2)).toEqual({ x: 4, y: 0 })
-    expect(state.actors.pursuer.destination).toBe('moon-gate')
-    expect(state.actors.pursuer.target).toBe('companion')
-  })
-
-  it('stays at the moon gate when no free shadow is visible', () => {
-    const state = createRunningState('crossroads', 'intense', 17)
-    state.actors.pursuer.position = { ...state.exit.position }
-
-    expect(pursuerNextStep(state, 1)).toEqual(state.exit.position)
+    expect(pursuerStepPath(state, 1)).toEqual([expected])
     expect(state.actors.pursuer.destination).toBe('moon-gate')
   })
 
-  it('makes the same observation and step across difficulties on a shared cadence tick', () => {
-    const decisions = (['relaxed', 'standard', 'intense'] as const).map((difficulty) => {
+  it('returns to the moon gate after capturing the player', () => {
+    const state = createRunningState('crossroads', 'standard', 17)
+    state.actors.pursuer.position = { x: 4, y: 0 }
+    state.actors.player.position = { x: 2, y: 0 }
+    state.actors.player.status = 'captured'
+
+    expect(selectPursuerDecision(buildPursuerObservation(state)).destination).toBe('moon-gate')
+  })
+
+  it('takes one step every tick and one bonus step at the difficulty interval', () => {
+    const counts = (['relaxed', 'standard', 'intense'] as const).map((difficulty) => {
       const state = createRunningState('crossroads', difficulty, 17)
       state.actors.pursuer.position = { x: 4, y: 0 }
       state.actors.player.position = { x: 0, y: 0 }
-      state.actors.companion.position = { x: 5, y: 0 }
-      const step = pursuerNextStep(state, 6)
-      return {
-        step,
-        target: state.actors.pursuer.target,
-        destination: state.actors.pursuer.destination,
-      }
+      const interval = { relaxed: 8, standard: 6, intense: 4 }[difficulty]
+      return [pursuerStepPath(state, 1).length, pursuerStepPath(state, interval).length]
     })
 
-    expect(decisions[1]).toEqual(decisions[0])
-    expect(decisions[2]).toEqual(decisions[0])
+    expect(counts).toEqual([
+      [1, 2],
+      [1, 2],
+      [1, 2],
+    ])
   })
 
-  it('builds a narrow observation without reading forbidden simulation fields', () => {
+  it('builds a narrow observation without reading the companion or private fields', () => {
     const state = createRunningState('crossroads', 'standard', 17)
+    Object.defineProperty(state.actors, 'companion', {
+      configurable: true,
+      get: () => {
+        throw new Error('forbidden companion read')
+      },
+    })
     for (const field of [
       'command',
       'activeModelLease',
       'difficulty',
       'objectives',
-      'exit',
       'decisionEpoch',
       'eventLog',
       'playerNavigation',
       'rngState',
+      'swapCharges',
     ] as const) {
       Object.defineProperty(state, field, {
         configurable: true,
@@ -187,12 +103,12 @@ describe('pursuer observation policy', () => {
     const observation = buildPursuerObservation(createRunningState('crossroads', 'standard', 17))
     const poisoned = { ...observation } as PursuerObservation & Record<string, unknown>
     for (const field of [
+      'companion',
       'command',
       'modelLease',
       'difficulty',
       'objectives',
       'voice',
-      'subtitle',
     ]) {
       Object.defineProperty(poisoned, field, {
         get: () => {
@@ -201,22 +117,6 @@ describe('pursuer observation policy', () => {
       })
     }
 
-    const baseline = selectPursuerDecision(observation)
-    const poisonedDecision = selectPursuerDecision(poisoned)
-    expect(poisonedDecision).toEqual(baseline)
-    expect(nextPursuerStep(poisoned, poisonedDecision)).toEqual(
-      nextPursuerStep(observation, baseline)
-    )
-  })
-
-  it('does not let hidden actor movement change the moon-gate route', () => {
-    const first = createRunningState('crossroads', 'standard', 17)
-    first.actors.pursuer.target = 'companion'
-    const movedHidden = structuredClone(first)
-    movedHidden.actors.companion.position = { x: 8, y: 0 }
-
-    expect(selectPursuerDecision(buildPursuerObservation(movedHidden))).toEqual(
-      selectPursuerDecision(buildPursuerObservation(first))
-    )
+    expect(selectPursuerDecision(poisoned)).toEqual(selectPursuerDecision(observation))
   })
 })

--- a/packages/game-shadow-chase/src/engine/pursuer-policy.ts
+++ b/packages/game-shadow-chase/src/engine/pursuer-policy.ts
@@ -5,24 +5,21 @@ import { nextStepOnShortestPath } from './pathfinding'
 import type { WalkableMap } from './rules'
 import type { Coordinate, ShadowActor, SimulationState } from './types'
 
-export type PursuerShadowId = ShadowActor['id']
+export type PursuerShadowId = 'player'
 export type PursuerDestination = PursuerShadowId | 'moon-gate'
 
 export interface PursuerObservation {
   readonly map: WalkableMap & { readonly moonGate: Coordinate }
   readonly pursuer: Coordinate
-  readonly shadows: readonly {
-    readonly id: PursuerShadowId
+  readonly player: {
     readonly position: Coordinate
     readonly status: ShadowActor['status']
-  }[]
-  readonly previousTarget: PursuerShadowId | null
+  }
 }
 
 export interface PursuerDecision {
   readonly visibleCandidates: readonly PursuerShadowId[]
   readonly destination: PursuerDestination
-  readonly targetMemory: PursuerShadowId | null
 }
 
 function immutableCoordinate(position: Coordinate): Coordinate {
@@ -49,48 +46,20 @@ export function buildPursuerObservation(state: SimulationState): PursuerObservat
   return Object.freeze({
     map: immutableObservationMap(map),
     pursuer: immutableCoordinate(state.actors.pursuer.position),
-    shadows: Object.freeze(
-      (['player', 'companion'] as const).map((id) =>
-        Object.freeze({
-          id,
-          position: immutableCoordinate(state.actors[id].position),
-          status: state.actors[id].status,
-        })
-      )
-    ),
-    previousTarget: state.actors.pursuer.target,
+    player: Object.freeze({
+      position: immutableCoordinate(state.actors.player.position),
+      status: state.actors.player.status,
+    }),
   })
 }
 
 export function selectPursuerDecision(observation: PursuerObservation): PursuerDecision {
-  const visibleCandidates = observation.shadows.filter(
-    (actor) =>
-      actor.status === 'free' &&
-      hasLineOfSight(observation.map, observation.pursuer, actor.position)
-  )
-  let destination: PursuerDestination = 'moon-gate'
-  let targetMemory = observation.previousTarget
-  if (visibleCandidates.length > 0) {
-    const distances = visibleCandidates.map((actor) => ({
-      actor,
-      // A visible actor shares an unobstructed row or column with the pursuer,
-      // so this direct segment is also the map's shortest walkable path.
-      distance:
-        Math.abs(observation.pursuer.x - actor.position.x) +
-        Math.abs(observation.pursuer.y - actor.position.y),
-    }))
-    const nearestDistance = Math.min(...distances.map((candidate) => candidate.distance))
-    const nearest = distances
-      .filter((candidate) => candidate.distance === nearestDistance)
-      .map((candidate) => candidate.actor.id)
-    destination =
-      targetMemory !== null && nearest.includes(targetMemory) ? targetMemory : nearest[0]
-    targetMemory = destination
-  }
+  const playerVisible =
+    observation.player.status === 'free' &&
+    hasLineOfSight(observation.map, observation.pursuer, observation.player.position)
   return Object.freeze({
-    visibleCandidates: Object.freeze(visibleCandidates.map((actor) => actor.id)),
-    destination,
-    targetMemory,
+    visibleCandidates: Object.freeze(playerVisible ? (['player'] as const) : []),
+    destination: playerVisible ? 'player' : 'moon-gate',
   })
 }
 
@@ -99,9 +68,7 @@ export function nextPursuerStep(
   decision: PursuerDecision
 ): Coordinate {
   const destinationPosition =
-    decision.destination === 'moon-gate'
-      ? observation.map.moonGate
-      : observation.shadows.find((actor) => actor.id === decision.destination)!.position
+    decision.destination === 'moon-gate' ? observation.map.moonGate : observation.player.position
   return (
     nextStepOnShortestPath(observation.map, observation.pursuer, destinationPosition) ??
     observation.pursuer
@@ -110,7 +77,7 @@ export function nextPursuerStep(
 
 function applyPursuerDecision(state: SimulationState, decision: PursuerDecision): void {
   state.actors.pursuer.destination = decision.destination
-  if (decision.targetMemory !== null) state.actors.pursuer.target = decision.targetMemory
+  state.actors.pursuer.target = 'player'
 }
 
 export function refreshPursuerDecision(state: SimulationState): PursuerDecision {
@@ -119,11 +86,24 @@ export function refreshPursuerDecision(state: SimulationState): PursuerDecision 
   return decision
 }
 
-export function pursuerNextStep(state: SimulationState, nextTick: number): Coordinate {
+export function pursuerStepPath(state: SimulationState, nextTick: number): readonly Coordinate[] {
   const observation = buildPursuerObservation(state)
   const decision = selectPursuerDecision(observation)
   applyPursuerDecision(state, decision)
-  return nextTick % DIFFICULTY_CONFIG[state.difficulty].pursuerCadence === 0
-    ? nextPursuerStep(observation, decision)
-    : state.actors.pursuer.position
+  const first = nextPursuerStep(observation, decision)
+  const path = [first]
+  const interval = DIFFICULTY_CONFIG[state.difficulty].pursuerBonusStepInterval
+  if (nextTick % interval === 0) {
+    const advancedObservation: PursuerObservation = Object.freeze({
+      ...observation,
+      pursuer: immutableCoordinate(first),
+    })
+    path.push(nextPursuerStep(advancedObservation, selectPursuerDecision(advancedObservation)))
+  }
+  return Object.freeze(path)
+}
+
+export function pursuerNextStep(state: SimulationState, nextTick: number): Coordinate {
+  const path = pursuerStepPath(state, nextTick)
+  return path[path.length - 1]
 }

--- a/packages/game-shadow-chase/src/engine/pursuer-rules.ts
+++ b/packages/game-shadow-chase/src/engine/pursuer-rules.ts
@@ -1,20 +1,18 @@
 export const PURSUER_RULE_COPY =
-  '追兵能看见整条没有墙遮挡的横竖直线：它追最近且未被捕获的可见影子，距离相同时不换目标；谁都看不见就返回月门。同格或迎面交叉会被捕获。诱敌只改变伙伴走位，难度只改变追兵速度和救援时间。'
+  '追兵只锁定你：横竖直线没有墙遮挡时追向你，看不见你就返回月门。它始终比你和伙伴略快；接触或迎面交叉仍会捕获任何一方。每收集一枚光核获得一次换位。'
 
 export const PURSUER_RULE_CONTRACT = Object.freeze({
-  eligibility: 'free-visible-shadows',
+  eligibility: 'free-visible-player-only',
   vision: Object.freeze({
     alignment: 'same-row-or-column',
     blocker: 'wall-between',
     range: 'full-map',
   }),
   selection: Object.freeze({
-    metric: 'shortest-path-distance',
-    tie: 'retain-last-eligible-actor-target',
-    initialFallback: 'player',
+    target: 'player-only',
   }),
   noVisibleDestination: 'moon-gate',
   capture: Object.freeze(['same-cell', 'opposite-edge-crossing']),
-  difficultyEffects: Object.freeze(['movement-cadence', 'rescue-time']),
-  decoyAuthority: 'companion-movement-only',
+  difficultyEffects: Object.freeze(['bonus-step-interval', 'rescue-time']),
+  swapEconomy: 'one-charge-per-collected-core',
 })

--- a/packages/game-shadow-chase/src/engine/reducer.test.ts
+++ b/packages/game-shadow-chase/src/engine/reducer.test.ts
@@ -21,33 +21,36 @@ describe('ten-phase reducer contract', () => {
     state.actors.companion.position = { x: 3, y: 1 }
     const next = advance(state, [
       action(state, 1, { type: 'player-move', direction: 'right' }),
-      action(state, 2, { type: 'companion-command', command: 'follow' }),
+      action(state, 2, { type: 'companion-command', command: 'support' }),
     ])
     expect(next.actors.player.position).toEqual({ x: 2, y: 1 })
     expect(next.actors.companion.position).toEqual({ x: 3, y: 1 })
   })
 
-  it('applies swap atomically and starts cooldown', () => {
+  it('applies a charged swap atomically and consumes the charge', () => {
     const state = createRunningState('courtyard', 'standard', 7)
+    state.swapCharges = 1
     const playerStart = state.actors.player.position
     const companionStart = state.actors.companion.position
     const next = advance(state, [action(state, 1, { type: 'swap' })])
     expect(next.actors.player.position).toEqual(companionStart)
     expect(next.actors.companion.position).toEqual(playerStart)
-    expect(next.cooldowns.swapReadyTick).toBeGreaterThan(next.tick)
+    expect(next.swapCharges).toBe(0)
   })
 
-  it('accepts a decoy command without granting the pursuer command knowledge', () => {
+  it('accepts an anchor command without granting the pursuer command knowledge', () => {
     const state = createRunningState('courtyard', 'standard', 7)
     state.tick = 1
-    const next = advance(state, [action(state, 1, { type: 'companion-command', command: 'decoy' })])
-    expect(next.command.intent).toBe('decoy')
-    expect(next.actors.pursuer.target).not.toBe('companion')
+    const next = advance(state, [
+      action(state, 1, { type: 'companion-command', command: 'anchor' }),
+    ])
+    expect(next.command.intent).toBe('anchor')
+    expect(next.actors.pursuer.target).toBe('player')
     expect(next.actors.pursuer.destination).toBe('moon-gate')
     expect(next.decisionEpoch).toBe(1)
   })
 
-  it('resolves contact even when pursuer cadence holds movement', () => {
+  it('resolves contact before the pursuer leaves an occupied tile', () => {
     const state = createRunningState('courtyard', 'relaxed', 7)
     state.actors.player.position = { ...state.actors.pursuer.position }
 

--- a/packages/game-shadow-chase/src/engine/reducer.ts
+++ b/packages/game-shadow-chase/src/engine/reducer.ts
@@ -1,15 +1,9 @@
-import {
-  DIFFICULTY_CONFIG,
-  MIN_RUN_TICKS,
-  RUN_CAP_TICKS,
-  SWAP_COOLDOWN_TICKS,
-  isSafeTick,
-} from './config'
+import { DIFFICULTY_CONFIG, MIN_RUN_TICKS, RUN_CAP_TICKS, isSafeTick } from './config'
 import { companionNextStep } from './companion-policy'
 import { validateModelProposal } from './intent-legality'
 import { getMap } from './maps'
 import { nextStepOnShortestPath, shortestPath } from './pathfinding'
-import { pursuerNextStep, refreshPursuerDecision } from './pursuer-policy'
+import { pursuerStepPath, refreshPursuerDecision } from './pursuer-policy'
 import { coordinatesEqual, isInsideMap, isWalkable, moved } from './rules'
 import type {
   Coordinate,
@@ -35,12 +29,12 @@ function cloneState(state: SimulationState): SimulationState {
 
 export interface ReducerPolicies {
   companion(state: SimulationState): Coordinate
-  pursuer(state: SimulationState, nextTick: number): Coordinate
+  pursuer(state: SimulationState, nextTick: number): Coordinate | readonly Coordinate[]
 }
 
 const DEFAULT_POLICIES: ReducerPolicies = {
   companion: companionNextStep,
-  pursuer: pursuerNextStep,
+  pursuer: pursuerStepPath,
 }
 
 export function advance(
@@ -86,7 +80,7 @@ export function advance(
       )
       next.command = {
         intent: action.command,
-        ...(action.command === 'split' && target ? { targetObjectiveId: target.id } : {}),
+        ...(action.command === 'scout' && target ? { targetObjectiveId: target.id } : {}),
       }
       next.activeModelLease = undefined
       next.decisionEpoch += 1
@@ -179,7 +173,11 @@ export function advance(
     }
   }
   let companionEnd = policies.companion(next)
-  const pursuerEnd = policies.pursuer(next, nextTick)
+  const pursuerResult = policies.pursuer(next, nextTick)
+  const plannedPursuerPath: Coordinate[] = Array.isArray(pursuerResult)
+    ? [...pursuerResult]
+    : [pursuerResult as Coordinate]
+  if (plannedPursuerPath.length === 0) throw new Error('Pursuer path cannot be empty')
   if (next.actors.pursuer.target !== state.actors.pursuer.target) {
     next.decisionEpoch += 1
   }
@@ -188,12 +186,12 @@ export function advance(
     swapRequested &&
     state.actors.player.status === 'free' &&
     state.actors.companion.status === 'free' &&
-    nextTick >= state.cooldowns.swapReadyTick
+    state.swapCharges > 0
   if (canSwap) {
     next.playerNavigation = undefined
     playerEnd = starts.companion
     companionEnd = starts.player
-    next.cooldowns.swapReadyTick = nextTick + SWAP_COOLDOWN_TICKS
+    next.swapCharges -= 1
     tickEvents.push({ tick: nextTick, type: 'swap' })
   } else {
     if (swapRequested) {
@@ -215,6 +213,35 @@ export function advance(
       companionEnd = starts.companion
     }
   }
+
+  const pursuerContactIndex = (
+    actorStart: Coordinate,
+    actorEnd: Coordinate,
+    path: readonly Coordinate[]
+  ): number => {
+    let pursuerStart = starts.pursuer
+    for (let index = 0; index < path.length; index += 1) {
+      const pursuerStep = path[index]
+      const actorStepStart = index === 0 ? actorStart : actorEnd
+      if (
+        coordinatesEqual(actorEnd, pursuerStep) ||
+        crossed(actorStepStart, actorEnd, pursuerStart, pursuerStep)
+      ) {
+        return index
+      }
+      pursuerStart = pursuerStep
+    }
+    return -1
+  }
+  const playerContactIndex =
+    state.actors.player.status === 'free'
+      ? pursuerContactIndex(starts.player, playerEnd, plannedPursuerPath)
+      : -1
+  const effectivePursuerPath =
+    playerContactIndex >= 0
+      ? plannedPursuerPath.slice(0, playerContactIndex + 1)
+      : plannedPursuerPath
+  const pursuerEnd = effectivePursuerPath[effectivePursuerPath.length - 1]
 
   next.actors.player.position = playerEnd
   next.actors.companion.position = companionEnd
@@ -245,9 +272,7 @@ export function advance(
   for (const actorId of ['player', 'companion'] as const) {
     const actor = next.actors[actorId]
     if (state.actors[actorId].status !== 'free') continue
-    const contact =
-      coordinatesEqual(actor.position, pursuerEnd) ||
-      crossed(starts[actorId], actor.position, starts.pursuer, pursuerEnd)
+    const contact = pursuerContactIndex(starts[actorId], actor.position, effectivePursuerPath) >= 0
     if (contact) {
       actor.status = 'captured'
       actor.rescueDeadlineTick = nextTick + DIFFICULTY_CONFIG[state.difficulty].rescueTicks
@@ -289,14 +314,19 @@ export function advance(
     return actor.status === 'captured' && nextTick >= (actor.rescueDeadlineTick ?? 0)
   })
 
-  for (const actorId of ['player', 'companion'] as const) {
-    const actor = next.actors[actorId]
-    if (actor.status !== 'free') continue
+  const player = next.actors.player
+  if (player.status === 'free') {
     for (const objective of next.objectives) {
-      if (!objective.collected && coordinatesEqual(actor.position, objective.position)) {
+      if (!objective.collected && coordinatesEqual(player.position, objective.position)) {
         objective.collected = true
+        next.swapCharges += 1
         next.decisionEpoch += 1
-        tickEvents.push({ tick: nextTick, type: 'core-collected', actorId, detail: objective.id })
+        tickEvents.push({
+          tick: nextTick,
+          type: 'core-collected',
+          actorId: 'player',
+          detail: objective.id,
+        })
       }
     }
   }

--- a/packages/game-shadow-chase/src/engine/replay.test.ts
+++ b/packages/game-shadow-chase/src/engine/replay.test.ts
@@ -11,7 +11,7 @@ const RECORD: ReplayRecord = {
   difficulty: 'standard',
   actions: [
     { applyAtTick: 1, sequence: 1, action: { type: 'player-move', direction: 'right' } },
-    { applyAtTick: 2, sequence: 2, action: { type: 'companion-command', command: 'split' } },
+    { applyAtTick: 2, sequence: 2, action: { type: 'companion-command', command: 'scout' } },
     { applyAtTick: 3, sequence: 3, action: { type: 'swap' } },
   ],
 }
@@ -36,12 +36,12 @@ describe('replay determinism', () => {
             requestId: '00000000-0000-4000-8000-000000000001',
             runId: runIdForSeed(RECORD.seed),
             decisionEpoch: 0,
-            proposal: { intent: 'decoy', bark: 'I will draw it away.' },
+            proposal: { intent: 'anchor', bark: 'I will establish a distant swap point.' },
             leaseTicks: 8,
           },
         },
       ],
     }
-    expect(replay(withLease, 4).activeModelLease?.intent).toBe('decoy')
+    expect(replay(withLease, 4).activeModelLease?.intent).toBe('anchor')
   })
 })

--- a/packages/game-shadow-chase/src/engine/reworked-core.test.ts
+++ b/packages/game-shadow-chase/src/engine/reworked-core.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+
+import { advance } from './reducer'
+import { createRunningState } from './rules'
+import type { QueuedAction, SimulationState } from './types'
+
+function action(
+  state: SimulationState,
+  sequence: number,
+  value: QueuedAction['action']
+): QueuedAction {
+  return { applyAtTick: state.tick + 1, sequence, action: value }
+}
+
+describe('player-only pursuit core', () => {
+  it('targets the visible player even when the companion is nearer', () => {
+    const state = createRunningState('crossroads', 'standard', 17)
+    state.actors.pursuer.position = { x: 4, y: 0 }
+    state.actors.player.position = { x: 0, y: 0 }
+    state.actors.companion.position = { x: 5, y: 0 }
+
+    const next = advance(state, [])
+
+    expect(next.actors.pursuer.destination).toBe('player')
+  })
+
+  it('moves an extra cell on an intense bonus tick without skipping player contact', () => {
+    const state = createRunningState('crossroads', 'intense', 17)
+    state.tick = 3
+    state.actors.pursuer.position = { x: 4, y: 0 }
+    state.actors.player.position = { x: 2, y: 0 }
+    state.actors.companion.position = { x: 8, y: 8 }
+
+    const next = advance(state, [])
+
+    expect(next.actors.pursuer.position).toEqual({ x: 2, y: 0 })
+    expect(next.actors.player.status).toBe('captured')
+  })
+
+  it('requires one collected core for each swap', () => {
+    const state = Object.assign(createRunningState('courtyard', 'standard', 7), {
+      swapCharges: 0,
+    })
+    const playerStart = { ...state.actors.player.position }
+    const companionStart = { ...state.actors.companion.position }
+
+    const rejected = advance(state, [action(state, 1, { type: 'swap' })])
+    expect(rejected.actors.player.position).toEqual(playerStart)
+    expect(rejected.actors.companion.position).toEqual(companionStart)
+    expect(rejected.eventLog.at(-1)?.type).toBe('swap-rejected')
+
+    rejected.actors.player.position = { ...rejected.objectives[0].position }
+    rejected.actors.pursuer.position = { x: 5, y: 5 }
+    const charged = advance(rejected, [], {
+      companion: (current) => current.actors.companion.position,
+      pursuer: (current) => current.actors.pursuer.position,
+    }) as SimulationState & { swapCharges: number }
+    expect(charged.swapCharges).toBe(1)
+
+    const swapped = advance(charged, [action(charged, 2, { type: 'swap' })]) as SimulationState & {
+      swapCharges: number
+    }
+    expect(swapped.swapCharges).toBe(0)
+  })
+
+  it('still captures the companion on incidental contact', () => {
+    const state = createRunningState('crossroads', 'standard', 17)
+    state.actors.pursuer.position = { x: 4, y: 0 }
+    state.actors.player.position = { x: 0, y: 0 }
+    state.actors.companion.position = { x: 3, y: 0 }
+
+    const next = advance(state, [], {
+      companion: (current) => current.actors.companion.position,
+      pursuer: () => ({ x: 3, y: 0 }),
+    })
+
+    expect(next.actors.companion.status).toBe('captured')
+    expect(next.actors.player.status).toBe('free')
+  })
+
+  it('does not let the companion collect a core or mint a swap charge', () => {
+    const state = createRunningState('courtyard', 'standard', 17)
+    state.actors.companion.position = { ...state.objectives[0].position }
+    state.actors.pursuer.position = { x: 5, y: 5 }
+
+    const next = advance(state, [], {
+      companion: (current) => current.actors.companion.position,
+      pursuer: (current) => current.actors.pursuer.position,
+    })
+
+    expect(next.objectives[0].collected).toBe(false)
+    expect(next.swapCharges).toBe(0)
+  })
+
+  it('allows the companion to rescue while the live pursuer returns to the moon gate', () => {
+    let state = createRunningState('courtyard', 'standard', 17)
+    state.actors.player.position = { x: 2, y: 1 }
+    state.actors.player.status = 'captured'
+    state.actors.player.rescueDeadlineTick = 24
+    state.actors.companion.position = { x: 0, y: 1 }
+    state.actors.pursuer.position = { x: 2, y: 1 }
+
+    while (
+      state.phase === 'running' &&
+      state.actors.player.status === 'captured' &&
+      state.tick < 24
+    ) {
+      state = advance(state, [])
+    }
+
+    expect(
+      state.eventLog.some((event) => event.type === 'rescue' && event.actorId === 'player')
+    ).toBe(true)
+    expect(state.phase).toBe('running')
+    expect(state.actors.companion.status).toBe('free')
+  })
+})

--- a/packages/game-shadow-chase/src/engine/rules.ts
+++ b/packages/game-shadow-chase/src/engine/rules.ts
@@ -84,8 +84,8 @@ export function createRunningState(
       collected: false,
     })),
     exit: { position: { ...map.exit }, enabled: false },
-    command: { intent: 'follow' },
-    cooldowns: { swapReadyTick: 0 },
+    command: { intent: 'support' },
+    swapCharges: 0,
     decisionEpoch: 0,
     eventLog: [],
   }

--- a/packages/game-shadow-chase/src/engine/types.ts
+++ b/packages/game-shadow-chase/src/engine/types.ts
@@ -1,6 +1,6 @@
 export type Direction = 'up' | 'down' | 'left' | 'right'
 export type Difficulty = 'relaxed' | 'standard' | 'intense'
-export type CompanionIntent = 'follow' | 'split' | 'decoy'
+export type CompanionIntent = 'support' | 'scout' | 'anchor'
 export type SimulationPhase = 'running' | 'win' | 'loss' | 'timeout'
 export type PlayerInputRejectionReason =
   | 'wall'
@@ -43,10 +43,10 @@ export interface ShadowActor {
 export interface PursuerActor {
   id: 'pursuer'
   position: Coordinate
-  /** Last observed shadow, used only to keep equal-distance ties stable. */
-  target: 'player' | 'companion'
+  /** The pursuer only locks onto the human-controlled shadow. */
+  target: 'player'
   /** Actual movement destination selected by the latest observation. */
-  destination: 'player' | 'companion' | 'moon-gate'
+  destination: 'player' | 'moon-gate'
 }
 
 export interface ObjectiveState extends ObjectiveDefinition {
@@ -124,7 +124,7 @@ export interface SimulationState {
   exit: { position: Coordinate; enabled: boolean }
   command: { intent: CompanionIntent; targetObjectiveId?: string }
   playerNavigation?: PlayerNavigation
-  cooldowns: { swapReadyTick: number }
+  swapCharges: number
   activeModelLease?: ModelLease
   decisionEpoch: number
   eventLog: EngineEvent[]

--- a/packages/game-shadow-chase/src/model/intent-client.test.ts
+++ b/packages/game-shadow-chase/src/model/intent-client.test.ts
@@ -11,13 +11,13 @@ function request(epoch: number): IntentRequest {
     decisionEpoch: epoch,
     observedTick: epoch,
     difficulty: 'standard',
-    command: 'follow',
+    command: 'support',
     actors: [],
     pursuer: { x: 1, y: 1 },
     objectives: [],
     exit: { x: 1, y: 1 },
-    cooldowns: { swapReadyTick: 0 },
-    allowedIntents: ['follow', 'split', 'decoy'],
+    swapCharges: 0,
+    allowedIntents: ['support', 'scout', 'anchor'],
   }
 }
 
@@ -56,7 +56,7 @@ describe('one-in-flight intent coordinator', () => {
       requestId: value.requestId,
       runId: value.runId,
       decisionEpoch: 1,
-      proposal: { intent: 'follow' },
+      proposal: { intent: 'support' },
       leaseTicks: 8,
     })
     await Promise.resolve()

--- a/packages/game-shadow-chase/src/model/intent-contract.test.ts
+++ b/packages/game-shadow-chase/src/model/intent-contract.test.ts
@@ -26,7 +26,7 @@ describe('model intent contract', () => {
       requestId: '00000000-0000-4000-8000-000000000001',
       runId: '00000000-0000-4000-8000-000000000002',
       decisionEpoch: 2,
-      proposal: { intent: 'decoy', bark: 'Take the core. I will draw it away.' },
+      proposal: { intent: 'anchor', bark: 'I will establish a distant swap point.' },
       leaseTicks: 8,
     })
     expect(parseIntentResponse(value).ok).toBe(true)
@@ -43,12 +43,12 @@ describe('model intent contract', () => {
     }
     expect(
       parseIntentResponse(
-        JSON.stringify({ ...base, proposal: { intent: 'follow', bark: 'a'.repeat(49) } })
+        JSON.stringify({ ...base, proposal: { intent: 'support', bark: 'a'.repeat(49) } })
       )
     ).toEqual({ ok: false, reason: 'bark' })
     expect(
       parseIntentResponse(
-        JSON.stringify({ ...base, proposal: { intent: 'follow', bark: 'safe\u0007' } })
+        JSON.stringify({ ...base, proposal: { intent: 'support', bark: 'safe\u0007' } })
       )
     ).toMatchObject({ ok: true, value: { proposal: { bark: 'safe' } } })
   })

--- a/packages/game-shadow-chase/src/model/intent-contract.ts
+++ b/packages/game-shadow-chase/src/model/intent-contract.ts
@@ -29,7 +29,7 @@ export interface IntentRequest {
   pursuer: Coordinate
   objectives: Array<{ id: string; position: Coordinate; collected: boolean }>
   exit: Coordinate
-  cooldowns: { swapReadyTick: number }
+  swapCharges: number
   allowedIntents: CompanionIntent[]
 }
 
@@ -97,18 +97,18 @@ export function parseIntentResponse(text: string): IntentParseResult {
   }
   const proposal = value.proposal as Record<string, unknown>
   const intent = proposal.intent
-  if (!['follow', 'split', 'decoy'].includes(String(intent))) {
+  if (!['support', 'scout', 'anchor'].includes(String(intent))) {
     return { ok: false, reason: 'schema' }
   }
   const allowedKeys =
-    intent === 'split' ? ['intent', 'targetObjectiveId', 'bark'] : ['intent', 'bark']
+    intent === 'scout' ? ['intent', 'targetObjectiveId', 'bark'] : ['intent', 'bark']
   if (Object.keys(proposal).some((key) => !allowedKeys.includes(key))) {
     return { ok: false, reason: 'schema' }
   }
-  if (intent === 'split' && typeof proposal.targetObjectiveId !== 'string') {
+  if (intent === 'scout' && typeof proposal.targetObjectiveId !== 'string') {
     return { ok: false, reason: 'schema' }
   }
-  if ((intent === 'follow' || intent === 'decoy') && proposal.targetObjectiveId !== undefined) {
+  if ((intent === 'support' || intent === 'anchor') && proposal.targetObjectiveId !== undefined) {
     return { ok: false, reason: 'schema' }
   }
   let bark: string | undefined
@@ -165,7 +165,7 @@ export function buildIntentRequest(state: SimulationState): IntentRequest {
       collected: objective.collected,
     })),
     exit: { ...state.exit.position },
-    cooldowns: { ...state.cooldowns },
-    allowedIntents: ['follow', 'split', 'decoy'],
+    swapCharges: state.swapCharges,
+    allowedIntents: ['support', 'scout', 'anchor'],
   }
 }

--- a/packages/game-shadow-chase/src/store/game-store.test.ts
+++ b/packages/game-shadow-chase/src/store/game-store.test.ts
@@ -102,9 +102,9 @@ describe('fixed-step external store', () => {
     const scheduler = new ManualScheduler()
     const store = createGameStore({ scheduler, seed: 5, mapId: 'courtyard', fetchIntent: null })
     store.start()
-    store.dispatch({ type: 'companion-command', command: 'decoy' })
+    store.dispatch({ type: 'companion-command', command: 'anchor' })
     scheduler.frame(TICK_MS)
-    expect(store.getSnapshot().command.intent).toBe('decoy')
+    expect(store.getSnapshot().command.intent).toBe('anchor')
   })
 
   it('preserves rapid discrete movement FIFO across successive ticks', () => {

--- a/packages/game-shadow-chase/src/voice/ShadowVoiceRuntime.test.tsx
+++ b/packages/game-shadow-chase/src/voice/ShadowVoiceRuntime.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createRunningState } from '../engine/rules'
-import type { SimulationState } from '../engine/types'
+import type { CompanionIntent, SimulationState } from '../engine/types'
 import { ShadowVoiceRuntime } from './ShadowVoiceRuntime'
 
 const voiceHarness = vi.hoisted(() => ({
@@ -49,13 +49,13 @@ vi.mock('./voice-eligibility', () => ({
 function RuntimeHarness({
   state,
   phase = 'planning',
-  strategy = 'follow',
+  strategy = 'support',
   onStrategy = vi.fn(),
 }: {
   state: SimulationState
   phase?: 'planning' | 'running'
-  strategy?: 'follow' | 'split' | 'decoy'
-  onStrategy?: (intent: 'follow' | 'split' | 'decoy') => void
+  strategy?: CompanionIntent
+  onStrategy?: (intent: CompanionIntent) => void
 }) {
   return (
     <ShadowVoiceRuntime
@@ -101,7 +101,7 @@ describe('Shadow voice production runtime', () => {
 
   it('configures one explicit-open shared session with exact Shadow context', () => {
     const state = createRunningState('courtyard', 'standard', 7)
-    render(<RuntimeHarness state={state} strategy="split" />)
+    render(<RuntimeHarness state={state} strategy="scout" />)
 
     const options = latestOptions()
     expect(options).toMatchObject({
@@ -122,8 +122,8 @@ describe('Shadow voice production runtime', () => {
         publicContext: {
           version: 1,
           phase: 'planning',
-          strategy: 'split',
-          allowedStrategies: ['follow', 'split', 'decoy'],
+          strategy: 'scout',
+          allowedStrategies: ['support', 'scout', 'anchor'],
         },
       },
     })
@@ -163,10 +163,10 @@ describe('Shadow voice production runtime', () => {
       text: string
     }) => void
 
-    act(() => deliver({ sequence: 4, text: '分头行动' }))
-    act(() => deliver({ sequence: 4, text: '去诱敌' }))
+    act(() => deliver({ sequence: 4, text: '去光核探路' }))
+    act(() => deliver({ sequence: 4, text: '去远处架点' }))
     expect(onStrategy).toHaveBeenCalledTimes(1)
-    expect(onStrategy).toHaveBeenCalledWith('split')
+    expect(onStrategy).toHaveBeenCalledWith('scout')
   })
 
   it('maps bounded errors to Chinese while deterministic controls remain available', () => {

--- a/packages/game-shadow-chase/src/voice/shadow-chase-context.test.ts
+++ b/packages/game-shadow-chase/src/voice/shadow-chase-context.test.ts
@@ -18,7 +18,7 @@ describe('Shadow Chase voice context', () => {
     state.objectives[0].collected = true
     state.actors.companion.status = 'captured'
 
-    const context = buildShadowChaseVoiceContext(state, 'planning', 'split')
+    const context = buildShadowChaseVoiceContext(state, 'planning', 'scout')
 
     expect(Object.keys(context)).toEqual([
       'version',
@@ -34,8 +34,8 @@ describe('Shadow Chase voice context', () => {
     expect(context).toMatchObject({
       version: 1,
       phase: 'planning',
-      strategy: 'split',
-      allowedStrategies: ['follow', 'split', 'decoy'],
+      strategy: 'scout',
+      allowedStrategies: ['support', 'scout', 'anchor'],
       map: { id: 'courtyard', width: 7, height: 7 },
       collectedObjectiveIds: ['core-aurora'],
       actors: [
@@ -62,28 +62,26 @@ describe('Shadow Chase voice context', () => {
       ).pursuerContract
     ).toEqual(PURSUER_RULE_CONTRACT)
     expect(PURSUER_RULE_CONTRACT).toEqual({
-      eligibility: 'free-visible-shadows',
+      eligibility: 'free-visible-player-only',
       vision: {
         alignment: 'same-row-or-column',
         blocker: 'wall-between',
         range: 'full-map',
       },
       selection: {
-        metric: 'shortest-path-distance',
-        tie: 'retain-last-eligible-actor-target',
-        initialFallback: 'player',
+        target: 'player-only',
       },
       noVisibleDestination: 'moon-gate',
       capture: ['same-cell', 'opposite-edge-crossing'],
-      difficultyEffects: ['movement-cadence', 'rescue-time'],
-      decoyAuthority: 'companion-movement-only',
+      difficultyEffects: ['bonus-step-interval', 'rescue-time'],
+      swapEconomy: 'one-charge-per-collected-core',
     })
   })
 
   it('ignores frame-only movement while tracking material game changes', () => {
     const base = createRunningState('crossroads', 'standard', 11)
     const baseline = shadowChaseVoiceStateSignature(
-      buildShadowChaseVoiceState(base, 'planning', 'follow')
+      buildShadowChaseVoiceState(base, 'planning', 'support')
     )
     const frameOnly = {
       ...base,
@@ -97,13 +95,13 @@ describe('Shadow Chase voice context', () => {
     }
 
     expect(
-      shadowChaseVoiceStateSignature(buildShadowChaseVoiceState(frameOnly, 'planning', 'follow'))
+      shadowChaseVoiceStateSignature(buildShadowChaseVoiceState(frameOnly, 'planning', 'support'))
     ).toBe(baseline)
     expect(
-      shadowChaseVoiceStateSignature(buildShadowChaseVoiceState(base, 'running', 'follow'))
+      shadowChaseVoiceStateSignature(buildShadowChaseVoiceState(base, 'running', 'support'))
     ).not.toBe(baseline)
     expect(
-      shadowChaseVoiceStateSignature(buildShadowChaseVoiceState(base, 'planning', 'decoy'))
+      shadowChaseVoiceStateSignature(buildShadowChaseVoiceState(base, 'planning', 'anchor'))
     ).not.toBe(baseline)
 
     const collected = {
@@ -114,7 +112,7 @@ describe('Shadow Chase voice context', () => {
       })),
     }
     expect(
-      shadowChaseVoiceStateSignature(buildShadowChaseVoiceState(collected, 'planning', 'follow'))
+      shadowChaseVoiceStateSignature(buildShadowChaseVoiceState(collected, 'planning', 'support'))
     ).not.toBe(baseline)
   })
 })

--- a/packages/game-shadow-chase/src/voice/shadow-chase-context.ts
+++ b/packages/game-shadow-chase/src/voice/shadow-chase-context.ts
@@ -11,7 +11,7 @@ export interface ShadowChaseVoiceContext {
   version: 1
   phase: 'planning' | 'running'
   strategy: CompanionIntent
-  allowedStrategies: ['follow', 'split', 'decoy']
+  allowedStrategies: ['support', 'scout', 'anchor']
   map: { id: string; width: number; height: number; walls: Coordinate[] }
   objectives: Array<{ id: string; position: Coordinate }>
   collectedObjectiveIds: string[]
@@ -25,17 +25,18 @@ export const SHADOW_CHASE_VOICE_MANUAL: GameVoiceManualData = {
     [SHADOW_CHASE_RULES_SECTION]: {
       goal: 'Collect all three light cores, survive until the moon gate opens, and exit together.',
       authority:
-        'The deterministic engine owns movement, collision, pursuit, rescue, cooldowns, and outcomes.',
+        'The deterministic engine owns movement, collision, pursuit, rescue, swap charges, and outcomes.',
       pursuerRule: PURSUER_RULE_COPY,
       pursuerContract: PURSUER_RULE_CONTRACT,
       strategies: {
-        follow: 'Stay near the player and prioritize rescue and joint exit.',
-        split: 'Take a separate objective route while deterministic safety rules remain active.',
-        decoy:
-          'Move the deterministic companion toward a visible lane where it can become the nearer free shadow. The command itself gives the pursuer no knowledge.',
+        support: 'Stay near the player to shorten rescue routes, while avoiding pursuer contact.',
+        scout:
+          'Move near the next light core without collecting it so the player can plan a route.',
+        anchor:
+          'Move far from the player to create a strong swap destination at the cost of rescue time.',
       },
       voiceCommands:
-        'Only an explicit final player utterance may request follow, split, or decoy. Assistant prose is informational.',
+        'Only an explicit final player utterance may request support, scout, or anchor. Assistant prose is informational.',
     },
   },
 }
@@ -50,7 +51,7 @@ export function buildShadowChaseVoiceContext(
     version: 1,
     phase,
     strategy,
-    allowedStrategies: ['follow', 'split', 'decoy'],
+    allowedStrategies: ['support', 'scout', 'anchor'],
     map: {
       id: map.id,
       width: map.width,

--- a/packages/game-shadow-chase/src/voice/strategy-command.test.ts
+++ b/packages/game-shadow-chase/src/voice/strategy-command.test.ts
@@ -4,28 +4,28 @@ import { classifyStrategyCommand } from './strategy-command'
 
 describe('explicit Chinese strategy command classifier', () => {
   it.each([
-    ['伙伴，跟着我。', 'follow'],
-    ['请跟随我', 'follow'],
-    ['跟我走！', 'follow'],
-    ['分头行动', 'split'],
-    ['我们分头。', 'split'],
-    ['分开走', 'split'],
-    ['去诱敌', 'decoy'],
-    ['请吸引追兵', 'decoy'],
-    ['把追兵引开！', 'decoy'],
+    ['伙伴，过来接应。', 'support'],
+    ['请保持接应', 'support'],
+    ['靠近我！', 'support'],
+    ['去光核探路', 'scout'],
+    ['去探路', 'scout'],
+    ['去光核附近站位', 'scout'],
+    ['去远处架点', 'anchor'],
+    ['建立换位点', 'anchor'],
+    ['拉开距离！', 'anchor'],
   ] as const)('accepts %s as %s', (text, intent) => {
     expect(classifyStrategyCommand(text)).toEqual({ kind: 'command', intent })
   })
 
   it.each([
-    '不要分头行动',
-    '我不需要你跟着我',
-    '别去诱敌',
-    '如果我们分开走呢',
-    '伙伴说“跟着我”',
-    '分头行动然后去诱敌',
+    '不要去光核探路',
+    '我不需要你靠近我',
+    '别去远处架点',
+    '如果我们拉开距离呢',
+    '伙伴说“过来接应”',
+    '去光核探路然后远处架点',
     '',
-    '跟着我\u0007',
+    '过来接应\u0007',
     '跟'.repeat(80),
   ])('rejects negated, hypothetical, ambiguous, or unsafe text: %s', (text) => {
     expect(classifyStrategyCommand(text).kind).toBe('clarify')

--- a/packages/game-shadow-chase/src/voice/strategy-command.ts
+++ b/packages/game-shadow-chase/src/voice/strategy-command.ts
@@ -4,9 +4,9 @@ const MAX_COMMAND_CODEPOINTS = 64
 const NEGATION_OR_HYPOTHETICAL = /不|别|如果|假如|要是|是否|建议|[吗呢？?]|["“”「」『』]/
 
 const FAMILIES: Array<{ intent: CompanionIntent; patterns: RegExp[] }> = [
-  { intent: 'follow', patterns: [/跟着我/, /跟随我/, /跟我走/] },
-  { intent: 'split', patterns: [/分头行动/, /我们分头/, /分开走/] },
-  { intent: 'decoy', patterns: [/去诱敌/, /吸引追兵/, /把追兵引开/] },
+  { intent: 'support', patterns: [/过来接应/, /保持接应/, /靠近我/] },
+  { intent: 'scout', patterns: [/去光核探路/, /去探路/, /光核附近站位/] },
+  { intent: 'anchor', patterns: [/远处架点/, /建立换位点/, /拉开距离/] },
 ]
 
 export type StrategyCommandResult =

--- a/packages/game-shadow-chase/src/voice/useShadowChaseVoice.test.tsx
+++ b/packages/game-shadow-chase/src/voice/useShadowChaseVoice.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
+import type { CompanionIntent } from '../engine/types'
 import { useShadowChaseVoice, type ShadowVoiceSource } from './useShadowChaseVoice'
 
 function VoiceHarness({
@@ -8,7 +9,7 @@ function VoiceHarness({
   onStrategy,
 }: {
   source: ShadowVoiceSource
-  onStrategy(intent: 'follow' | 'split' | 'decoy'): void
+  onStrategy(intent: CompanionIntent): void
 }) {
   useShadowChaseVoice(source, onStrategy)
   return null
@@ -19,13 +20,13 @@ describe('Shadow voice authority seam', () => {
     const onStrategy = vi.fn()
     const source: ShadowVoiceSource = {
       status: 'listening',
-      playerTranscript: '分头行动',
-      companionText: '我建议分头行动',
-      finalPlayerUtterance: { sequence: 7, text: '分头行动' },
+      playerTranscript: '去光核探路',
+      companionText: '我建议去光核探路',
+      finalPlayerUtterance: { sequence: 7, text: '去光核探路' },
     }
     const view = render(<VoiceHarness source={source} onStrategy={onStrategy} />)
     expect(onStrategy).toHaveBeenCalledTimes(1)
-    expect(onStrategy).toHaveBeenCalledWith('split')
+    expect(onStrategy).toHaveBeenCalledWith('scout')
     view.rerender(<VoiceHarness source={{ ...source }} onStrategy={onStrategy} />)
     expect(onStrategy).toHaveBeenCalledTimes(1)
   })
@@ -37,7 +38,7 @@ describe('Shadow voice authority seam', () => {
         source={{
           status: 'speaking',
           playerTranscript: '',
-          companionText: '我建议去诱敌',
+          companionText: '我建议去远处架点',
         }}
         onStrategy={onStrategy}
       />

--- a/packages/platform-ai/src/manual-injection.test.ts
+++ b/packages/platform-ai/src/manual-injection.test.ts
@@ -54,7 +54,7 @@ describe('assembleLlmContext — manual subset selection by game state', () => {
       manualData,
       gameState: {
         relevantSections: [],
-        publicContext: { version: 1, phase: 'planning', strategy: 'follow' },
+        publicContext: { version: 1, phase: 'planning', strategy: 'support' },
       },
     })
     expect(messages[0].content).toContain(PUBLIC_GAME_CONTEXT_FENCE_OPEN)

--- a/packages/platform-ai/src/provider-config.test.ts
+++ b/packages/platform-ai/src/provider-config.test.ts
@@ -134,7 +134,7 @@ describe('resolveConfig — shadow chase voice', () => {
     expect(resolved.stt).toEqual({ provider: 'volcengine', model: 'bigmodel' })
     expect(resolved.tts).toEqual({ provider: 'volcengine', model: '' })
     expect(resolved.systemPromptConfig.role).toContain('双影追逃')
-    expect(resolved.systemPromptConfig.ruleTemplate.join('\n')).toContain('跟随、分头、诱敌')
+    expect(resolved.systemPromptConfig.ruleTemplate.join('\n')).toContain('接应、探路、架点')
   })
 })
 

--- a/packages/platform-ai/src/provider-config.ts
+++ b/packages/platform-ai/src/provider-config.ts
@@ -267,10 +267,10 @@ const PROVIDER_REGISTRY: Record<GameId, ProviderConfig> = {
   },
   'shadow-chase': {
     systemPromptConfig: {
-      role: '你是玩家在《双影追逃》里的既有 AI 伙伴。你和一名玩家共同观察同一张地图，用简短中文讨论跟随、分头、诱敌三种高层策略；游戏引擎始终拥有行动与胜负的最终权威。',
+      role: '你是玩家在《双影追逃》里的既有 AI 伙伴。你和一名玩家共同观察同一张地图，用简短中文讨论接应、探路、架点三种高层策略；游戏引擎始终拥有行动与胜负的最终权威。',
       ruleTemplate: [
         '只依据平台注入的当前公开局面讨论策略；不知道的事实直接说明不知道，绝不编造地图、位置、记忆或规则。',
-        '你可以建议跟随、分头、诱敌，但建议和回应只提供信息，绝不声称自己已经替玩家切换策略、移动角色或改变游戏状态。',
+        '你可以建议接应、探路、架点，但建议和回应只提供信息，绝不声称自己已经替玩家切换策略、移动角色或改变游戏状态。',
         '确定性引擎负责逐帧移动、寻路、追击、碰撞、救援、冷却与胜负；不要给坐标级路径，不要要求游戏等待你的回答。',
         '玩家或语音、模型、麦克风、网络失败时，游戏仍由按钮和确定性伙伴继续；不要把连接问题描述成游戏暂停。',
         '回复一到两句中文口语，不用 markdown、括号、列表或字段名；先说当前判断，再给至多一个可执行建议。',
@@ -288,7 +288,7 @@ const INTENT_PROVIDER_REGISTRY: Record<GameId, IntentProviderConfig> = {
       role: 'You are the player’s existing AI companion in Shadow Chase. Propose one sparse, high-level legal intent; deterministic game rules remain authoritative.',
       ruleTemplate: [
         'Choose exactly one intent from the supplied allowedIntents list.',
-        'Use follow or decoy without a target. Use split only with one reachable, uncollected objective id supplied in the state.',
+        'Use support or anchor without a target. Use scout only with one reachable, uncollected objective id supplied in the state.',
         'Never propose coordinates, paths, game-rule changes, identity changes, assets, or memory writes.',
         'Return exactly one JSON object matching the requested response schema and no surrounding text.',
       ],

--- a/packages/platform-ai/src/session-update-gamestate.test.ts
+++ b/packages/platform-ai/src/session-update-gamestate.test.ts
@@ -184,8 +184,8 @@ describe('real VoiceSessionDO — update-gamestate (continuous run, module advan
     const context = {
       version: 1,
       phase: 'planning',
-      strategy: 'follow',
-      allowedStrategies: ['follow', 'split', 'decoy'],
+      strategy: 'support',
+      allowedStrategies: ['support', 'scout', 'anchor'],
       map: { id: 'courtyard', width: 9, height: 9, walls: [{ x: 2, y: 2 }] },
       objectives: [{ id: 'core-a', position: { x: 1, y: 2 } }],
       collectedObjectiveIds: [],

--- a/packages/platform-ai/src/shadow-chase-intent.test.ts
+++ b/packages/platform-ai/src/shadow-chase-intent.test.ts
@@ -32,7 +32,7 @@ function validBody(): ShadowChaseIntentRequest {
     decisionEpoch: 3,
     observedTick: 40,
     difficulty: 'standard',
-    command: 'follow',
+    command: 'support',
     actors: [
       { id: 'player', position: { x: 1, y: 1 }, status: 'free' },
       { id: 'companion', position: { x: 2, y: 1 }, status: 'free' },
@@ -44,8 +44,8 @@ function validBody(): ShadowChaseIntentRequest {
       { id: 'core-c', position: { x: 5, y: 3 }, collected: true },
     ],
     exit: { x: 6, y: 1 },
-    cooldowns: { swapReadyTick: 60 },
-    allowedIntents: ['follow', 'split', 'decoy'],
+    swapCharges: 1,
+    allowedIntents: ['support', 'scout', 'anchor'],
   }
 }
 
@@ -68,7 +68,7 @@ function validModelOutput(body = validBody()): string {
     requestId: body.requestId,
     runId: body.runId,
     decisionEpoch: body.decisionEpoch,
-    proposal: { intent: 'split', targetObjectiveId: 'core-a', bark: 'I will take core A.' },
+    proposal: { intent: 'scout', targetObjectiveId: 'core-a', bark: 'I will scout core A.' },
     leaseTicks: LEASE_DEFAULT_TICKS,
   })
 }
@@ -171,7 +171,7 @@ describe('shadow chase intent contract', () => {
       parseShadowChaseIntentResponse(
         JSON.stringify({
           ...base,
-          proposal: { intent: 'split', targetObjectiveId: 'core-c' },
+          proposal: { intent: 'scout', targetObjectiveId: 'core-c' },
         }),
         body
       ).ok
@@ -184,7 +184,7 @@ describe('shadow chase intent contract', () => {
     for (const bark of ['safe\u0007', 'a'.repeat(MAX_BARK_CODEPOINTS + 1)]) {
       expect(
         parseShadowChaseIntentResponse(
-          JSON.stringify({ ...base, proposal: { intent: 'follow', bark } }),
+          JSON.stringify({ ...base, proposal: { intent: 'support', bark } }),
           body
         ).ok
       ).toBe(false)
@@ -193,7 +193,7 @@ describe('shadow chase intent contract', () => {
       parseShadowChaseIntentResponse(
         JSON.stringify({
           ...base,
-          proposal: { intent: 'follow', bark: '😀'.repeat(MAX_BARK_CODEPOINTS) },
+          proposal: { intent: 'support', bark: '😀'.repeat(MAX_BARK_CODEPOINTS) },
         }),
         body
       ).ok

--- a/packages/platform-ai/src/shadow-chase-intent.ts
+++ b/packages/platform-ai/src/shadow-chase-intent.ts
@@ -19,7 +19,7 @@ const OBJECTIVE_COUNT = 3
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 const STABLE_ID_PATTERN = /^[a-z][a-z0-9-]{0,31}$/
 
-export type ShadowChaseIntent = 'follow' | 'split' | 'decoy'
+export type ShadowChaseIntent = 'support' | 'scout' | 'anchor'
 export type ShadowChaseDifficulty = 'relaxed' | 'standard' | 'intense'
 
 export interface ShadowChaseCoordinate {
@@ -51,7 +51,7 @@ export interface ShadowChaseIntentRequest {
   pursuer: ShadowChaseCoordinate
   objectives: ShadowChaseIntentObjective[]
   exit: ShadowChaseCoordinate
-  cooldowns: { swapReadyTick: number }
+  swapCharges: number
   allowedIntents: ShadowChaseIntent[]
 }
 
@@ -106,7 +106,7 @@ function isStableId(value: unknown): value is string {
 }
 
 function isIntent(value: unknown): value is ShadowChaseIntent {
-  return value === 'follow' || value === 'split' || value === 'decoy'
+  return value === 'support' || value === 'scout' || value === 'anchor'
 }
 
 function isDifficulty(value: unknown): value is ShadowChaseDifficulty {
@@ -158,7 +158,7 @@ export function validateShadowChaseIntentRequest(
       'pursuer',
       'objectives',
       'exit',
-      'cooldowns',
+      'swapCharges',
       'allowedIntents',
     ])
   ) {
@@ -202,12 +202,8 @@ export function validateShadowChaseIntentRequest(
   if (!isCoordinate(value.exit)) {
     return { ok: false, reason: 'exit' }
   }
-  if (
-    !isRecord(value.cooldowns) ||
-    !hasExactKeys(value.cooldowns, ['swapReadyTick']) ||
-    !isSafeIntegerBetween(value.cooldowns.swapReadyTick, 0, Number.MAX_SAFE_INTEGER)
-  ) {
-    return { ok: false, reason: 'cooldowns' }
+  if (!isSafeIntegerBetween(value.swapCharges, 0, OBJECTIVE_COUNT)) {
+    return { ok: false, reason: 'swapCharges' }
   }
   if (
     !Array.isArray(value.allowedIntents) ||
@@ -261,7 +257,7 @@ export function parseShadowChaseIntentResponse(
   if (!isIntent(intent) || !request.allowedIntents.includes(intent)) {
     return { ok: false, reason: 'intent' }
   }
-  const targetExpected = intent === 'split'
+  const targetExpected = intent === 'scout'
   const proposalKeys = Object.keys(proposal)
   const allowedKeys = targetExpected
     ? new Set(['intent', 'targetObjectiveId', 'bark'])
@@ -391,8 +387,8 @@ function buildMessages(
     runId: request.runId,
     decisionEpoch: request.decisionEpoch,
     proposal: {
-      intent: 'follow | split | decoy',
-      targetObjectiveId: 'required only for split',
+      intent: 'support | scout | anchor',
+      targetObjectiveId: 'required only for scout',
       bark: `optional, at most ${MAX_BARK_CODEPOINTS} Unicode code points`,
     },
     leaseTicks: `${LEASE_MIN_TICKS}..${LEASE_MAX_TICKS}`,

--- a/packages/platform-ai/src/shadow-chase-voice-context.test.ts
+++ b/packages/platform-ai/src/shadow-chase-voice-context.test.ts
@@ -8,8 +8,8 @@ function validContext(): Record<string, unknown> {
   return {
     version: 1,
     phase: 'planning',
-    strategy: 'follow',
-    allowedStrategies: ['follow', 'split', 'decoy'],
+    strategy: 'support',
+    allowedStrategies: ['support', 'scout', 'anchor'],
     map: { id: 'courtyard', width: 9, height: 9, walls: [{ x: 2, y: 2 }] },
     objectives: [
       { id: 'core-a', position: { x: 1, y: 2 } },

--- a/packages/platform-ai/src/shadow-chase-voice-context.ts
+++ b/packages/platform-ai/src/shadow-chase-voice-context.ts
@@ -5,14 +5,14 @@ export const MAX_SHADOW_CHASE_VOICE_WALLS = 64
 export const MAX_SHADOW_CHASE_VOICE_OBJECTIVES = 3
 export const MAX_SHADOW_CHASE_VOICE_ID_CODEPOINTS = 32
 
-type Strategy = 'follow' | 'split' | 'decoy'
+type Strategy = 'support' | 'scout' | 'anchor'
 type Coordinate = { x: number; y: number }
 
 export interface ShadowChaseVoiceContext {
   version: 1
   phase: 'planning' | 'running'
   strategy: Strategy
-  allowedStrategies: ['follow', 'split', 'decoy']
+  allowedStrategies: ['support', 'scout', 'anchor']
   map: { id: string; width: number; height: number; walls: Coordinate[] }
   objectives: Array<{ id: string; position: Coordinate }>
   collectedObjectiveIds: string[]
@@ -87,13 +87,13 @@ export function validateShadowChaseVoiceContext(value: unknown): ShadowChaseVoic
   if (value.version !== 1 || (value.phase !== 'planning' && value.phase !== 'running')) {
     return { ok: false, reason: 'version-phase' }
   }
-  if (!['follow', 'split', 'decoy'].includes(String(value.strategy))) {
+  if (!['support', 'scout', 'anchor'].includes(String(value.strategy))) {
     return { ok: false, reason: 'strategy' }
   }
   if (
     !Array.isArray(value.allowedStrategies) ||
     value.allowedStrategies.length !== 3 ||
-    value.allowedStrategies.join(',') !== 'follow,split,decoy'
+    value.allowedStrategies.join(',') !== 'support,scout,anchor'
   ) {
     return { ok: false, reason: 'allowed-strategies' }
   }


### PR DESCRIPTION
## Summary

- Rework Shadow Chase around a player-only pursuer target, deterministic difficulty-based bonus steps, and incidental companion capture on every traversed cell.
- Replace cooldown swaps with one charge per player-collected core, and replace the ineffective follow/split/decoy set with support/scout/anchor positioning that cannot collect objectives for the player.
- Align rescue behavior, Chinese player copy, voice commands, Platform AI contracts, documentation, and regression coverage with the shared visible rules.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

## Test plan

- [x] `pnpm --filter @amiclaw/game-shadow-chase test:run` — 115 tests
- [x] `pnpm --filter @amiclaw/platform-ai test:run` — 384 tests
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm build`
- [x] `pnpm e2e:audit` — clean 33/33 reconciliation
- [x] `pnpm test:e2e` — 40 Chromium tests
- [x] Manual desktop and 390×844 mobile play: core collection, earned swap, incidental capture, rescue, recapture, and control reachability

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

🤖 Generated with [Claude Code](https://claude.com/claude-code)
