### PR TITLE
feat(api): add companion assets endpoint with welcome grant

### DIFF
--- a/functions/api/companion/assets.ts
+++ b/functions/api/companion/assets.ts
@@ -1,0 +1,25 @@
+import { handleGetCompanionAssets } from '../../../packages/api/src/handlers/companion-assets'
+import type { CompanionApiEnv } from '../../../packages/api/src/handlers/companion-shared'
+import { applyCorsHeaders, buildCorsHeaders } from '../../../packages/api/src/cors'
+
+interface Context {
+  request: Request
+  env: CompanionApiEnv
+}
+
+const CORS_METHODS = 'GET, OPTIONS'
+
+export async function onRequest(context: Context): Promise<Response> {
+  const { request, env } = context
+  const corsHeaders = buildCorsHeaders(request, CORS_METHODS)
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  if (request.method === 'GET') {
+    return applyCorsHeaders(await handleGetCompanionAssets(request, env), corsHeaders)
+  }
+
+  return applyCorsHeaders(new Response('Method Not Allowed', { status: 405 }), corsHeaders)
+}

--- a/packages/api/src/handlers/companion-assets.test.ts
+++ b/packages/api/src/handlers/companion-assets.test.ts
@@ -1,0 +1,214 @@
+/**
+ * HTTP-semantics tests for GET /api/companion/assets (reward-economy balance +
+ * ledger read; L2 design §2 + §6 welcome grant, endpoint side), run against the
+ * REAL schema (node:sqlite adapter) and the FakeKV session store.
+ *
+ * Pinned here (acceptance criteria):
+ *  - unauthenticated -> 401 (require-session gate);
+ *  - the welcome grant mints EXACTLY once: +10 with welcome_granted true on the
+ *    first read, then absent/no-op on every later read;
+ *  - balance is the SUM over a mix of positive credits and negative deducts;
+ *  - the keyset cursor round-trips a full ledger with no overlap or gap;
+ *  - a request-supplied user_id never becomes the owner (session identity wins);
+ *  - the entries DTO exposes no internal `id` (it lives only in the cursor).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createTestDb } from '../../../companion-memory/src/test-support/sqlite-db'
+import type { CompanionDb } from '../../../companion-memory/src/db'
+import type { DomainDeps } from '../../../companion-memory/src/deps'
+import {
+  creditCheckinReward,
+  creditWelcomeGrant,
+  creditWinReward,
+  deductSessionMinutes,
+} from '../../../companion-memory/src/ledger'
+import { FakeKV } from '../auth/fake-kv'
+import type { CompanionApiEnv } from './companion-shared'
+import { handleGetCompanionAssets } from './companion-assets'
+
+const NOW = '2026-06-11T10:00:00.000Z'
+const TODAY = '2026-06-11'
+
+async function makeEnv(): Promise<{ env: CompanionApiEnv; db: CompanionDb }> {
+  const kv = new FakeKV()
+  await kv.put(
+    'session:sess-a',
+    JSON.stringify({ user_id: 'user-a', email: 'a@example.com', created_at: NOW })
+  )
+  const db = createTestDb()
+  return { env: { AUTH: kv.asKV(), COMPANION_DB: db }, db }
+}
+
+function authedRequest(path: string, init: RequestInit = {}): Request {
+  return new Request(`https://claw.amio.fans${path}`, {
+    ...init,
+    headers: { Cookie: 'amiclaw_session=sess-a', ...(init.headers ?? {}) },
+  })
+}
+
+function anonRequest(path: string, init: RequestInit = {}): Request {
+  return new Request(`https://claw.amio.fans${path}`, init)
+}
+
+/**
+ * Deterministic clock: each ledger write gets a strictly-later `earned_at`, so
+ * insertion order equals chronological order (and the newest-first list is the
+ * exact reverse). Ids are a stable counter, decoupled from the clock.
+ */
+function makeSeqDeps(): DomainDeps {
+  let idN = 0
+  let tsN = 0
+  const base = Date.parse(NOW)
+  return {
+    newId: () => `id-${(idN++).toString().padStart(4, '0')}`,
+    now: () => new Date(base + tsN++ * 1000).toISOString(),
+  }
+}
+
+interface AssetEntry {
+  amount: number
+  source_product: string
+  kind: string
+  earned_at: string
+}
+
+interface AssetsBody {
+  asset_type: string
+  balance: number
+  entries: AssetEntry[]
+  next_cursor?: string
+  welcome_granted?: boolean
+}
+
+/**
+ * Seed a mixed ledger for `user-a`: +10 welcome, +5 win, +3 checkin, -2 session
+ * (balance 16). Written oldest->newest, so newest-first reads back as
+ * session, checkin, win, welcome.
+ */
+async function seedMixedLedger(db: CompanionDb): Promise<void> {
+  const deps = makeSeqDeps()
+  await creditWelcomeGrant(db, 'user-a', deps)
+  await creditWinReward(db, {
+    userId: 'user-a',
+    gameId: 'bombsquad',
+    runId: 'r1',
+    today: TODAY,
+    deps,
+  })
+  await creditCheckinReward(db, 'user-a', TODAY, deps)
+  await deductSessionMinutes(db, {
+    userId: 'user-a',
+    sessionId: 's1',
+    minutes: 2,
+    fundingSource: 'earned',
+    deps,
+  })
+}
+
+describe('GET /api/companion/assets — require-session gate', () => {
+  it('rejects an unauthenticated request with 401', async () => {
+    const { env } = await makeEnv()
+    const response = await handleGetCompanionAssets(anonRequest('/api/companion/assets'), env)
+    expect(response.status).toBe(401)
+  })
+})
+
+describe('GET /api/companion/assets — welcome grant (mints exactly once)', () => {
+  it('mints +10 with welcome_granted true on the first read, then no-ops', async () => {
+    const { env } = await makeEnv()
+
+    const first = await handleGetCompanionAssets(authedRequest('/api/companion/assets'), env)
+    expect(first.status).toBe(200)
+    expect(first.headers.get('Cache-Control')).toBe('no-store')
+    const firstBody = (await first.json()) as AssetsBody
+    expect(firstBody.welcome_granted).toBe(true)
+    expect(firstBody.balance).toBe(10)
+    expect(firstBody.asset_type).toBe('starburst')
+    expect(firstBody.entries.map((e) => e.kind)).toEqual(['welcome'])
+
+    const second = await handleGetCompanionAssets(authedRequest('/api/companion/assets'), env)
+    const secondBody = (await second.json()) as AssetsBody
+    // The flag is present ONLY on the minting request.
+    expect(secondBody.welcome_granted).toBeUndefined()
+    // Still exactly one welcome row — the grant did not double-mint.
+    expect(secondBody.balance).toBe(10)
+    expect(secondBody.entries).toHaveLength(1)
+  })
+})
+
+describe('GET /api/companion/assets — balance over mixed entries', () => {
+  it('sums positive credits and negative deducts, newest first', async () => {
+    const { env, db } = await makeEnv()
+    await seedMixedLedger(db)
+
+    const response = await handleGetCompanionAssets(authedRequest('/api/companion/assets'), env)
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as AssetsBody
+
+    // Welcome was pre-seeded, so the endpoint mint no-ops (no flag).
+    expect(body.welcome_granted).toBeUndefined()
+    expect(body.balance).toBe(16) // 10 + 5 + 3 - 2
+    expect(body.entries.map((e) => e.kind)).toEqual(['session', 'checkin', 'win', 'welcome'])
+    expect(body.entries.map((e) => e.amount)).toEqual([-2, 3, 5, 10])
+  })
+})
+
+describe('GET /api/companion/assets — keyset pagination round-trip', () => {
+  it('walks the full ledger via next_cursor with no overlap or gap', async () => {
+    const { env, db } = await makeEnv()
+    await seedMixedLedger(db) // 4 entries
+
+    const page1 = await handleGetCompanionAssets(
+      authedRequest('/api/companion/assets?limit=2'),
+      env
+    )
+    const body1 = (await page1.json()) as AssetsBody
+    expect(body1.entries.map((e) => e.kind)).toEqual(['session', 'checkin'])
+    expect(body1.next_cursor).toBeDefined()
+
+    const page2 = await handleGetCompanionAssets(
+      authedRequest(
+        `/api/companion/assets?limit=2&cursor=${encodeURIComponent(body1.next_cursor as string)}`
+      ),
+      env
+    )
+    const body2 = (await page2.json()) as AssetsBody
+    expect(body2.entries.map((e) => e.kind)).toEqual(['win', 'welcome'])
+    // Last page — no further cursor.
+    expect(body2.next_cursor).toBeUndefined()
+  })
+})
+
+describe('GET /api/companion/assets — owner is server-derived', () => {
+  it('ignores a request-supplied user_id and returns the session user balance', async () => {
+    const { env, db } = await makeEnv()
+    await seedMixedLedger(db) // user-a -> balance 16
+    // A DIFFERENT user with a different balance — must never leak through.
+    await creditWelcomeGrant(db, 'user-b') // user-b -> balance 10
+
+    const response = await handleGetCompanionAssets(
+      authedRequest('/api/companion/assets?user_id=user-b'),
+      env
+    )
+    const body = (await response.json()) as AssetsBody
+    expect(body.balance).toBe(16) // user-a (session), not user-b (10)
+  })
+})
+
+describe('GET /api/companion/assets — entries DTO shape', () => {
+  it('never exposes the internal row id', async () => {
+    const { env, db } = await makeEnv()
+    await seedMixedLedger(db)
+
+    const response = await handleGetCompanionAssets(authedRequest('/api/companion/assets'), env)
+    const body = (await response.json()) as AssetsBody
+    expect(body.entries.length).toBeGreaterThan(0)
+    for (const entry of body.entries) {
+      expect(entry).not.toHaveProperty('id')
+      expect(entry).not.toHaveProperty('source_ref')
+      expect(entry).not.toHaveProperty('source_key')
+      expect(Object.keys(entry).sort()).toEqual(['amount', 'earned_at', 'kind', 'source_product'])
+    }
+  })
+})

--- a/packages/api/src/handlers/companion-assets.ts
+++ b/packages/api/src/handlers/companion-assets.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /api/companion/assets — the reward-economy balance + ledger read path
+ * (L2 design §2). `asset_entry` is a companion-memory-owned table, so this joins
+ * the `/api/companion/*` family: require-session guarded, owner `user_id`
+ * derived EXCLUSIVELY from the session (never the request).
+ *
+ * On every authenticated read it first attempts the one-time +10 welcome grant
+ * (idempotent `welcome:{userId}`; design §6) — so a user whose first economy
+ * action is viewing their balance self-heals the grant — then returns the
+ * current balance and a keyset page of recent ledger entries. `welcome_granted`
+ * is set true ONLY on the request that actually mints the grant, driving a
+ * one-time "+10 见面礼" UI beat; every later read omits it.
+ *
+ * The grant is fail-open: a D1 failure while minting never blocks the balance
+ * read (welcome_granted just stays false). The row `id` is never exposed — it
+ * lives only inside the opaque cursor (design §2, finding 7).
+ */
+
+import type { CompanionAssetsResponse } from '../../../../shared/companion-types'
+import { ASSET_TYPE_STARBURST } from '../../../companion-memory/src/economy'
+import {
+  creditWelcomeGrant,
+  listAssetEntries,
+  readBalance,
+} from '../../../companion-memory/src/ledger'
+import { requireSession } from '../auth/require-session'
+import { jsonResponse } from '../auth/respond'
+import type { CompanionApiEnv } from './companion-shared'
+
+export async function handleGetCompanionAssets(
+  request: Request,
+  env: CompanionApiEnv
+): Promise<Response> {
+  const auth = await requireSession(env.AUTH, request)
+  if (!auth.ok) return auth.response
+
+  const userId = auth.session.user_id
+
+  // Welcome grant self-heals on the first balance view (idempotent, fail-open).
+  // Mint BEFORE reading balance so a brand-new user's balance already shows +10.
+  let welcomeGranted = false
+  try {
+    welcomeGranted = (await creditWelcomeGrant(env.COMPANION_DB, userId)).credited
+  } catch {
+    // Fail-open: a D1 failure while minting must never block the balance read.
+  }
+
+  const url = new URL(request.url)
+  const limitRaw = url.searchParams.get('limit')
+  const limit = limitRaw === null ? undefined : Number.parseInt(limitRaw, 10)
+  const cursor = url.searchParams.get('cursor') ?? undefined
+
+  const balance = await readBalance(env.COMPANION_DB, userId)
+  const page = await listAssetEntries(env.COMPANION_DB, userId, {
+    ...(limit !== undefined && Number.isFinite(limit) ? { limit } : {}),
+    ...(cursor !== undefined ? { cursor } : {}),
+  })
+
+  const body: CompanionAssetsResponse = {
+    asset_type: ASSET_TYPE_STARBURST,
+    balance,
+    entries: page.entries,
+    ...(page.nextCursor !== undefined ? { next_cursor: page.nextCursor } : {}),
+    ...(welcomeGranted ? { welcome_granted: true } : {}),
+  }
+  return jsonResponse(body, 200, { 'Cache-Control': 'no-store' })
+}

--- a/shared/companion-types.ts
+++ b/shared/companion-types.ts
@@ -180,3 +180,44 @@ export interface MemoriesResponse {
   /** Opaque keyset cursor for the next page; absent on the last page. */
   next_cursor?: string
 }
+
+// --- Reward-economy balance / ledger (starburst) -----------------------------
+
+/**
+ * Per-row display kind on the balance ledger, derived from the row's
+ * `source_key` prefix server-side (`win:` / `checkin:` / `welcome:` /
+ * `session:`), never stored. Defined here as the wire SSOT; the domain package
+ * (`packages/companion-memory/src/ledger.ts`) keeps a structurally identical
+ * local copy, mirroring how `MemoryView` relates to its D1 record.
+ */
+export type AssetEntryKind = 'win' | 'checkin' | 'welcome' | 'session' | 'other'
+
+/**
+ * One ledger row as returned by `GET /api/companion/assets`. The internal row
+ * `id` is NEVER exposed here — it lives only inside the opaque `next_cursor`
+ * (design §2); `source_ref` is internal provenance and also omitted.
+ */
+export interface AssetEntryView {
+  /** Signed amount: positive credit (reward/grant), negative deduct (spend). */
+  amount: number
+  source_product: string
+  kind: AssetEntryKind
+  earned_at: string
+}
+
+/**
+ * Body of `GET /api/companion/assets` — the reward-economy balance plus a
+ * keyset page of recent ledger entries (design §2). Balance is the SUM over the
+ * append-only ledger; `starburst` is the only asset type in v1 (UI renders 星芒).
+ * Owner identity is server-derived (require-session guard); no inbound
+ * `user_id`.
+ */
+export interface CompanionAssetsResponse {
+  asset_type: 'starburst'
+  balance: number
+  entries: AssetEntryView[]
+  /** Opaque keyset cursor for the next page; absent on the last page. */
+  next_cursor?: string
+  /** True ONLY on the request that first mints the +10 welcome grant (one-time UI beat). */
+  welcome_granted?: boolean
+}


### PR DESCRIPTION
## Summary
- PR-2 of the reward-economy v1 train (stacked on #244): `GET /api/companion/assets` balance surface with self-healing idempotent welcome grant (+10 on first authenticated balance read, `welcome_granted` flags the minting request only).
- `CompanionAssetsResponse` wire type (balance SUM + keyset-paginated entries with derived display kind; no `id`/`source_key` on the wire; zero-amount capped markers excluded).
- Thin Pages Function mirroring the sibling companion entry; `Cache-Control: no-store`; owner strictly server-derived.

## Test plan
- [x] 6 new handler tests (401 unauth, welcome exactly-once + same-response balance, mixed-entry balance, cursor round-trip, no inbound user_id, no id leak)
- [x] api suite 237/237 green on the stacked ledger; api + companion-memory typecheck green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGPThR1FJ81CRf716PQ1yM