### PR TITLE
feat(shadow-chase): align UI with Atlas v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.1.0...HEAD)
 
+**Shadow Chase now reads at a glance** — Improved. Setup, tactical planning, the
+live chase, and results now use the shared Atlas page, navigation, button, status,
+and icon-control grammar. Compact diagrams show that three collected cores open
+the moon gate immediately, both shadows must exit, and captures require rescue.
+The pursuer strip now reflects deterministic shortest-path pursuit, its switch
+from the player to the companion only while the player is captured, contact and
+crossing captures, core-earned swaps, and immediate gate unlock. Exact objective,
+rescue, and pursuer rules remain available in a collapsed disclosure.
+
+Shadow Chase also registers one bounded moon-blue accent for its title, shadows,
+companion, and game-owned ritual graphics. Pursuer and rescue risk use platform
+danger, cores and success use platform positive green, and primary actions and
+focus stay warm gold. BombSquad rose and Oracle violet no longer leak into the
+game.
+
 **Radio Cipher joins AMIO Arcade** — Added. A new voice game at
 `claw.amio.fans/radio-cipher`. You are the listener, tuning a static-swept radio
 to catch an encrypted transmission by ear; your AI partner (or a friend) holds

--- a/e2e/steps/shadow-chase.steps.ts
+++ b/e2e/steps/shadow-chase.steps.ts
@@ -11,6 +11,9 @@ Given('Shadow Chase optional network handoffs are unavailable', async ({ page })
 })
 
 Then('the Shadow Chase opening rule is complete', async ({ page }) => {
+  const ruleDisclosure = page.getByText('规则说明', { exact: true })
+  await expect(ruleDisclosure).toBeVisible()
+  await ruleDisclosure.click()
   const copy = await page.locator('body').innerText()
   expect(copy).toContain('战术准备结束后追兵立即行动')
   expect(copy).toContain('收集三枚光核')
@@ -20,7 +23,11 @@ Then('the Shadow Chase opening rule is complete', async ({ page }) => {
   expect(copy).toContain(
     '追兵始终以略快速度走最短路：玩家自由时只追玩家，玩家被捕时转追伙伴，玩家获救后立即转回。碰到任意一方都会捕获；每枚光核提供一次换位，三枚集齐后月门立即开启。'
   )
-  const pursuerRule = await page.getByRole('region', { name: '追兵规则' }).locator('p').innerText()
+  const pursuerRule = await page
+    .getByRole('region', { name: '追兵规则' })
+    .locator('p')
+    .last()
+    .innerText()
   await page.locator('html').evaluate((element, rule) => {
     ;(element as HTMLElement).dataset.shadowPursuerRule = rule
   }, pursuerRule)
@@ -28,13 +35,17 @@ Then('the Shadow Chase opening rule is complete', async ({ page }) => {
 
 Then('the Shadow Chase planning map is visible and frozen', async ({ page }) => {
   await expect(page.getByRole('application', { name: '双影追逃地图' })).toBeVisible()
-  await expect(page.getByText('战术准备')).toBeVisible()
+  await expect(page.getByRole('heading', { name: '制定策略' })).toBeVisible()
+  await expect(page.getByText('地图冻结', { exact: true })).toBeVisible()
   await expect(page.getByRole('button', { name: '立即出发' })).toBeVisible()
   await expect(page.getByRole('application', { name: '双影追逃地图' })).toHaveAttribute(
     'aria-disabled',
     'true'
   )
   const setupRule = await page.locator('html').getAttribute('data-shadow-pursuer-rule')
+  const ruleDisclosure = page.getByText('规则说明', { exact: true })
+  await expect(ruleDisclosure).toBeVisible()
+  await ruleDisclosure.click()
   const planningRule = await page.getByRole('region', { name: '追兵规则' }).locator('p').innerText()
   expect(planningRule).toBe(setupRule)
   const board = page.getByRole('application', { name: '双影追逃地图' })
@@ -43,8 +54,8 @@ Then('the Shadow Chase planning map is visible and frozen', async ({ page }) => 
 
 Then('the Shadow Chase board and essential controls are visible', async ({ page }) => {
   await expect(page.getByRole('application', { name: '双影追逃地图' })).toBeVisible()
-  await expect(page.getByText('光核', { exact: true })).toBeVisible()
-  await expect(page.getByText('救援', { exact: true })).toBeVisible()
+  await expect(page.getByLabel('光核 0 / 3')).toBeVisible()
+  await expect(page.getByText('双方安全', { exact: true })).toBeVisible()
   await expect(page.getByRole('button', { name: '交换位置 · 0' })).toBeVisible()
   await expect(page.getByRole('button', { name: '向上移动' })).toBeVisible()
 })

--- a/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
+++ b/packages/game-bombsquad/src/pages/ResultPage.survey.test.tsx
@@ -179,7 +179,7 @@ describe('ResultPage endgame survey (fold-in entry)', () => {
     openSurveyEntry()
     expect(screen.getByRole('dialog', { name: '聊聊这一局' })).toBeInTheDocument()
     expect(screen.getByText('你这局用的是哪个 AI 工具？')).toBeInTheDocument()
-  })
+  }, 10000)
 
   it('practice win: the entry waits out the full celebration window, not the base delay (F11)', () => {
     surveyMock.hasAnsweredSurvey.mockReturnValue(false)

--- a/packages/game-shadow-chase/src/App.test.tsx
+++ b/packages/game-shadow-chase/src/App.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import { App } from './App'
+import { OBJECTIVE_RULE_COPY } from './components/PursuerRule'
 import { PURSUER_RULE_COPY } from './engine/pursuer-rules'
 import type { ShadowVoiceSource } from './voice/useShadowChaseVoice'
 
@@ -12,17 +13,34 @@ const BUTTON_ONLY_VOICE: ShadowVoiceSource = {
 }
 
 describe('playable shell semantics', () => {
-  it('uses Chinese-first copy and enters frozen map-visible planning', () => {
-    render(<App voiceSource={BUTTON_ONLY_VOICE} />)
+  it('leads with the objective graphic and keeps exact rules collapsed by default', () => {
+    const view = render(<App voiceSource={BUTTON_ONLY_VOICE} />)
     expect(screen.getByRole('heading', { name: '双影追逃' })).toBeTruthy()
-    expect(screen.getByText(/收集三枚光核/)).toBeTruthy()
+    expect(
+      screen.getByLabelText('收集三枚光核，月门立即开启，两道影子一起撤离；被捕获后需要倒计时救援')
+    ).toBeTruthy()
+    expect(view.container.querySelectorAll('.objective-node svg')).toHaveLength(4)
+    expect(OBJECTIVE_RULE_COPY).toBe(
+      '收集三枚光核，月门会立即开启，再与伙伴一起抵达出口撤离。战术准备结束后追兵立即行动；任何一方被捕获，都要在倒计时结束前完成救援。'
+    )
+    expect(screen.getByText(OBJECTIVE_RULE_COPY)).toBeTruthy()
     expect(screen.getByText(PURSUER_RULE_COPY)).toBeTruthy()
     expect(screen.getByRole('region', { name: '追兵规则' })).toBeTruthy()
+    expect(view.container.querySelector('details')?.open).toBe(false)
+    for (const step of ['最短略快', '目标切换', '接触捕获', '光核换位', '三核开门']) {
+      expect(screen.getByText(step)).toBeTruthy()
+    }
+  })
+
+  it('enters frozen map-visible planning without expanding the exact pursuer rule', () => {
+    const view = render(<App voiceSource={BUTTON_ONLY_VOICE} />)
     fireEvent.click(screen.getByRole('button', { name: '查看地图并制定策略' }))
     expect(screen.getByRole('application', { name: '双影追逃地图' })).toBeTruthy()
-    expect(screen.getByText('战术准备')).toBeTruthy()
+    expect(screen.getByRole('heading', { name: '制定策略' })).toBeTruthy()
+    expect(screen.getByText('地图冻结')).toBeTruthy()
     expect(screen.getByText(PURSUER_RULE_COPY)).toBeTruthy()
     expect(screen.getByRole('region', { name: '追兵规则' })).toBeTruthy()
+    expect(view.container.querySelector('details')?.open).toBe(false)
     expect(screen.getAllByText('20')).toHaveLength(2)
     expect(screen.getByRole('button', { name: '立即出发' })).toBeTruthy()
   })
@@ -34,7 +52,9 @@ describe('playable shell semantics', () => {
       expect(screen.getByRole('button', { name }).getAttribute('aria-pressed')).not.toBeNull()
     }
     fireEvent.click(screen.getByRole('button', { name: '立即出发' }))
-    expect(screen.getByRole('button', { name: '交换位置 · 0' })).toBeTruthy()
+    expect(
+      screen.getByRole('button', { name: '交换位置 · 0' }).getAttribute('aria-keyshortcuts')
+    ).toBe('Space')
     expect(screen.getByText('键盘可用 WASD、方向键，空格换位')).toBeTruthy()
   })
 

--- a/packages/game-shadow-chase/src/components/Hud.tsx
+++ b/packages/game-shadow-chase/src/components/Hud.tsx
@@ -1,6 +1,7 @@
 import { RUN_CAP_TICKS, TICK_MS } from '../engine/config'
 import { rescueTicksRemaining } from '../engine/reducer'
 import type { SimulationState } from '../engine/types'
+import { ClockIcon, CoreIcon, GateIcon, ShieldIcon, SwapIcon } from './ShadowChaseIcons'
 
 function formatTime(tick: number): string {
   const seconds = Math.floor((tick * TICK_MS) / 1000)
@@ -20,25 +21,25 @@ export function Hud({ state }: { state: SimulationState }) {
     : `还需收集 ${state.objectives.length - collected} 枚光核`
   return (
     <header className="hud" aria-label="追逃状态">
-      <div>
-        <span className="hud-label">时间</span>
+      <div aria-label={`时间 ${formatTime(state.tick)}`}>
+        <ClockIcon className="hud-icon" />
         <strong className="hud-value">{formatTime(state.tick)}</strong>
         <span className="sr-only">，上限 {formatTime(RUN_CAP_TICKS)}</span>
       </div>
-      <div>
-        <span className="hud-label">光核</span>
+      <div className="hud-positive" aria-label={`光核 ${collected} / 3`}>
+        <CoreIcon className="hud-icon" />
         <strong className="hud-value">{collected} / 3</strong>
       </div>
-      <div>
-        <span className="hud-label">月门</span>
+      <div className={state.exit.enabled ? 'hud-positive' : ''} aria-label={`月门 ${gateStatus}`}>
+        <GateIcon className="hud-icon" />
         <strong className="hud-value">{gateStatus}</strong>
       </div>
-      <div>
-        <span className="hud-label">换位</span>
+      <div aria-label={`换位 ${state.swapCharges} 次`}>
+        <SwapIcon className="hud-icon" />
         <strong className="hud-value">{state.swapCharges} 次</strong>
       </div>
-      <div className={captured ? 'rescue-alert' : ''}>
-        <span className="hud-label">救援</span>
+      <div className={captured ? 'rescue-alert' : 'hud-positive'}>
+        <ShieldIcon className="hud-icon" />
         <strong className="hud-value">
           {captured
             ? `${recentRescue?.actorId === captured.id ? (captured.id === 'player' ? '你再次被捕' : '伙伴再次被捕') : captured.id === 'player' ? '你' : '伙伴'} · ${((captured.ticks ?? 0) * TICK_MS) / 1000} 秒`

--- a/packages/game-shadow-chase/src/components/MoveControls.tsx
+++ b/packages/game-shadow-chase/src/components/MoveControls.tsx
@@ -1,20 +1,22 @@
+import { IconButton } from '@amiclaw/ui'
+
 import type { Direction } from '../engine/types'
 
 export function MoveControls({ onMove }: { onMove(direction: Direction): void }) {
   return (
     <div className="direction-pad" aria-label="移动控制">
-      <button type="button" className="up" aria-label="向上移动" onClick={() => onMove('up')}>
+      <IconButton className="up" variant="bare" label="向上移动" onClick={() => onMove('up')}>
         ↑
-      </button>
-      <button type="button" className="left" aria-label="向左移动" onClick={() => onMove('left')}>
+      </IconButton>
+      <IconButton className="left" variant="bare" label="向左移动" onClick={() => onMove('left')}>
         ←
-      </button>
-      <button type="button" className="down" aria-label="向下移动" onClick={() => onMove('down')}>
+      </IconButton>
+      <IconButton className="down" variant="bare" label="向下移动" onClick={() => onMove('down')}>
         ↓
-      </button>
-      <button type="button" className="right" aria-label="向右移动" onClick={() => onMove('right')}>
+      </IconButton>
+      <IconButton className="right" variant="bare" label="向右移动" onClick={() => onMove('right')}>
         →
-      </button>
+      </IconButton>
     </div>
   )
 }

--- a/packages/game-shadow-chase/src/components/PlanningDurationControl.tsx
+++ b/packages/game-shadow-chase/src/components/PlanningDurationControl.tsx
@@ -1,3 +1,5 @@
+import { IconButton } from '@amiclaw/ui'
+
 import {
   MAX_PLANNING_SECONDS,
   MIN_PLANNING_SECONDS,
@@ -13,26 +15,26 @@ export function PlanningDurationControl({
 }) {
   return (
     <div className="planning-duration" aria-label="战术准备时长">
-      <button
-        type="button"
-        aria-label="减少战术准备时间"
+      <IconButton
+        label="减少战术准备时间"
+        variant="bare"
         disabled={seconds <= MIN_PLANNING_SECONDS}
         onClick={() => onChange(seconds - PLANNING_STEP_SECONDS)}
       >
         −
-      </button>
+      </IconButton>
       <span className="planning-duration-value">
         <strong>{seconds}</strong>
         <span>秒</span>
       </span>
-      <button
-        type="button"
-        aria-label="增加战术准备时间"
+      <IconButton
+        label="增加战术准备时间"
+        variant="bare"
         disabled={seconds >= MAX_PLANNING_SECONDS}
         onClick={() => onChange(seconds + PLANNING_STEP_SECONDS)}
       >
         ＋
-      </button>
+      </IconButton>
     </div>
   )
 }

--- a/packages/game-shadow-chase/src/components/PlanningScreen.tsx
+++ b/packages/game-shadow-chase/src/components/PlanningScreen.tsx
@@ -1,3 +1,5 @@
+import { Button, Chip } from '@amiclaw/ui'
+
 import type { PlanningSnapshot } from '../planning/planning-controller'
 import { PlanningDurationControl } from './PlanningDurationControl'
 import { PursuerRule } from './PursuerRule'
@@ -13,21 +15,22 @@ export function PlanningScreen({
 }) {
   return (
     <header className={planning.urgentSecond ? 'planning-header urgent' : 'planning-header'}>
-      <div>
-        <p className="eyebrow">战术准备</p>
-        <h1>先看地图，再决定伙伴策略</h1>
-        <p>追逃尚未开始。地图与角色保持冻结，语音连接失败也不会延长倒计时。</p>
-        <PursuerRule />
+      <div className="planning-title">
+        <Chip variant="dev">地图冻结</Chip>
+        <h1>制定策略</h1>
       </div>
       <div className="planning-countdown" aria-label="战术准备倒计时">
-        <span className="planning-countdown-label">剩余</span>
         <strong>{planning.remainingSeconds}</strong>
         <span>秒</span>
       </div>
-      <PlanningDurationControl seconds={planning.selectedSeconds} onChange={onDurationChange} />
-      <button className="primary-button planning-start" type="button" onClick={onStartNow}>
+      <div className="planning-duration-wrap">
+        <span className="planning-duration-label">准备时长</span>
+        <PlanningDurationControl seconds={planning.selectedSeconds} onChange={onDurationChange} />
+      </div>
+      <PursuerRule />
+      <Button variant="primary" className="planning-start" onClick={onStartNow}>
         立即出发
-      </button>
+      </Button>
       {planning.urgentSecond && (
         <span className="sr-only" role="status" aria-live="assertive">
           {planning.urgentSecond}

--- a/packages/game-shadow-chase/src/components/PursuerRule.tsx
+++ b/packages/game-shadow-chase/src/components/PursuerRule.tsx
@@ -1,10 +1,65 @@
 import { PURSUER_RULE_COPY } from '../engine/pursuer-rules'
 
-export function PursuerRule() {
+export const OBJECTIVE_RULE_COPY =
+  '收集三枚光核，月门会立即开启，再与伙伴一起抵达出口撤离。战术准备结束后追兵立即行动；任何一方被捕获，都要在倒计时结束前完成救援。'
+
+function RuleVisual() {
+  return (
+    <div
+      className="rule-strip"
+      aria-label="追兵走确定性最短路且始终略快；玩家自由时只追玩家，玩家被捕时转追伙伴，获救后转回；接触或迎面交叉会捕获任一方；每枚光核提供一次换位；三枚集齐后月门立即开启"
+    >
+      <span className="rule-step">
+        <svg viewBox="0 0 44 32" aria-hidden="true">
+          <path className="danger-stroke" d="M4 26c5-15 13-5 18-16 3-6 8-6 17-6m-5-3 5 3-4 5" />
+          <path className="shadow-stroke" d="M34 27v-8l4-5 4 5v8" />
+        </svg>
+        <span>最短略快</span>
+      </span>
+      <span className="rule-step">
+        <svg viewBox="0 0 44 32" aria-hidden="true">
+          <path className="shadow-stroke" d="M3 26V15l5-7 5 7v11M31 26V15l5-7 5 7v11" />
+          <path className="danger-stroke" d="M18 8h8m-3-3 3 3-3 3M26 22h-8m3-3-3 3 3 3" />
+        </svg>
+        <span>目标切换</span>
+      </span>
+      <span className="rule-step">
+        <svg viewBox="0 0 44 32" aria-hidden="true">
+          <path className="shadow-stroke" d="M4 26 19 9m-6 0h6v6" />
+          <path className="danger-stroke" d="M40 26 25 9m6 0h-6v6M18 21l8-8m0 8-8-8" />
+        </svg>
+        <span>接触捕获</span>
+      </span>
+      <span className="rule-step">
+        <svg viewBox="0 0 44 32" aria-hidden="true">
+          <path className="positive-stroke" d="m8 5 7 6-3 11H4L1 11Z" />
+          <path className="shadow-stroke" d="M20 10h20m-5-5 5 5-5 5M40 23H20m5 5-5-5 5-5" />
+        </svg>
+        <span>光核换位</span>
+      </span>
+      <span className="rule-step">
+        <svg viewBox="0 0 44 32" aria-hidden="true">
+          <path
+            className="positive-stroke"
+            d="M3 7h9m-4-4 4 4-4 4M3 16h9m-4-4 4 4-4 4M3 25h9m-4-4 4 4-4 4"
+          />
+          <path className="positive-stroke" d="M21 28V14l9-10 9 10v14M27 28V17h6v11" />
+        </svg>
+        <span>三核开门</span>
+      </span>
+    </div>
+  )
+}
+
+export function PursuerRule({ includeObjective = false }: { includeObjective?: boolean }) {
   return (
     <section className="pursuer-rule" aria-label="追兵规则">
-      <strong>追兵规则</strong>
-      <p>{PURSUER_RULE_COPY}</p>
+      <RuleVisual />
+      <details>
+        <summary>规则说明</summary>
+        {includeObjective && <p>{OBJECTIVE_RULE_COPY}</p>}
+        <p>{PURSUER_RULE_COPY}</p>
+      </details>
     </section>
   )
 }

--- a/packages/game-shadow-chase/src/components/ResultScreen.tsx
+++ b/packages/game-shadow-chase/src/components/ResultScreen.tsx
@@ -1,3 +1,5 @@
+import { BackLink, Button, Chip, PageHeader } from '@amiclaw/ui'
+
 import type { SimulationState } from '../engine/types'
 
 function causalBeat(state: SimulationState): string {
@@ -14,26 +16,37 @@ export function ResultScreen({ state, onRestart }: { state: SimulationState; onR
   const won = state.phase === 'win'
   return (
     <main className="result-shell">
-      <p className="eyebrow">本局结束</p>
-      <h1>{won ? '两道影子一起回家了。' : '这一次，月路关闭了。'}</h1>
-      <p>{causalBeat(state)}</p>
-      <dl className="result-stats">
-        <div>
-          <dt>结果</dt>
-          <dd>{won ? '成功撤离' : state.phase === 'timeout' ? '时间结束' : '追逃失败'}</dd>
+      <PageHeader
+        className="result-header"
+        back={<BackLink variant="inline" label="AMIO Arcade" href="/" />}
+        eyebrow={<Chip variant={won ? 'live' : 'dev'}>{won ? '成功撤离' : '本局结束'}</Chip>}
+        title={<span className="sr-only">双影追逃结算</span>}
+      />
+      <section className={won ? 'result-card won' : 'result-card'}>
+        <div className="result-mark" aria-hidden="true">
+          <span />
+          <span />
         </div>
-        <div>
-          <dt>光核</dt>
-          <dd>{state.objectives.filter((objective) => objective.collected).length} / 3</dd>
-        </div>
-        <div>
-          <dt>时间</dt>
-          <dd>{(state.tick / 4).toFixed(1)} 秒</dd>
-        </div>
-      </dl>
-      <button className="primary-button" type="button" onClick={onRestart}>
-        再玩一次
-      </button>
+        <h1>{won ? '两道影子一起回家了。' : '这一次，月路关闭了。'}</h1>
+        <p>{causalBeat(state)}</p>
+        <dl className="result-stats">
+          <div>
+            <dt>结果</dt>
+            <dd>{won ? '成功撤离' : state.phase === 'timeout' ? '时间结束' : '追逃失败'}</dd>
+          </div>
+          <div>
+            <dt>光核</dt>
+            <dd>{state.objectives.filter((objective) => objective.collected).length} / 3</dd>
+          </div>
+          <div>
+            <dt>时间</dt>
+            <dd>{(state.tick / 4).toFixed(1)} 秒</dd>
+          </div>
+        </dl>
+        <Button variant="primary" full onClick={onRestart}>
+          再玩一次
+        </Button>
+      </section>
     </main>
   )
 }

--- a/packages/game-shadow-chase/src/components/ShadowChaseIcons.tsx
+++ b/packages/game-shadow-chase/src/components/ShadowChaseIcons.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from 'react'
+
+interface IconProps {
+  className?: string
+}
+
+function IconFrame({ children, className }: IconProps & { children: ReactNode }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 32 32"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  )
+}
+
+export function CoreIcon(props: IconProps) {
+  return (
+    <IconFrame {...props}>
+      <path d="m16 3 10 8-4 15H10L6 11Z" />
+    </IconFrame>
+  )
+}
+
+export function GateIcon(props: IconProps) {
+  return (
+    <IconFrame {...props}>
+      <circle cx="16" cy="16" r="13" />
+      <path d="M10 26V14l6-7 6 7v12" />
+    </IconFrame>
+  )
+}
+
+export function ShadowsIcon(props: IconProps) {
+  return (
+    <IconFrame {...props}>
+      <path d="M3 27V13l5-8 5 8v14M19 27V13l5-8 5 8v14" />
+    </IconFrame>
+  )
+}
+
+export function RescueIcon(props: IconProps) {
+  return (
+    <IconFrame {...props}>
+      <circle cx="11" cy="17" r="7" />
+      <path d="m7 13 8 8m0-8-8 8M23 7v9l5 4" />
+    </IconFrame>
+  )
+}
+
+export function ClockIcon(props: IconProps) {
+  return (
+    <IconFrame {...props}>
+      <circle cx="16" cy="18" r="11" />
+      <path d="M16 18v-7M12 3h8" />
+    </IconFrame>
+  )
+}
+
+export function SwapIcon(props: IconProps) {
+  return (
+    <IconFrame {...props}>
+      <path d="M5 11h21m-5-5 5 5-5 5M27 23H6m5 5-5-5 5-5" />
+    </IconFrame>
+  )
+}
+
+export function ShieldIcon(props: IconProps) {
+  return (
+    <IconFrame {...props}>
+      <path d="M16 29s11-5 11-15V6L16 3 5 6v8c0 10 11 15 11 15Z" />
+      <path d="m10 16 4 4 8-9" />
+    </IconFrame>
+  )
+}
+
+export function MicrophoneIcon(props: IconProps) {
+  return (
+    <IconFrame {...props}>
+      <rect x="11" y="3" width="10" height="18" rx="5" />
+      <path d="M7 16a9 9 0 0 0 18 0M16 25v4" />
+    </IconFrame>
+  )
+}
+
+export function StopIcon(props: IconProps) {
+  return (
+    <IconFrame {...props}>
+      <rect x="8" y="8" width="16" height="16" rx="2" />
+    </IconFrame>
+  )
+}
+
+export function StrategyIcon({ intent, className }: IconProps & { intent: string }) {
+  if (intent === 'support') {
+    return (
+      <IconFrame className={className}>
+        <circle cx="11" cy="16" r="5" />
+        <circle cx="23" cy="16" r="5" />
+        <path d="M16 16h2" />
+      </IconFrame>
+    )
+  }
+  if (intent === 'scout') {
+    return (
+      <IconFrame className={className}>
+        <path d="M16 27V8m0 7L7 5m9 10 9-10M4 5h5v5m14-5h5v5" />
+      </IconFrame>
+    )
+  }
+  return (
+    <IconFrame className={className}>
+      <circle cx="10" cy="16" r="5" />
+      <path d="M17 16h11m-5-5 5 5-5 5" />
+    </IconFrame>
+  )
+}

--- a/packages/game-shadow-chase/src/components/StartScreen.tsx
+++ b/packages/game-shadow-chase/src/components/StartScreen.tsx
@@ -1,6 +1,9 @@
+import { BackLink, Button, Chip, PageHeader } from '@amiclaw/ui'
+
 import type { Difficulty } from '../engine/types'
 import { PlanningDurationControl } from './PlanningDurationControl'
 import { PursuerRule } from './PursuerRule'
+import { CoreIcon, GateIcon, RescueIcon, ShadowsIcon } from './ShadowChaseIcons'
 
 interface StartScreenProps {
   difficulty: Difficulty
@@ -15,47 +18,96 @@ interface StartScreenProps {
 export function StartScreen(props: StartScreenProps) {
   return (
     <main className="start-shell">
-      <p className="eyebrow">AMIO Arcade · 一名玩家与一位 AI 伙伴</p>
-      <h1>双影追逃</h1>
-      <p className="secondary-title">Dual Shadow Chase</p>
-      <p className="start-rule">
-        收集三枚光核，月门会立即开启，再与伙伴一起抵达出口撤离。战术准备结束后追兵立即行动；任何一方被捕获，都要在倒计时结束前完成救援。
-      </p>
-      <PursuerRule />
-      <div className="start-options" aria-label="本局设置">
-        <label>
-          难度
-          <select
-            value={props.difficulty}
-            onChange={(event) => props.onDifficultyChange(event.target.value as Difficulty)}
-          >
-            <option value="relaxed">轻松 · 每 2 秒多走 1 格</option>
-            <option value="standard">标准 · 每 1.5 秒多走 1 格</option>
-            <option value="intense">紧张 · 每 1 秒多走 1 格</option>
-          </select>
-        </label>
-        <label>
-          地图
-          <select value={props.mapId} onChange={(event) => props.onMapChange(event.target.value)}>
-            <option value="courtyard">星辉庭院</option>
-            <option value="crossroads">月下十字路</option>
-            <option value="moon-vault">月影秘库</option>
-          </select>
-        </label>
+      <PageHeader
+        className="start-header"
+        back={<BackLink variant="inline" label="AMIO Arcade" href="/" />}
+        eyebrow={
+          <div className="start-eyebrow">
+            <span>一名玩家 · 一位 AI 伙伴</span>
+            <Chip variant="live">可游玩</Chip>
+          </div>
+        }
+        title={<span className="game-title">双影追逃</span>}
+        lead={<span className="secondary-title">Dual Shadow Chase</span>}
+      />
+
+      <div
+        className="objective-flow"
+        aria-label="收集三枚光核，月门立即开启，两道影子一起撤离；被捕获后需要倒计时救援"
+      >
+        <span className="objective-node objective-core">
+          <CoreIcon />
+          <strong>×3</strong>
+        </span>
+        <span className="objective-arrow" aria-hidden="true">
+          →
+        </span>
+        <span className="objective-node">
+          <GateIcon />
+          <strong>开启</strong>
+        </span>
+        <span className="objective-arrow" aria-hidden="true">
+          →
+        </span>
+        <span className="objective-node objective-shadows">
+          <ShadowsIcon />
+          <strong>撤离</strong>
+        </span>
+        <span className="objective-node objective-rescue">
+          <RescueIcon />
+          <strong>救援</strong>
+        </span>
       </div>
-      <div className="start-planning-option">
-        <span>战术准备时长</span>
-        <PlanningDurationControl
-          seconds={props.planningSeconds}
-          onChange={props.onPlanningSecondsChange}
-        />
+
+      <div className="setup-grid">
+        <section className="ritual-card" aria-label="双影仪式图形">
+          <div className="shadow-ritual" aria-hidden="true">
+            <span className="shadow-glyph" />
+            <span className="shadow-glyph companion" />
+          </div>
+          <p>两道影子，一条归路</p>
+        </section>
+
+        <section className="settings-card" aria-label="本局设置">
+          <h2>本局设置</h2>
+          <div className="start-options">
+            <label>
+              难度
+              <select
+                value={props.difficulty}
+                onChange={(event) => props.onDifficultyChange(event.target.value as Difficulty)}
+              >
+                <option value="relaxed">轻松 · 每 2 秒多走 1 格</option>
+                <option value="standard">标准 · 每 1.5 秒多走 1 格</option>
+                <option value="intense">紧张 · 每 1 秒多走 1 格</option>
+              </select>
+            </label>
+            <label>
+              地图
+              <select
+                value={props.mapId}
+                onChange={(event) => props.onMapChange(event.target.value)}
+              >
+                <option value="courtyard">星辉庭院</option>
+                <option value="crossroads">月下十字路</option>
+                <option value="moon-vault">月影秘库</option>
+              </select>
+            </label>
+          </div>
+          <div className="start-planning-option">
+            <span>战术准备</span>
+            <PlanningDurationControl
+              seconds={props.planningSeconds}
+              onChange={props.onPlanningSecondsChange}
+            />
+          </div>
+          <PursuerRule includeObjective />
+          <Button variant="primary" full onClick={props.onStart}>
+            查看地图并制定策略
+          </Button>
+          <p className="control-hint">WASD · 方向键 · 点击地图 · Space 换位</p>
+        </section>
       </div>
-      <button className="primary-button" type="button" onClick={props.onStart}>
-        查看地图并制定策略
-      </button>
-      <p className="control-hint">
-        追逃开始后可用 WASD、方向键、方向按钮或点击地图移动，按空格交换位置。
-      </p>
     </main>
   )
 }

--- a/packages/game-shadow-chase/src/components/StrategyPanel.test.tsx
+++ b/packages/game-shadow-chase/src/components/StrategyPanel.test.tsx
@@ -44,7 +44,8 @@ describe('StrategyPanel voice controls', () => {
       render(panel(voice(status, { stop })))
 
       const button = screen.getByRole('button', { name: '停止伙伴语音' })
-      expect(button.className).toContain('voice-control')
+      expect(button.textContent).toBe('')
+      expect(button.getAttribute('aria-label')).toBe('停止伙伴语音')
       fireEvent.click(button)
       expect(stop).toHaveBeenCalledTimes(1)
       for (const label of ['接应', '探路', '架点']) {

--- a/packages/game-shadow-chase/src/components/StrategyPanel.tsx
+++ b/packages/game-shadow-chase/src/components/StrategyPanel.tsx
@@ -1,5 +1,8 @@
+import { IconButton } from '@amiclaw/ui'
+
 import type { CompanionIntent, SimulationState } from '../engine/types'
 import type { ShadowVoiceView } from '../voice/useShadowChaseVoice'
+import { MicrophoneIcon, StopIcon, StrategyIcon, SwapIcon } from './ShadowChaseIcons'
 
 const STRATEGIES: Array<{ intent: CompanionIntent; label: string; effect: string }> = [
   { intent: 'support', label: '接应', effect: '伙伴保持在你附近，缩短被捕后的救援路线。' },
@@ -51,10 +54,19 @@ export function StrategyPanel({
 
   return (
     <section className="strategy-panel" aria-label="伙伴策略">
-      <div>
-        <span className="strategy-label">当前策略</span>
-        <strong className="strategy-current">{active.label}</strong>
-        <p className="strategy-effect">{active.effect}</p>
+      <div className="companion-presence">
+        <span className="companion-dot" aria-hidden="true" />
+        <strong>伙伴 · {active.label}</strong>
+        <span className="voice-state">{VOICE_STATUS[voice.status]}</span>
+        {voice.stop ? (
+          <IconButton label="停止伙伴语音" variant="bare" onClick={voice.stop}>
+            <StopIcon />
+          </IconButton>
+        ) : voice.start ? (
+          <IconButton label="开启伙伴语音" variant="bare" onClick={voice.start}>
+            <MicrophoneIcon />
+          </IconButton>
+        ) : null}
       </div>
       <div className="command-row" aria-label="选择伙伴策略">
         {STRATEGIES.map((item) => (
@@ -65,37 +77,26 @@ export function StrategyPanel({
             aria-pressed={activeIntent === item.intent}
             onClick={() => onStrategy(item.intent)}
           >
-            {item.label}
+            <StrategyIcon intent={item.intent} />
+            <span>{item.label}</span>
           </button>
         ))}
       </div>
-      <div className="strategy-recommendation">
-        <span className="strategy-label">伙伴建议 / 回应</span>
-        <p>{recommendation}</p>
-      </div>
-      <div className="voice-strategy" aria-label="伙伴语音">
-        <span className="strategy-label">语音 · {VOICE_STATUS[voice.status]}</span>
-        {voice.stop ? (
-          <button type="button" className="voice-control" onClick={voice.stop}>
-            停止伙伴语音
-          </button>
-        ) : voice.start ? (
-          <button type="button" className="voice-control" onClick={voice.start}>
-            开启伙伴语音
-          </button>
-        ) : null}
-        <p>
-          <strong>你说的话：</strong>
-          {voice.playerTranscript || '可使用“过来接应”“去光核探路”“去远处架点”明确下令。'}
-        </p>
-        <p>
-          <strong>伙伴字幕：</strong>
-          {voice.companionText || '语音不可用时，策略按钮仍然完整可用。'}
-        </p>
+      {planning && <p className="strategy-effect">{active.effect}</p>}
+      {(state.activeModelLease || voice.playerTranscript || voice.companionText) && (
+        <div className="companion-caption" aria-label="伙伴建议与语音字幕">
+          <span>{recommendation}</span>
+          {voice.playerTranscript && <span>你：{voice.playerTranscript}</span>}
+          {voice.companionText && <span>伙伴：{voice.companionText}</span>}
+        </div>
+      )}
+      <div className="voice-feedback" aria-live="polite">
         {voice.commandResult?.kind === 'clarify' && (
           <p className="voice-clarify">请只说一种明确策略：接应、探路或架点。</p>
         )}
-        {voice.statusMessage && <p className="voice-status-message">{voice.statusMessage}</p>}
+        {voice.status === 'error' && voice.statusMessage && (
+          <p className="voice-status-message">{voice.statusMessage}</p>
+        )}
       </div>
       <button
         className="swap-button"
@@ -105,13 +106,14 @@ export function StrategyPanel({
         aria-describedby="swap-reason"
         onClick={onSwap}
       >
+        <SwapIcon />
         交换位置 · {state.swapCharges}
       </button>
       <span id="swap-reason" className="control-reason">
         {planning
-          ? '追逃开始后才能交换。'
+          ? '追逃开始后'
           : state.swapCharges === 0
-            ? '每收集一枚光核获得一次交换。'
+            ? '收集光核获得换位'
             : swapDisabled
               ? '双方都未被捕获时才能交换。'
               : `现在可交换 ${state.swapCharges} 次；按空格可快速交换。`}

--- a/packages/game-shadow-chase/src/styles/global.css
+++ b/packages/game-shadow-chase/src/styles/global.css
@@ -11,17 +11,15 @@ body,
 
 body {
   min-width: 320px;
-  color: var(--text-1, #fff);
-  font-family: var(--font-body, system-ui, sans-serif);
-  background:
-    radial-gradient(circle at 18% 16%, rgba(74, 158, 255, 0.13), transparent 34%),
-    radial-gradient(circle at 82% 78%, rgba(180, 120, 255, 0.12), transparent 30%),
-    linear-gradient(
-      180deg,
-      var(--bg-grad-start, #06060f),
-      var(--bg-grad-mid-1, #0b1232) 42%,
-      var(--bg-grad-end, #050511)
-    );
+  color: var(--text-1);
+  font-family: var(--font-body);
+  background: linear-gradient(
+    180deg,
+    var(--bg-grad-start),
+    var(--bg-grad-mid-1) 42%,
+    var(--bg-grad-mid-2) 72%,
+    var(--bg-grad-end)
+  );
 }
 
 button,
@@ -33,8 +31,10 @@ select {
 }
 
 button:focus-visible,
-select:focus-visible {
-  outline: 2px solid var(--amio-yellow, #ffe53e);
+select:focus-visible,
+a:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--amio-yellow);
   outline-offset: 3px;
 }
 
@@ -49,98 +49,222 @@ button:disabled {
 
 .start-shell,
 .result-shell {
-  display: grid;
-  width: min(92vw, 680px);
+  width: min(1200px, calc(100% - 32px));
   min-height: 100vh;
   margin: 0 auto;
-  padding: max(40px, env(safe-area-inset-top)) 20px max(40px, env(safe-area-inset-bottom));
-  place-content: center;
-  text-align: center;
+  padding: max(32px, env(safe-area-inset-top)) 0 max(56px, env(safe-area-inset-bottom));
 }
 
-.eyebrow,
-.hud-label,
-.control-hint,
-.keyboard-hint,
-.control-reason {
-  color: var(--text-3, rgba(255, 255, 255, 0.55));
-  font-size: 0.75rem;
+.start-header,
+.result-header {
+  position: relative;
+}
+
+.start-header h2 {
+  margin-top: var(--space-3);
+}
+
+.start-eyebrow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  color: var(--text-3);
+  font: var(--type-label);
   letter-spacing: 0.12em;
-  text-transform: uppercase;
 }
 
-h1 {
-  margin: 12px 0 16px;
-  font-family: var(--font-display, system-ui, sans-serif);
-  font-size: clamp(2.4rem, 8vw, 5.25rem);
-  line-height: 0.96;
+.game-title {
+  color: var(--sc-moon-blue);
+  font: 700 clamp(2.8rem, 8vw, 5.4rem) / 0.98 var(--font-display);
+  letter-spacing: -0.05em;
+  text-shadow: 0 0 28px var(--sc-moon-blue-soft);
 }
 
 .secondary-title {
-  margin: -8px 0 18px;
-  color: var(--text-3, rgba(255, 255, 255, 0.55));
-  font-family: var(--font-display, system-ui, sans-serif);
-  letter-spacing: 0.08em;
+  color: var(--text-4);
+  font: var(--type-mono-caps);
+  letter-spacing: 0.12em;
 }
 
-.start-rule,
-.result-shell > p:not(.eyebrow) {
-  max-width: 580px;
-  margin: 0 auto 28px;
-  color: var(--text-2, rgba(255, 255, 255, 0.7));
-  font-size: clamp(1rem, 3vw, 1.25rem);
-  line-height: 1.65;
+.objective-flow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin: calc(-1 * var(--space-2)) 0 var(--space-6);
 }
 
-.pursuer-rule {
-  max-width: 580px;
-  margin: 0 auto 18px;
-  padding: 9px 11px;
-  border: 1px solid var(--border-hairline, rgba(255, 255, 255, 0.06));
-  border-radius: var(--radius-md, 10px);
-  color: var(--text-3, rgba(255, 255, 255, 0.55));
-  background: rgba(0, 0, 0, 0.14);
-  font-size: 0.78rem;
-  line-height: 1.5;
-  text-align: left;
+.objective-node {
+  display: inline-flex;
+  min-height: 54px;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-pill);
+  color: var(--text-2);
+  background: var(--glass-soft);
+  font-family: var(--font-numeric);
 }
 
-.pursuer-rule strong {
-  color: var(--text-2, rgba(255, 255, 255, 0.7));
+.objective-node svg {
+  width: 30px;
+  height: 30px;
 }
 
-.pursuer-rule p {
-  margin: 3px 0 0;
+.objective-core {
+  color: var(--sc-core);
+}
+
+.objective-shadows {
+  color: var(--sc-shadow);
+}
+
+.objective-rescue {
+  color: var(--sc-pursuer);
+}
+
+.objective-arrow {
+  color: var(--text-4);
+}
+
+.setup-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(340px, 0.85fr);
+  gap: var(--space-5);
+}
+
+.ritual-card,
+.settings-card,
+.planning-header,
+.board-panel,
+.control-panel,
+.hud > div,
+.result-card {
+  border: 1px solid var(--border-hairline);
+  background: var(--glass-card);
+  box-shadow: var(--shadow-elevated);
+  backdrop-filter: var(--glass-blur);
+}
+
+.ritual-card {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  min-height: 440px;
+  place-items: center;
+  padding: var(--space-10);
+  border-radius: var(--radius-3xl);
+}
+
+.ritual-card::after {
+  position: absolute;
+  inset: 18%;
+  border: 1px solid var(--sc-moon-blue-border);
+  border-radius: 46% 54% 50% 50%;
+  content: '';
+  transform: rotate(-7deg);
+}
+
+.ritual-card p {
+  position: absolute;
+  right: var(--space-6);
+  bottom: var(--space-5);
+  left: var(--space-6);
+  z-index: 2;
+  margin: 0;
+  color: var(--text-2);
+  text-align: center;
+}
+
+.shadow-ritual {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  gap: var(--space-12);
+  color: var(--sc-ritual);
+}
+
+.shadow-glyph {
+  position: relative;
+  width: 84px;
+  height: 112px;
+  filter: drop-shadow(0 0 18px var(--sc-moon-blue-border));
+}
+
+.shadow-glyph::before {
+  position: absolute;
+  inset: 9px 14px 0;
+  border: 3px solid currentcolor;
+  border-radius: 52% 48% 46% 54%;
+  content: '';
+  transform: rotate(8deg);
+}
+
+.shadow-glyph.companion::before {
+  transform: rotate(-8deg);
+}
+
+.shadow-glyph::after {
+  position: absolute;
+  top: 33px;
+  left: 31px;
+  width: 20px;
+  height: 20px;
+  border: 3px solid currentcolor;
+  content: '';
+  transform: rotate(45deg);
+}
+
+.settings-card {
+  padding: var(--space-6);
+  border-radius: var(--radius-2xl);
+}
+
+.settings-card h2 {
+  margin: 0 0 var(--space-5);
+  font: var(--type-h2);
 }
 
 .start-options {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  margin-bottom: 18px;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+}
+
+.start-options label,
+.start-planning-option {
+  display: grid;
+  gap: var(--space-2);
+  color: var(--text-3);
+  font: var(--type-body-sm);
+  text-align: left;
+}
+
+select {
+  width: 100%;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--surface-dark);
 }
 
 .start-planning-option {
-  display: grid;
-  gap: 8px;
-  margin-bottom: 18px;
-  color: var(--text-3, rgba(255, 255, 255, 0.55));
-  font-size: 0.82rem;
-  text-align: left;
+  margin-bottom: var(--space-4);
 }
 
 .planning-duration {
   display: grid;
-  grid-template-columns: 48px minmax(88px, 1fr) 48px;
-  gap: 8px;
+  grid-template-columns: 48px minmax(80px, 1fr) 48px;
+  gap: var(--space-2);
   align-items: center;
 }
 
-.planning-duration button,
-.voice-control {
-  border: 1px solid var(--border-soft, rgba(255, 255, 255, 0.1));
-  border-radius: var(--radius-md, 10px);
-  background: rgba(255, 255, 255, 0.04);
+.planning-duration > button {
+  border: 1px solid var(--border-soft);
+  background: var(--amio-overlay-hover);
 }
 
 .planning-duration-value {
@@ -148,65 +272,181 @@ h1 {
   min-height: 48px;
   align-items: baseline;
   justify-content: center;
-  gap: 5px;
-  border: 1px solid var(--border-hairline, rgba(255, 255, 255, 0.06));
-  border-radius: var(--radius-md, 10px);
-  background: rgba(0, 0, 0, 0.25);
+  gap: var(--space-1);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-md);
+  background: var(--surface-dark);
 }
 
 .planning-duration-value strong {
-  font-family: var(--font-numeric, system-ui, sans-serif);
-  font-size: 1.35rem;
+  font: var(--type-num-stat);
+}
+
+.planning-duration-value span {
+  color: var(--text-4);
+  font: var(--type-label);
+}
+
+.pursuer-rule {
+  margin-bottom: var(--space-4);
+  padding: var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-lg);
+  background: var(--surface-dark);
+}
+
+.rule-strip {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--space-1);
+}
+
+.rule-step {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-1);
+  place-items: center;
+  padding: var(--space-2) 2px;
+  color: var(--text-4);
+  font: var(--type-label);
+}
+
+.rule-step svg {
+  width: 44px;
+  height: 32px;
+  fill: none;
+  stroke: currentcolor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.rule-step .danger-stroke {
+  color: var(--sc-pursuer);
+  stroke: currentcolor;
+}
+
+.rule-step .shadow-stroke {
+  color: var(--sc-shadow);
+  stroke: currentcolor;
+}
+
+.rule-step .positive-stroke {
+  color: var(--sc-core);
+  stroke: currentcolor;
+}
+
+.pursuer-rule details {
+  margin-top: var(--space-2);
+  border-top: 1px solid var(--border-hairline);
+}
+
+.pursuer-rule summary {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
+  color: var(--text-4);
+  cursor: pointer;
+  font: var(--type-body-sm);
+  list-style: none;
+}
+
+.pursuer-rule summary::-webkit-details-marker {
+  display: none;
+}
+
+.pursuer-rule summary::before {
+  content: 'ⓘ';
+}
+
+.pursuer-rule details[open] summary {
+  color: var(--text-2);
+}
+
+.pursuer-rule p {
+  margin: 0;
+  padding: var(--space-1) var(--space-2) var(--space-2);
+  color: var(--text-3);
+  font: var(--type-body-sm);
+  line-height: var(--lh-loose);
+}
+
+.control-hint,
+.keyboard-hint,
+.control-reason {
+  color: var(--text-4);
+  font: var(--type-label);
+  letter-spacing: 0.08em;
+}
+
+.control-hint {
+  margin: var(--space-3) 0 0;
+  text-align: center;
+}
+
+.game-shell {
+  width: min(100%, 1180px);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: max(16px, env(safe-area-inset-top)) 16px max(24px, env(safe-area-inset-bottom));
 }
 
 .planning-header {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto minmax(200px, 260px) minmax(150px, 200px);
-  gap: 16px;
+  grid-template-columns: minmax(160px, 1fr) auto minmax(190px, 240px) auto;
+  gap: var(--space-4);
   align-items: center;
-  margin-bottom: 14px;
-  padding: 14px 16px;
-  border: 1px solid var(--border-hairline, rgba(255, 255, 255, 0.06));
-  border-radius: var(--radius-xl, 20px);
-  background: var(--glass-card, rgba(41, 43, 45, 0.4));
+  margin-bottom: var(--space-4);
+  padding: var(--space-4);
+  border-radius: var(--radius-xl);
 }
 
-.planning-header h1 {
-  margin: 4px 0 6px;
-  font-size: clamp(1.3rem, 3vw, 2rem);
-  line-height: 1.1;
-}
-
-.planning-header p {
-  margin: 0;
-  color: var(--text-2, rgba(255, 255, 255, 0.7));
-  line-height: 1.45;
+.planning-title h1 {
+  margin: var(--space-2) 0 0;
+  font: var(--type-h1);
 }
 
 .planning-countdown {
-  display: grid;
-  min-width: 84px;
-  text-align: center;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-1);
+  color: var(--text-4);
 }
 
 .planning-countdown strong {
-  color: var(--amio-yellow, #ffe53e);
-  font-family: var(--font-numeric, system-ui, sans-serif);
-  font-size: 2.2rem;
+  color: var(--amio-yellow);
+  font: var(--type-num-large);
 }
 
-.planning-countdown-label {
-  color: var(--text-3, rgba(255, 255, 255, 0.55));
-  font-size: 0.75rem;
+.planning-duration-wrap {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.planning-duration-label {
+  color: var(--text-4);
+  font: var(--type-label);
+}
+
+.planning-header > .pursuer-rule {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.planning-start {
+  min-width: 150px;
 }
 
 .planning-header.urgent {
-  border-color: rgba(255, 229, 62, 0.55);
+  border-color: var(--border-yellow-soft);
 }
 
 .planning-header.urgent .planning-countdown strong {
-  text-shadow: 0 0 18px rgba(255, 229, 62, 0.6);
   animation: planning-pulse 0.75s ease-in-out infinite alternate;
+  text-shadow: 0 0 18px var(--amio-yellow-glow-60);
 }
 
 @keyframes planning-pulse {
@@ -215,102 +455,75 @@ h1 {
   }
 }
 
-.start-options label {
-  display: grid;
-  gap: 8px;
-  color: var(--text-3, rgba(255, 255, 255, 0.55));
-  font-size: 0.82rem;
-  text-align: left;
-}
-
-select {
-  padding: 0 12px;
-  border: 1px solid var(--border-soft, rgba(255, 255, 255, 0.1));
-  border-radius: var(--radius-md, 10px);
-  background: rgba(0, 0, 0, 0.55);
-}
-
-.primary-button {
-  width: 100%;
-  padding: 14px 24px;
-  border: 0;
-  border-radius: var(--radius-pill, 9999px);
-  color: #171300;
-  font-weight: 700;
-  background: var(--amio-yellow, #ffe53e);
-  box-shadow: var(--glow-yellow, 0 0 22px rgba(255, 229, 62, 0.45));
-}
-
-.control-hint {
-  margin-top: 18px;
-  line-height: 1.5;
-}
-
-.game-shell {
-  width: min(100%, 1180px);
-  min-height: 100vh;
-  margin: 0 auto;
-  padding: max(16px, env(safe-area-inset-top)) 16px max(20px, env(safe-area-inset-bottom));
-}
-
 .hud {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 8px;
-  margin-bottom: 14px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
 }
 
 .hud > div {
-  display: grid;
+  display: flex;
   min-height: 68px;
-  padding: 10px 12px;
-  border: 1px solid var(--border-hairline, rgba(255, 255, 255, 0.06));
-  border-radius: var(--radius-lg, 16px);
-  background: var(--glass-card, rgba(41, 43, 45, 0.4));
-  align-content: center;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-lg);
+}
+
+.hud-icon {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  color: var(--text-4);
 }
 
 .hud-value {
-  margin-top: 4px;
-  font-family: var(--font-numeric, system-ui, sans-serif);
-  font-size: clamp(0.9rem, 2vw, 1.15rem);
+  font: var(--type-num-stat);
+  font-size: clamp(0.78rem, 1.7vw, 1rem);
+}
+
+.hud .hud-positive {
+  color: var(--sc-core);
+}
+
+.hud .hud-positive .hud-icon {
+  color: var(--sc-core);
 }
 
 .hud .rescue-alert {
-  border-color: rgba(255, 107, 157, 0.55);
+  border-color: var(--sc-pursuer-border);
+  color: var(--sc-pursuer);
+}
+
+.hud .rescue-alert .hud-icon {
+  color: var(--sc-pursuer);
 }
 
 .play-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(250px, 320px);
-  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 330px);
+  gap: var(--space-4);
   align-items: start;
-}
-
-.board-panel,
-.control-panel {
-  border: 1px solid var(--border-hairline, rgba(255, 255, 255, 0.06));
-  background: var(--glass-card, rgba(41, 43, 45, 0.4));
-  backdrop-filter: var(--glass-blur, blur(20px));
 }
 
 .board-panel {
   overflow: hidden;
-  padding: 14px;
-  border-radius: var(--radius-3xl, 30px);
+  padding: var(--space-3);
+  border-radius: var(--radius-3xl);
 }
 
 .control-panel {
   display: grid;
-  gap: 16px;
-  padding: 16px;
-  border-radius: var(--radius-xl, 20px);
+  gap: var(--space-4);
+  padding: var(--space-4);
+  border-radius: var(--radius-xl);
 }
 
 .game-board {
   display: block;
   width: 100%;
-  max-height: calc(100vh - 160px);
+  max-height: calc(100vh - 150px);
   touch-action: none;
 }
 
@@ -329,64 +542,65 @@ select {
 .pursuer-destination-indicator line,
 .pursuer-destination-indicator circle {
   fill: none;
-  stroke: rgba(255, 229, 62, 0.42);
+  stroke: var(--border-yellow-soft);
   stroke-width: 1.5;
   stroke-dasharray: 4 6;
 }
 
 .pursuer-arrowhead path {
-  fill: rgba(255, 229, 62, 0.58);
+  fill: var(--amio-yellow-glow-60);
 }
 
 .path-target {
-  fill: rgba(255, 229, 62, 0.08);
-  stroke: var(--amio-yellow, #ffe53e);
+  fill: var(--amio-yellow-glow-10);
+  stroke: var(--amio-yellow);
   stroke-width: 2;
   stroke-dasharray: 5 4;
 }
 
 .board-cell {
   fill: var(--sc-cell);
-  stroke: rgba(255, 255, 255, 0.04);
+  stroke: var(--border-hairline);
 }
 
 .board-cell.wall {
   fill: var(--sc-wall);
-  stroke: rgba(255, 255, 255, 0.18);
+  stroke: var(--border-soft);
 }
 
 .exit circle {
-  fill: rgba(255, 255, 255, 0.04);
-  stroke: var(--text-4, rgba(255, 255, 255, 0.4));
+  fill: var(--glass-soft);
+  stroke: var(--text-4);
   stroke-width: 2;
 }
 
 .exit path {
   fill: none;
-  stroke: var(--text-4, rgba(255, 255, 255, 0.4));
+  stroke: var(--text-4);
   stroke-width: 3;
 }
 
 .exit.enabled circle,
 .exit.enabled path {
-  stroke: var(--amio-yellow, #ffe53e);
-  filter: drop-shadow(0 0 8px rgba(255, 229, 62, 0.5));
+  stroke: var(--sc-core);
+  filter: drop-shadow(0 0 8px var(--sc-positive-glow));
 }
 
 .core path {
   fill: var(--sc-core);
-  stroke: #d8ffe0;
+  stroke: var(--text-1);
   stroke-width: 2;
-  filter: drop-shadow(0 0 7px rgba(75, 210, 102, 0.6));
+  filter: drop-shadow(0 0 7px var(--sc-positive-glow));
 }
 
 .shadow,
 .pursuer {
-  transition: transform var(--transition-fast, 0.15s ease);
+  transition: transform var(--transition-fast);
 }
 
 .shadow circle {
-  fill: rgba(5, 5, 17, 0.9);
+  fill: var(--sc-shadow-fill);
+  stroke: currentcolor;
   stroke-width: 3;
 }
 
@@ -394,16 +608,9 @@ select {
   fill: currentcolor;
 }
 
-.shadow.player {
-  color: var(--sc-player);
-}
-
+.shadow.player,
 .shadow.companion {
-  color: var(--sc-companion);
-}
-
-.shadow circle {
-  stroke: currentcolor;
+  color: var(--sc-shadow);
 }
 
 .shadow.captured {
@@ -415,7 +622,7 @@ select {
 }
 
 .pursuer circle {
-  fill: rgba(255, 107, 157, 0.12);
+  fill: var(--sc-pursuer-soft);
   stroke: var(--sc-pursuer);
   stroke-width: 3;
 }
@@ -425,114 +632,137 @@ select {
   stroke-width: 3;
 }
 
-.companion-bark {
-  overflow: hidden;
-  margin: 12px 0 0;
-  color: var(--text-2, rgba(255, 255, 255, 0.7));
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.companion-bark span {
-  color: var(--sc-companion);
-}
-
 .input-feedback {
   min-height: 1.5em;
-  margin: 10px 4px 0;
-  color: var(--amio-yellow, #ffe53e);
+  margin: var(--space-2) var(--space-1) 0;
+  color: var(--amio-yellow);
   font-size: 0.85rem;
   text-align: center;
 }
 
-.command-panel {
-  display: grid;
-  gap: 10px;
-}
-
 .strategy-panel {
   display: grid;
-  gap: 14px;
+  gap: var(--space-3);
 }
 
-.strategy-label {
-  display: block;
-  margin-bottom: 4px;
-  color: var(--text-3, rgba(255, 255, 255, 0.55));
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
+.companion-presence {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-2);
+  font: var(--type-body-sm);
 }
 
-.strategy-current {
-  color: var(--amio-yellow, #ffe53e);
-  font-size: 1.2rem;
+.companion-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--sc-companion);
+  box-shadow: 0 0 12px var(--sc-moon-blue-glow);
 }
 
-.strategy-effect,
-.strategy-recommendation p,
-.voice-strategy p {
-  margin: 5px 0 0;
-  color: var(--text-2, rgba(255, 255, 255, 0.7));
-  font-size: 0.82rem;
-  line-height: 1.55;
+.voice-state {
+  overflow: hidden;
+  margin-left: auto;
+  color: var(--text-4);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.strategy-recommendation,
-.voice-strategy {
-  padding: 10px;
-  border: 1px solid var(--border-hairline, rgba(255, 255, 255, 0.06));
-  border-radius: var(--radius-md, 10px);
-  background: rgba(0, 0, 0, 0.18);
-}
-
-.voice-control {
-  width: 100%;
-  margin: 4px 0 6px;
-}
-
-.voice-clarify {
-  color: var(--amio-yellow, #ffe53e) !important;
-}
-
-.voice-status-message {
-  color: var(--text-3, rgba(255, 255, 255, 0.55)) !important;
+.companion-presence svg,
+.swap-button svg {
+  width: 22px;
+  height: 22px;
 }
 
 .command-row {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 6px;
+  gap: var(--space-2);
 }
 
-.command-button,
-.swap-button,
-.direction-pad button {
-  border: 1px solid var(--border-soft, rgba(255, 255, 255, 0.1));
-  border-radius: var(--radius-md, 10px);
-  background: rgba(255, 255, 255, 0.04);
+.command-button {
+  display: grid;
+  min-height: 62px;
+  place-items: center;
+  gap: 2px;
+  padding: var(--space-1);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  color: var(--text-3);
+  background: var(--amio-overlay-hover);
+}
+
+.command-button svg {
+  width: 30px;
+  height: 24px;
+  color: var(--sc-companion);
+}
+
+.command-button span {
+  font: var(--type-body-sm);
 }
 
 .command-button[aria-pressed='true'] {
-  border-color: var(--amio-yellow, #ffe53e);
-  color: var(--amio-yellow, #ffe53e);
-  background: var(--amio-yellow-glow-10, rgba(255, 229, 62, 0.1));
+  border-color: var(--border-yellow-soft);
+  color: var(--text-1);
+  background: var(--amio-yellow-glow-10);
+}
+
+.strategy-effect,
+.companion-caption,
+.voice-feedback p {
+  margin: 0;
+  color: var(--text-3);
+  font: var(--type-body-sm);
+  line-height: var(--lh-loose);
+}
+
+.companion-caption {
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  border-left: 2px solid var(--sc-moon-blue-border);
+}
+
+.voice-feedback:empty {
+  display: none;
+}
+
+.voice-clarify {
+  color: var(--amio-yellow) !important;
 }
 
 .swap-button {
-  width: 100%;
+  display: inline-flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-4);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  color: var(--text-2);
+  background: var(--amio-overlay-hover);
 }
 
 .control-reason {
   min-height: 1.2em;
-  letter-spacing: 0.04em;
-  text-transform: none;
+  text-align: center;
 }
 
 .direction-pad {
   display: grid;
   grid-template: repeat(2, 48px) / repeat(3, 48px);
-  gap: 6px;
+  gap: var(--space-2);
   justify-content: center;
+}
+
+.direction-pad button {
+  border: 1px solid var(--border-soft);
+  background: var(--amio-overlay-hover);
 }
 
 .direction-pad .up {
@@ -556,29 +786,102 @@ select {
   text-align: center;
 }
 
+.result-shell {
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.result-header {
+  margin-bottom: 0;
+}
+
+.result-header h2 {
+  margin: 0;
+}
+
+.result-card {
+  align-self: center;
+  width: min(760px, 100%);
+  margin: var(--space-6) auto;
+  padding: clamp(28px, 6vw, 56px);
+  border-radius: var(--radius-3xl);
+  text-align: center;
+}
+
+.result-mark {
+  position: relative;
+  width: 96px;
+  height: 96px;
+  margin: 0 auto var(--space-6);
+  border: 2px solid var(--sc-pursuer-border);
+  border-radius: 50%;
+  color: var(--sc-pursuer);
+}
+
+.result-card.won .result-mark {
+  border-color: var(--sc-positive-border);
+  color: var(--sc-core);
+  box-shadow: 0 0 30px var(--sc-positive-soft);
+}
+
+.result-mark span {
+  position: absolute;
+  top: 22px;
+  width: 28px;
+  height: 48px;
+  border: 2px solid currentcolor;
+  border-radius: 50%;
+}
+
+.result-mark span:first-child {
+  left: 20px;
+  transform: rotate(-12deg);
+}
+
+.result-mark span:last-child {
+  right: 20px;
+  transform: rotate(12deg);
+}
+
+.result-card h1 {
+  margin: 0;
+  font: 700 clamp(2.2rem, 7vw, 4.4rem) / 1 var(--font-display);
+  letter-spacing: -0.05em;
+}
+
+.result-card > p {
+  max-width: 500px;
+  margin: var(--space-4) auto var(--space-6);
+  color: var(--text-2);
+  line-height: var(--lh-loose);
+}
+
 .result-stats {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
-  margin: 0 0 18px;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-6);
 }
 
 .result-stats div {
-  padding: 16px 8px;
-  border: 1px solid var(--border-hairline, rgba(255, 255, 255, 0.06));
-  border-radius: var(--radius-lg, 16px);
-  background: var(--glass-card, rgba(41, 43, 45, 0.4));
+  padding: var(--space-4) var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-lg);
+  background: var(--surface-dark);
 }
 
 .result-stats dt {
-  color: var(--text-3, rgba(255, 255, 255, 0.55));
-  font-size: 0.75rem;
+  color: var(--text-4);
+  font: var(--type-label);
 }
 
 .result-stats dd {
-  margin: 8px 0 0;
-  font-weight: 700;
-  text-transform: capitalize;
+  margin: var(--space-2) 0 0;
+  font: var(--type-num-stat);
+}
+
+.result-card.won .result-stats dd {
+  color: var(--sc-core);
 }
 
 .sr-only {
@@ -592,91 +895,130 @@ select {
   white-space: nowrap;
 }
 
-@media (max-width: 760px) {
-  .game-shell {
-    padding-inline: 8px;
-  }
-
-  .hud {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .hud > div {
-    min-height: 56px;
-    padding: 7px 10px;
-  }
-
+@media (max-width: 900px) {
+  .setup-grid,
   .play-layout {
     grid-template-columns: 1fr;
   }
 
-  .planning-header {
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 10px;
-    padding: 10px;
+  .play-layout {
+    max-width: 760px;
+    margin-inline: auto;
   }
 
-  .planning-header > .planning-duration,
+  .ritual-card {
+    min-height: 320px;
+  }
+
+  .planning-header {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .planning-duration-wrap,
   .planning-start {
     grid-column: span 1;
   }
 
+  .game-board {
+    max-height: 58vh;
+  }
+}
+
+@media (max-width: 660px) {
+  .start-shell,
+  .result-shell {
+    width: min(calc(100% - 20px), 1200px);
+    padding-top: max(20px, env(safe-area-inset-top));
+  }
+
+  .game-title {
+    font-size: clamp(2.7rem, 17vw, 4.5rem);
+  }
+
+  .objective-flow {
+    gap: var(--space-2);
+  }
+
+  .objective-node {
+    min-height: 48px;
+    padding-inline: var(--space-2);
+  }
+
+  .setup-grid {
+    min-width: 0;
+    gap: var(--space-3);
+  }
+
+  .setup-grid > *,
+  .start-options,
+  .start-options label,
+  .settings-card,
+  .pursuer-rule,
+  select {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .ritual-card,
+  .settings-card {
+    width: 100%;
+  }
+
+  .start-options {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-card {
+    padding: var(--space-4);
+  }
+
+  .rule-strip {
+    grid-template-columns: repeat(5, minmax(56px, 1fr));
+    overflow-x: auto;
+  }
+
+  .game-shell {
+    padding-inline: var(--space-2);
+  }
+
+  .planning-header {
+    gap: var(--space-2);
+    padding: var(--space-3);
+  }
+
+  .planning-duration-wrap,
+  .planning-start {
+    grid-column: 1 / -1;
+  }
+
+  .hud {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hud > div {
+    min-height: 58px;
+    padding: var(--space-2);
+  }
+
+  .hud > div:last-child {
+    grid-column: 1 / -1;
+  }
+
   .board-panel {
-    padding: 8px;
-    border-radius: var(--radius-xl, 20px);
+    padding: var(--space-2);
+    border-radius: var(--radius-xl);
+  }
+
+  .control-panel {
+    padding: var(--space-3);
   }
 
   .game-board {
     max-height: 52vh;
   }
 
-  .control-panel {
-    grid-template-columns: 1fr auto;
-    gap: 10px;
-    padding: 10px;
-  }
-
-  .strategy-panel {
-    grid-column: 1 / -1;
-  }
-
-  .keyboard-hint {
-    display: none;
-  }
-}
-
-@media (max-width: 480px) {
-  .start-options {
-    grid-template-columns: 1fr;
-  }
-
-  .command-row {
-    gap: 4px;
-  }
-
-  .command-button {
-    padding-inline: 6px;
-    font-size: 0.78rem;
-  }
-
   .result-stats {
     grid-template-columns: 1fr;
-  }
-
-  .planning-header {
-    grid-template-columns: 1fr auto;
-  }
-
-  .planning-header > div:first-child {
-    grid-column: 1 / -1;
-  }
-
-  .planning-header > .planning-duration {
-    grid-column: 1 / -1;
-  }
-
-  .planning-start {
-    grid-column: 1 / -1;
   }
 }
 

--- a/packages/game-shadow-chase/src/styles/tokens.css
+++ b/packages/game-shadow-chase/src/styles/tokens.css
@@ -1,9 +1,24 @@
 :root {
   color-scheme: dark;
-  --sc-player: var(--amio-yellow, #ffe53e);
-  --sc-companion: var(--accent-violet, #b478ff);
-  --sc-pursuer: #ff6b9d;
-  --sc-core: var(--amio-positive, #4bd266);
-  --sc-cell: rgba(255, 255, 255, 0.035);
-  --sc-wall: rgba(255, 255, 255, 0.12);
+
+  /* Shadow Chase's single registered accent layer: Atlas moon blue. */
+  --sc-moon-blue: var(--accent-blue);
+  --sc-moon-blue-soft: rgba(74, 158, 255, 0.1);
+  --sc-moon-blue-border: rgba(74, 158, 255, 0.28);
+  --sc-moon-blue-glow: rgba(74, 158, 255, 0.42);
+
+  /* Named presentation roles keep semantics in the Atlas platform palette. */
+  --sc-shadow: var(--sc-moon-blue);
+  --sc-companion: var(--sc-moon-blue);
+  --sc-ritual: var(--sc-moon-blue);
+  --sc-pursuer: var(--amio-danger);
+  --sc-pursuer-soft: var(--amio-danger-surface);
+  --sc-pursuer-border: var(--amio-danger-border);
+  --sc-core: var(--amio-positive);
+  --sc-positive-soft: var(--glass-soft);
+  --sc-positive-border: var(--amio-positive);
+  --sc-positive-glow: var(--amio-positive);
+  --sc-cell: var(--glass-soft);
+  --sc-wall: var(--amio-overlay-press);
+  --sc-shadow-fill: rgba(var(--chrome-surface-rgb), 0.9);
 }


### PR DESCRIPTION
## Summary

- Rebuild Shadow Chase setup, planning, running, and result presentation around graphics-first Atlas v2 patterns while preserving the current pursuit, capture, rescue, swap, and exit behavior.
- Register a bounded moon-blue game accent, map state feedback to platform semantic tokens, remove leaked BombSquad and Oracle colors, and adopt shared `@amiclaw/ui` primitives where their semantics fit.
- Keep exact rules in an accessible collapsed disclosure, document the visual contract, and stabilize one existing BombSquad survey test under full-workspace load with a local 10-second timeout.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor or cleanup
- [x] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

### Test plan

- [x] `pnpm --filter @amiclaw/game-shadow-chase test:run` — 122 tests
- [x] `pnpm --filter @amiclaw/game-shadow-chase typecheck`
- [x] `pnpm --filter @amiclaw/game-shadow-chase build`
- [x] `pnpm --filter @amiclaw/game-bombsquad test:run` — 508 tests
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:run` — 2,239 tests across 13 packages
- [x] `pnpm build`
- [x] Chrome interaction at 1280×900, 390×844, and 320×844, including setup, planning, running movement, collapsed/expanded rules, and result presentation

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

No breaking changes.

## Attribution

Codex managed the implementation and independent verification. Claude Code attribution: none; no Claude Code-authored change is included.