### PR TITLE
fix(platform): approved followup batch — clean anon probe, explicit claim, token polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.0.0...HEAD)
 
+**Anonymous settlement stops logging a console error** — Fixed. An anonymous
+player's win used to leave a single red `401 /api/arcade/profile` line in the
+browser console. The identity read now answers a clean `204` (no account to
+resolve) instead, so a settlement is error-free end to end. No visible gameplay
+change — the anonymous run still stays off the leaderboard and shows the same
+calm login invite.
+
+**Opening「我的」no longer writes to your account** — Changed. Visiting `/me`
+used to auto-save this device's unsaved records into your account on load. Now
+that visit is read-only: the「本设备记录」card shows how many records are pending
+and you save them with an explicit「保存到账号」tap. Nothing is saved without your
+action.
+
 **Botanical Garden joins Arcade** - A new co-op care game: you tend a night
 garden of five species while plants decay in real time, and your AI companion
 becomes the botanist who holds the care manual. Signed in, your existing

--- a/e2e/steps/fixtures.ts
+++ b/e2e/steps/fixtures.ts
@@ -23,7 +23,7 @@
  *     so the modal never interferes with non-survey result-page journeys.
  */
 import { test as base, createBdd } from 'playwright-bdd'
-import type { Page } from '@playwright/test'
+import type { Page, TestInfo } from '@playwright/test'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
@@ -212,6 +212,9 @@ interface LeaderboardState {
 /** Per-test shared state + run-driving helpers. */
 export class World {
   readonly page: Page
+  /** The running test's info — used only for per-test screenshot output paths.
+   *  Assigned by the fixture wiring right after construction. */
+  testInfo!: TestInfo
   readonly answers = ANSWERS
   readonly seedT = ANSWERS.seed
   readonly leaderboard: LeaderboardState
@@ -291,6 +294,17 @@ export class World {
   /** Jump the controlled clock forward, firing each due timer at most once. */
   async fastForwardPast(ms: number): Promise<void> {
     await this.page.clock.fastForward(ms)
+  }
+
+  /**
+   * Capture a settlement-state screenshot into this test's own output dir —
+   * free evidence for preview rounds (the three identity states: anonymous,
+   * signed-in AI-ask, signed-in rank). `testInfo.outputPath` gives each test a
+   * unique directory, so parallel workers never race on a shared file. Purely
+   * evidence: no assertion depends on it, so it stays cheap and non-flaky.
+   */
+  async captureSettlement(state: string): Promise<void> {
+    await this.page.screenshot({ path: this.testInfo.outputPath(`settlement-${state}.png`) })
   }
 
   scene(): RunScene {
@@ -486,6 +500,7 @@ export const test = base.extend<{ world: World }>({
   world: [
     async ({ page, context }, use, testInfo) => {
       const world = new World(page)
+      world.testInfo = testInfo
 
       await context.grantPermissions(['clipboard-read', 'clipboard-write'])
 
@@ -565,9 +580,15 @@ export const test = base.extend<{ world: World }>({
 
       // Arcade profile — the static-build harness has no D1 or auth cookie
       // runtime. Signed-in scenarios get an honest empty account profile; signed-
-      // out scenarios get the same 401 shape as production.
+      // out scenarios mirror production: an anonymous GET profile answers 204
+      // (no account to resolve, no console-noise 401 — audit F27); an anonymous
+      // claim stays 401.
       await page.route('**/api/arcade/profile**', async (route) => {
         if (!world.authIdentity) {
+          if (route.request().method() === 'GET') {
+            await route.fulfill({ status: 204, headers: { 'Cache-Control': 'no-store' } })
+            return
+          }
           await route.fulfill({
             status: 401,
             contentType: 'application/json',

--- a/e2e/steps/result.steps.ts
+++ b/e2e/steps/result.steps.ts
@@ -82,11 +82,13 @@ Given('I am signed in with the leaderboard name {string}', async ({ world }, nam
   world.publicLabel = name
 })
 
-Then('the result page asks which AI I played with', async ({ page }) => {
+Then('the result page asks which AI I played with', async ({ page, world }) => {
   // First-time BYO signed-in win: the tool is not inferable and none is stored,
   // so the settlement shows ONE inline row of SSOT chips — no popup, no gate.
   await expect(page.getByRole('dialog')).toHaveCount(0)
   await expect(page.getByText('和哪个 AI 一起玩的？')).toBeVisible()
+  // Identity-state evidence: signed-in first-BYO win (AI-tool ask).
+  await world.captureSettlement('signed-in-ai-ask')
 })
 
 When('I pick AI assistant {string} in the settlement', async ({ page }, assistant: string) => {
@@ -107,10 +109,12 @@ Then('no leaderboard score is submitted', async ({ world, page }) => {
   expect(world.leaderboard.submissions).toHaveLength(0)
 })
 
-Then('the result page shows my global rank', async ({ page }) => {
+Then('the result page shows my global rank', async ({ page, world }) => {
   // The Atlas result page shows the rank in a card — a "全球排名" label cell
   // and a "#N / total" value cell — rather than the old "全球排名：#N" line.
   await expect(page.getByText('全球排名')).toBeVisible()
+  // Identity-state evidence: signed-in win with a resolved leaderboard rank.
+  await world.captureSettlement('signed-in-rank')
 })
 
 Then('the leaderboard table renders without horizontal overflow', async ({ page }) => {

--- a/e2e/steps/survey.steps.ts
+++ b/e2e/steps/survey.steps.ts
@@ -22,6 +22,9 @@ Given(
     } else {
       await world.drivePracticeToResult()
     }
+    // Identity-state evidence: this survey-fresh device is anonymous, so the
+    // settlement is the anonymous state (login invite, run stays off the board).
+    await world.captureSettlement(`anon-${mode}`)
   }
 )
 

--- a/packages/api/src/handlers/arcade-profile.test.ts
+++ b/packages/api/src/handlers/arcade-profile.test.ts
@@ -82,10 +82,13 @@ describe('arcade profile handlers', () => {
     vi.useRealTimers()
   })
 
-  it('requires a session for account profile reads', async () => {
+  it('answers 204 (not 401) for an anonymous account profile read so it makes no console noise (F27)', async () => {
+    // An anonymous GET has no account to resolve; the server accepts it as a
+    // no-content read rather than 401, so an anonymous player's settlement does
+    // not spray a red 401 into the console. The client reads 204 as `anon`.
     const response = await handleGetArcadeProfile(request(undefined, ''), await env())
 
-    expect(response.status).toBe(401)
+    expect(response.status).toBe(204)
   })
 
   it('claims bounded local events into the signed-in account idempotently', async () => {

--- a/packages/api/src/handlers/arcade-profile.ts
+++ b/packages/api/src/handlers/arcade-profile.ts
@@ -31,7 +31,14 @@ export async function handleGetArcadeProfile(
   env: ArcadeProfileApiEnv
 ): Promise<Response> {
   const auth = await requireSession(env.AUTH, request)
-  if (!auth.ok) return auth.response
+  // An anonymous read has no account profile to resolve. Answer 204 (accepted,
+  // no content) rather than 401 so an anonymous player's settlement never paints
+  // a red 401 into the console on every win — mirroring the settlement-event
+  // endpoint below (audit F27). The client reads 204 as `anon` and keeps its
+  // device-local record. POST claim keeps 401 — it is a genuine authenticated
+  // write, not a legal anonymous read. no-store: the anon-vs-authed answer
+  // varies by cookie, so a shared cache must never reuse it.
+  if (!auth.ok) return new Response(null, { status: 204, headers: { 'Cache-Control': 'no-store' } })
 
   const [profile, publicProfile] = await Promise.all([
     readArcadeAccountProfile(env.COMPANION_DB, auth.session.user_id),

--- a/packages/arcade-profile/src/api-client.test.ts
+++ b/packages/arcade-profile/src/api-client.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `fetchArcadeProfile` status → result mapping.
+ *
+ * The anonymous read is a NON-error: the server answers 204 (no session to
+ * resolve a profile for) so an anonymous player's settlement makes no red
+ * console noise (audit F27). 401 is kept mapped to `anon` for defensiveness.
+ * Both must resolve to `{ kind: 'anon' }`, never `error`.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchArcadeProfile } from './api-client'
+
+function stubFetch(response: Response | (() => never)): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => (typeof response === 'function' ? response() : Promise.resolve(response)))
+  )
+}
+
+const OK_BODY = {
+  profile: { daily_loop: { streak: { current_days: 3 } } },
+  public_profile: { claimed: true, public_label: 'Nova' },
+}
+
+describe('fetchArcadeProfile', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('maps an anonymous 204 to anon (no console-noise 401)', async () => {
+    stubFetch(new Response(null, { status: 204 }))
+    expect(await fetchArcadeProfile()).toEqual({ kind: 'anon' })
+  })
+
+  it('still maps a 401 to anon (defensive)', async () => {
+    stubFetch(new Response(JSON.stringify({ error: 'unauthorized' }), { status: 401 }))
+    expect(await fetchArcadeProfile()).toEqual({ kind: 'anon' })
+  })
+
+  it('maps a 200 body to ok with the profile + public profile', async () => {
+    stubFetch(new Response(JSON.stringify(OK_BODY), { status: 200 }))
+    expect(await fetchArcadeProfile()).toEqual({
+      kind: 'ok',
+      profile: OK_BODY.profile,
+      publicProfile: OK_BODY.public_profile,
+    })
+  })
+
+  it('maps a 5xx to error', async () => {
+    stubFetch(new Response('boom', { status: 500 }))
+    expect(await fetchArcadeProfile()).toEqual({ kind: 'error' })
+  })
+
+  it('maps a network throw to error', async () => {
+    stubFetch(() => {
+      throw new Error('offline')
+    })
+    expect(await fetchArcadeProfile()).toEqual({ kind: 'error' })
+  })
+})

--- a/packages/arcade-profile/src/api-client.ts
+++ b/packages/arcade-profile/src/api-client.ts
@@ -47,7 +47,12 @@ export type ArcadeStreakLeaderboardReadResult =
 export async function fetchArcadeProfile(): Promise<ArcadeProfileReadResult> {
   try {
     const res = await fetch(`${apiBase()}/api/arcade/profile`, { credentials: 'include' })
-    if (res.status === 401) return { kind: 'anon' }
+    // 204 = anonymous (no session to resolve a profile for): the server answers
+    // 204 rather than 401 so an anonymous player's settlement makes no red
+    // console noise (mirrors the events endpoint, audit F27). 401 is kept for
+    // defensiveness. Both resolve to `anon` — the caller then keeps its
+    // device-local record and shows the calm login invite.
+    if (res.status === 204 || res.status === 401) return { kind: 'anon' }
     if (!res.ok) return { kind: 'error' }
     const data = (await res.json()) as ArcadeProfileResponse
     return { kind: 'ok', profile: data.profile, publicProfile: publicProfileOf(data) }

--- a/packages/platform/src/components/home/FooterPitch.module.css
+++ b/packages/platform/src/components/home/FooterPitch.module.css
@@ -7,7 +7,14 @@
   padding: 60px 40px;
   border: 1px solid var(--border-yellow-soft);
   border-radius: var(--radius-3xl);
-  background: linear-gradient(135deg, rgba(255, 229, 62, 0.08), rgba(180, 120, 255, 0.04));
+  /* Faint yellow→violet wash, derived from the brand tokens (was raw
+     rgba(255,229,62,.08) / rgba(180,120,255,.04)). color-mix keeps the stops
+     tied to --amio-yellow / --accent-violet so a brand-hue change carries. */
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--amio-yellow) 8%, transparent),
+    color-mix(in srgb, var(--accent-violet) 4%, transparent)
+  );
   text-align: center;
 }
 

--- a/packages/platform/src/pages/AccountPage.test.tsx
+++ b/packages/platform/src/pages/AccountPage.test.tsx
@@ -415,7 +415,10 @@ describe('AccountPage /me', () => {
     expect(screen.queryByText('本设备的星轨。')).not.toBeInTheDocument()
   })
 
-  it('auto-claims the current device records into the account on login (F7)', async () => {
+  it('does NOT claim device records on load; only an explicit「保存到账号」tap claims', async () => {
+    // Product ethos: opening /me is a read, never a silent account write. The
+    // device-records card surfaces the pending count + a「保存到账号」button; the
+    // claim fires only when the player taps it.
     seedLocalProfile(localStore)
     const fetchSpy = stubApi({
       session: AUTHED,
@@ -426,7 +429,16 @@ describe('AccountPage /me', () => {
     })
     renderAccount('/me')
 
-    // No manual tap — the claim fires automatically once signed in.
+    // The card renders and names the pending records, but no claim has fired on
+    // load — /me stayed read-only.
+    const saveButton = await screen.findByRole('button', { name: '保存到账号' })
+    expect(screen.queryByText('已保存')).not.toBeInTheDocument()
+    expect(
+      fetchSpy.mock.calls.some((call) => urlOf(call[0]).includes('/api/arcade/profile/claim'))
+    ).toBe(false)
+
+    // The explicit tap claims and confirms.
+    fireEvent.click(saveButton)
     expect(await screen.findByText('已保存')).toBeInTheDocument()
     await waitFor(() => {
       expect(

--- a/packages/platform/src/pages/AccountPage.tsx
+++ b/packages/platform/src/pages/AccountPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Button, ConicAvatar, Disclosure, EyebrowTag, GlassCard } from '@amiclaw/ui'
 import type {
@@ -420,7 +420,6 @@ function ClaimLocalProfileCard({
   onClaimed: () => void
 }) {
   const [status, setStatus] = useState<'idle' | 'claiming' | 'claimed' | 'error'>('idle')
-  const autoClaimedRef = useRef(false)
 
   const handleClaim = useCallback(async () => {
     if (!localProfile) return
@@ -443,23 +442,11 @@ function ClaimLocalProfileCard({
     setStatus('claimed')
   }, [localProfile, claimableEvents, onLocalProfileChange, onClaimed])
 
-  // Auto-claim the CURRENT device's unsaved records on login (F7): once signed
-  // in, the intent to save this device's own records to the account is
-  // unambiguous, and the claim endpoint is idempotent — so fire it once
-  // automatically instead of stranding the player on a manual「保存到账号」tap
-  // that made a logged-in account look empty despite real play. The manual
-  // button below stays for edge states (an auto-claim that failed can be
-  // retried). Latched so it fires at most once per mount.
-  useEffect(() => {
-    if (autoClaimedRef.current) return
-    if (!localProfile || claimableEvents.length === 0) return
-    autoClaimedRef.current = true
-    // Defer off the effect body so the claim's initial `setStatus('claiming')`
-    // runs in an async continuation, not a synchronous cascading render
-    // (react-hooks/set-state-in-effect).
-    void Promise.resolve().then(handleClaim)
-  }, [localProfile, claimableEvents, handleClaim])
-
+  // No auto-claim on load: opening /me is a read, and a write the user did not
+  // ask for (product ethos: no silent writes a player wouldn't expect). This
+  // device's unsaved records surface below with an explicit「保存到账号」tap — the
+  // claim fires only when the player asks for it, so /me stays read-only until
+  // then. The card copy names the pending count so nothing is hidden.
   if (!localProfile || (claimableEvents.length === 0 && status !== 'claimed')) return null
 
   return (


### PR DESCRIPTION
## Summary

- The settlement page's anonymous profile probe resolves 204 instead of 401 — the product's only error-class network line in normal use disappears (all consumers route through the single client mapper)
- Opening /me no longer fires an automatic profile claim; saving device records to the account is an explicit 「保存到账号」 action (product honesty: no silent writes)
- FooterPitch gradients tokenized (color-mix on brand tokens, pixel-equivalent); settlement e2e specs now capture identity-state screenshots as evidence

Owner-approved followup batch from the UI-redesign completion gate. Independent verification: approve, 0 blocking; full e2e 39/40 with the single red reproduced as a pre-existing harness flake outside this diff (signed-in homepage-entry step, flaky in isolation on unchanged code).

## Test plan

- [x] typecheck / unit (arcade-profile 50 · api 231 · platform 211) / build
- [x] Full `pnpm test:e2e` (one pre-existing flake documented in rounds/fb-verify.md)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeeXJpTJtqNxfjzU6PMdLz