### PR TITLE
feat(platform-ai): backward-compatible co_build action protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.1.0...HEAD)
 
+**The platform companion learns to act in co-build games** — Added. The voice
+AI pipeline gains a backward-compatible action channel: in games flagged as
+co-build, the companion's reply can carry one structured board action
+(place/remove a piece) alongside its speech, parsed through a bounded splitter
+that never leaks protocol markers into the voice and validated against the
+game's vocabulary before it touches the board. Existing games are untouched —
+the capability is off by default per game, non-co-build replies are
+byte-identical, and a barge-in that cuts the companion off also cancels its
+pending move. Groundwork for Sound Garden, where the companion plants rhythm
+roots in your shared garden.
+
 **Shadow Chase now reads at a glance** — Improved. Setup, tactical planning, the
 live chase, and results now use the shared Atlas page, navigation, button, status,
 and icon-control grammar. Compact diagrams show that three collected cores open

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -21,6 +21,7 @@
     "../../shared/voice/audio-capture.ts",
     "../../shared/voice/audio-context.ts",
     "../../shared/voice/audio-playback.ts",
-    "../../shared/voice/use-game-voice-session.ts"
+    "../../shared/voice/use-game-voice-session.ts",
+    "../../shared/voice/use-game-voice-session.action.test.ts"
   ]
 }

--- a/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
+++ b/packages/game-bombsquad/src/voice/voice-session-protocol.test.ts
@@ -167,12 +167,15 @@ describe('voiceReducer', () => {
     expect(next.playerTranscript).toBe('no final flag here')
   })
 
-  it('audio chunks do not change aiText but their done flag closes the turn', () => {
+  it('audio chunks do not change aiText and never close the turn; the terminal text chunk does', () => {
+    // Audio frames are pinned `done: false` (the server never ends a turn on
+    // audio — only the terminal text chunk carries `done: true`).
     const next = run(
       { type: 'connecting' },
       { type: 'frame', frame: { type: 'created', sessionId: 's1' } },
       { type: 'frame', frame: { type: 'chunk', kind: 'text', text: 'ok', done: false } },
-      { type: 'frame', frame: { type: 'chunk', kind: 'audio', audio: 'AAAA', done: true } }
+      { type: 'frame', frame: { type: 'chunk', kind: 'audio', audio: 'AAAA', done: false } },
+      { type: 'frame', frame: { type: 'chunk', kind: 'text', text: '', done: true } }
     )
     expect(next.aiText).toBe('ok')
     expect(next.turnDone).toBe(true)

--- a/packages/platform-ai/src/cobuild-splitter.test.ts
+++ b/packages/platform-ai/src/cobuild-splitter.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ACTION_MAX_BYTES,
+  CO_BUILD_CLOSE,
+  CO_BUILD_OPEN,
+  CoBuildSplitter,
+  buildCoBuildInstruction,
+} from './cobuild-splitter'
+import { CO_BUILD_VERBS, parseCoBuildActions } from './sound-garden-action'
+import type { CoBuildAction } from './contract'
+
+/**
+ * Drive a splitter over a delta sequence, returning the total SPEECH emitted
+ * (every `push` return concatenated with the `flush` speech) and the parsed
+ * actions. This is exactly how `streamLlmTts` consumes it.
+ */
+function run(deltas: string[]): { speech: string; actions: CoBuildAction[] } {
+  const splitter = new CoBuildSplitter(parseCoBuildActions)
+  let speech = ''
+  for (const d of deltas) speech += splitter.push(d)
+  const flushed = splitter.flush()
+  speech += flushed.speech
+  return { speech, actions: flushed.actions }
+}
+
+describe('CoBuildSplitter', () => {
+  it('streams pure speech immediately and parses a trailing fenced action block', () => {
+    const { speech, actions } = run([
+      '你好，我先放一个底鼓打底。',
+      `${CO_BUILD_OPEN}[{"op":"place","piece_type":"kick","slot":1}]${CO_BUILD_CLOSE}`,
+    ])
+    expect(speech).toBe('你好，我先放一个底鼓打底。')
+    expect(actions).toEqual([{ op: 'place', pieceType: 'kick', slot: 1 }])
+    // No fence byte reached the speech stream.
+    expect(speech).not.toContain('<<<')
+    expect(speech).not.toContain('ACTIONS')
+  })
+
+  it('detects a fence that spans a delta boundary without leaking the marker', () => {
+    const { speech, actions } = run([
+      '放个底鼓。<<<AC',
+      'TIONS>>>[{"op":"place","piece_type":"kick","slot":1}',
+      ']<<<END_ACTIONS>>>',
+    ])
+    expect(speech).toBe('放个底鼓。')
+    expect(actions).toEqual([{ op: 'place', pieceType: 'kick', slot: 1 }])
+    expect(speech).not.toContain('<<<')
+  })
+
+  it('never leaks the CLOSE marker or action-block content to speech', () => {
+    const { speech } = run([
+      'ok.',
+      `${CO_BUILD_OPEN}[{"op":"remove","piece_type":"snare","slot":2}]${CO_BUILD_CLOSE}trailing junk`,
+    ])
+    expect(speech).toBe('ok.')
+    expect(speech).not.toContain('END_ACTIONS')
+    expect(speech).not.toContain('remove')
+    expect(speech).not.toContain('trailing junk')
+  })
+
+  it('does NOT swallow a real sentence that merely ends in a fence-prefix look-alike', () => {
+    // The model never opened a fence; the trailing "<<" is genuine speech and
+    // must be released verbatim at stream end (delayed, not lost).
+    const { speech, actions } = run(['看这里<<'])
+    expect(speech).toBe('看这里<<')
+    expect(actions).toEqual([])
+  })
+
+  it('releases a longer partial-prefix that never completes into a fence', () => {
+    const { speech, actions } = run(['注意', '<<<ACTI'])
+    expect(speech).toBe('注意<<<ACTI')
+    expect(actions).toEqual([])
+  })
+
+  it('emits no action chunk when there is no fence at all', () => {
+    const { speech, actions } = run(['就聊聊天，', '这一拍先不动。'])
+    expect(speech).toBe('就聊聊天，这一拍先不动。')
+    expect(actions).toEqual([])
+  })
+
+  it('drops actions on a parse-reject but keeps the speech', () => {
+    const { speech, actions } = run([
+      '我想放这个。',
+      `${CO_BUILD_OPEN}[{"op":"place","piece_type":"kick"`, // malformed JSON, missing CLOSE
+    ])
+    expect(speech).toBe('我想放这个。')
+    expect(actions).toEqual([])
+  })
+
+  it('DISCARD_ACTIONS: an over-ACTION_MAX-byte block NEVER reaches speech, yields empty actions, keeps pre-fence speech', () => {
+    const huge = 'x'.repeat(ACTION_MAX_BYTES + 500)
+    const { speech, actions } = run([
+      'pre-fence speech stays.',
+      `${CO_BUILD_OPEN}[`,
+      huge,
+      `]${CO_BUILD_CLOSE}`,
+    ])
+    // The pre-fence speech already streamed and is delivered.
+    expect(speech).toBe('pre-fence speech stays.')
+    // Overflow → terminal discard → empty actions.
+    expect(actions).toEqual([])
+    // Neither the markers nor the overflow content leaked to TTS/text.
+    expect(speech).not.toContain('<<<')
+    expect(speech).not.toContain('x'.repeat(50))
+    expect(speech).not.toContain('END_ACTIONS')
+  })
+
+  it('DISCARD is terminal: deltas after overflow are swallowed', () => {
+    const huge = 'y'.repeat(ACTION_MAX_BYTES + 100)
+    const splitter = new CoBuildSplitter(parseCoBuildActions)
+    let speech = splitter.push('speech.')
+    speech += splitter.push(`${CO_BUILD_OPEN}${huge}`) // overflow → discard
+    speech += splitter.push('this must not appear as speech')
+    const flushed = splitter.flush()
+    speech += flushed.speech
+    expect(speech).toBe('speech.')
+    expect(flushed.actions).toEqual([])
+  })
+
+  it('measures ACTION_MAX in UTF-8 BYTES, not code units (multi-byte content)', () => {
+    // Each 好 is 3 UTF-8 bytes: 700 chars = 2100 bytes > 2048 → discard.
+    const multibyte = '好'.repeat(700)
+    const { speech, actions } = run(['前置。', `${CO_BUILD_OPEN}${multibyte}${CO_BUILD_CLOSE}`])
+    expect(speech).toBe('前置。')
+    expect(actions).toEqual([])
+  })
+
+  it('flush is idempotent (never double-releases the held carry)', () => {
+    const splitter = new CoBuildSplitter(parseCoBuildActions)
+    // '看' streams immediately; the '<<' partial-prefix is HELD for flush.
+    expect(splitter.push('看<<')).toBe('看')
+    expect(splitter.flush()).toEqual({ speech: '<<', actions: [] })
+    expect(splitter.flush()).toEqual({ speech: '', actions: [] })
+  })
+})
+
+describe('buildCoBuildInstruction', () => {
+  it('names the exact fence markers and the game verb vocabulary', () => {
+    const instruction = buildCoBuildInstruction({ verbs: CO_BUILD_VERBS })
+    expect(instruction).toContain(CO_BUILD_OPEN)
+    expect(instruction).toContain(CO_BUILD_CLOSE)
+    expect(instruction).toContain('place')
+    expect(instruction).toContain('remove')
+  })
+})

--- a/packages/platform-ai/src/cobuild-splitter.ts
+++ b/packages/platform-ai/src/cobuild-splitter.ts
@@ -1,0 +1,152 @@
+/**
+ * Bounded incremental speech/action splitter for the co_build channel.
+ *
+ * A co_build-capable partner emits its spoken reply followed by a trailing fenced
+ * action block, e.g.
+ *
+ *   你好，我先放一个底鼓打底。<<<ACTIONS>>>[{"op":"place","piece_type":"kick","slot":1}]<<<END_ACTIONS>>>
+ *
+ * The server must stream the SPEECH to TTS immediately (no whole-reply buffering)
+ * while never letting a fence marker or action-block byte reach TTS, and never
+ * swallowing a genuine speech prefix. A naive `buffer + delta` scan cannot do all
+ * three, so this runs a 3-state machine with a bounded carry buffer:
+ *
+ *   SPEECH → ACTIONS → DISCARD (terminal once entered)
+ *
+ * - SPEECH holds back only the longest suffix of the stream that could still grow
+ *   into `OPEN` (≤ `CARRY_MAX` chars); everything definitely-not-a-prefix streams
+ *   out at once. If the fence never materializes, `flush` releases the held carry
+ *   verbatim, so no speech is ever lost.
+ * - On `OPEN` the marker bytes are consumed (never emitted) and everything after
+ *   it accumulates in the action buffer, which never touches TTS.
+ * - The action buffer is capped at `ACTION_MAX_BYTES` UTF-8 bytes; exceeding it
+ *   enters the terminal DISCARD state, which clears the buffer and swallows every
+ *   remaining delta this turn — the already-streamed pre-fence speech is kept, but
+ *   no action chunk is produced and no marker/JSON byte can leak.
+ *
+ * The splitter is per-turn: construct a fresh one for each reply.
+ */
+
+import type { CoBuildAction } from './contract'
+
+/** Fence markers. Mirror them verbatim in the prompt instruction (see below). */
+export const CO_BUILD_OPEN = '<<<ACTIONS>>>'
+export const CO_BUILD_CLOSE = '<<<END_ACTIONS>>>'
+
+/** Most chars that could be a partial `OPEN` prefix, held back in SPEECH state. */
+const CARRY_MAX = CO_BUILD_OPEN.length - 1
+
+/**
+ * UTF-8 BYTE cap on the captured action text (cf. Shadow Chase's
+ * `MAX_MODEL_OUTPUT_BYTES`). Bounds a hostile / runaway action block.
+ */
+export const ACTION_MAX_BYTES = 2048
+
+type SplitterState = 'speech' | 'actions' | 'discard'
+
+const encoder = new TextEncoder()
+
+/** Length of the longest suffix of `s` that is a prefix of `OPEN` (0..CARRY_MAX). */
+function longestOpenPrefixSuffix(s: string): number {
+  const max = Math.min(s.length, CARRY_MAX)
+  for (let k = max; k > 0; k -= 1) {
+    if (s.endsWith(CO_BUILD_OPEN.slice(0, k))) return k
+  }
+  return 0
+}
+
+/** The trailing speech + parsed actions produced when the LLM stream ends. */
+export interface CoBuildFlushResult {
+  /** Trailing speech to emit (the held carry in SPEECH state; '' otherwise). */
+  speech: string
+  /** Parsed actions, or `[]` on discard / parse-reject / no fence. */
+  actions: CoBuildAction[]
+}
+
+export class CoBuildSplitter {
+  private state: SplitterState = 'speech'
+  private carry = ''
+  private actionBuf = ''
+  private ended = false
+
+  /** `parse` is the game's strict co_build parse-guard (rejects the whole set → null). */
+  constructor(private readonly parse: (raw: string) => CoBuildAction[] | null) {}
+
+  /**
+   * Feed one LLM text delta. Returns the SPEECH portion to emit now (never a fence
+   * marker, never action-block content). A partial `OPEN` prefix (≤ `CARRY_MAX`
+   * chars) is withheld until the next delta or `flush`.
+   */
+  push(delta: string): string {
+    if (this.state === 'discard') return ''
+    if (this.state === 'actions') {
+      this.actionBuf += delta
+      this.guardOverflow()
+      return ''
+    }
+    // SPEECH
+    this.carry += delta
+    const openAt = this.carry.indexOf(CO_BUILD_OPEN)
+    if (openAt !== -1) {
+      const speech = this.carry.slice(0, openAt)
+      this.actionBuf = this.carry.slice(openAt + CO_BUILD_OPEN.length)
+      this.state = 'actions'
+      this.carry = ''
+      this.guardOverflow()
+      return speech
+    }
+    const keep = longestOpenPrefixSuffix(this.carry)
+    const cut = this.carry.length - keep
+    const speech = this.carry.slice(0, cut)
+    this.carry = this.carry.slice(cut)
+    return speech
+  }
+
+  private guardOverflow(): void {
+    if (encoder.encode(this.actionBuf).byteLength > ACTION_MAX_BYTES) {
+      this.actionBuf = ''
+      this.state = 'discard'
+    }
+  }
+
+  /**
+   * Flush at LLM stream end. In SPEECH state the held carry IS real speech (no
+   * fence ever came) — return it. In DISCARD state return nothing. In ACTIONS
+   * state strip a trailing `CLOSE` if present and parse the body (parse-reject
+   * → `[]`). Idempotent.
+   */
+  flush(): CoBuildFlushResult {
+    if (this.ended) return { speech: '', actions: [] }
+    this.ended = true
+    if (this.state === 'speech') {
+      const speech = this.carry
+      this.carry = ''
+      return { speech, actions: [] }
+    }
+    if (this.state === 'discard') {
+      return { speech: '', actions: [] }
+    }
+    const body = this.actionBuf.split(CO_BUILD_CLOSE)[0]
+    return { speech: '', actions: this.parse(body) ?? [] }
+  }
+}
+
+/**
+ * Build the per-game co_build prompt instruction. Appended to the system message
+ * ONLY when a game has a co_build capability, so every other game's prompt is
+ * byte-identical. Uses the exact `OPEN` / `CLOSE` markers the splitter parses, so
+ * the model and the parser can never drift.
+ */
+export function buildCoBuildInstruction(coBuild: { verbs: readonly string[] }): string {
+  return [
+    'Co-build channel: besides speaking, you may place or remove pieces on the shared board.',
+    'To do so, append EXACTLY ONE fenced action block at the very END of your reply, after all',
+    'your spoken words. The block is a JSON array of moves. Format:',
+    `${CO_BUILD_OPEN}[{"op":"place","piece_type":"kick","slot":1}]${CO_BUILD_CLOSE}`,
+    `- "op" is one of: ${coBuild.verbs.join(', ')}.`,
+    '- "piece_type" is the piece to place or remove; "slot" is a 1-based integer.',
+    '- The fenced block is parsed as structured moves and is NEVER read aloud: keep every',
+    '  human-facing word in your speech, and put ONLY the JSON array inside the fence.',
+    '- Omit the fence entirely on a turn where you make no move. Never emit more than one fence.',
+  ].join('\n')
+}

--- a/packages/platform-ai/src/contract.ts
+++ b/packages/platform-ai/src/contract.ts
@@ -74,12 +74,33 @@ export interface GameState {
 }
 
 /**
+ * One partner build move on the co_build channel. Verb vocabulary is aligned to
+ * the future MCP tool surface (`place` / `remove` / `get_state`); `slot` is a
+ * 1-based timeline index. Emitted by a co_build-capable game's partner inside a
+ * fenced action block in the LLM stream, extracted server-side, and delivered to
+ * the client as an `action` chunk — never spoken.
+ */
+export interface CoBuildAction {
+  op: 'place' | 'remove'
+  pieceType: string
+  slot: number
+}
+
+/**
  * One chunk of the AI's streamed response. A turn produces an ordered stream of
  * these: a leading STREAMING series of `transcript` chunks carrying the player's
  * recognized utterance as it is recognized, then the incremental assistant text
- * plus the synthesized audio frames pushed back over the same WebSocket. `kind`
- * discriminates them; `done` marks the final chunk of a turn so the consumer can
- * close out the turn without a separate end signal.
+ * plus the synthesized audio frames pushed back over the same WebSocket, and —
+ * for a co_build-capable game — an optional `action` chunk carrying the partner's
+ * structured board moves. `kind` discriminates them; `done` marks the final chunk
+ * of a turn so the consumer can close out the turn without a separate end signal.
+ *
+ * This is a discriminated union on `kind`. Every pre-existing runtime yield
+ * already conforms to a variant shape, so the migration from the prior
+ * optional-field interface is type-level only. The `done` contract is structural:
+ * ONLY the AI reply's terminal `text` chunk carries `done: true` and closes the
+ * turn; `audio`, `transcript`, and `action` are pinned `done: false`, so none of
+ * them can ever terminate a turn — turn termination is always a text event.
  *
  * The `transcript` variant is the PLAYER's own recognized speech (the STT
  * result), surfaced BEFORE the AI reply streams so the client can build a live
@@ -87,29 +108,18 @@ export interface GameState {
  * chunks (`final: false`) each carrying the running CUMULATIVE recognized text
  * (not a delta) as the ASR stabilizes more of the utterance, then exactly one
  * terminal chunk (`final: true`) carrying the COMPLETE utterance once STT
- * finishes. A benign no-speech turn streams none. Transcript chunks never carry
- * AI text and never set `done` (the turn's terminal `done` is always the AI
- * reply's last `text` chunk).
+ * finishes. A benign no-speech turn streams none.
+ *
+ * The `action` variant is emitted at most once per turn (when the partner's reply
+ * contained a valid, non-empty fenced action block), after the speech/audio and
+ * before the terminal `done` chunk. Absent for every game without a co_build
+ * capability, so those games' streams are byte-identical to before.
  */
-export interface AiResponseChunk {
-  /** Which modality this chunk carries. */
-  kind: 'text' | 'audio' | 'transcript'
-  /**
-   * Incremental assistant text (present when `kind === 'text'`), or the player's
-   * running/complete recognized utterance (present when `kind === 'transcript'`).
-   */
-  text?: string
-  /** Synthesized TTS audio frame (present when `kind === 'audio'`). */
-  audio?: Uint8Array
-  /**
-   * For a `transcript` chunk: `false` on an interim running-text update, `true`
-   * on the terminal complete-utterance chunk. Absent for `text` / `audio` chunks
-   * (those use `done` for turn termination, not `final`).
-   */
-  final?: boolean
-  /** True on the last chunk of the current turn. */
-  done: boolean
-}
+export type AiResponseChunk =
+  | { kind: 'text'; text: string; done: boolean } // done:true only on the terminal chunk
+  | { kind: 'audio'; audio: Uint8Array; done: false }
+  | { kind: 'transcript'; text: string; final: boolean; done: false }
+  | { kind: 'action'; actions: CoBuildAction[]; done: false } // never closes the turn
 
 /**
  * Returned by `endSession`. Carries session metadata and the metering mount
@@ -217,8 +227,10 @@ export interface VoiceSessionContract {
 
   /**
    * Subscribe to the session's AI response stream — incremental assistant text
-   * and synthesized audio frames. Semantic placeholder: does not promise a
-   * synchronous or one-shot shape.
+   * and synthesized audio frames, plus (for a co_build-capable game) at most one
+   * `action` chunk carrying the partner's structured board moves, yielded after
+   * the speech/audio and before the terminal `done` text chunk. Semantic
+   * placeholder: does not promise a synchronous or one-shot shape.
    */
   onAiResponse(sessionId: SessionId): AsyncIterable<AiResponseChunk>
 

--- a/packages/platform-ai/src/index.ts
+++ b/packages/platform-ai/src/index.ts
@@ -18,6 +18,7 @@ export type {
   ManualData,
   GameState,
   AiResponseChunk,
+  CoBuildAction,
   SessionSummary,
   VoiceSessionContract,
 } from './contract'
@@ -43,6 +44,7 @@ export type {
   ProviderLayer,
   LayerSelection,
   SystemPromptConfig,
+  CoBuildConfig,
   ProviderConfig,
   ResolvedConfig,
 } from './provider-config'

--- a/packages/platform-ai/src/provider-config.ts
+++ b/packages/platform-ai/src/provider-config.ts
@@ -24,7 +24,8 @@
  * the timeout + fallback followup is actually implemented and wired.
  */
 
-import type { GameId } from './contract'
+import type { CoBuildAction, GameId } from './contract'
+import { CO_BUILD_VERBS, parseCoBuildActions } from './sound-garden-action'
 
 /** The three pipeline layers a provider can be selected for. */
 export type ProviderLayer = 'stt' | 'llm' | 'tts'
@@ -59,12 +60,27 @@ export interface SystemPromptConfig {
   ruleTemplate: string[]
 }
 
+/**
+ * Per-game co_build capability. Present only for a game whose partner emits
+ * structured board moves alongside speech (Sound Garden); ABSENT for every other
+ * game, so the fence splitter never runs, no action instruction is added to the
+ * prompt, and their voice streams stay byte-identical.
+ */
+export interface CoBuildConfig {
+  /** Verb vocabulary offered to the model in the prompt and accepted by `parse`. */
+  verbs: readonly string[]
+  /** Strict parse-guard: raw fence body → validated actions, or null to drop the set. */
+  parse: (raw: string) => CoBuildAction[] | null
+}
+
 /** Full per-game provider configuration, keyed by `gameId` in the registry. */
 export interface ProviderConfig {
   systemPromptConfig: SystemPromptConfig
   llm: LayerSelection
   stt: LayerSelection
   tts: LayerSelection
+  /** Optional co_build capability. Absent = no structured action channel. */
+  coBuild?: CoBuildConfig
 }
 
 /**
@@ -306,6 +322,37 @@ const PROVIDER_REGISTRY: Record<GameId, ProviderConfig> = {
     stt: { provider: 'volcengine', model: 'bigmodel' },
     tts: { provider: 'volcengine', model: '' },
   },
+  'sound-garden': {
+    systemPromptConfig: {
+      // Chinese, agent-voice: the player's existing companion, here as their
+      // 园丁伙伴 co-building a singing garden. This is the ONLY game with a
+      // co_build capability — the partner both speaks AND places/removes pieces on
+      // the shared timeline. The harmony matrix + live board ride in as injected
+      // manual + public game context (server-side ground truth); this prompt
+      // frames the duty + tone and defers every relation to the injected data.
+      // The fenced action-output contract is added separately, gated by `coBuild`
+      // (see `buildCoBuildInstruction`), so it is never restated here.
+      role: '你是玩家的既有 AI 伙伴，此刻在《声音花园》里当他的园丁搭档。你们在一条 8 拍的时间线上，一人负责节奏根、一人负责旋律花，一起种出一座会唱歌的花园。你手里有这一关的和声矩阵和当前公开局面，玩家只能看到花园本身；你通过语音和亲手放置元素，引导你们把和声总分种到目标、让花园绽放。',
+      ruleTemplate: [
+        '只依据上下文注入的和声矩阵与公开局面作答，绝不编造关系或分数；矩阵是唯一事实来源，你只把它翻成一句此刻能执行的口语建议，绝不复述矩阵原文、规则表或内部字段。',
+        '你只负责自己那一侧（节奏根或旋律花）的元素，只放置或移除你这一侧、且还有剩余材料的元素；玩家负责另一侧，你可以建议但不替他放。',
+        '同一拍两侧都有元素才计分：synergy 最好、compatible 次之、neutral 平淡、incompatible 会倒扣要避开；用有限的材料把它们放在最能共鸣的拍上，帮玩家避开刺耳组合，朝目标分推进。',
+        '这是自由流、无失败的玩法——绽放是奖励不是终点；养到开花就一起高兴一句，分数暂时落后也只沉着地把当前局面说清，不安慰、不打气、不列清单。',
+        '你的语音回复会被原样朗读，只输出纯口语：不要括号、方括号、星号或任何 markdown，不要念字段名、英文值或坐标；元素、拍号都用中文自然说出来（说「第一拍放个底鼓打底」而不是「slot 1 place kick」）。',
+        '作为玩家的老搭档，语气温暖、简洁、笃定；可以自然带一句你们的相处，但绝不编造没发生过的事，也绝不喋喋不休、不硬找话题。',
+        '始终用中文，口语、自然、精确。',
+      ],
+    },
+    // Same verified DeepSeek + Volcengine stack as `bombsquad` / `botanical-garden`
+    // (see the `demo` entry for the per-layer rationale).
+    llm: { provider: 'deepseek', model: 'deepseek-v4-flash' },
+    stt: { provider: 'volcengine', model: 'bigmodel' },
+    tts: { provider: 'volcengine', model: '' },
+    // The co_build capability: the partner emits `place` / `remove` moves inside a
+    // fenced action block, extracted by the bounded splitter and validated by the
+    // strict parse-guard before reaching the client.
+    coBuild: { verbs: CO_BUILD_VERBS, parse: parseCoBuildActions },
+  },
 }
 
 const INTENT_PROVIDER_REGISTRY: Record<GameId, IntentProviderConfig> = {
@@ -359,6 +406,11 @@ export function resolveConfig(gameId: GameId): ResolvedConfig {
     llm: cloneLayer(config.llm),
     stt: cloneLayer(config.stt),
     tts: cloneLayer(config.tts),
+    // Pass the co_build capability through by reference: it is an immutable
+    // registry object (a readonly verb list + a pure parse-guard function), so
+    // handing out the reference cannot corrupt the registry the way a mutable
+    // layer selection could.
+    ...(config.coBuild !== undefined ? { coBuild: config.coBuild } : {}),
   }
 }
 

--- a/packages/platform-ai/src/session-cobuild-action.test.ts
+++ b/packages/platform-ai/src/session-cobuild-action.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Session-level proof of the co_build channel, driving the REAL `VoiceSessionDO`
+ * under workerd. The same fence-emitting LLM is run against a co_build-capable
+ * game (`sound-garden`) and a non-co_build game (`demo-mock`):
+ *
+ *  - co_build: the DO emits ONE `{type:'action'}` frame carrying the parsed moves,
+ *    and the fence markers + action JSON are stripped from every text chunk (never
+ *    spoken).
+ *  - non-co_build (the regression assertion): NO `action` frame is emitted and the
+ *    text stream is BYTE-IDENTICAL to the raw model output — the fence flows through
+ *    untouched, proving the splitter never runs when a game has no `coBuild`.
+ */
+
+const providerControl = vi.hoisted(() => ({
+  override: undefined as import('./turn-pipeline').TurnProviders | undefined,
+}))
+
+vi.mock('./providers/factory', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./providers/factory')>()
+  return {
+    ...actual,
+    createProviders: (...args: Parameters<typeof actual.createProviders>) =>
+      providerControl.override ?? actual.createProviders(...args),
+  }
+})
+
+import type { LlmProvider } from './providers/types'
+import {
+  createSessionOverWs,
+  makeSessionDo,
+  makeTurnProviders,
+  messagesOfType,
+  openSocket,
+  sawDoneChunk,
+  TestSocket,
+  waitFor,
+  waitForMessage,
+} from './session-do-test-kit'
+
+const OPEN = '<<<ACTIONS>>>'
+const CLOSE = '<<<END_ACTIONS>>>'
+const ACTION_JSON = '[{"op":"place","piece_type":"kick","slot":1}]'
+const SPEECH = '好的，我放个底鼓打底。'
+/** The full raw model output (speech + trailing fenced action block). */
+const RAW = `${SPEECH}${OPEN}${ACTION_JSON}${CLOSE}`
+
+/** An LLM that speaks, then appends the fenced action block across several deltas. */
+function makeFenceLlm(): LlmProvider {
+  return {
+    async *streamCompletion() {
+      yield { content: '好的，', done: false }
+      yield { content: '我放个底鼓打底。', done: false }
+      yield { content: OPEN, done: false }
+      yield { content: ACTION_JSON, done: false }
+      yield { content: CLOSE, done: true }
+    },
+  }
+}
+
+const textTurn = (text: string) => JSON.stringify({ type: 'text-turn', text })
+const END = JSON.stringify({ type: 'end' })
+
+function joinedText(socket: TestSocket): string {
+  return messagesOfType(socket, 'chunk')
+    .filter((c) => c.kind === 'text')
+    .map((c) => (typeof c.text === 'string' ? c.text : ''))
+    .join('')
+}
+
+beforeEach(() => {
+  providerControl.override = undefined
+})
+
+describe('real VoiceSessionDO — co_build action channel', () => {
+  it('co_build game: emits ONE action frame and strips the fence from the spoken text', async () => {
+    providerControl.override = makeTurnProviders(makeFenceLlm()).providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket, 'sound-garden')
+
+    socket.send(textTurn('放个底鼓吧'))
+    await waitFor(() => sawDoneChunk(socket), 'reply done')
+
+    // Exactly one action frame with the parsed move.
+    const actionFrames = messagesOfType(socket, 'action')
+    expect(actionFrames).toHaveLength(1)
+    expect(actionFrames[0].actions).toEqual([{ op: 'place', pieceType: 'kick', slot: 1 }])
+
+    // The spoken text is the speech only — no fence marker, no action JSON.
+    const text = joinedText(socket)
+    expect(text).toBe(SPEECH)
+    expect(text).not.toContain('<<<')
+    expect(text).not.toContain('ACTIONS')
+    expect(text).not.toContain('piece_type')
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+  })
+
+  it('non-co_build game: emits NO action frame and the text is byte-identical to the raw output', async () => {
+    providerControl.override = makeTurnProviders(makeFenceLlm()).providers
+    const session = makeSessionDo()
+    const socket = await openSocket(session, 'user-A')
+    await createSessionOverWs(socket, 'demo-mock')
+
+    socket.send(textTurn('放个底鼓吧'))
+    await waitFor(() => sawDoneChunk(socket), 'reply done')
+
+    // No action frame at all — the splitter never runs for a game without coBuild.
+    expect(messagesOfType(socket, 'action')).toHaveLength(0)
+
+    // The text stream carries the FULL raw output, fence markers included: the
+    // pipeline behaves exactly as before the co_build change.
+    expect(joinedText(socket)).toBe(RAW)
+
+    socket.send(END)
+    await waitForMessage(socket, 'summary')
+  })
+})

--- a/packages/platform-ai/src/session-do.ts
+++ b/packages/platform-ai/src/session-do.ts
@@ -95,6 +95,7 @@ import type { ProviderEnv } from './providers/factory'
 import { assembleSession } from './session-assembly'
 import { traceTurn, traceTurnError } from './trace'
 import { validateShadowChaseVoiceContext } from './shadow-chase-voice-context'
+import { validateSoundGardenVoiceContext } from './sound-garden-voice-context'
 import {
   runClosingTurn,
   runOpeningTurn,
@@ -260,12 +261,29 @@ function normalizeVoiceGameState(gameId: string, gameState: GameState | undefine
   ) {
     throw new Error('session-do: invalid game state')
   }
-  if (gameId !== 'shadow-chase') return { relevantSections: [...relevantSections] }
-  const validated = validateShadowChaseVoiceContext(gameState?.publicContext)
-  if (!validated.ok) {
-    throw new Error(`session-do: invalid shadow chase context (${validated.reason})`)
+  if (gameId === 'shadow-chase') {
+    const validated = validateShadowChaseVoiceContext(gameState?.publicContext)
+    if (!validated.ok) {
+      throw new Error(`session-do: invalid shadow chase context (${validated.reason})`)
+    }
+    return { relevantSections: [...relevantSections], publicContext: validated.value }
   }
-  return { relevantSections: [...relevantSections], publicContext: validated.value }
+  if (gameId === 'sound-garden') {
+    // The board snapshot is optional at the protocol layer: absent = no board
+    // injected this turn (the game always pushes one in normal play, but a bare
+    // `create` without one is benign). When present it is UNTRUSTED input that
+    // gets injected into the prompt, so it is validated + bounded before it is
+    // trusted; an invalid board is rejected loudly.
+    if (gameState?.publicContext === undefined) {
+      return { relevantSections: [...relevantSections] }
+    }
+    const validated = validateSoundGardenVoiceContext(gameState.publicContext)
+    if (!validated.ok) {
+      throw new Error(`session-do: invalid sound garden context (${validated.reason})`)
+    }
+    return { relevantSections: [...relevantSections], publicContext: validated.value }
+  }
+  return { relevantSections: [...relevantSections] }
 }
 
 /**
@@ -1139,11 +1157,11 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
           ws.send(
             JSON.stringify({
               type: 'transcript',
-              text: chunk.text ?? '',
-              final: chunk.final ?? false,
+              text: chunk.text,
+              final: chunk.final,
             })
           )
-        } else if (chunk.kind === 'audio' && chunk.audio) {
+        } else if (chunk.kind === 'audio') {
           ws.send(
             JSON.stringify({
               type: 'chunk',
@@ -1152,12 +1170,24 @@ export class VoiceSessionDO extends Agent<SessionDoEnv> {
               done: chunk.done,
             })
           )
+        } else if (chunk.kind === 'action') {
+          // The partner's structured board moves (co_build games only) — its OWN
+          // wire frame, NOT a `chunk`: `{type:'action', actions}`. It carries no
+          // `done` (pinned `done:false` in the union), so the AI reply's terminal
+          // text `chunk` still closes the turn. Absent for every non-co_build
+          // game, so those games' wire streams are unchanged.
+          ws.send(
+            JSON.stringify({
+              type: 'action',
+              actions: chunk.actions,
+            })
+          )
         } else {
           ws.send(
             JSON.stringify({
               type: 'chunk',
               kind: 'text',
-              text: chunk.text ?? '',
+              text: chunk.text,
               done: chunk.done,
             })
           )

--- a/packages/platform-ai/src/sound-garden-action.test.ts
+++ b/packages/platform-ai/src/sound-garden-action.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CO_BUILD_VERBS,
+  SOUND_GARDEN_PIECE_TYPES,
+  parseCoBuildActions,
+} from './sound-garden-action'
+
+/**
+ * The strict co_build parse-guard: valid moves parse (accepting either wire
+ * `piece_type` or `pieceType`), a validly-empty array yields `[]`, and ANY
+ * structural violation drops the WHOLE set (`null`) — never throws. Game-specific
+ * legality (lane / range / material) is NOT enforced here; only shape.
+ */
+describe('parseCoBuildActions', () => {
+  it('exposes the aligned verb vocabulary', () => {
+    expect(CO_BUILD_VERBS).toEqual(['place', 'remove'])
+  })
+
+  it('exposes the authoritative 8-element Sound Garden vocabulary', () => {
+    expect(SOUND_GARDEN_PIECE_TYPES).toEqual([
+      'kick',
+      'snare',
+      'hihat',
+      'clap',
+      'bell',
+      'chime',
+      'flute',
+      'harp',
+    ])
+  })
+
+  it('parses every element of the authoritative vocabulary', () => {
+    for (const pieceType of SOUND_GARDEN_PIECE_TYPES) {
+      expect(parseCoBuildActions(`[{"op":"place","piece_type":"${pieceType}","slot":1}]`)).toEqual([
+        { op: 'place', pieceType, slot: 1 },
+      ])
+    }
+  })
+
+  it('parses a single valid place action', () => {
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"kick","slot":1}]')).toEqual([
+      { op: 'place', pieceType: 'kick', slot: 1 },
+    ])
+  })
+
+  it('parses multiple valid actions preserving order', () => {
+    expect(
+      parseCoBuildActions(
+        '[{"op":"place","piece_type":"kick","slot":1},{"op":"remove","piece_type":"snare","slot":3}]'
+      )
+    ).toEqual([
+      { op: 'place', pieceType: 'kick', slot: 1 },
+      { op: 'remove', pieceType: 'snare', slot: 3 },
+    ])
+  })
+
+  it('accepts camelCase pieceType as well as snake_case piece_type', () => {
+    expect(parseCoBuildActions('[{"op":"place","pieceType":"bell","slot":2}]')).toEqual([
+      { op: 'place', pieceType: 'bell', slot: 2 },
+    ])
+  })
+
+  it('treats a validly-empty array as no actions', () => {
+    expect(parseCoBuildActions('[]')).toEqual([])
+  })
+
+  it('treats an empty / whitespace body as no actions', () => {
+    expect(parseCoBuildActions('')).toEqual([])
+    expect(parseCoBuildActions('   ')).toEqual([])
+  })
+
+  it('tolerates a ```json code fence around the array', () => {
+    expect(
+      parseCoBuildActions('```json\n[{"op":"place","piece_type":"kick","slot":1}]\n```')
+    ).toEqual([{ op: 'place', pieceType: 'kick', slot: 1 }])
+  })
+
+  it('rejects invalid JSON (null, whole set dropped)', () => {
+    expect(parseCoBuildActions('[{"op":"place",')).toBeNull()
+    expect(parseCoBuildActions('not json at all')).toBeNull()
+  })
+
+  it('rejects a non-array body (object)', () => {
+    expect(parseCoBuildActions('{"op":"place","piece_type":"kick","slot":1}')).toBeNull()
+  })
+
+  it('rejects an unknown / forged verb', () => {
+    expect(parseCoBuildActions('[{"op":"destroy","piece_type":"kick","slot":1}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"","piece_type":"kick","slot":1}]')).toBeNull()
+  })
+
+  it('rejects a non-string / empty / missing piece type', () => {
+    expect(parseCoBuildActions('[{"op":"place","piece_type":42,"slot":1}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"","slot":1}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"place","slot":1}]')).toBeNull()
+  })
+
+  it('rejects a forged piece type outside the vocabulary', () => {
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"drum","slot":1}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"guitar","slot":1}]')).toBeNull()
+    // A hostile element name (would be a forged move on the client board).
+    expect(parseCoBuildActions('[{"op":"remove","piece_type":"__proto__","slot":1}]')).toBeNull()
+  })
+
+  it('rejects a typo / wrong-case of a real element (exact-token match only)', () => {
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"Kick","slot":1}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"kicks","slot":1}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"bel","slot":1}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"place","piece_type":" kick","slot":1}]')).toBeNull()
+  })
+
+  it('drops the whole set when one action names an unknown element', () => {
+    expect(
+      parseCoBuildActions(
+        '[{"op":"place","piece_type":"kick","slot":1},{"op":"place","piece_type":"tuba","slot":2}]'
+      )
+    ).toBeNull()
+  })
+
+  it('rejects a non-integer / non-positive slot (1-based)', () => {
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"kick","slot":1.5}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"kick","slot":0}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"kick","slot":-2}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"kick","slot":"1"}]')).toBeNull()
+  })
+
+  it('drops the WHOLE set when any one action is invalid (reject-on-invalid)', () => {
+    expect(
+      parseCoBuildActions(
+        '[{"op":"place","piece_type":"kick","slot":1},{"op":"place","piece_type":"snare","slot":0}]'
+      )
+    ).toBeNull()
+  })
+
+  it('rejects a non-object array element', () => {
+    expect(parseCoBuildActions('["place kick at 1"]')).toBeNull()
+    expect(parseCoBuildActions('[null]')).toBeNull()
+  })
+})

--- a/packages/platform-ai/src/sound-garden-action.ts
+++ b/packages/platform-ai/src/sound-garden-action.ts
@@ -1,0 +1,92 @@
+/**
+ * Strict parse-guard for the Sound Garden co_build action channel.
+ *
+ * The partner (an LLM) emits its board moves as a JSON array inside a fenced
+ * action block; the bounded splitter (`cobuild-splitter.ts`) extracts the raw
+ * body and hands it here. This guard mirrors the probe's wire contract
+ * (`game-sound-garden` `normalizePartnerReply` / `parsePartnerReply`) and Shadow
+ * Chase's reject-on-invalid stance (`shadow-chase-intent.ts`
+ * `parseShadowChaseIntentResponse`): any violation — non-array body, unknown verb,
+ * a piece type outside the fixed Sound Garden vocabulary, non-integer / non-positive
+ * slot — drops the WHOLE action set (the partner still speaks) and never throws.
+ *
+ * Board-state legality (piece belongs to THIS partner's lane, slot in range,
+ * material still available) is NOT checked here — that stays client-side in the
+ * game's own `filterLegalActions` guard, which owns the live board. This layer
+ * bounds the SHAPE and the element VOCABULARY (op must be a known verb, pieceType
+ * a known element) before the action reaches the client.
+ */
+
+import type { CoBuildAction } from './contract'
+
+/**
+ * The co_build verb vocabulary. Single source shared by the parse guard (the
+ * accepted `op` set) and the per-game prompt instruction (`buildCoBuildInstruction`
+ * lists these to the model). Aligned to the future MCP tool surface.
+ */
+export const CO_BUILD_VERBS = ['place', 'remove'] as const
+
+const VERB_SET = new Set<string>(CO_BUILD_VERBS)
+
+/**
+ * The authoritative Sound Garden element vocabulary — the 8 fixed piece types
+ * (4 rhythm + 4 melody). This mirrors `entity_types` in the game-type source of
+ * truth (`packages/creation/fixtures/sound-garden/game-type.yaml`) and the probe's
+ * `RHYTHM_TYPES` / `MELODY_TYPES`. It lives here (not imported from `@amiclaw/creation`)
+ * to avoid a runtime YAML-loading dependency in the voice pipeline; if it ever
+ * drifts, the game-type YAML is the SSOT. The parse-guard rejects any pieceType
+ * outside this set, so a forged or hallucinated element never reaches the client.
+ */
+export const SOUND_GARDEN_PIECE_TYPES = [
+  'kick',
+  'snare',
+  'hihat',
+  'clap',
+  'bell',
+  'chime',
+  'flute',
+  'harp',
+] as const
+
+const PIECE_TYPE_SET = new Set<string>(SOUND_GARDEN_PIECE_TYPES)
+
+/**
+ * Parse and validate the raw fence body into a list of co_build actions.
+ *
+ * Tolerates an optional ```json code fence around the array (the model
+ * occasionally wraps it), then requires a JSON array whose every element is a
+ * well-shaped action. Returns `null` on ANY violation so the caller drops the
+ * entire set; returns `[]` for a validly-empty array (no move this turn). Never
+ * throws.
+ *
+ * Accepts either the wire `piece_type` (snake_case, matching the probe's
+ * DeepSeek contract) or `pieceType`, normalizing both to `pieceType`.
+ */
+export function parseCoBuildActions(raw: string): CoBuildAction[] | null {
+  const stripped = raw
+    .trim()
+    .replace(/^```(?:json)?/i, '')
+    .replace(/```$/, '')
+    .trim()
+  if (stripped === '') return []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stripped)
+  } catch {
+    return null
+  }
+  if (!Array.isArray(parsed)) return null
+  const actions: CoBuildAction[] = []
+  for (const entry of parsed) {
+    if (typeof entry !== 'object' || entry === null) return null
+    const record = entry as Record<string, unknown>
+    const op = record.op
+    const pieceType = record.piece_type ?? record.pieceType
+    const slot = record.slot
+    if (typeof op !== 'string' || !VERB_SET.has(op)) return null
+    if (typeof pieceType !== 'string' || !PIECE_TYPE_SET.has(pieceType)) return null
+    if (typeof slot !== 'number' || !Number.isInteger(slot) || slot < 1) return null
+    actions.push({ op: op as 'place' | 'remove', pieceType, slot })
+  }
+  return actions
+}

--- a/packages/platform-ai/src/sound-garden-voice-context.test.ts
+++ b/packages/platform-ai/src/sound-garden-voice-context.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MAX_SOUND_GARDEN_VOICE_CONTEXT_BYTES,
+  validateSoundGardenVoiceContext,
+} from './sound-garden-voice-context'
+
+/** A well-formed board snapshot fixture (8-beat timeline). */
+function validBoard(): Record<string, unknown> {
+  return {
+    slots: 8,
+    melody: [null, 'bell', null, null, null, null, null, null],
+    rhythm: ['kick', null, null, null, null, null, null, null],
+    score: 5,
+    target: 12,
+    bloomed: false,
+    partnerRemaining: { kick: 2, snare: 1 },
+    playerRemaining: { bell: 3 },
+    partnerArchetype: 'rhythm_piece',
+    trigger: 'player_planted',
+  }
+}
+
+describe('validateSoundGardenVoiceContext', () => {
+  it('accepts a well-formed board and returns a defensive clone', () => {
+    const board = validBoard()
+    const result = validateSoundGardenVoiceContext(board)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toEqual(board)
+      expect(result.value).not.toBe(board)
+    }
+  })
+
+  it('accepts a bloomed board with a negative score dip', () => {
+    const board = { ...validBoard(), bloomed: true, score: -3 }
+    expect(validateSoundGardenVoiceContext(board).ok).toBe(true)
+  })
+
+  const rejects: Array<[string, Record<string, unknown>, string]> = [
+    ['extra key', { ...validBoard(), extra: 1 }, 'keys'],
+    [
+      'missing key',
+      (() => {
+        const b = validBoard()
+        delete b.trigger
+        return b
+      })(),
+      'keys',
+    ],
+    ['non-integer slots', { ...validBoard(), slots: 8.5 }, 'slots'],
+    ['zero slots', { ...validBoard(), slots: 0 }, 'slots'],
+    ['too many slots', { ...validBoard(), slots: 999 }, 'slots'],
+    ['lane length mismatch', { ...validBoard(), melody: [null, 'bell'] }, 'lanes'],
+    [
+      'lane bad token',
+      { ...validBoard(), rhythm: ['Kick!', null, null, null, null, null, null, null] },
+      'lanes',
+    ],
+    ['non-integer score', { ...validBoard(), score: 1.5 }, 'score'],
+    ['negative target', { ...validBoard(), target: -1 }, 'score'],
+    ['out-of-range score', { ...validBoard(), score: 10_000_000 }, 'score'],
+    ['non-boolean bloomed', { ...validBoard(), bloomed: 'yes' }, 'bloomed'],
+    ['pool non-integer value', { ...validBoard(), partnerRemaining: { kick: 1.5 } }, 'pool'],
+    ['pool negative value', { ...validBoard(), playerRemaining: { bell: -1 } }, 'pool'],
+    ['pool bad key', { ...validBoard(), partnerRemaining: { 'Bad Key': 1 } }, 'pool'],
+    ['bad archetype', { ...validBoard(), partnerArchetype: 'drummer' }, 'archetype'],
+    ['bad trigger', { ...validBoard(), trigger: 'whenever' }, 'trigger'],
+  ]
+
+  it.each(rejects)('rejects %s with reason "%s"', (_label, board, reason) => {
+    const result = validateSoundGardenVoiceContext(board)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe(reason)
+  })
+
+  it('rejects a non-object payload', () => {
+    expect(validateSoundGardenVoiceContext(null).ok).toBe(false)
+    expect(validateSoundGardenVoiceContext('board').ok).toBe(false)
+    expect(validateSoundGardenVoiceContext([]).ok).toBe(false)
+  })
+
+  it('rejects an oversized payload (size cap before shape)', () => {
+    // Inflate a pool key name past the byte cap so serialization exceeds it.
+    const board = {
+      ...validBoard(),
+      partnerRemaining: { ['k'.repeat(MAX_SOUND_GARDEN_VOICE_CONTEXT_BYTES + 10)]: 1 },
+    }
+    const result = validateSoundGardenVoiceContext(board)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('size')
+  })
+})

--- a/packages/platform-ai/src/sound-garden-voice-context.ts
+++ b/packages/platform-ai/src/sound-garden-voice-context.ts
@@ -1,0 +1,153 @@
+/**
+ * Strict public context accepted from the Sound Garden voice client.
+ *
+ * Mirrors `shadow-chase-voice-context.ts`: the board snapshot the game pushes on
+ * every utterance is UNTRUSTED input that ends up injected (data-fenced) into the
+ * LLM prompt, so it is bounded here before it is trusted — size cap, exact key
+ * set, per-field type + range checks. Rejection returns a reason; it never throws.
+ *
+ * The exact piece vocabulary (which token is a legal kick/bell/…) is NOT enforced
+ * here — that stays with the game's client-side legality guard and engine, which
+ * own the board. This layer only bounds SHAPE and SIZE of untrusted input, so it
+ * does not couple to the game's piece list; slot occupants are validated as
+ * bounded lowercase tokens or `null`.
+ */
+
+export const MAX_SOUND_GARDEN_VOICE_CONTEXT_BYTES = 4_096
+export const MAX_SOUND_GARDEN_VOICE_SLOTS = 32
+export const MAX_SOUND_GARDEN_VOICE_POOL_KEYS = 16
+export const MAX_SOUND_GARDEN_VOICE_TOKEN_CODEPOINTS = 32
+/** Bound on |score| and |target| so a hostile payload cannot inject a huge number. */
+export const MAX_SOUND_GARDEN_VOICE_SCORE_MAGNITUDE = 100_000
+
+type Archetype = 'rhythm_piece' | 'melody_piece'
+type Trigger = 'session_start' | 'player_planted' | 'player_spoke' | 'idle'
+type Pool = Record<string, number>
+
+export interface SoundGardenVoiceContext {
+  slots: number
+  /** melody[slotIndex] = the placed melody token, or null. Length === slots. */
+  melody: (string | null)[]
+  rhythm: (string | null)[]
+  score: number
+  target: number
+  bloomed: boolean
+  partnerRemaining: Pool
+  playerRemaining: Pool
+  partnerArchetype: Archetype
+  trigger: Trigger
+}
+
+export type SoundGardenVoiceContextValidation =
+  | { ok: true; value: SoundGardenVoiceContext }
+  | { ok: false; reason: string }
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function exactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort()
+  const sorted = [...expected].sort()
+  return actual.length === sorted.length && actual.every((key, index) => key === sorted[index])
+}
+
+function pieceToken(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    [...value].length > 0 &&
+    [...value].length <= MAX_SOUND_GARDEN_VOICE_TOKEN_CODEPOINTS &&
+    /^[a-z][a-z0-9-]*$/.test(value)
+  )
+}
+
+function slotLane(value: unknown, slots: number): value is (string | null)[] {
+  return (
+    Array.isArray(value) &&
+    value.length === slots &&
+    value.every((entry) => entry === null || pieceToken(entry))
+  )
+}
+
+function pool(value: unknown): value is Pool {
+  if (!record(value)) return false
+  const keys = Object.keys(value)
+  if (keys.length > MAX_SOUND_GARDEN_VOICE_POOL_KEYS) return false
+  return keys.every(
+    (key) =>
+      pieceToken(key) &&
+      Number.isSafeInteger(value[key]) &&
+      (value[key] as number) >= 0 &&
+      (value[key] as number) <= MAX_SOUND_GARDEN_VOICE_SLOTS
+  )
+}
+
+function boundedScore(value: unknown): value is number {
+  return (
+    Number.isSafeInteger(value) &&
+    Math.abs(value as number) <= MAX_SOUND_GARDEN_VOICE_SCORE_MAGNITUDE
+  )
+}
+
+function serializedBytes(value: unknown): number {
+  try {
+    return new TextEncoder().encode(JSON.stringify(value)).byteLength
+  } catch {
+    return Number.POSITIVE_INFINITY
+  }
+}
+
+export function validateSoundGardenVoiceContext(value: unknown): SoundGardenVoiceContextValidation {
+  if (serializedBytes(value) > MAX_SOUND_GARDEN_VOICE_CONTEXT_BYTES) {
+    return { ok: false, reason: 'size' }
+  }
+  if (
+    !record(value) ||
+    !exactKeys(value, [
+      'slots',
+      'melody',
+      'rhythm',
+      'score',
+      'target',
+      'bloomed',
+      'partnerRemaining',
+      'playerRemaining',
+      'partnerArchetype',
+      'trigger',
+    ])
+  ) {
+    return { ok: false, reason: 'keys' }
+  }
+  const slots = value.slots
+  if (
+    !Number.isSafeInteger(slots) ||
+    (slots as number) < 1 ||
+    (slots as number) > MAX_SOUND_GARDEN_VOICE_SLOTS
+  ) {
+    return { ok: false, reason: 'slots' }
+  }
+  if (!slotLane(value.melody, slots as number) || !slotLane(value.rhythm, slots as number)) {
+    return { ok: false, reason: 'lanes' }
+  }
+  if (!boundedScore(value.score) || !boundedScore(value.target) || (value.target as number) < 0) {
+    return { ok: false, reason: 'score' }
+  }
+  if (typeof value.bloomed !== 'boolean') {
+    return { ok: false, reason: 'bloomed' }
+  }
+  if (!pool(value.partnerRemaining) || !pool(value.playerRemaining)) {
+    return { ok: false, reason: 'pool' }
+  }
+  if (value.partnerArchetype !== 'rhythm_piece' && value.partnerArchetype !== 'melody_piece') {
+    return { ok: false, reason: 'archetype' }
+  }
+  if (
+    value.trigger !== 'session_start' &&
+    value.trigger !== 'player_planted' &&
+    value.trigger !== 'player_spoke' &&
+    value.trigger !== 'idle'
+  ) {
+    return { ok: false, reason: 'trigger' }
+  }
+  return { ok: true, value: structuredClone(value) as unknown as SoundGardenVoiceContext }
+}

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -5,12 +5,14 @@ import {
   CLOSING_DIRECTIVE_TIMEOUT,
   closingDirectiveFor,
   OPENING_DIRECTIVE,
+  runClosingTurn,
   runOpeningTurn,
   runTurn,
   splitSentences,
   type SessionState,
   type TurnProviders,
 } from './turn-pipeline'
+import { CO_BUILD_VERBS, parseCoBuildActions } from './sound-garden-action'
 import { createDeepSeekLlmProvider } from './providers/deepseek'
 import type { AiResponseChunk, AudioChunk, ManualData } from './contract'
 import type {
@@ -181,7 +183,10 @@ describe('runTurn', () => {
     // Text chunks arrive, audio chunks arrive, exactly one terminal done chunk.
     const textChunks = chunks.filter((c) => c.kind === 'text' && !c.done)
     const audioChunks = chunks.filter((c) => c.kind === 'audio')
-    expect(textChunks.map((c) => c.text)).toEqual(['Cut the ', 'blue wire.'])
+    expect(textChunks.map((c) => (c.kind === 'text' ? c.text : ''))).toEqual([
+      'Cut the ',
+      'blue wire.',
+    ])
     expect(audioChunks.length).toBeGreaterThan(0)
 
     const doneChunks = chunks.filter((c) => c.done)
@@ -288,7 +293,10 @@ describe('runTurn', () => {
     // terminal done — the transcript chunk (kind 'transcript', done false) is not
     // counted among them.
     const textChunks = chunks.filter((c) => c.kind === 'text' && !c.done)
-    expect(textChunks.map((c) => c.text)).toEqual(['Cut the ', 'blue wire.'])
+    expect(textChunks.map((c) => (c.kind === 'text' ? c.text : ''))).toEqual([
+      'Cut the ',
+      'blue wire.',
+    ])
     expect(chunks.filter((c) => c.kind === 'audio').length).toBeGreaterThan(0)
     expect(chunks.filter((c) => c.done)).toHaveLength(1)
     expect(chunks.at(-1)?.done).toBe(true)
@@ -712,7 +720,7 @@ describe('runTurn', () => {
     expect(ttsReceived).toEqual(['Cut the tail.'])
     // It also surfaces as a text chunk (not the empty terminal one).
     const textChunks = chunks.filter((c) => c.kind === 'text' && !c.done)
-    expect(textChunks.map((c) => c.text)).toEqual(['Cut the ', 'tail.'])
+    expect(textChunks.map((c) => (c.kind === 'text' ? c.text : ''))).toEqual(['Cut the ', 'tail.'])
   })
 
   it('cleans up the TTS side when a provider rejects mid-turn', async () => {
@@ -833,7 +841,10 @@ describe('runOpeningTurn', () => {
 
     // The greeting streams as text + audio chunks plus exactly one terminal done.
     const textChunks = chunks.filter((c) => c.kind === 'text' && !c.done)
-    expect(textChunks.map((c) => c.text)).toEqual(['你好！', '请描述你看到的。'])
+    expect(textChunks.map((c) => (c.kind === 'text' ? c.text : ''))).toEqual([
+      '你好！',
+      '请描述你看到的。',
+    ])
     expect(chunks.filter((c) => c.kind === 'audio').length).toBeGreaterThan(0)
     expect(chunks.filter((c) => c.done)).toHaveLength(1)
     expect(ttsReceived).toEqual(['你好！', '请描述你看到的。'])
@@ -907,5 +918,62 @@ describe('closingDirectiveFor — outcome-aware recap register', () => {
     ]) {
       expect(d).toMatch(/name (a |the )specific module/)
     }
+  })
+})
+
+// --- co_build turn gating: opening + regular emit actions; closing never does --
+
+/** A co_build-capable state (the game's `coBuild` capability wired onto config). */
+function coBuildState(): SessionState {
+  const base = freshState()
+  return {
+    ...base,
+    config: {
+      ...base.config,
+      coBuild: { verbs: CO_BUILD_VERBS, parse: parseCoBuildActions },
+    },
+  }
+}
+
+/** An LLM that speaks then appends a valid trailing fenced action block. */
+function fenceLlm(): LlmProvider {
+  return rawLlm([
+    { content: '好的，', done: false },
+    { content: '我放个底鼓打底。', done: false },
+    {
+      content: '<<<ACTIONS>>>[{"op":"place","piece_type":"kick","slot":1}]<<<END_ACTIONS>>>',
+      done: true,
+    },
+  ])
+}
+
+describe('co_build turn gating', () => {
+  it('the closing recap emits ZERO action frames (partner does not move during goodbye)', async () => {
+    const chunks = await collect(
+      runClosingTurn({ llm: fenceLlm(), tts: mockTts([]) }, coBuildState())
+    )
+    expect(chunks.filter((c) => c.kind === 'action')).toHaveLength(0)
+  })
+
+  it('the opening greeting DOES emit an action frame (gate is closing-only)', async () => {
+    const chunks = await collect(
+      runOpeningTurn({ llm: fenceLlm(), tts: mockTts([]) }, coBuildState())
+    )
+    const actions = chunks.filter((c) => c.kind === 'action')
+    expect(actions).toHaveLength(1)
+    expect(actions[0].kind === 'action' && actions[0].actions).toEqual([
+      { op: 'place', pieceType: 'kick', slot: 1 },
+    ])
+  })
+
+  it('a regular player turn DOES emit an action frame', async () => {
+    const chunks = await collect(
+      runTurn(
+        providers(mockStt([{ text: '放个底鼓', isFinal: true }]), fenceLlm(), mockTts([])),
+        coBuildState(),
+        fromArray<AudioChunk>([new Uint8Array([1])])
+      )
+    )
+    expect(chunks.filter((c) => c.kind === 'action')).toHaveLength(1)
   })
 })

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -25,7 +25,7 @@
  */
 
 import type { CompanionContext } from '../../companion-memory/src/types'
-import type { AiResponseChunk, AudioChunk, RecapOutcome } from './contract'
+import type { AiResponseChunk, AudioChunk, CoBuildAction, RecapOutcome } from './contract'
 import type {
   ChatMessage,
   LlmProvider,
@@ -35,8 +35,9 @@ import type {
   TtsProvider,
 } from './providers/types'
 import { assembleLlmContext, type GameState } from './manual-injection'
-import type { ResolvedConfig } from './provider-config'
+import type { CoBuildConfig, ResolvedConfig } from './provider-config'
 import type { ManualData } from './contract'
+import { CoBuildSplitter, buildCoBuildInstruction } from './cobuild-splitter'
 import { traceTurn } from './trace'
 
 /** Usage counters accumulated across a session (mirrors `SessionSummary.usage`). */
@@ -293,14 +294,33 @@ interface LlmTtsResult {
   ttsFrameCount: number
 }
 
-/** Assemble the deterministic server-side system message(s) for a turn. */
-function assembleSystem(state: SessionState): ChatMessage[] {
-  return assembleLlmContext({
+/**
+ * Assemble the deterministic server-side system message(s) for a turn. The
+ * `coBuild` argument is the co_build capability ACTIVE FOR THIS TURN (not simply
+ * `state.config.coBuild`): the opening greeting and regular player turns pass the
+ * game's capability, but the closing recap passes `undefined` so the partner is
+ * neither invited to move nor able to — its goodbye stays action-free.
+ */
+function assembleSystem(state: SessionState, coBuild: CoBuildConfig | undefined): ChatMessage[] {
+  const messages = assembleLlmContext({
     systemPromptConfig: state.config.systemPromptConfig,
     manualData: state.manualData,
     gameState: state.gameState,
     ...(state.companionContext !== undefined ? { companionContext: state.companionContext } : {}),
   })
+  // Co_build-active turn: append the fenced action-output instruction to the
+  // system message. Gated on the per-turn capability, so a game without `coBuild`
+  // (and the closing recap, which passes `undefined`) gets a byte-identical
+  // prompt — the block is never added. This is the OUTPUT-protocol directive; it
+  // stays out of `assembleLlmContext` (which owns INPUT context).
+  if (coBuild !== undefined && messages.length > 0) {
+    const [system, ...rest] = messages
+    return [
+      { ...system, content: `${system.content}\n\n${buildCoBuildInstruction(coBuild)}` },
+      ...rest,
+    ]
+  }
+  return messages
 }
 
 /** Apply the LLM token usage + TTS output-seconds of a settled turn to state. */
@@ -351,21 +371,38 @@ function applySttUsage(
  * chunks (NO terminal `done` — the caller emits that after its own settle). It
  * is I/O-free beyond driving the injected LLM/TTS providers, and reports the
  * per-turn tally as the generator's return value so the caller can settle usage
- * and history. Reused by both `runTurn` (player-audio turn) and
- * `runOpeningTurn` (the AI-first greeting).
+ * and history. Reused by `runReply` (player-audio turn), `runOpeningTurn` (the
+ * AI-first greeting), and `runClosingTurn` (the settlement recap).
+ *
+ * Co_build (`coBuild` present): every LLM delta passes through the bounded fence
+ * splitter, so only SPEECH reaches the text/TTS stream; the partner's structured
+ * moves surface as AT MOST ONE `{kind:'action'}` chunk yielded AFTER all speech
+ * and audio, BEFORE the caller's terminal `done` text chunk (`action` is pinned
+ * `done: false`, so it never ends the turn). With `coBuild` absent the splitter
+ * never runs, no action chunk is ever produced, and the text stream is unchanged.
  */
 async function* streamLlmTts(
   providers: Pick<TurnProviders, 'llm' | 'tts'>,
   model: string,
   messages: ChatMessage[],
   turnStart: number,
-  traceSessionId?: string
+  traceSessionId?: string,
+  coBuild?: CoBuildConfig
 ): AsyncGenerator<AiResponseChunk, LlmTtsResult> {
   // LLM + TTS run concurrently: the LLM loop segments text into sentences and
   // feeds a queue the TTS provider drains. We interleave text chunks (as the
   // LLM streams) with audio chunks (as TTS produces them).
   const sentenceQueue = new SentenceQueue()
   const ttsIterator = providers.tts.synthesize(sentenceQueue)[Symbol.asyncIterator]()
+
+  // Co_build fence splitter: for a co_build-capable game, every LLM delta passes
+  // through the splitter, which returns only the SPEECH portion (the fence markers
+  // and action-block content are captured, never spoken). Absent for every other
+  // game, so `toSpeech` is the identity and the text stream is unchanged. The
+  // parsed actions (if any) surface as a single `action` chunk after the loop.
+  const splitter = coBuild ? new CoBuildSplitter(coBuild.parse) : undefined
+  const toSpeech = (raw: string): string => (splitter ? splitter.push(raw) : raw)
+  let pendingActions: CoBuildAction[] = []
 
   // Turn-trace counters for the LLM->TTS boundary (the deploy task's last
   // sighting put the park here). Pure instrumentation: counting + first-event
@@ -433,8 +470,6 @@ async function* streamLlmTts(
           nextLlmPromise = undefined
           if (!result.done && result.value.content.length > 0) {
             const delta = result.value.content
-            assistantText += delta
-            pending += delta
             llmDeltaCount += 1
             if (!firstDeltaTraced) {
               firstDeltaTraced = true
@@ -443,7 +478,24 @@ async function* streamLlmTts(
                 elapsedMs: Date.now() - turnStart,
               })
             }
-            yield { kind: 'text', text: delta, done: false }
+            const speech = toSpeech(delta)
+            if (speech.length > 0) {
+              assistantText += speech
+              pending += speech
+              yield { kind: 'text', text: speech, done: false }
+            }
+          }
+          // Flush the splitter at stream end: release any held trailing speech
+          // (SPEECH state — no fence ever came) and capture the parsed actions.
+          // A no-coBuild turn has no splitter, so this is skipped entirely.
+          if (splitter) {
+            const flushed = splitter.flush()
+            if (flushed.speech.length > 0) {
+              assistantText += flushed.speech
+              pending += flushed.speech
+              yield { kind: 'text', text: flushed.speech, done: false }
+            }
+            pendingActions = flushed.actions
           }
           const { sentences, remainder } = splitSentences(pending)
           for (const sentence of sentences) queueSentence(sentence)
@@ -466,8 +518,6 @@ async function* streamLlmTts(
         } else {
           const delta = result.value.content
           if (delta.length > 0) {
-            assistantText += delta
-            pending += delta
             llmDeltaCount += 1
             if (!firstDeltaTraced) {
               firstDeltaTraced = true
@@ -476,10 +526,15 @@ async function* streamLlmTts(
                 elapsedMs: Date.now() - turnStart,
               })
             }
-            yield { kind: 'text', text: delta, done: false }
-            const { sentences, remainder } = splitSentences(pending)
-            for (const sentence of sentences) queueSentence(sentence)
-            pending = remainder
+            const speech = toSpeech(delta)
+            if (speech.length > 0) {
+              assistantText += speech
+              pending += speech
+              yield { kind: 'text', text: speech, done: false }
+              const { sentences, remainder } = splitSentences(pending)
+              for (const sentence of sentences) queueSentence(sentence)
+              pending = remainder
+            }
           }
           nextLlmPromise = llmStream.next()
         }
@@ -521,6 +576,15 @@ async function* streamLlmTts(
     sentenceQueue.close()
     await ttsIterator.return?.(undefined)
     await llmStream.return?.(undefined)
+  }
+
+  // The partner's structured board moves (co_build only), emitted as ONE `action`
+  // chunk AFTER all speech/audio and BEFORE the caller's terminal `done` chunk.
+  // Only a co_build turn that produced a valid, non-empty action set reaches here
+  // with actions; every other turn skips this (`pendingActions` stays empty), so
+  // the chunk stream is unchanged.
+  if (pendingActions.length > 0) {
+    yield { kind: 'action', actions: pendingActions, done: false }
   }
 
   return { assistantText, ttsAudioBytes, llmDeltaCount, sentenceCount, ttsFrameCount }
@@ -611,7 +675,11 @@ export async function* runReply(
   // Inject: deterministic system message (role + rules + manual subset), then the
   // rolling history, then this turn's player utterance.
   const userMessage: ChatMessage = { role: 'user', content: playerText }
-  const messages: ChatMessage[] = [...assembleSystem(state), ...state.history, userMessage]
+  const messages: ChatMessage[] = [
+    ...assembleSystem(state, state.config.coBuild),
+    ...state.history,
+    userMessage,
+  ]
 
   // LLM + TTS run concurrently via the shared half.
   const result = yield* streamLlmTts(
@@ -619,7 +687,8 @@ export async function* runReply(
     state.config.llm.model,
     messages,
     turnStart,
-    state.traceSessionId
+    state.traceSessionId,
+    state.config.coBuild
   )
 
   // Settle turn state: record history, count, and usage; emit the terminal chunk
@@ -752,14 +821,25 @@ export async function* runClosingTurn(
 ): AsyncIterable<AiResponseChunk> {
   const turnStart = Date.now()
   const userMessage: ChatMessage = { role: 'user', content: closingDirectiveFor(outcome) }
-  const messages: ChatMessage[] = [...assembleSystem(state), ...state.history, userMessage]
+  // coBuild = undefined for the recap: no action instruction in the prompt AND no
+  // splitter, so the goodbye is fully action-free (see the streamLlmTts call below).
+  const messages: ChatMessage[] = [
+    ...assembleSystem(state, undefined),
+    ...state.history,
+    userMessage,
+  ]
 
+  // Co_build is DELIBERATELY off for the closing recap (coBuild = undefined): the
+  // partner says goodbye, it does not make board moves during the settlement.
+  // Actions are enabled for the opening greeting and regular player turns only, so
+  // no `action` frame can be emitted here even if the model tries a fence.
   const result = yield* streamLlmTts(
     providers,
     state.config.llm.model,
     messages,
     turnStart,
-    state.traceSessionId
+    state.traceSessionId,
+    undefined
   )
 
   // Settle: the closing directive is synthetic and must never leak into history
@@ -802,14 +882,19 @@ export async function* runOpeningTurn(
 ): AsyncIterable<AiResponseChunk> {
   const turnStart = Date.now()
   const userMessage: ChatMessage = { role: 'user', content: OPENING_DIRECTIVE }
-  const messages: ChatMessage[] = [...assembleSystem(state), ...state.history, userMessage]
+  const messages: ChatMessage[] = [
+    ...assembleSystem(state, state.config.coBuild),
+    ...state.history,
+    userMessage,
+  ]
 
   const result = yield* streamLlmTts(
     providers,
     state.config.llm.model,
     messages,
     turnStart,
-    state.traceSessionId
+    state.traceSessionId,
+    state.config.coBuild
   )
 
   // Settle. The opening directive is synthetic and must never leak into history

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,6 +560,24 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  shared:
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+
 packages:
 
   '@adobe/css-tools@4.4.4':

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@amiclaw/shared",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "jsdom": "^29.1.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "vitest": "^4.1.9"
+  }
+}

--- a/shared/vitest.config.mjs
+++ b/shared/vitest.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Minimal test runner for the game-agnostic `shared/` code (voice protocol +
+ * hook). jsdom so `renderHook` can drive the React hook; no bundler aliases are
+ * needed because the specs import their targets by relative path.
+ *
+ * This config is `.mjs` (not `.ts`) on purpose: `packages/api`'s tsconfig globs
+ * all of `../../shared/**` under Workers options, and a `.ts` config here would
+ * be type-checked by api (pulling `vitest/config` + its node:sqlite types into
+ * api's program and breaking it). A `.mjs` file is invisible to that glob.
+ */
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+})

--- a/shared/voice/use-game-voice-session.action.test.ts
+++ b/shared/voice/use-game-voice-session.action.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+
+/**
+ * PR-1 backward-compat proof for the co_build `action` frame.
+ *
+ * The shared hook grew ONE explicit branch: an `action` frame is handed to the
+ * optional `onAction` callback and then RETURNS — it never reaches `voiceReducer`.
+ * This proves the single handling path:
+ *   - with NO `onAction` (every existing game): the frame is a pure no-op — ZERO
+ *     reducer dispatches (exposed-state reference unchanged) and no throw;
+ *   - with `onAction`: the callback receives `frame.actions`, and STILL nothing is
+ *     dispatched to `voiceReducer`.
+ *
+ * `voiceReducer` is wrapped with a call-recording spy so "never enters the reducer"
+ * is asserted directly, not merely inferred from unchanged state. It also covers:
+ *   - barge-in transactional semantics: an action frame from a turn the player
+ *     barged in on is dropped (shares the abandoned turn's fate);
+ *   - turn-termination is a text-only event (audio never closes a turn).
+ */
+
+const reducerLog = vi.hoisted(() => ({ actions: [] as Array<{ type: string; frame?: unknown }> }))
+
+vi.mock('./voice-session-protocol', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./voice-session-protocol')>()
+  return {
+    ...actual,
+    voiceReducer: (
+      state: import('./voice-session-protocol').VoiceSessionState,
+      action: import('./voice-session-protocol').VoiceAction
+    ) => {
+      reducerLog.actions.push(action as { type: string; frame?: unknown })
+      return actual.voiceReducer(state, action)
+    },
+  }
+})
+
+// Controllable audio doubles so the barge-in path is drivable without a real
+// AudioContext / mic: a test flips playback "playing" and invokes the captured VAD
+// `onSpeechStart` to trigger a barge-in (which sets the hook's suppress flag).
+const audioCtl = vi.hoisted(() => ({
+  playing: false,
+  onSpeechStart: null as null | (() => void),
+}))
+
+vi.mock('./audio-playback', () => ({
+  createPcmPlayback: () => ({
+    play: () => {},
+    interrupt: () => {},
+    teardown: () => {},
+    isPlaying: () => audioCtl.playing,
+  }),
+}))
+
+vi.mock('./audio-capture', () => ({
+  createPcmCapture: () => ({
+    start: (opts: { onSpeechStart: () => void }) => {
+      audioCtl.onSpeechStart = opts.onSpeechStart
+    },
+    stop: () => {},
+  }),
+}))
+
+import { useGameVoiceSession } from './use-game-voice-session'
+import { initialVoiceState, voiceReducer } from './voice-session-protocol'
+import type { ServerFrame } from './voice-session-protocol'
+
+// --- Minimal WebSocket double: the hook connects on mount, then we hand it the
+// `action` frame directly. We never fire `created`, so the mic / AudioContext
+// path is never touched. ---
+class MockWebSocket {
+  static OPEN = 1
+  static CLOSED = 3
+  static instances: MockWebSocket[] = []
+  readyState = 0
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: ((event: { code: number; reason?: string }) => void) | null = null
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this)
+  }
+  send(): void {}
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.({ code: 1000 })
+  }
+  deliver(frame: ServerFrame): void {
+    this.onmessage?.({ data: JSON.stringify(frame) })
+  }
+}
+
+const manualData = { version: 'v1', sections: {} }
+const gameState = { relevantSections: [] as string[] }
+const ACTIONS = [{ op: 'place' as const, pieceType: 'kick', slot: 1 }]
+const actionFrame: ServerFrame = { type: 'action', actions: ACTIONS }
+
+/** How many reducer dispatches carried a `frame` action of the given wire type. */
+function frameDispatchCount(frameType: string): number {
+  return reducerLog.actions.filter(
+    (a) => a.type === 'frame' && (a.frame as { type?: string } | undefined)?.type === frameType
+  ).length
+}
+
+beforeEach(() => {
+  reducerLog.actions = []
+  MockWebSocket.instances = []
+  audioCtl.playing = false
+  audioCtl.onSpeechStart = null
+  vi.stubGlobal('WebSocket', MockWebSocket)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useGameVoiceSession — co_build action frame (PR-1 compat proof)', () => {
+  it('with NO onAction: an action frame dispatches ZERO reducer actions and does not throw', () => {
+    const { result } = renderHook(() =>
+      useGameVoiceSession({ manualData, gameState, gameId: 'bombsquad' })
+    )
+    const ws = MockWebSocket.instances[0]
+    expect(ws).toBeDefined()
+
+    const dispatchesBefore = reducerLog.actions.length
+    const stateBefore = result.current
+
+    expect(() => act(() => ws.deliver(actionFrame))).not.toThrow()
+
+    // Nothing was dispatched to the reducer for the action frame.
+    expect(reducerLog.actions.length).toBe(dispatchesBefore)
+    expect(frameDispatchCount('action')).toBe(0)
+    // Exposed-state reference is unchanged (no re-render from the reducer).
+    expect(result.current).toBe(stateBefore)
+    expect(result.current.status).toBe(stateBefore.status)
+  })
+
+  it('with onAction: the callback receives frame.actions and STILL nothing is dispatched to voiceReducer', () => {
+    const onAction = vi.fn()
+    renderHook(() =>
+      useGameVoiceSession({ manualData, gameState, gameId: 'sound-garden', onAction })
+    )
+    const ws = MockWebSocket.instances[0]
+    expect(ws).toBeDefined()
+
+    const dispatchesBefore = reducerLog.actions.length
+
+    act(() => ws.deliver(actionFrame))
+
+    // The callback got exactly the frame's actions.
+    expect(onAction).toHaveBeenCalledTimes(1)
+    expect(onAction).toHaveBeenCalledWith(ACTIONS)
+    // And the action frame never entered the reducer.
+    expect(reducerLog.actions.length).toBe(dispatchesBefore)
+    expect(frameDispatchCount('action')).toBe(0)
+  })
+
+  it('a non-action frame still routes through the reducer (the branch is action-only)', () => {
+    const onAction = vi.fn()
+    renderHook(() =>
+      useGameVoiceSession({ manualData, gameState, gameId: 'sound-garden', onAction })
+    )
+    const ws = MockWebSocket.instances[0]
+
+    // A `transcript` frame dispatches through the reducer as normal (no audio path).
+    act(() => ws.deliver({ type: 'transcript', text: 'hi', final: false }))
+
+    expect(frameDispatchCount('transcript')).toBe(1)
+    expect(onAction).not.toHaveBeenCalled()
+  })
+})
+
+describe('useGameVoiceSession — barge-in transactional semantics', () => {
+  it('drops the action frame of a turn the player barged in on, then resumes on the next turn', () => {
+    const onAction = vi.fn()
+    renderHook(() =>
+      useGameVoiceSession({ manualData, gameState, gameId: 'sound-garden', onAction })
+    )
+    const ws = MockWebSocket.instances[0]
+
+    // Session live; a reply begins streaming (text chunk, not yet done).
+    act(() => ws.deliver({ type: 'created', sessionId: 's1' }))
+    act(() => ws.deliver({ type: 'chunk', kind: 'text', text: 'placing', done: false }))
+
+    // The player barges in over the AI's audio → this turn is abandoned.
+    audioCtl.playing = true
+    act(() => audioCtl.onSpeechStart?.())
+
+    // Ordering: partial playback → action → done, under barge-in ⇒ NO onAction call.
+    act(() => ws.deliver({ type: 'action', actions: ACTIONS }))
+    expect(onAction).not.toHaveBeenCalled()
+
+    // The abandoned turn's terminal `done` clears the suppression; the NEXT turn's
+    // action delivers normally (the drop is turn-scoped, not permanent).
+    act(() => ws.deliver({ type: 'chunk', kind: 'text', text: '', done: true }))
+    act(() => ws.deliver({ type: 'action', actions: ACTIONS }))
+    expect(onAction).toHaveBeenCalledTimes(1)
+    expect(onAction).toHaveBeenCalledWith(ACTIONS)
+  })
+})
+
+describe('turn termination is a text-only event', () => {
+  it('an audio chunk never closes a turn; the terminal text chunk does', () => {
+    // Wire-realistic frames: audio is pinned `done: false`; only text carries
+    // `done: true`, so only the terminal text chunk flips `turnDone`.
+    let s = voiceReducer(initialVoiceState, { type: 'connecting' })
+    s = voiceReducer(s, { type: 'frame', frame: { type: 'created', sessionId: 's1' } })
+    s = voiceReducer(s, {
+      type: 'frame',
+      frame: { type: 'chunk', kind: 'text', text: 'hi', done: false },
+    })
+    s = voiceReducer(s, {
+      type: 'frame',
+      frame: { type: 'chunk', kind: 'audio', audio: 'AAAA', done: false },
+    })
+    expect(s.turnDone).toBe(false)
+    s = voiceReducer(s, {
+      type: 'frame',
+      frame: { type: 'chunk', kind: 'text', text: '', done: true },
+    })
+    expect(s.turnDone).toBe(true)
+  })
+
+  it('the ServerFrame type forbids an audio frame that closes a turn', () => {
+    // @ts-expect-error audio chunks are pinned done:false — only text can end a turn.
+    const bad: ServerFrame = { type: 'chunk', kind: 'audio', audio: 'x', done: true }
+    void bad
+  })
+})

--- a/shared/voice/use-game-voice-session.ts
+++ b/shared/voice/use-game-voice-session.ts
@@ -48,6 +48,7 @@ import {
   deriveConversationPhase,
   initialVoiceState,
   voiceReducer,
+  type CoBuildAction,
   type ConversationPhase,
   type ServerFrame,
   type VoiceStatus,
@@ -168,6 +169,14 @@ export interface UseGameVoiceSessionOptions {
   getGameState?: () => GameVoiceState
   /** Called once for the terminal transcript frame of each player utterance. */
   onFinalTranscript?: (utterance: { sequence: number; text: string }) => void
+  /**
+   * Called with the partner's structured board moves when a co_build game's server
+   * emits an `action` frame. This is the SOLE handling path for `action` frames —
+   * they never enter `voiceReducer`. Omitted by every non-co_build consumer
+   * (BombSquad / botanical / shadow-chase / lobby), for whom an `action` frame (which
+   * their server never sends anyway) is a no-op.
+   */
+  onAction?: (actions: CoBuildAction[]) => void
 }
 
 export interface UseGameVoiceSessionResult {
@@ -239,6 +248,7 @@ export function useGameVoiceSession(
     guards,
     getGameState,
     onFinalTranscript,
+    onAction,
   } = options
 
   const [state, dispatch] = useReducer(voiceReducer, initialVoiceState)
@@ -275,6 +285,7 @@ export function useGameVoiceSession(
   const streakDaysRef = useRef<number | undefined>(streakDays)
   const getGameStateRef = useRef(getGameState)
   const onFinalTranscriptRef = useRef(onFinalTranscript)
+  const onActionRef = useRef(onAction)
   useEffect(() => {
     manualDataRef.current = manualData
     gameStateRef.current = gameState
@@ -283,6 +294,7 @@ export function useGameVoiceSession(
     streakDaysRef.current = streakDays
     getGameStateRef.current = getGameState
     onFinalTranscriptRef.current = onFinalTranscript
+    onActionRef.current = onAction
   })
 
   // Side-effect handles (never trigger re-render).
@@ -654,6 +666,22 @@ export function useGameVoiceSession(
       try {
         frame = JSON.parse(event.data) as ServerFrame
       } catch {
+        return
+      }
+      if (frame.type === 'action') {
+        // The SOLE handling path for co_build `action` frames: hand the partner's
+        // structured moves to the game's callback and STOP — the frame never
+        // reaches `safeDispatch`/`voiceReducer`, so the exposed session state is
+        // untouched. Absent callback (every non-co_build game) ⇒ a pure no-op.
+        //
+        // Barge-in transactional semantics: a turn's actions share the fate of its
+        // speech. When the player barged in on this turn (`suppressTurnRef`), the
+        // reply was abandoned — its trailing chunks (text + audio) are already being
+        // dropped until its `done`, so its action frame is dropped in lockstep. The
+        // move belonged to a turn the player interrupted; delivering it would mutate
+        // the board for a reply the player chose to override.
+        if (suppressTurnRef.current) return
+        onActionRef.current?.(frame.actions)
         return
       }
       if (frame.type === 'created') {

--- a/shared/voice/voice-session-protocol.ts
+++ b/shared/voice/voice-session-protocol.ts
@@ -34,6 +34,19 @@
 export type SessionSummaryPayload = unknown
 
 /**
+ * One co_build partner board move. A STRUCTURAL mirror of the server's
+ * `@amiclaw/platform-ai` `CoBuildAction` — re-declared here (not imported) so
+ * `shared/` stays free of any `@amiclaw/*` workspace dependency, exactly as the
+ * server envelope shapes are. A co_build game re-narrows to the concrete type at
+ * its own boundary; other games never see an `action` frame at all.
+ */
+export interface CoBuildAction {
+  op: 'place' | 'remove'
+  pieceType: string
+  slot: number
+}
+
+/**
  * Connection lifecycle surfaced to the panel. This is the SOCKET state, distinct
  * from the in-conversation `ConversationPhase` (listening / thinking / speaking)
  * which the hands-free model layers on top of a live `ready` session.
@@ -91,12 +104,25 @@ export function deriveConversationPhase(s: PhaseSignals): ConversationPhase {
  * channel), `summary` on `end`, and a non-fatal in-band `error` (e.g.
  * `turn_in_flight`, `already_created`) that does NOT close the socket. `final` is
  * optional; a missing flag is treated as a non-terminal interim.
+ *
+ * The `action` frame carries a co_build partner's structured board moves (co_build
+ * games only). It is its OWN frame — NOT a `chunk` — and carries no `done` (the AI
+ * reply's terminal text `chunk` still closes the turn). It is handled by the hook's
+ * single explicit `onAction` branch and NEVER reaches `voiceReducer`; a game without
+ * an `onAction` callback ignores it (a no-op, not an unknown-frame surfacing).
+ *
+ * Turn termination is a TEXT event: the `text` chunk is the only variant that can
+ * carry `done: true`. The `audio` chunk is pinned `done: false` (audio frames never
+ * close a turn — they interleave with text and the turn ends on the terminal text
+ * chunk), matching the server contract; `transcript` and `action` carry no `done`
+ * at all. So the type structurally guarantees no non-text frame can end a turn.
  */
 export type ServerFrame =
   | { type: 'created'; sessionId: string }
   | { type: 'transcript'; text: string; final?: boolean }
   | { type: 'chunk'; kind: 'text'; text?: string; done: boolean }
-  | { type: 'chunk'; kind: 'audio'; audio?: string; done: boolean }
+  | { type: 'chunk'; kind: 'audio'; audio?: string; done: false }
+  | { type: 'action'; actions: CoBuildAction[] }
   | { type: 'summary'; summary: SessionSummaryPayload }
   | { type: 'error'; code?: string; message?: string }
 


### PR DESCRIPTION
## Summary

- The voice AI pipeline gains a structured **action channel** for co-build games: `AiResponseChunk` becomes a discriminated union with an `action` variant (required `actions`, `done:false`); a bounded three-state splitter (SPEECH → ACTIONS → DISCARD_ACTIONS, UTF-8-byte cap) guarantees protocol markers never leak into TTS; the shared client hook handles action frames in one explicit `onAction`-only branch that never touches the reducer.
- **Per-game `coBuild` capability flag — existing games OFF**: prompt instruction and action output are both gated; closing recap turns are action-free; barge-in cancels the abandoned turn's pending action. Adds the `sound-garden` provider entry with a strict action parser (unknown piece types rejected) as groundwork for Sound Garden.
- Backward compatibility proven, not asserted: byte-identical non-co_build regression test; consumer suites unchanged (bombsquad 508, botanical 71, shadow-chase 121, platform 211); platform-ai 441, shared 6, manual 71.

## Review notes

- One bombsquad protocol test asserting the retired "audio done flag closes the turn" behavior was reframed to the tightened contract (test-only change).
- `shared/package.json` (new test-runner package) deliberately declares **no** `"type"` field: `manual/build.ts` default-imports `shared/symbols.ts` via CJS interop, and an ESM declaration breaks it (caught by the manual suite in pre-commit).
- Design doc: task `integrate-sound-garden-arcade` L2 architecture note (vault), cross-model verified.

## Test plan

- [x] Full repo typecheck
- [x] platform-ai 441 / shared 6 / manual 71
- [x] Consumer regression: bombsquad 508, botanical 71, shadow-chase 121, platform 211
- [x] Byte-identical non-co_build stream regression
- [x] eslint + prettier on touched paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Wc24r89aktaszk8JE3JC
