### PR TITLE
feat(game-sound-garden): platformize Sound Garden on the co_build protocol

### DIFF
--- a/packages/creation/src/index.ts
+++ b/packages/creation/src/index.ts
@@ -22,6 +22,9 @@ export type {
   TimedTick,
   TimerStatus,
 } from './engine/engine'
+// Per-element placement-state key, for consumers that read raw element state from
+// `EngineSnapshot.elements[id]` (e.g. a presentation layer deriving lane occupancy).
+export { PLACEMENT_STATE } from './engine/rules'
 
 // Bounded solution search (solver).
 export { searchSolution, solutionDriversForTarget } from './engine/search'

--- a/packages/game-sound-garden/README.md
+++ b/packages/game-sound-garden/README.md
@@ -1,0 +1,62 @@
+# 声音花园 (Sound Garden) — playability probe
+
+A standalone, playable probe for the **co_build** game "声音花园", built on the
+`@amiclaw/creation` engine (zero engine changes). You and an AI 园丁伙伴 plant a
+singing garden on an 8-beat timeline: you place pieces on your lane, the partner
+answers on the other lane, and same-beat pairs score through a hidden harmony
+matrix. Free-flow, no-fail — reaching the target score makes the garden bloom.
+
+> Standalone by construction: this package is **not** wired into
+> `scripts/assemble-pages.mjs`, so it never reaches production (`claw.amio.fans`).
+
+## Run it
+
+```bash
+pnpm --filter @amiclaw/game-sound-garden dev
+# open the printed http://localhost:<port>/sound-garden/  (Chrome recommended)
+```
+
+- **Chrome is recommended** — the browser voice input (push-to-talk ASR) uses
+  Web Speech (`webkitSpeechRecognition`), which is a Chrome/Chromium feature.
+- Tap any piece / the play button to unlock audio (iOS/Chrome autoplay policy).
+- No keys are required to play. Everything below is optional enrichment.
+
+## Optional keys (real AI partner + voice)
+
+Copy `.env.example` to `.env` and fill in either key. They are read
+**server-side only** by the dev API and never reach the browser.
+
+| Key                | Enables                                           |
+| ------------------ | ------------------------------------------------- |
+| `DEEPSEEK_API_KEY` | Real LLM partner brain (`/api/partner`, DeepSeek) |
+| `VOLC_API_KEY`     | Doubao TTS 2.0 partner voice (`/api/tts`)         |
+
+The client asks `/api/capabilities` at session start and picks its brain + voice
+from what is present.
+
+## Degradation chain (always playable)
+
+| Concern       | With key                    | Without key / on failure                  |
+| ------------- | --------------------------- | ----------------------------------------- |
+| Partner brain | DeepSeek via `/api/partner` | Offline **scripted brain** (per turn)     |
+| Partner voice | Doubao TTS via `/api/tts`   | Browser **speechSynthesis** → else silent |
+| Player voice  | Push-to-talk Web Speech ASR | Mic chip hidden (type-free play)          |
+
+Every online path falls back on the next failure, so a dead key, a dead
+Volcengine grant, or an unsupported browser never blocks play. A production
+`vite build` has no dev server at all — the built preview simply runs fully
+offline (scripted brain + browser voice).
+
+> **Note:** the Doubao TTS path is correct-by-construction (the binary-WS codec
+> is lifted from `packages/platform-ai/src/providers/volcengine.ts`) but is
+> **unverified end-to-end** — the Volcengine grant could not be checked from the
+> repo. speechSynthesis is the load-bearing voice fallback.
+
+## Scripts
+
+| Script              | What it does                         |
+| ------------------- | ------------------------------------ |
+| `dev`               | Vite dev server + the dev API routes |
+| `build`             | `tsc && vite build` (static SPA)     |
+| `typecheck`         | `tsc --noEmit`                       |
+| `test` / `test:run` | Vitest (watch / once)                |

--- a/packages/game-sound-garden/index.html
+++ b/packages/game-sound-garden/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <!-- Inline data-URI favicon so standalone dev does not 404 on /favicon.ico
+         (in production the platform shell serves the root favicon). -->
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>%F0%9F%8C%B8</text></svg>"
+    />
+    <title>声音花园 — AMIO Arcade</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/game-sound-garden/package.json
+++ b/packages/game-sound-garden/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@amiclaw/game-sound-garden",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "dependencies": {
+    "@amiclaw/creation": "workspace:*",
+    "js-yaml": "^4.2.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "@amiclaw/ui": "workspace:*"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^16.3.2",
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^26.0.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "jsdom": "^29.1.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9",
+    "@amiclaw/platform-ai": "workspace:*"
+  }
+}

--- a/packages/game-sound-garden/src/App.tsx
+++ b/packages/game-sound-garden/src/App.tsx
@@ -1,0 +1,59 @@
+/**
+ * Top-level screen state machine: level select ↔ playing. No router — a single
+ * screen with two states keeps the standalone probe minimal. The GameScreen is
+ * keyed by (level, side, run) so restart / next-level / side-swap remount a
+ * fresh store.
+ */
+
+import { useState } from 'react'
+import { levelByIndex, LEVELS } from './game/levels'
+import type { Side } from './game/types'
+import { GameScreen } from './ui/GameScreen'
+import { LevelSelect } from './ui/LevelSelect'
+
+type View = { screen: 'select' } | { screen: 'play'; levelIndex: number; side: Side; run: number }
+
+export function App() {
+  const [view, setView] = useState<View>({ screen: 'select' })
+
+  if (view.screen === 'select') {
+    return (
+      <LevelSelect
+        onStart={(levelIndex, side) =>
+          setView({ screen: 'play', levelIndex, side, run: Date.now() })
+        }
+      />
+    )
+  }
+
+  const level = levelByIndex(view.levelIndex)
+  if (!level) {
+    return (
+      <LevelSelect
+        onStart={(levelIndex, side) =>
+          setView({ screen: 'play', levelIndex, side, run: Date.now() })
+        }
+      />
+    )
+  }
+  const hasNext = LEVELS.some((l) => l.index === view.levelIndex + 1)
+
+  return (
+    <GameScreen
+      key={`${view.levelIndex}-${view.side}-${view.run}`}
+      level={level}
+      side={view.side}
+      hasNext={hasNext}
+      onExit={() => setView({ screen: 'select' })}
+      onReplay={() => setView({ ...view, run: Date.now() })}
+      onNext={() =>
+        setView({
+          screen: 'play',
+          levelIndex: view.levelIndex + 1,
+          side: view.side,
+          run: Date.now(),
+        })
+      }
+    />
+  )
+}

--- a/packages/game-sound-garden/src/audio/engine.ts
+++ b/packages/game-sound-garden/src/audio/engine.ts
@@ -1,0 +1,373 @@
+/**
+ * Web Audio engine — 8 synthesized voices + an 8-step lookahead scheduler,
+ * lifted from the validated rough-cut recipe (distinctness beats realism;
+ * fixed pentatonic melody pitches so any combination sounds musical).
+ *
+ * The AudioContext is created lazily on the first user gesture (iOS unlock).
+ * When Web Audio is unavailable the loop degrades gracefully to a visual-only
+ * playhead so placement + scoring stay fully playable.
+ */
+
+import { PIECE_META } from '../game/constants'
+import type { MelodyType, PieceType, RhythmType } from '../game/constants'
+
+interface AudioNodes {
+  ctx: AudioContext
+  master: GainNode
+  noise: AudioBuffer
+}
+
+const STEP_SEC = 60 / 96 / 2 // ~96 BPM eighth-note grid → 0.3125s/step, 2.5s loop
+const LOOKAHEAD = 0.1
+const SCHED_MS = 25
+
+function noiseSource(n: AudioNodes): AudioBufferSourceNode {
+  const s = n.ctx.createBufferSource()
+  s.buffer = n.noise
+  return s
+}
+
+// ---- rhythm voices ---------------------------------------------------------
+
+function playKick(n: AudioNodes, t: number): void {
+  const o = n.ctx.createOscillator()
+  const g = n.ctx.createGain()
+  o.type = 'sine'
+  o.frequency.setValueAtTime(160, t)
+  o.frequency.exponentialRampToValueAtTime(48, t + 0.13)
+  g.gain.setValueAtTime(0.0001, t)
+  g.gain.exponentialRampToValueAtTime(1.0, t + 0.006)
+  g.gain.exponentialRampToValueAtTime(0.0001, t + 0.28)
+  o.connect(g)
+  g.connect(n.master)
+  o.start(t)
+  o.stop(t + 0.3)
+}
+
+function playSnare(n: AudioNodes, t: number): void {
+  const s = noiseSource(n)
+  const bp = n.ctx.createBiquadFilter()
+  const g = n.ctx.createGain()
+  bp.type = 'bandpass'
+  bp.frequency.value = 1800
+  bp.Q.value = 0.8
+  g.gain.setValueAtTime(0.0001, t)
+  g.gain.exponentialRampToValueAtTime(0.7, t + 0.005)
+  g.gain.exponentialRampToValueAtTime(0.0001, t + 0.2)
+  s.connect(bp)
+  bp.connect(g)
+  g.connect(n.master)
+  s.start(t)
+  s.stop(t + 0.22)
+  const o = n.ctx.createOscillator()
+  const og = n.ctx.createGain()
+  o.type = 'triangle'
+  o.frequency.value = 190
+  og.gain.setValueAtTime(0.0001, t)
+  og.gain.exponentialRampToValueAtTime(0.25, t + 0.005)
+  og.gain.exponentialRampToValueAtTime(0.0001, t + 0.12)
+  o.connect(og)
+  og.connect(n.master)
+  o.start(t)
+  o.stop(t + 0.14)
+}
+
+function playHihat(n: AudioNodes, t: number): void {
+  const s = noiseSource(n)
+  const hp = n.ctx.createBiquadFilter()
+  const g = n.ctx.createGain()
+  hp.type = 'highpass'
+  hp.frequency.value = 7000
+  g.gain.setValueAtTime(0.0001, t)
+  g.gain.exponentialRampToValueAtTime(0.35, t + 0.002)
+  g.gain.exponentialRampToValueAtTime(0.0001, t + 0.06)
+  s.connect(hp)
+  hp.connect(g)
+  g.connect(n.master)
+  s.start(t)
+  s.stop(t + 0.07)
+}
+
+function playClap(n: AudioNodes, t: number): void {
+  const offs = [0, 0.012, 0.026]
+  offs.forEach((off, i) => {
+    const s = noiseSource(n)
+    const bp = n.ctx.createBiquadFilter()
+    const g = n.ctx.createGain()
+    bp.type = 'bandpass'
+    bp.frequency.value = 1200
+    bp.Q.value = 1.0
+    const tt = t + off
+    const dur = i === 2 ? 0.15 : 0.05
+    g.gain.setValueAtTime(0.0001, tt)
+    g.gain.exponentialRampToValueAtTime(i === 2 ? 0.5 : 0.3, tt + 0.002)
+    g.gain.exponentialRampToValueAtTime(0.0001, tt + dur)
+    s.connect(bp)
+    bp.connect(g)
+    g.connect(n.master)
+    s.start(tt)
+    s.stop(tt + dur + 0.02)
+  })
+}
+
+// ---- melody voices (fixed pentatonic pitches) ------------------------------
+
+function playBell(n: AudioNodes, t: number, f: number): void {
+  const o = n.ctx.createOscillator()
+  const g = n.ctx.createGain()
+  o.type = 'triangle'
+  o.frequency.value = f
+  g.gain.setValueAtTime(0.0001, t)
+  g.gain.exponentialRampToValueAtTime(0.5, t + 0.008)
+  g.gain.exponentialRampToValueAtTime(0.0001, t + 0.9)
+  o.connect(g)
+  g.connect(n.master)
+  o.start(t)
+  o.stop(t + 0.92)
+  const o2 = n.ctx.createOscillator()
+  const g2 = n.ctx.createGain()
+  o2.type = 'triangle'
+  o2.frequency.value = f * 2.01
+  g2.gain.setValueAtTime(0.0001, t)
+  g2.gain.exponentialRampToValueAtTime(0.18, t + 0.008)
+  g2.gain.exponentialRampToValueAtTime(0.0001, t + 0.5)
+  o2.connect(g2)
+  g2.connect(n.master)
+  o2.start(t)
+  o2.stop(t + 0.52)
+}
+
+function playChime(n: AudioNodes, t: number, f: number): void {
+  const car = n.ctx.createOscillator()
+  const cg = n.ctx.createGain()
+  const mod = n.ctx.createOscillator()
+  const mg = n.ctx.createGain()
+  car.type = 'sine'
+  car.frequency.value = f
+  mod.type = 'sine'
+  mod.frequency.value = f * 2.76
+  mg.gain.setValueAtTime(f * 3, t)
+  mg.gain.exponentialRampToValueAtTime(f * 0.4, t + 0.6)
+  mod.connect(mg)
+  mg.connect(car.frequency)
+  cg.gain.setValueAtTime(0.0001, t)
+  cg.gain.exponentialRampToValueAtTime(0.4, t + 0.01)
+  cg.gain.exponentialRampToValueAtTime(0.0001, t + 1.1)
+  car.connect(cg)
+  cg.connect(n.master)
+  mod.start(t)
+  car.start(t)
+  mod.stop(t + 1.12)
+  car.stop(t + 1.12)
+}
+
+function playFlute(n: AudioNodes, t: number, f: number): void {
+  const o = n.ctx.createOscillator()
+  const g = n.ctx.createGain()
+  o.type = 'sine'
+  o.frequency.value = f
+  const lfo = n.ctx.createOscillator()
+  const lg = n.ctx.createGain()
+  lfo.frequency.value = 5
+  lg.gain.value = 4
+  lfo.connect(lg)
+  lg.connect(o.frequency)
+  g.gain.setValueAtTime(0.0001, t)
+  g.gain.linearRampToValueAtTime(0.34, t + 0.09)
+  g.gain.setValueAtTime(0.34, t + 0.34)
+  g.gain.exponentialRampToValueAtTime(0.0001, t + 0.7)
+  o.connect(g)
+  g.connect(n.master)
+  lfo.start(t)
+  o.start(t)
+  lfo.stop(t + 0.72)
+  o.stop(t + 0.72)
+}
+
+function playHarp(n: AudioNodes, t: number, f: number): void {
+  const notes: [number, number, number][] = [
+    [f * 0.75, 0, 0.18],
+    [f, 0.03, 0.5],
+  ]
+  notes.forEach(([freq, off, dur]) => {
+    const o = n.ctx.createOscillator()
+    const g = n.ctx.createGain()
+    o.type = 'triangle'
+    o.frequency.value = freq
+    const tt = t + off
+    g.gain.setValueAtTime(0.0001, tt)
+    g.gain.exponentialRampToValueAtTime(0.4, tt + 0.004)
+    g.gain.exponentialRampToValueAtTime(0.0001, tt + dur)
+    o.connect(g)
+    g.connect(n.master)
+    o.start(tt)
+    o.stop(tt + dur + 0.02)
+  })
+}
+
+function playVoice(n: AudioNodes, type: PieceType, t: number): void {
+  switch (type) {
+    case 'kick':
+      return playKick(n, t)
+    case 'snare':
+      return playSnare(n, t)
+    case 'hihat':
+      return playHihat(n, t)
+    case 'clap':
+      return playClap(n, t)
+    case 'bell':
+    case 'chime':
+    case 'flute':
+    case 'harp': {
+      const f = PIECE_META[type].freq ?? 440
+      if (type === 'bell') return playBell(n, t, f)
+      if (type === 'chime') return playChime(n, t, f)
+      if (type === 'flute') return playFlute(n, t, f)
+      return playHarp(n, t, f)
+    }
+  }
+}
+
+export interface LoopStep {
+  rhythm: RhythmType | null
+  melody: MelodyType | null
+}
+
+export interface LoopOptions {
+  /** Pieces at a given 0-based step, read fresh each step (live board). */
+  getStep: (step: number) => LoopStep
+  /** Fires as the visual playhead reaches each step. */
+  onStep: (step: number) => void
+}
+
+export class AudioEngine {
+  private nodes: AudioNodes | null = null
+  private enabled: boolean | null = null
+  private playing = false
+  private currentStep = 0
+  private nextNoteTime = 0
+  private schedTimer: ReturnType<typeof setInterval> | null = null
+  private visualTimer: ReturnType<typeof setInterval> | null = null
+  private rafId: number | null = null
+  private queue: { step: number; time: number }[] = []
+  private options: LoopOptions | null = null
+
+  /** True once Web Audio is confirmed available; false when it failed. */
+  get available(): boolean {
+    return this.enabled === true
+  }
+
+  /** True while it is known Web Audio could not initialize. */
+  get unavailable(): boolean {
+    return this.enabled === false
+  }
+
+  get isPlaying(): boolean {
+    return this.playing
+  }
+
+  /** Lazily create the AudioContext on a user gesture. Returns whether audio works. */
+  ensure(): boolean {
+    if (this.enabled !== null) {
+      if (this.enabled && this.nodes && this.nodes.ctx.state === 'suspended') {
+        void this.nodes.ctx.resume()
+      }
+      return this.enabled
+    }
+    try {
+      const AC =
+        window.AudioContext ??
+        (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+      if (!AC) throw new Error('no AudioContext')
+      const ctx = new AC()
+      const master = ctx.createGain()
+      master.gain.value = 0.55
+      master.connect(ctx.destination)
+      const len = Math.floor(ctx.sampleRate * 1.0)
+      const noise = ctx.createBuffer(1, len, ctx.sampleRate)
+      const data = noise.getChannelData(0)
+      for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1
+      if (ctx.state === 'suspended') void ctx.resume()
+      this.nodes = { ctx, master, noise }
+      this.enabled = true
+    } catch {
+      this.enabled = false
+    }
+    return this.enabled
+  }
+
+  /** Preview one piece immediately (also serves as the audio-unlock gesture). */
+  preview(type: PieceType): void {
+    if (!this.ensure() || !this.nodes) return
+    playVoice(this.nodes, type, this.nodes.ctx.currentTime + 0.02)
+  }
+
+  start(options: LoopOptions): void {
+    if (this.playing) return
+    this.options = options
+    this.playing = true
+    this.currentStep = 0
+    const ok = this.ensure()
+    if (ok && this.nodes) {
+      this.queue = []
+      this.nextNoteTime = this.nodes.ctx.currentTime + 0.06
+      this.schedTimer = setInterval(() => this.schedule(), SCHED_MS)
+      this.rafId = requestAnimationFrame(() => this.drawPlayhead())
+    } else {
+      // visual-only fallback
+      let step = 0
+      options.onStep(0)
+      this.visualTimer = setInterval(() => {
+        step = (step + 1) % 8
+        options.onStep(step)
+      }, STEP_SEC * 1000)
+    }
+  }
+
+  stop(): void {
+    if (!this.playing) return
+    this.playing = false
+    if (this.schedTimer) {
+      clearInterval(this.schedTimer)
+      this.schedTimer = null
+    }
+    if (this.visualTimer) {
+      clearInterval(this.visualTimer)
+      this.visualTimer = null
+    }
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId)
+      this.rafId = null
+    }
+    this.queue = []
+    this.options?.onStep(-1)
+  }
+
+  dispose(): void {
+    this.stop()
+    if (this.nodes) void this.nodes.ctx.close()
+    this.nodes = null
+  }
+
+  private schedule(): void {
+    if (!this.nodes || !this.options) return
+    while (this.nextNoteTime < this.nodes.ctx.currentTime + LOOKAHEAD) {
+      const step = this.currentStep
+      const { rhythm, melody } = this.options.getStep(step)
+      if (rhythm) playVoice(this.nodes, rhythm, this.nextNoteTime)
+      if (melody) playVoice(this.nodes, melody, this.nextNoteTime)
+      this.queue.push({ step, time: this.nextNoteTime })
+      this.nextNoteTime += STEP_SEC
+      this.currentStep = (this.currentStep + 1) % 8
+    }
+  }
+
+  private drawPlayhead(): void {
+    if (!this.playing || !this.nodes || !this.options) return
+    while (this.queue.length && this.queue[0].time <= this.nodes.ctx.currentTime) {
+      this.options.onStep(this.queue[0].step)
+      this.queue.shift()
+    }
+    this.rafId = requestAnimationFrame(() => this.drawPlayhead())
+  }
+}

--- a/packages/game-sound-garden/src/game/build-level.ts
+++ b/packages/game-sound-garden/src/game/build-level.ts
@@ -1,0 +1,120 @@
+/**
+ * Combinatorial level expansion (L2 arch note B3).
+ *
+ * The engine's construction model toggles the `__placed` state of
+ * DESIGN-TIME-declared elements (engine.ts / rules.ts) — it has no notion of
+ * the player choosing a slot at runtime. To give the player free placement we
+ * pre-generate EVERY (piece_type, slot) candidate as an element, start them all
+ * unplaced (`initial_state.occupied: []`), and let `place_piece` flip the one
+ * the player/partner chose. 8 slots × (4 rhythm + 4 melody) = 64 candidates.
+ *
+ * This is engine-inert on counts: the 64-element count structurally exceeds
+ * `difficulty_budget.element_count.max = 16`, so the validator's
+ * budget_compliance check would FAIL — but the live engine ignores the budget
+ * (it only reads elements / rules / initial_state / win_condition). That gap is
+ * engine-sufficiency finding F3, confirmed in practice here.
+ */
+
+import type { Level, LevelElement, LevelRule } from '@amiclaw/creation'
+import { MELODY_TYPES, RHYTHM_TYPES } from './constants'
+import type { LevelConfig, Pool } from './types'
+
+/** Deterministic element id for a (lane, type, slot) candidate. */
+export function elementId(prefix: 'r' | 'm', type: string, slot: number): string {
+  return `${prefix}_${type}_s${slot}`
+}
+
+function materialEntries(pool: Pool, archetype: string, typeKey: string) {
+  return Object.entries(pool)
+    .filter(([, count]) => (count ?? 0) > 0)
+    .map(([type, count]) => ({ archetype, [typeKey]: type, count: count as number }))
+}
+
+/**
+ * Expand a LevelConfig into a Level the engine can run. All 64 candidates start
+ * unplaced; the harmony matrix + score threshold come from the config.
+ */
+export function buildLevel(cfg: LevelConfig): Level {
+  const elements: LevelElement[] = []
+  for (let slot = 1; slot <= cfg.slots; slot++) {
+    for (const r of RHYTHM_TYPES) {
+      elements.push({
+        id: elementId('r', r, slot),
+        archetype: 'rhythm_piece',
+        params: { rhythm_type: r, timeline_slot: slot },
+      })
+    }
+    for (const m of MELODY_TYPES) {
+      elements.push({
+        id: elementId('m', m, slot),
+        archetype: 'melody_piece',
+        params: { melody_type: m, timeline_slot: slot },
+      })
+    }
+  }
+
+  const matrixRows: [string, string, string][] = []
+  for (const r of RHYTHM_TYPES) {
+    for (const m of MELODY_TYPES) {
+      matrixRows.push([r, m, cfg.matrix[r][m]])
+    }
+  }
+
+  const allIds = elements.map((e) => e.id)
+  const harmonyRule: LevelRule = {
+    id: 'rule-harmony',
+    template: 'harmony_rule',
+    bindings: { matrix: matrixRows },
+    target_elements: allIds,
+  }
+
+  // Role views over every element (both roles see the full shared timeline —
+  // co_build). Used only by getRoleView; placement flows through performAction.
+  const rhythmView = (id: string, isRhythm: boolean) => ({
+    element_id: id,
+    visible_attributes: isRhythm
+      ? ['rhythm_type', 'timeline_slot']
+      : ['melody_type', 'timeline_slot'],
+    visible_states: [],
+  })
+  const elementViews = elements.map((e) => rhythmView(e.id, e.archetype === 'rhythm_piece'))
+
+  return {
+    metadata: {
+      id: cfg.id,
+      game_type: 'sound-garden',
+      game_type_version: '1.0.0',
+      title: cfg.name,
+      author: 'sound-garden-probe',
+      created_at: '2026-07-10T00:00:00+08:00',
+    },
+    // Engine-inert bookkeeping. element_count intentionally reflects the true
+    // 64-candidate expansion (see F3) rather than a budget-legal fiction.
+    difficulty: {
+      element_count: elements.length,
+      rule_count: 1,
+      partition_complexity: 2.0,
+      total_score: cfg.target,
+    },
+    communication_estimate: {
+      round_trips: 5,
+      estimated_seconds: 40,
+      time_limit_seconds: 240,
+      feasibility: 'feasible',
+    },
+    initial_state: { timeline_slots: cfg.slots, occupied: [] },
+    available_materials: {
+      rhythm_builder: materialEntries(cfg.rhythmPool, 'rhythm_piece', 'rhythm_type'),
+      melody_builder: materialEntries(cfg.melodyPool, 'melody_piece', 'melody_type'),
+    },
+    elements,
+    rules: [harmonyRule],
+    information_partition: {
+      role_assignments: [
+        { role: 'rhythm_builder', element_views: elementViews },
+        { role: 'melody_builder', element_views: elementViews },
+      ],
+    },
+    win_condition: { type: 'score_threshold', params: { target_score: cfg.target } },
+  }
+}

--- a/packages/game-sound-garden/src/game/constants.ts
+++ b/packages/game-sound-garden/src/game/constants.ts
@@ -1,0 +1,66 @@
+/**
+ * Piece taxonomy + display metadata + the relation→score map.
+ *
+ * The 8 piece types (4 rhythm + 4 melody) are the fixed sound-garden
+ * vocabulary (game-type.yaml). Display labels are Chinese instantiation data;
+ * melody frequencies are a fixed pentatonic set so any combination sounds
+ * musical (lifted from the validated rough-cut synth recipe). The relation
+ * scores are DERIVED from the loaded GameType so they can never drift from
+ * what the engine actually scores.
+ */
+
+import { SOUND_GARDEN_GAME_TYPE } from './gametype'
+import type { RelationName } from './types'
+
+export const RHYTHM_TYPES = ['kick', 'snare', 'hihat', 'clap'] as const
+export const MELODY_TYPES = ['bell', 'chime', 'flute', 'harp'] as const
+
+export type RhythmType = (typeof RHYTHM_TYPES)[number]
+export type MelodyType = (typeof MELODY_TYPES)[number]
+export type PieceType = RhythmType | MelodyType
+
+export interface PieceMeta {
+  emoji: string
+  label: string
+  /** Fundamental pitch (Hz) for melody voices; absent for rhythm voices. */
+  freq?: number
+}
+
+export const PIECE_META: Record<PieceType, PieceMeta> = {
+  // rhythm roots (earthy percussion)
+  kick: { emoji: '🥁', label: '底鼓' },
+  snare: { emoji: '🪘', label: '军鼓' },
+  hihat: { emoji: '💠', label: '踩镲' },
+  clap: { emoji: '👏', label: '拍掌' },
+  // melody flowers (fixed pentatonic pitches)
+  bell: { emoji: '🔔', label: '铃铛', freq: 523.25 }, // C5
+  chime: { emoji: '🎐', label: '风铃', freq: 659.25 }, // E5
+  flute: { emoji: '🪈', label: '笛音', freq: 783.99 }, // G5
+  harp: { emoji: '🎶', label: '竖琴', freq: 880.0 }, // A5
+}
+
+/** relation → points, derived from the GameType's harmony_rule template. */
+export const RELATION_SCORES: Record<RelationName, number> = (() => {
+  const template = SOUND_GARDEN_GAME_TYPE.rule_templates.find(
+    (t) => t.type === 'interaction_matrix'
+  )
+  const scores =
+    template && template.type === 'interaction_matrix'
+      ? template.matrix_schema.relation_scores
+      : undefined
+  if (!scores) throw new Error('sound-garden GameType is missing relation_scores')
+  return {
+    synergy: scores.synergy ?? 3,
+    compatible: scores.compatible ?? 2,
+    neutral: scores.neutral ?? 1,
+    incompatible: scores.incompatible ?? -1,
+  }
+})()
+
+/** Per-pair feedback shown after both lanes fill a slot (never the full matrix). */
+export const RELATION_FEEDBACK: Record<RelationName, { text: string }> = {
+  synergy: { text: '✨ 共鸣' },
+  compatible: { text: '🌿 和谐' },
+  neutral: { text: '· 平淡' },
+  incompatible: { text: '⚡ 刺耳' },
+}

--- a/packages/game-sound-garden/src/game/gametype.smoke.test.ts
+++ b/packages/game-sound-garden/src/game/gametype.smoke.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { GameSession } from '@amiclaw/creation'
+import { SOUND_GARDEN_GAME_TYPE } from './gametype'
+
+describe('cross-package resolution smoke test', () => {
+  it('loads the sound-garden GameType from the creation fixture', () => {
+    expect(SOUND_GARDEN_GAME_TYPE.id).toBe('sound-garden')
+    expect(SOUND_GARDEN_GAME_TYPE.co_play_form).toBe('co_build')
+  })
+
+  it('can import the real GameSession class', () => {
+    expect(typeof GameSession).toBe('function')
+  })
+})

--- a/packages/game-sound-garden/src/game/gametype.ts
+++ b/packages/game-sound-garden/src/game/gametype.ts
@@ -1,0 +1,16 @@
+/**
+ * The Sound Garden GameType — loaded verbatim from the creation package's
+ * validated fixture (`@amiclaw/creation/fixtures/sound-garden/game-type.yaml`)
+ * so the probe uses the exact same vocabulary, action registry, and
+ * relation_scores the engine and validator were designed against. Zero drift:
+ * this is a re-use, not a re-declaration.
+ *
+ * Levels supply their OWN harmony matrix + win threshold (see levels.ts);
+ * only the GameType-level vocabulary and relation_scores come from here.
+ */
+
+import { loadGameType } from '@amiclaw/creation'
+import type { GameType } from '@amiclaw/creation'
+import gameTypeYaml from '../../../creation/fixtures/sound-garden/game-type.yaml?raw'
+
+export const SOUND_GARDEN_GAME_TYPE: GameType = loadGameType(gameTypeYaml)

--- a/packages/game-sound-garden/src/game/levels.ts
+++ b/packages/game-sound-garden/src/game/levels.ts
@@ -1,0 +1,90 @@
+/**
+ * The three shipped levels (L2 arch note B4). Rising tension comes from
+ * pool scarcity + matrix traps + a rising score bar — NOT from a fail state
+ * (free-flow, no-fail bloom).
+ *
+ * Each level defines its OWN harmony matrix. Level 1's matrix is the fixture
+ * base (mostly friendly, one lone incompatible). Level 3's matrix is trapped
+ * (several incompatible penalties) with `harp` as a safe "wildcard" that never
+ * traps. Winnability under scarcity is not machine-guaranteed by the engine
+ * (solver is scarcity-blind, F5), so reachability.test.ts brute-forces every
+ * legal joint placement and asserts each target is reachable.
+ */
+
+import type { HarmonyMatrix, LevelConfig } from './types'
+
+// Level 1 · 学步 — teach the plant→hear→partner-reacts loop. Ample pieces,
+// mostly synergy/compatible, one lone trap (snare×flute) so "harsh" exists.
+const LV1_MATRIX: HarmonyMatrix = {
+  kick: { bell: 'synergy', chime: 'neutral', flute: 'compatible', harp: 'compatible' },
+  snare: { bell: 'neutral', chime: 'synergy', flute: 'incompatible', harp: 'neutral' },
+  hihat: { bell: 'compatible', chime: 'compatible', flute: 'synergy', harp: 'neutral' },
+  clap: { bell: 'neutral', chime: 'neutral', flute: 'neutral', harp: 'synergy' },
+}
+
+// Level 2 · 取舍 — scarcity forces choosing WHICH slots to co-locate the few
+// pieces on. Clear synergy diagonal, mostly neutral filler, no traps.
+const LV2_MATRIX: HarmonyMatrix = {
+  kick: { bell: 'synergy', chime: 'neutral', flute: 'neutral', harp: 'compatible' },
+  snare: { bell: 'neutral', chime: 'synergy', flute: 'neutral', harp: 'neutral' },
+  hihat: { bell: 'compatible', chime: 'neutral', flute: 'synergy', harp: 'neutral' },
+  clap: { bell: 'neutral', chime: 'neutral', flute: 'neutral', harp: 'synergy' },
+}
+
+// Level 3 · 荆棘 — trapped matrix. Wrong pairings actively subtract; the safe
+// path is found via the partner (who alone holds the matrix). `harp` is the
+// wildcard: never a trap, compatible everywhere, synergy on clap.
+const LV3_MATRIX: HarmonyMatrix = {
+  kick: { bell: 'synergy', chime: 'incompatible', flute: 'neutral', harp: 'compatible' },
+  snare: { bell: 'incompatible', chime: 'synergy', flute: 'neutral', harp: 'compatible' },
+  hihat: { bell: 'neutral', chime: 'incompatible', flute: 'synergy', harp: 'compatible' },
+  clap: { bell: 'incompatible', chime: 'neutral', flute: 'incompatible', harp: 'synergy' },
+}
+
+export const LEVELS: LevelConfig[] = [
+  {
+    id: 'sg-lv1-xuebu',
+    index: 1,
+    name: '学步',
+    subtitle: '第一座花园',
+    slots: 8,
+    target: 8,
+    matrix: LV1_MATRIX,
+    // Ample: 2 of each type, 8 slots. Max achievable is far above target.
+    melodyPool: { bell: 2, chime: 2, flute: 2, harp: 2 },
+    rhythmPool: { kick: 2, snare: 2, hihat: 2, clap: 2 },
+    tension: '材料充足，先学会种植与倾听',
+  },
+  {
+    id: 'sg-lv2-qushe',
+    index: 2,
+    name: '取舍',
+    subtitle: '每一株都要用在刀刃上',
+    slots: 8,
+    target: 10,
+    matrix: LV2_MATRIX,
+    // Scarce: 1 of each type. Max = perfect synergy diagonal (12). Target 10
+    // demands strong pairing — must co-locate pieces on their synergy slots.
+    melodyPool: { bell: 1, chime: 1, flute: 1, harp: 1 },
+    rhythmPool: { kick: 1, snare: 1, hihat: 1, clap: 1 },
+    tension: '材料稀缺——放错拍子就浪费了',
+  },
+  {
+    id: 'sg-lv3-jingji',
+    index: 3,
+    name: '荆棘',
+    subtitle: '刺耳的陷阱藏在其中',
+    slots: 8,
+    target: 13,
+    matrix: LV3_MATRIX,
+    // Scarce + a doubled wildcard (harp ×2 / clap ×2). Max = 15 (diagonal +
+    // double clap×harp). Target 13 leaves almost no room for a trap.
+    melodyPool: { bell: 1, chime: 1, flute: 1, harp: 2 },
+    rhythmPool: { kick: 1, snare: 1, hihat: 1, clap: 2 },
+    tension: '错误配对会倒扣——靠伙伴避开荆棘',
+  },
+]
+
+export function levelByIndex(index: number): LevelConfig | undefined {
+  return LEVELS.find((lv) => lv.index === index)
+}

--- a/packages/game-sound-garden/src/game/reachability.test.ts
+++ b/packages/game-sound-garden/src/game/reachability.test.ts
@@ -1,0 +1,47 @@
+/**
+ * B4 winnability net + engine-agreement cross-check.
+ *
+ * For every shipped level: (1) brute-force the max achievable score under the
+ * level's scarcity and assert it is >= target (a level whose target is
+ * unreachable under its own pools would fail here and never ship); (2) play the
+ * optimal placement through the REAL GameSession and assert the engine's own
+ * score equals the brute-forced max and the win fires — proving the
+ * presentation reachability model and the engine agree.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { GameSession } from '@amiclaw/creation'
+import { buildLevel, elementId } from './build-level'
+import { SOUND_GARDEN_GAME_TYPE } from './gametype'
+import { LEVELS } from './levels'
+import { bestPlacement } from './reachability'
+
+describe('level reachability (winnability net)', () => {
+  for (const cfg of LEVELS) {
+    it(`Lv${cfg.index} · ${cfg.name}: max achievable score >= target`, () => {
+      const best = bestPlacement(cfg)
+      expect(best.score).toBeGreaterThanOrEqual(cfg.target)
+    })
+
+    it(`Lv${cfg.index} · ${cfg.name}: the engine agrees the optimal placement wins`, () => {
+      const best = bestPlacement(cfg)
+      const level = buildLevel(cfg)
+      const session = new GameSession(SOUND_GARDEN_GAME_TYPE, level)
+
+      for (const pair of best.pairs) {
+        const r = session.performAction('rhythm_builder', 'place_piece', {
+          element_id: elementId('r', pair.rhythmType, pair.slot),
+        })
+        const m = session.performAction('melody_builder', 'place_piece', {
+          element_id: elementId('m', pair.melodyType, pair.slot),
+        })
+        expect(r.ok).toBe(true)
+        expect(m.ok).toBe(true)
+      }
+
+      // The engine's own scoring must equal the brute-forced maximum.
+      expect(session.score()).toBe(best.score)
+      expect(session.isWon()).toBe(true)
+    })
+  }
+})

--- a/packages/game-sound-garden/src/game/reachability.ts
+++ b/packages/game-sound-garden/src/game/reachability.ts
@@ -1,0 +1,84 @@
+/**
+ * Winnability safety net (L2 arch note B4 / finding F5).
+ *
+ * The engine's solver is scarcity-blind (material counts are presentation-only,
+ * F1), so nothing machine-confirms that a scarce level's `target` is even
+ * reachable. This module brute-forces the max achievable score under the
+ * level's own scarcity (per-type pool counts + one-piece-per-slot). The state
+ * space is tiny — a handful of pieces per side — so exhaustive enumeration is
+ * instant.
+ *
+ * Only same-slot rhythm×melody pairs score, and the matrix is slot-independent,
+ * so max achievable score reduces to a max-weight matching between the rhythm
+ * pool and the melody pool, capped at the slot count. A negative (incompatible)
+ * pairing is never beneficial — leaving a piece unplaced scores 0 — so the
+ * optimum drops traps rather than pairing them.
+ */
+
+import { RELATION_SCORES } from './constants'
+import type { MelodyType, RhythmType } from './constants'
+import type { HarmonyMatrix, LevelConfig, Pool } from './types'
+
+export interface BestPair {
+  rhythmType: RhythmType
+  melodyType: MelodyType
+  /** 1-based slot assignment (arbitrary distinct slot — scoring is slot-independent). */
+  slot: number
+}
+
+export interface BestPlacement {
+  score: number
+  pairs: BestPair[]
+}
+
+function expandPool<T extends string>(pool: Pool): T[] {
+  const instances: T[] = []
+  for (const [type, count] of Object.entries(pool)) {
+    for (let i = 0; i < (count ?? 0); i++) instances.push(type as T)
+  }
+  return instances
+}
+
+interface SubResult {
+  score: number
+  pairs: { rhythmType: RhythmType; melodyType: MelodyType }[]
+}
+
+function solve(
+  melody: MelodyType[],
+  mi: number,
+  rhythmLeft: RhythmType[],
+  slotsLeft: number,
+  matrix: HarmonyMatrix
+): SubResult {
+  if (mi >= melody.length || slotsLeft === 0) return { score: 0, pairs: [] }
+  const m = melody[mi]
+  // Option A: leave this melody piece unplaced.
+  let best = solve(melody, mi + 1, rhythmLeft, slotsLeft, matrix)
+  // Option B: pair it with each distinct available rhythm type.
+  const tried = new Set<RhythmType>()
+  for (let ri = 0; ri < rhythmLeft.length; ri++) {
+    const r = rhythmLeft[ri]
+    if (tried.has(r)) continue
+    tried.add(r)
+    const gain = RELATION_SCORES[matrix[r][m]]
+    const rest = rhythmLeft.slice(0, ri).concat(rhythmLeft.slice(ri + 1))
+    const sub = solve(melody, mi + 1, rest, slotsLeft - 1, matrix)
+    const total = gain + sub.score
+    if (total > best.score) {
+      best = { score: total, pairs: [{ rhythmType: r, melodyType: m }, ...sub.pairs] }
+    }
+  }
+  return best
+}
+
+/** Max achievable score + one optimal placement for a level's scarcity. */
+export function bestPlacement(cfg: LevelConfig): BestPlacement {
+  const melody = expandPool<MelodyType>(cfg.melodyPool)
+  const rhythm = expandPool<RhythmType>(cfg.rhythmPool)
+  const result = solve(melody, 0, rhythm, cfg.slots, cfg.matrix)
+  return {
+    score: result.score,
+    pairs: result.pairs.map((p, i) => ({ ...p, slot: i + 1 })),
+  }
+}

--- a/packages/game-sound-garden/src/game/store.test.ts
+++ b/packages/game-sound-garden/src/game/store.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest'
+import { GameStore } from './store'
+import { LEVELS, levelByIndex } from './levels'
+import type { PartnerBrain } from '../partner/brain'
+import type { BoardSnapshot } from './types'
+
+// Bus timers are pushed far out so only explicit runPartnerTurn calls react —
+// keeps the store logic deterministic without fake timers.
+const INERT_BUS = { debounceMs: 1_000_000, idleMs: 1_000_000 }
+
+function lv(index: number) {
+  const cfg = levelByIndex(index)
+  if (!cfg) throw new Error(`no level ${index}`)
+  return cfg
+}
+
+describe('GameStore', () => {
+  it('opens with a greeting and an empty board', async () => {
+    const store = new GameStore(lv(1), 'melody', { busConfig: INERT_BUS })
+    await store.whenIdle()
+    const s = store.getSnapshot()
+    expect(s.chat.length).toBe(1)
+    expect(s.score).toBe(0)
+    expect(s.melody.every((x) => x === null)).toBe(true)
+    store.dispose()
+  })
+
+  it('the partner lays a synergizing rhythm under a planted melody', async () => {
+    const store = new GameStore(lv(1), 'melody', { busConfig: INERT_BUS })
+    await store.whenIdle()
+    store.plantPlayer('bell', 1)
+    await store.runPartnerTurn('player_planted')
+    const s = store.getSnapshot()
+    expect(s.melody[0]).toBe('bell')
+    expect(s.rhythm[0]).toBe('kick') // kick×bell = synergy in Lv1
+    expect(s.score).toBe(3)
+    expect(s.relations[0]).toBe('synergy')
+    store.dispose()
+  })
+
+  it('a cooperative playthrough reaches bloom (no-fail free-flow)', async () => {
+    const store = new GameStore(lv(1), 'melody', { busConfig: INERT_BUS })
+    await store.whenIdle()
+    for (const [type, slot] of [
+      ['bell', 1],
+      ['chime', 2],
+      ['flute', 3],
+    ] as const) {
+      store.plantPlayer(type, slot)
+      await store.runPartnerTurn('player_planted')
+    }
+    const s = store.getSnapshot()
+    expect(s.score).toBeGreaterThanOrEqual(s.target)
+    expect(s.bloomed).toBe(true)
+    expect(s.chat.some((line) => line.text.includes('绽放'))).toBe(true)
+    store.dispose()
+  })
+
+  it('enforces presentation-owned scarcity (F1)', async () => {
+    const store = new GameStore(lv(2), 'melody', { busConfig: INERT_BUS })
+    await store.whenIdle()
+    // Lv2 pool has bell ×1.
+    store.plantPlayer('bell', 1)
+    store.plantPlayer('bell', 2) // no bell left — must be refused
+    const s = store.getSnapshot()
+    expect(s.melody[0]).toBe('bell')
+    expect(s.melody[1]).toBe(null)
+    const bell = s.palette.find((p) => p.type === 'bell')
+    expect(bell?.remaining).toBe(0)
+    store.dispose()
+  })
+
+  it('replacing a piece on a slot restores the old piece to the pool', async () => {
+    const store = new GameStore(lv(1), 'melody', { busConfig: INERT_BUS })
+    await store.whenIdle()
+    store.plantPlayer('bell', 1)
+    store.plantPlayer('chime', 1) // replace bell with chime on slot 1
+    const s = store.getSnapshot()
+    expect(s.melody[0]).toBe('chime')
+    // bell returned to the pool (Lv1 bell ×2 → both still available)
+    expect(s.palette.find((p) => p.type === 'bell')?.remaining).toBe(2)
+    store.dispose()
+  })
+
+  it('supports side-swap (player controls the rhythm lane)', async () => {
+    const store = new GameStore(lv(1), 'rhythm', { busConfig: INERT_BUS })
+    await store.whenIdle()
+    expect(store.getSnapshot().playerArchetype).toBe('rhythm_piece')
+    store.plantPlayer('kick', 1)
+    await store.runPartnerTurn('player_planted')
+    const s = store.getSnapshot()
+    expect(s.rhythm[0]).toBe('kick')
+    expect(s.melody[0]).toBe('bell') // partner (melody) answers kick with bell synergy
+    expect(s.score).toBe(3)
+    store.dispose()
+  })
+
+  it('ships three levels', () => {
+    expect(LEVELS.map((l) => l.index)).toEqual([1, 2, 3])
+  })
+
+  it('a malicious partner cannot corrupt material via forged remove actions (r14)', async () => {
+    // Seeds one kick, then issues forged removes (occupied-wrong-type + empty
+    // slot) plus a place that would DUPLICATE the single scarce kick if the
+    // forged remove wrongly freed its count.
+    const malicious: PartnerBrain = {
+      react: async (snap: BoardSnapshot) => {
+        if (snap.trigger === 'session_start') {
+          return { speech: 'seed', actions: [{ op: 'place', pieceType: 'kick', slot: 1 }] }
+        }
+        return {
+          speech: 'attack',
+          actions: [
+            { op: 'remove', pieceType: 'snare', slot: 1 }, // slot 1 holds kick, not snare
+            { op: 'place', pieceType: 'kick', slot: 3 }, // would duplicate the single kick
+            { op: 'remove', pieceType: 'clap', slot: 2 }, // empty slot
+          ],
+        }
+      },
+    }
+    // Lv2 has kick ×1 — a duplication would be visible as a negative remaining.
+    const store = new GameStore(lv(2), 'melody', { brain: malicious, busConfig: INERT_BUS })
+    await store.whenIdle()
+    store.plantPlayer('bell', 1) // scores kick×bell synergy on slot 1
+
+    const before = store.getSnapshot()
+    expect(before.rhythm[0]).toBe('kick')
+    expect(before.melody[0]).toBe('bell')
+    const beforeRhythm = [...before.rhythm]
+    const beforeMelody = [...before.melody]
+    const beforeScore = before.score
+
+    await store.runPartnerTurn('player_planted')
+
+    const after = store.getSnapshot()
+    expect(after.rhythm).toEqual(beforeRhythm) // no kick@3 duplicate; kick@1 intact
+    expect(after.melody).toEqual(beforeMelody)
+    expect(after.score).toBe(beforeScore)
+    expect(after.rhythm.filter((x) => x === 'kick').length).toBe(1) // single scarce kick
+    store.dispose()
+  })
+})
+
+// --- PR-2: settlement latch + platform (mode②) partner driver --------------
+
+describe('GameStore — first-bloom settlement latch (PR-2 §4)', () => {
+  it('latches settled on the first bloom and never un-settles on a later score dip', async () => {
+    const store = new GameStore(lv(1), 'melody', { busConfig: INERT_BUS })
+    await store.whenIdle()
+    for (const [type, slot] of [
+      ['bell', 1],
+      ['chime', 2],
+      ['flute', 3],
+    ] as const) {
+      store.plantPlayer(type, slot)
+      await store.runPartnerTurn('player_planted')
+    }
+    expect(store.getSnapshot().bloomed).toBe(true)
+    expect(store.getSnapshot().settled).toBe(true)
+
+    // Removing the player's pieces drops the score below target — bloomed flips
+    // back, but the settlement latch stays true for the run's lifetime.
+    store.removePlayer(1)
+    store.removePlayer(2)
+    store.removePlayer(3)
+    const s = store.getSnapshot()
+    expect(s.bloomed).toBe(false)
+    expect(s.settled).toBe(true)
+    store.dispose()
+  })
+
+  it('is not settled before the first bloom', async () => {
+    const store = new GameStore(lv(1), 'melody', { busConfig: INERT_BUS })
+    await store.whenIdle()
+    expect(store.getSnapshot().settled).toBe(false)
+    store.dispose()
+  })
+})
+
+describe('GameStore — platform (mode②) partner driver', () => {
+  it('fires no scripted turn: no greeting, no opening move on the board', async () => {
+    const store = new GameStore(lv(1), 'melody', { partnerMode: 'platform', busConfig: INERT_BUS })
+    const s = store.getSnapshot()
+    expect(s.chat.length).toBe(0) // no scripted greeting
+    expect(s.rhythm.every((x) => x === null)).toBe(true) // no scripted opening move
+    store.dispose()
+  })
+
+  it('applyPartnerActions runs the co_build moves through the same legality guard', async () => {
+    const store = new GameStore(lv(1), 'melody', { partnerMode: 'platform', busConfig: INERT_BUS })
+    store.plantPlayer('bell', 1)
+    // A legal partner move (rhythm lane) is applied; an illegal one (melody piece
+    // on the rhythm partner, out of range) is dropped by the guard.
+    store.applyPartnerActions([
+      { op: 'place', pieceType: 'kick', slot: 1 },
+      { op: 'place', pieceType: 'bell', slot: 2 }, // wrong lane → dropped
+    ])
+    const s = store.getSnapshot()
+    expect(s.rhythm[0]).toBe('kick') // legal move applied
+    expect(s.rhythm[1]).toBeNull() // illegal move dropped
+    expect(s.score).toBe(3) // kick×bell synergy
+    store.dispose()
+  })
+
+  it('voiceGameState exposes the static sections + the live board publicContext', async () => {
+    const store = new GameStore(lv(1), 'melody', { partnerMode: 'platform', busConfig: INERT_BUS })
+    store.plantPlayer('bell', 1)
+    const gs = store.voiceGameState()
+    expect(gs.relevantSections).toEqual(['matrix', 'rules'])
+    expect(gs.publicContext.melody[0]).toBe('bell')
+    expect(gs.publicContext.partnerArchetype).toBe('rhythm_piece')
+    expect(gs.publicContext.target).toBe(store.getSnapshot().target)
+    store.dispose()
+  })
+})
+
+describe('GameStore — late-reply session-version guard (r13 medium)', () => {
+  it('drops applyPartnerActions that land after the store is disposed', async () => {
+    const store = new GameStore(lv(1), 'melody', { partnerMode: 'platform', busConfig: INERT_BUS })
+    store.plantPlayer('bell', 1)
+    // The run is torn down (level switch / replay remounts a fresh store).
+    store.dispose()
+    // A late partner reply from the retired session must NOT mutate the engine.
+    store.applyPartnerActions([{ op: 'place', pieceType: 'kick', slot: 1 }])
+    expect(store.getSnapshot().rhythm.every((x) => x === null)).toBe(true)
+  })
+})

--- a/packages/game-sound-garden/src/game/store.ts
+++ b/packages/game-sound-garden/src/game/store.ts
@@ -1,0 +1,502 @@
+/**
+ * Framework-free game store (precedent: creation/dev/store.ts).
+ *
+ * Owns everything the engine does NOT: presentation scarcity, per-lane slot
+ * exclusivity, side assignment, the partner loop, chat, and toasts. All
+ * placement lives in the engine — lanes, remaining counts, score, and bloom are
+ * DERIVED from `session.getState()` each emit, so the UI can never desync from
+ * engine truth (this is the mitigation for risk #4 / F2). React binds through
+ * `subscribe` + `getSnapshot` (useSyncExternalStore), so the store stays
+ * testable in plain Node.
+ */
+
+import { GameSession } from '@amiclaw/creation'
+import { PLACEMENT_STATE } from '@amiclaw/creation'
+import {
+  MELODY_TYPES,
+  PIECE_META,
+  RELATION_FEEDBACK,
+  RELATION_SCORES,
+  RHYTHM_TYPES,
+} from './constants'
+import type { MelodyType, PieceType, RhythmType } from './constants'
+import { buildLevel, elementId } from './build-level'
+import { SOUND_GARDEN_GAME_TYPE } from './gametype'
+import type {
+  Archetype,
+  BoardSnapshot,
+  ChatLine,
+  LevelConfig,
+  PartnerAction,
+  PartnerTrigger,
+  Pool,
+  RelationName,
+  Role,
+  Side,
+} from './types'
+import { PartnerBrain, ScriptedPartnerBrain } from '../partner/brain'
+import { filterLegalActions } from '../partner/legality'
+import { TriggerBus, TriggerBusConfig } from '../partner/trigger-bus'
+import { NullVoice, VoiceIO } from '../voice/voice-io'
+
+const BLOOM_LINE = '🌸 花园绽放了！我们一起种出了一首歌。'
+
+export interface ToastEvent {
+  seq: number
+  text: string
+  tone: RelationName | 'info'
+}
+
+/** Immutable snapshot consumed by React (stable ref between emits). */
+export interface SoundGardenState {
+  levelId: string
+  levelIndex: number
+  levelName: string
+  levelSubtitle: string
+  slots: number
+  target: number
+  score: number
+  bloomed: boolean
+  /**
+   * First-bloom settlement latch (PR-2 §4). Latches `true` on the FIRST `isWon()`
+   * transition and stays latched for the run — a later score dip / piece removal
+   * never un-settles it. Play continues after the latch (the garden stays
+   * interactive); only a full remount (replay / next level / side-swap) resets it.
+   */
+  settled: boolean
+  playerSide: Side
+  playerArchetype: Archetype
+  partnerArchetype: Archetype
+  /** melody piece per slot (0-based), engine-derived. */
+  melody: (MelodyType | null)[]
+  rhythm: (RhythmType | null)[]
+  /** per-slot relation once both lanes fill (display echo — never the full matrix). */
+  relations: (RelationName | null)[]
+  /** The player-controlled lane's types in display order, with remaining counts. */
+  palette: { type: PieceType; remaining: number }[]
+  chat: ChatLine[]
+  toast: ToastEvent | null
+}
+
+export interface GameStoreDeps {
+  brain?: PartnerBrain
+  voice?: VoiceIO
+  busConfig?: TriggerBusConfig
+  /**
+   * Partner driver (PR-2). `'scripted'` (default, anon tier): the internal
+   * ScriptedPartnerBrain + local voice + trigger bus drive the partner, including
+   * the pre-seeded opening move on `session_start`. `'platform'` (mode②): the
+   * partner is the platform co_build voice session — NO internal brain / bus turns
+   * fire; the session applies moves via {@link GameStore.applyPartnerActions} and
+   * pulls the board via {@link GameStore.voiceGameState}.
+   */
+  partnerMode?: 'scripted' | 'platform'
+}
+
+export class GameStore {
+  private readonly cfg: LevelConfig
+  private readonly session: GameSession
+  private readonly brain: PartnerBrain
+  private readonly voice: VoiceIO
+  private readonly bus: TriggerBus
+
+  private readonly side: Side
+  private readonly playerArchetype: Archetype
+  private readonly partnerArchetype: Archetype
+  private readonly playerRole: Role
+  private readonly partnerRole: Role
+  private readonly playerPrefix: 'r' | 'm'
+  private readonly partnerPrefix: 'r' | 'm'
+  private readonly playerPool: Pool
+  private readonly partnerPool: Pool
+  /** mode② (platform partner) vs anon scripted partner — see {@link GameStoreDeps.partnerMode}. */
+  private readonly platform: boolean
+
+  /** First-bloom settlement latch (never un-set within a run). */
+  private settled = false
+  /**
+   * Session-version guard (r13 medium): set on dispose (level switch / replay /
+   * side-swap remounts a fresh store). A late partner reply from the old session
+   * — an `applyPartnerActions` landing after the switch — is dropped, so it can
+   * never mutate the retired run's engine.
+   */
+  private disposed = false
+
+  private listeners = new Set<() => void>()
+  private chatLines: ChatLine[] = []
+  private chatSeq = 0
+  private toast: ToastEvent | null = null
+  private toastSeq = 0
+  private cached: SoundGardenState
+  /** Player utterance captured by push-to-talk, consumed by the next turn. */
+  private pendingUtterance: string | null = null
+  /** Resolves when the current partner turn settles (test hook). */
+  private lastTurn: Promise<void> = Promise.resolve()
+
+  constructor(cfg: LevelConfig, side: Side = 'melody', deps: GameStoreDeps = {}) {
+    this.cfg = cfg
+    this.side = side
+    this.session = new GameSession(SOUND_GARDEN_GAME_TYPE, buildLevel(cfg))
+
+    if (side === 'melody') {
+      this.playerArchetype = 'melody_piece'
+      this.partnerArchetype = 'rhythm_piece'
+      this.playerRole = 'melody_builder'
+      this.partnerRole = 'rhythm_builder'
+      this.playerPrefix = 'm'
+      this.partnerPrefix = 'r'
+      this.playerPool = cfg.melodyPool
+      this.partnerPool = cfg.rhythmPool
+    } else {
+      this.playerArchetype = 'rhythm_piece'
+      this.partnerArchetype = 'melody_piece'
+      this.playerRole = 'rhythm_builder'
+      this.partnerRole = 'melody_builder'
+      this.playerPrefix = 'r'
+      this.partnerPrefix = 'm'
+      this.playerPool = cfg.rhythmPool
+      this.partnerPool = cfg.melodyPool
+    }
+
+    this.platform = deps.partnerMode === 'platform'
+    this.brain = deps.brain ?? new ScriptedPartnerBrain(cfg.matrix, this.partnerArchetype)
+    this.voice = deps.voice ?? new NullVoice()
+    this.bus = new TriggerBus((t) => this.runPartnerTurn(t), deps.busConfig)
+
+    this.cached = this.build()
+    // Anon tier only: the scripted partner runs on the trigger bus. The opening
+    // greeting goes through the bus too, so it shares the serial guard with
+    // player-driven turns (no session_start bypass, r7 fix); the bus fires
+    // session_start immediately and sets `lastTurn` synchronously so whenIdle()
+    // resolves it. mode② drives the partner from the platform session instead, so
+    // the bus never starts and no scripted turn fires.
+    if (!this.platform) {
+      this.bus.start()
+      this.bus.notify('session_start')
+    }
+  }
+
+  // ---- React binding (useSyncExternalStore) --------------------------------
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  getSnapshot = (): SoundGardenState => this.cached
+
+  // ---- Player actions ------------------------------------------------------
+
+  /** Plant (or replace) the player's piece at a 1-based slot. */
+  plantPlayer(type: PieceType, slot: number): void {
+    if (slot < 1 || slot > this.cfg.slots) return
+    if (!(type in this.playerPool)) return
+    const current = this.placedTypeAt(this.playerPrefix, slot)
+    if (current !== type && this.remainingFor(this.playerPool, this.playerPrefix)[type]! <= 0) {
+      this.setToast(`手里没有更多的${this.label(type)}了`, 'info')
+      this.emit()
+      return
+    }
+    if (current !== null && current !== type) {
+      this.session.performAction(this.playerRole, 'remove_piece', {
+        element_id: elementId(this.playerPrefix, current, slot),
+      })
+    }
+    if (current !== type) {
+      this.session.performAction(this.playerRole, 'place_piece', {
+        element_id: elementId(this.playerPrefix, type, slot),
+      })
+    }
+    this.emitPlacementToast(slot)
+    this.emit()
+    this.notifyBus('player_planted')
+  }
+
+  // ---- Push-to-talk (Round B) ----------------------------------------------
+
+  /** Whether push-to-talk ASR is available (drives mic-chip visibility). */
+  get micAvailable(): boolean {
+    return this.voice.canListen
+  }
+
+  /** Capture one player utterance via the voice driver (UI awaits this). */
+  captureUtterance(): Promise<string> {
+    return this.voice.listen()
+  }
+
+  /** Force-stop an in-flight capture (mic-chip second tap). */
+  stopListening(): void {
+    this.voice.stopListening()
+  }
+
+  /** Hand a captured utterance to the partner (fires a `player_spoke` turn). */
+  submitUtterance(text: string): void {
+    const trimmed = text.trim()
+    if (!trimmed) return
+    this.pendingUtterance = trimmed
+    this.pushChat(trimmed, 'player')
+    this.emit()
+    this.notifyBus('player_spoke')
+  }
+
+  private takePendingUtterance(): string {
+    const utterance = this.pendingUtterance ?? ''
+    this.pendingUtterance = null
+    return utterance
+  }
+
+  /** Remove the player's piece at a 1-based slot. */
+  removePlayer(slot: number): void {
+    const current = this.placedTypeAt(this.playerPrefix, slot)
+    if (current === null) return
+    this.session.performAction(this.playerRole, 'remove_piece', {
+      element_id: elementId(this.playerPrefix, current, slot),
+    })
+    this.setToast(`移走了${this.label(current)}`, 'info')
+    this.emit()
+    this.notifyBus('player_planted')
+  }
+
+  // ---- Partner loop --------------------------------------------------------
+
+  /** One partner turn. Public so tests can drive it without the bus timers. */
+  runPartnerTurn(trigger: PartnerTrigger): Promise<void> {
+    const run = this.doPartnerTurn(trigger)
+    this.lastTurn = run
+    return run
+  }
+
+  /** Fire a board-change trigger to the scripted partner (anon only; no-op in mode②). */
+  private notifyBus(trigger: PartnerTrigger): void {
+    if (!this.platform) this.bus.notify(trigger)
+  }
+
+  /**
+   * Apply the platform partner's co_build moves (mode②). The moves arrive already
+   * shape-/vocabulary-validated by the server parse-guard; they still pass through
+   * the SAME client legality guard the scripted partner uses (lane / range /
+   * material against the live board) before reaching the engine. Illegal moves are
+   * dropped (logged); the partner's speech is handled by the platform voice panel.
+   */
+  applyPartnerActions(actions: PartnerAction[]): void {
+    // Session-version guard: a reply that lands after the run was torn down (level
+    // switch / replay) is dropped — it belongs to a retired session.
+    if (this.disposed || actions.length === 0) return
+    const { legal, dropped } = filterLegalActions(actions, {
+      partnerArchetype: this.partnerArchetype,
+      slots: this.cfg.slots,
+      partnerSlots: this.laneArray(this.partnerPrefix),
+      partnerRemaining: this.remainingFor(this.partnerPool, this.partnerPrefix),
+    })
+    if (dropped.length > 0) {
+      console.warn('[sound-garden] dropped illegal partner actions', dropped)
+    }
+    for (const action of legal) this.applyPartnerAction(action)
+    this.emit()
+  }
+
+  /**
+   * The platform voice session's `getGameState` source (mode②): the manual
+   * sections the partner needs (static: matrix + rules) plus the live board as the
+   * bounded `publicContext` (validated server-side by
+   * `validateSoundGardenVoiceContext`). Pulled by the hook on each speech-start.
+   */
+  voiceGameState(): { relevantSections: string[]; publicContext: BoardSnapshot } {
+    return {
+      relevantSections: ['matrix', 'rules'],
+      publicContext: this.boardSnapshot('player_planted'),
+    }
+  }
+
+  private async doPartnerTurn(trigger: PartnerTrigger): Promise<void> {
+    const wasBloomed = this.session.isWon()
+    const utterance = this.takePendingUtterance()
+    let speech = ''
+    let actions: PartnerAction[] = []
+    try {
+      const reaction = await this.brain.react(this.boardSnapshot(trigger), utterance)
+      speech = reaction.speech
+      actions = reaction.actions
+    } catch (err) {
+      console.warn('[sound-garden] partner brain failed', err)
+    }
+
+    const { legal, dropped } = filterLegalActions(actions, {
+      partnerArchetype: this.partnerArchetype,
+      slots: this.cfg.slots,
+      partnerSlots: this.laneArray(this.partnerPrefix),
+      partnerRemaining: this.remainingFor(this.partnerPool, this.partnerPrefix),
+    })
+    if (dropped.length > 0) {
+      console.warn('[sound-garden] dropped illegal partner actions', dropped)
+    }
+    for (const action of legal) this.applyPartnerAction(action)
+
+    if (speech) this.pushChat(speech)
+    if (!wasBloomed && this.session.isWon()) this.pushChat(BLOOM_LINE)
+    this.emit()
+
+    if (speech) {
+      // Fire-and-forget: the partner's SPEECH is a cosmetic side effect and must
+      // NOT gate the serial trigger bus. Awaiting it here let a hung / never-
+      // resolving `speechSynthesis.speak` (no user gesture, a throttled tab, no
+      // loaded voice) keep the turn `busy` forever — so every later
+      // `player_planted` was held pending and the partner silently stopped
+      // responding. Speaking in the background (each `speak()` cancels the prior)
+      // keeps the partner loop live regardless of TTS state; the turn settles as
+      // soon as the board + chat are applied.
+      void this.voice.speak(speech).catch((err) => {
+        console.warn('[sound-garden] voice.speak failed', err)
+      })
+    }
+  }
+
+  /** Apply one guard-approved partner action, enforcing lane exclusivity. */
+  private applyPartnerAction(action: PartnerAction): void {
+    const el = elementId(this.partnerPrefix, action.pieceType, action.slot)
+    if (action.op === 'remove') {
+      this.session.performAction(this.partnerRole, 'remove_piece', { element_id: el })
+      return
+    }
+    const current = this.placedTypeAt(this.partnerPrefix, action.slot)
+    if (current !== null && current !== action.pieceType) {
+      this.session.performAction(this.partnerRole, 'remove_piece', {
+        element_id: elementId(this.partnerPrefix, current, action.slot),
+      })
+    }
+    if (current !== action.pieceType) {
+      this.session.performAction(this.partnerRole, 'place_piece', { element_id: el })
+    }
+  }
+
+  // ---- Lifecycle -----------------------------------------------------------
+
+  dispose(): void {
+    this.disposed = true
+    this.bus.dispose()
+    this.voice.dispose()
+  }
+
+  /** Test hook: resolves when the last partner turn settles. */
+  whenIdle(): Promise<void> {
+    return this.lastTurn
+  }
+
+  // ---- Derivation (engine is the single source of truth) -------------------
+
+  private laneArray(prefix: 'r' | 'm'): (PieceType | null)[] {
+    const types = prefix === 'r' ? RHYTHM_TYPES : MELODY_TYPES
+    const state = this.session.getState().elements
+    const arr: (PieceType | null)[] = new Array(this.cfg.slots).fill(null)
+    for (let slot = 1; slot <= this.cfg.slots; slot++) {
+      for (const t of types) {
+        if (state[elementId(prefix, t, slot)]?.[PLACEMENT_STATE] === 'placed') {
+          arr[slot - 1] = t
+          break
+        }
+      }
+    }
+    return arr
+  }
+
+  private placedTypeAt(prefix: 'r' | 'm', slot: number): PieceType | null {
+    return this.laneArray(prefix)[slot - 1]
+  }
+
+  private remainingFor(pool: Pool, prefix: 'r' | 'm'): Record<PieceType, number> {
+    const lane = this.laneArray(prefix)
+    const out = {} as Record<PieceType, number>
+    for (const [type, count] of Object.entries(pool)) {
+      const placed = lane.filter((x) => x === type).length
+      out[type as PieceType] = (count ?? 0) - placed
+    }
+    return out
+  }
+
+  private boardSnapshot(trigger: PartnerTrigger): BoardSnapshot {
+    return {
+      slots: this.cfg.slots,
+      melody: this.laneArray('m') as (MelodyType | null)[],
+      rhythm: this.laneArray('r') as (RhythmType | null)[],
+      score: this.session.score() ?? 0,
+      target: this.cfg.target,
+      bloomed: this.session.isWon(),
+      partnerRemaining: this.remainingFor(this.partnerPool, this.partnerPrefix),
+      playerRemaining: this.remainingFor(this.playerPool, this.playerPrefix),
+      partnerArchetype: this.partnerArchetype,
+      trigger,
+    }
+  }
+
+  // ---- Presentation helpers ------------------------------------------------
+
+  private label(type: PieceType): string {
+    return PIECE_META[type].label
+  }
+
+  private emitPlacementToast(slot: number): void {
+    const melody = this.laneArray('m')[slot - 1] as MelodyType | null
+    const rhythm = this.laneArray('r')[slot - 1] as RhythmType | null
+    if (melody && rhythm) {
+      const relation = this.cfg.matrix[rhythm][melody]
+      const score = RELATION_SCORES[relation]
+      const text = `第${slot}拍 · ${RELATION_FEEDBACK[relation].text} ${score >= 0 ? '+' : ''}${score}`
+      this.setToast(text, relation)
+    } else {
+      this.setToast('独自生长——配上另一侧才会共鸣', 'info')
+    }
+  }
+
+  private setToast(text: string, tone: RelationName | 'info'): void {
+    this.toastSeq += 1
+    this.toast = { seq: this.toastSeq, text, tone }
+  }
+
+  private pushChat(text: string, speaker: 'partner' | 'player' = 'partner'): void {
+    this.chatSeq += 1
+    this.chatLines = [...this.chatLines, { seq: this.chatSeq, text, speaker }].slice(-6)
+  }
+
+  private build(): SoundGardenState {
+    const bloomed = this.session.isWon()
+    // First-bloom settlement latch: once won, `settled` stays true for the run's
+    // lifetime — a later score dip never un-settles it (only a remount resets it).
+    if (bloomed) this.settled = true
+    const melody = this.laneArray('m') as (MelodyType | null)[]
+    const rhythm = this.laneArray('r') as (RhythmType | null)[]
+    const relations = melody.map((m, i) => {
+      const r = rhythm[i]
+      return m && r ? this.cfg.matrix[r][m] : null
+    })
+    const remaining = this.remainingFor(this.playerPool, this.playerPrefix)
+    const paletteTypes = this.playerPrefix === 'm' ? MELODY_TYPES : RHYTHM_TYPES
+    const palette = paletteTypes
+      .filter((t) => t in this.playerPool)
+      .map((t) => ({ type: t as PieceType, remaining: remaining[t] ?? 0 }))
+    return {
+      levelId: this.cfg.id,
+      levelIndex: this.cfg.index,
+      levelName: this.cfg.name,
+      levelSubtitle: this.cfg.subtitle,
+      slots: this.cfg.slots,
+      target: this.cfg.target,
+      score: this.session.score() ?? 0,
+      bloomed,
+      settled: this.settled,
+      playerSide: this.side,
+      playerArchetype: this.playerArchetype,
+      partnerArchetype: this.partnerArchetype,
+      melody,
+      rhythm,
+      relations,
+      palette,
+      chat: this.chatLines,
+      toast: this.toast,
+    }
+  }
+
+  private emit(): void {
+    this.cached = this.build()
+    for (const listener of this.listeners) listener()
+  }
+}

--- a/packages/game-sound-garden/src/game/types.ts
+++ b/packages/game-sound-garden/src/game/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Presentation-layer types for the Sound Garden probe.
+ *
+ * These sit ABOVE the creation engine: the engine knows nothing about
+ * scarcity, slot exclusivity, or sides — those are all presentation concerns
+ * (L2 arch note A4 / F1 / F2). The engine only sees the Level that build_level
+ * produces from a LevelConfig.
+ */
+
+import type { MelodyType, PieceType, RhythmType } from './constants'
+
+export type RelationName = 'synergy' | 'compatible' | 'neutral' | 'incompatible'
+
+/** rhythm_type → melody_type → relation. Each level supplies its own. */
+export type HarmonyMatrix = Record<RhythmType, Record<MelodyType, RelationName>>
+
+/** Which archetype the PLAYER controls. Partner takes the other (side-swap). */
+export type Side = 'melody' | 'rhythm'
+
+export type Archetype = 'melody_piece' | 'rhythm_piece'
+export type Role = 'melody_builder' | 'rhythm_builder'
+
+/** A per-type material pool (presentation-owned scarcity — engine-inert). */
+export type Pool = Partial<Record<PieceType, number>>
+
+export interface LevelConfig {
+  id: string
+  /** 1-based level number. */
+  index: number
+  /** Short Chinese name, e.g. 学步 / 取舍 / 荆棘. */
+  name: string
+  subtitle: string
+  slots: number
+  /** score_threshold win target. */
+  target: number
+  matrix: HarmonyMatrix
+  /** Material pool for the MELODY lane (whoever controls it). Lane-scoped, not player-scoped. */
+  melodyPool: Pool
+  /** Material pool for the RHYTHM lane (whoever controls it). Lane-scoped, not player-scoped. */
+  rhythmPool: Pool
+  /** One-line tension description surfaced on the level card. */
+  tension: string
+}
+
+/** Immutable board view handed to the partner brain each turn. */
+export interface BoardSnapshot {
+  slots: number
+  /** melody[slotIndex] = melody type placed there, or null. slotIndex is 0-based. */
+  melody: (MelodyType | null)[]
+  rhythm: (RhythmType | null)[]
+  score: number
+  target: number
+  bloomed: boolean
+  /** Remaining counts for the partner's own pool (its scarcity). */
+  partnerRemaining: Pool
+  /** Remaining counts for the player's pool (visible to the partner). */
+  playerRemaining: Pool
+  /** Which archetype the partner controls this session. */
+  partnerArchetype: Archetype
+  trigger: PartnerTrigger
+}
+
+export type PartnerTrigger = 'session_start' | 'player_planted' | 'player_spoke' | 'idle'
+
+/** A single partner move. `slot` is 1-based (matches timeline_slot). */
+export interface PartnerAction {
+  op: 'place' | 'remove'
+  pieceType: PieceType
+  slot: number
+}
+
+export interface PartnerReaction {
+  speech: string
+  actions: PartnerAction[]
+}
+
+/** One chat line in the partner strip. */
+export interface ChatLine {
+  seq: number
+  text: string
+  speaker: 'partner' | 'player'
+}

--- a/packages/game-sound-garden/src/main.tsx
+++ b/packages/game-sound-garden/src/main.tsx
@@ -1,0 +1,10 @@
+import { createRoot } from 'react-dom/client'
+import { App } from './App'
+// Atlas platform shell (cosmic bg + text/border/semantic tokens) FIRST, then the
+// game's registered accent layer, then the game styles that consume both.
+import '@amiclaw/ui/styles/tokens.css'
+import '@amiclaw/ui/styles/animations.css'
+import './styles/tokens.css'
+import './styles/sound-garden.css'
+
+createRoot(document.getElementById('root') as HTMLElement).render(<App />)

--- a/packages/game-sound-garden/src/partner/brain.test.ts
+++ b/packages/game-sound-garden/src/partner/brain.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { ScriptedPartnerBrain } from './brain'
+import { levelByIndex } from '../game/levels'
+import type { BoardSnapshot } from '../game/types'
+
+function snapshot(overrides: Partial<BoardSnapshot>): BoardSnapshot {
+  return {
+    slots: 8,
+    melody: new Array(8).fill(null),
+    rhythm: new Array(8).fill(null),
+    score: 0,
+    target: 8,
+    bloomed: false,
+    partnerRemaining: { kick: 1, snare: 1, hihat: 1, clap: 1 },
+    playerRemaining: { bell: 2, chime: 2, flute: 2, harp: 2 },
+    partnerArchetype: 'rhythm_piece',
+    trigger: 'player_planted',
+    ...overrides,
+  }
+}
+
+const lv1 = levelByIndex(1)!
+const lv3 = levelByIndex(3)!
+
+describe('ScriptedPartnerBrain', () => {
+  // --- Anon opening move pre-seed (PR-2, r13 followup) ----------------------
+
+  it('session_start yields exactly one greeting line', async () => {
+    const brain = new ScriptedPartnerBrain(lv1.matrix, 'rhythm_piece')
+    const r = await brain.react(snapshot({ trigger: 'session_start' }))
+    expect(r.speech.length).toBeGreaterThan(0)
+  })
+
+  it('session_start applies exactly one legal opening place', async () => {
+    const brain = new ScriptedPartnerBrain(lv1.matrix, 'rhythm_piece')
+    const r = await brain.react(snapshot({ trigger: 'session_start' }))
+    expect(r.actions).toHaveLength(1)
+    expect(r.actions[0].op).toBe('place')
+    // The opening piece is from the partner's own lane (rhythm), on a valid slot,
+    // and material the partner actually has.
+    expect(['kick', 'snare', 'hihat', 'clap']).toContain(r.actions[0].pieceType)
+    expect(r.actions[0].slot).toBeGreaterThanOrEqual(1)
+    expect(r.actions[0].slot).toBeLessThanOrEqual(8)
+  })
+
+  it('the opening move is deterministic (highest-synergy-potential piece on slot 1)', async () => {
+    const brain = new ScriptedPartnerBrain(lv1.matrix, 'rhythm_piece')
+    const r = await brain.react(snapshot({ trigger: 'session_start' }))
+    // Lv1: kick synergizes with bell; kick has the best potential of the rhythm lane.
+    expect(r.actions[0]).toEqual({ op: 'place', pieceType: 'kick', slot: 1 })
+  })
+
+  it('a later player_planted / player_spoke trigger never re-emits the opening move', async () => {
+    const brain = new ScriptedPartnerBrain(lv1.matrix, 'rhythm_piece')
+    await brain.react(snapshot({ trigger: 'session_start' }))
+    // A later trigger with no player pieces on the board plans nothing (the opening
+    // is not re-emitted — the pre-seed branch is trigger-gated to session_start).
+    for (const trigger of ['player_planted', 'player_spoke'] as const) {
+      const r = await brain.react(snapshot({ trigger }))
+      expect(r.actions).toHaveLength(0)
+    }
+  })
+
+  it('session_start with no partner material yields a greeting and no action', async () => {
+    const brain = new ScriptedPartnerBrain(lv1.matrix, 'rhythm_piece')
+    const r = await brain.react(
+      snapshot({
+        trigger: 'session_start',
+        partnerRemaining: { kick: 0, snare: 0, hihat: 0, clap: 0 },
+      })
+    )
+    expect(r.speech.length).toBeGreaterThan(0)
+    expect(r.actions).toHaveLength(0)
+  })
+
+  it('lays the synergy rhythm under a planted melody', async () => {
+    const brain = new ScriptedPartnerBrain(lv1.matrix, 'rhythm_piece')
+    const board = snapshot({ melody: ['bell', ...new Array(7).fill(null)] })
+    const r = await brain.react(board)
+    expect(r.actions).toEqual([{ op: 'place', pieceType: 'kick', slot: 1 }]) // kick×bell synergy
+  })
+
+  it('avoids incompatible traps (Lv3 matrix)', async () => {
+    const brain = new ScriptedPartnerBrain(lv3.matrix, 'rhythm_piece')
+    // In Lv3, snare×bell and clap×bell are incompatible; kick×bell is synergy.
+    const board = snapshot({
+      melody: ['bell', ...new Array(7).fill(null)],
+      partnerRemaining: { kick: 1, snare: 1, hihat: 1, clap: 2 },
+    })
+    const r = await brain.react(board)
+    expect(r.actions[0]).toEqual({ op: 'place', pieceType: 'kick', slot: 1 })
+  })
+
+  it('swaps away a trap it can improve on', async () => {
+    const brain = new ScriptedPartnerBrain(lv3.matrix, 'rhythm_piece')
+    // snare sits under bell (incompatible -1); kick (synergy) is available.
+    const board = snapshot({
+      melody: ['bell', ...new Array(7).fill(null)],
+      rhythm: ['snare', ...new Array(7).fill(null)],
+      partnerRemaining: { kick: 1, snare: 0, hihat: 1, clap: 2 },
+    })
+    const r = await brain.react(board)
+    expect(r.actions).toEqual([
+      { op: 'remove', pieceType: 'snare', slot: 1 },
+      { op: 'place', pieceType: 'kick', slot: 1 },
+    ])
+  })
+
+  it('works when swapped to the melody side', async () => {
+    const brain = new ScriptedPartnerBrain(lv1.matrix, 'melody_piece')
+    const board = snapshot({
+      partnerArchetype: 'melody_piece',
+      rhythm: ['kick', ...new Array(7).fill(null)],
+      partnerRemaining: { bell: 1, chime: 1, flute: 1, harp: 1 },
+    })
+    const r = await brain.react(board)
+    expect(r.actions[0]).toEqual({ op: 'place', pieceType: 'bell', slot: 1 }) // kick×bell synergy
+  })
+})

--- a/packages/game-sound-garden/src/partner/brain.ts
+++ b/packages/game-sound-garden/src/partner/brain.ts
@@ -1,0 +1,233 @@
+/**
+ * Partner brain seam (L2 arch note B3 / B5).
+ *
+ * `PartnerBrain` is the one interface the game loop depends on. Round A ships
+ * `ScriptedPartnerBrain` — a fully offline collaborator that holds the level's
+ * harmony matrix (the player never sees it) and lays synergizing pieces on the
+ * player's slots while avoiding the traps. Round B adds an `HttpPartnerBrain`
+ * that POSTs the same snapshot to `/api/partner` (DeepSeek) and returns the
+ * same `{speech, actions[]}` shape — a drop-in behind this interface.
+ *
+ * The brain PROPOSES actions; the legality guard (legality.ts) validates them
+ * against the live board before they reach the engine. The brain simulates its
+ * own remaining pool while planning so its proposals are usually already legal.
+ */
+
+import { MELODY_TYPES, RELATION_SCORES, RHYTHM_TYPES } from '../game/constants'
+import type { MelodyType, PieceType, RhythmType } from '../game/constants'
+import type {
+  Archetype,
+  BoardSnapshot,
+  HarmonyMatrix,
+  PartnerAction,
+  PartnerReaction,
+  Pool,
+  RelationName,
+} from '../game/types'
+
+export interface PartnerBrain {
+  react(snapshot: BoardSnapshot, utterance?: string): Promise<PartnerReaction>
+}
+
+interface Lines {
+  greeting: string
+  praise: string[]
+  gentle: string[]
+  fix: string[]
+  observe: string[]
+  idle: string[]
+}
+
+export class ScriptedPartnerBrain implements PartnerBrain {
+  private readonly matrix: HarmonyMatrix
+  private readonly partnerArchetype: Archetype
+  private readonly valid: readonly PieceType[]
+  private readonly lines: Lines
+  private turn = 0
+
+  constructor(matrix: HarmonyMatrix, partnerArchetype: Archetype) {
+    this.matrix = matrix
+    this.partnerArchetype = partnerArchetype
+    this.valid = partnerArchetype === 'rhythm_piece' ? RHYTHM_TYPES : MELODY_TYPES
+    this.lines = buildLines(partnerArchetype)
+  }
+
+  async react(snapshot: BoardSnapshot, _utterance?: string): Promise<PartnerReaction> {
+    this.turn += 1
+    if (snapshot.trigger === 'session_start') {
+      // Anon-tier opening move (PR-2): unlike mode②, the anon scripted partner has
+      // no AI-first greeting turn, so the opening is built here. Return the greeting
+      // AND exactly one legal opening `place` — the partner-lane piece with the best
+      // synergy potential, on the first empty slot — so the player always starts with
+      // something to build against. The store applies it through `filterLegalActions`;
+      // this branch is trigger-gated, so a later `player_planted` / `player_spoke`
+      // never re-emits it.
+      const opening = this.pickOpeningMove(snapshot)
+      return { speech: this.lines.greeting, actions: opening ? [opening] : [] }
+    }
+
+    const playerLane = this.partnerArchetype === 'rhythm_piece' ? snapshot.melody : snapshot.rhythm
+    const partnerLane = this.partnerArchetype === 'rhythm_piece' ? snapshot.rhythm : snapshot.melody
+    const remaining: Pool = { ...snapshot.partnerRemaining }
+    const partnerSlots: (PieceType | null)[] = [...partnerLane]
+
+    const actions: PartnerAction[] = []
+    let bestPlacedRelation: RelationName | null = null
+    let fixedTrap = false
+
+    for (let i = 0; i < snapshot.slots; i++) {
+      const playerType = playerLane[i]
+      if (!playerType) continue
+      const current = partnerSlots[i]
+      const plan = this.planSlot(playerType, current, remaining)
+      if (plan.kind === 'none') continue
+
+      if (current !== null && (plan.kind === 'swap' || plan.kind === 'remove')) {
+        if (this.relationOf(current, playerType) === 'incompatible') fixedTrap = true
+        actions.push({ op: 'remove', pieceType: current, slot: i + 1 })
+        remaining[current] = (remaining[current] ?? 0) + 1
+        partnerSlots[i] = null
+      }
+      if (plan.kind === 'place' || plan.kind === 'swap') {
+        actions.push({ op: 'place', pieceType: plan.type, slot: i + 1 })
+        remaining[plan.type] = (remaining[plan.type] ?? 0) - 1
+        partnerSlots[i] = plan.type
+        const rel = this.relationOf(plan.type, playerType)
+        if (
+          bestPlacedRelation === null ||
+          RELATION_SCORES[rel] > RELATION_SCORES[bestPlacedRelation]
+        ) {
+          bestPlacedRelation = rel
+        }
+      }
+    }
+
+    return { speech: this.pickSpeech(snapshot.trigger, bestPlacedRelation, fixedTrap), actions }
+  }
+
+  /**
+   * Pick the anon opening move: the partner-lane piece with the highest synergy
+   * POTENTIAL (its best relation over every opposite-lane type), placed on the
+   * first empty partner slot. Deterministic — ties break by `this.valid` order and
+   * the lowest empty slot. Returns null if the partner has no material / no slot.
+   */
+  private pickOpeningMove(snapshot: BoardSnapshot): PartnerAction | null {
+    const partnerLane = this.partnerArchetype === 'rhythm_piece' ? snapshot.rhythm : snapshot.melody
+    const opposite = this.partnerArchetype === 'rhythm_piece' ? MELODY_TYPES : RHYTHM_TYPES
+    let slot = -1
+    for (let i = 0; i < snapshot.slots; i++) {
+      if (partnerLane[i] === null) {
+        slot = i + 1
+        break
+      }
+    }
+    if (slot === -1) return null
+    let bestType: PieceType | null = null
+    let bestScore = Number.NEGATIVE_INFINITY
+    for (const type of this.valid) {
+      if ((snapshot.partnerRemaining[type] ?? 0) <= 0) continue
+      let potential = Number.NEGATIVE_INFINITY
+      for (const opp of opposite) {
+        potential = Math.max(potential, RELATION_SCORES[this.relationOf(type, opp as PieceType)])
+      }
+      if (potential > bestScore) {
+        bestScore = potential
+        bestType = type
+      }
+    }
+    if (bestType === null) return null
+    return { op: 'place', pieceType: bestType, slot }
+  }
+
+  /** Best move for one player-occupied slot: keep, swap, place, or clear a trap. */
+  private planSlot(
+    playerType: PieceType,
+    current: PieceType | null,
+    remaining: Pool
+  ):
+    | { kind: 'none' }
+    | { kind: 'place'; type: PieceType }
+    | { kind: 'swap'; type: PieceType }
+    | { kind: 'remove' } {
+    const currentScore =
+      current !== null ? RELATION_SCORES[this.relationOf(current, playerType)] : 0
+    // Candidate = any type still in the pool, or the piece already here.
+    let bestType: PieceType | null = null
+    let bestScore = currentScore
+    for (const type of this.valid) {
+      const available = (remaining[type] ?? 0) > 0 || type === current
+      if (!available) continue
+      const score = RELATION_SCORES[this.relationOf(type, playerType)]
+      if (score > bestScore) {
+        bestScore = score
+        bestType = type
+      }
+    }
+    // Leaving the slot empty scores 0 — clear a trap the pool can't improve on.
+    if (bestScore < 0 && current !== null) return { kind: 'remove' }
+    if (bestType === null || bestType === current) return { kind: 'none' }
+    return { kind: current === null ? 'place' : 'swap', type: bestType }
+  }
+
+  private relationOf(partnerType: PieceType, playerType: PieceType): RelationName {
+    const rhythm = (
+      this.partnerArchetype === 'rhythm_piece' ? partnerType : playerType
+    ) as RhythmType
+    const melody = (
+      this.partnerArchetype === 'rhythm_piece' ? playerType : partnerType
+    ) as MelodyType
+    return this.matrix[rhythm][melody]
+  }
+
+  private pickSpeech(
+    trigger: BoardSnapshot['trigger'],
+    bestRelation: RelationName | null,
+    fixedTrap: boolean
+  ): string {
+    if (trigger === 'idle') return rotate(this.lines.idle, this.turn)
+    if (fixedTrap) return rotate(this.lines.fix, this.turn)
+    if (bestRelation === 'synergy') return rotate(this.lines.praise, this.turn)
+    if (bestRelation === 'compatible' || bestRelation === 'neutral') {
+      return rotate(this.lines.gentle, this.turn)
+    }
+    return rotate(this.lines.observe, this.turn)
+  }
+}
+
+function rotate(pool: string[], turn: number): string {
+  return pool[turn % pool.length]
+}
+
+function buildLines(partnerArchetype: Archetype): Lines {
+  const partnerIsRhythm = partnerArchetype === 'rhythm_piece'
+  const playerNoun = partnerIsRhythm ? '旋律花' : '节奏根'
+  const partnerNoun = partnerIsRhythm ? '节奏根' : '旋律花'
+  return {
+    greeting: `我是你的园丁伙伴。你在时间线上种下${playerNoun}，我就在同一拍为它铺一层最合适的${partnerNoun}——一起让花园唱起来。`,
+    praise: [
+      '这一拍共鸣了，听见了吗？两株缠在一起唱。',
+      '漂亮，正是我想配的那株。花园亮了一格。',
+      '就是这个搭配——再来几拍就绽放了。',
+    ],
+    gentle: [
+      '和上了，但还差点火候。换一株也许更亮。',
+      '能长，先记着这拍，回头也许能更响。',
+      '嗯，稳稳地长着。我们慢慢凑齐更好的。',
+    ],
+    fix: [
+      '这两株有点吵，我换了根节奏压住它。',
+      '刚才那拍刺耳，我给它挪了个更配的。',
+      '别急，我把打架的那根换掉了，好多了。',
+    ],
+    observe: [
+      '我先听听这一拍，暂时没有更好的根可配。',
+      '手里的材料用得差不多了，挑着来。',
+      '这拍先留着，等你再种一株我好接。',
+    ],
+    idle: [
+      '还有空着的拍子，试试在那儿种一株？',
+      '别停，多种几株，绽放就在眼前。',
+      '想听哪种搭配？种下去我们一起试。',
+    ],
+  }
+}

--- a/packages/game-sound-garden/src/partner/legality.test.ts
+++ b/packages/game-sound-garden/src/partner/legality.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { filterLegalActions } from './legality'
+import type { LegalityContext } from './legality'
+import type { PartnerAction } from '../game/types'
+
+function ctx(overrides: Partial<LegalityContext> = {}): LegalityContext {
+  return {
+    partnerArchetype: 'rhythm_piece',
+    slots: 8,
+    partnerSlots: new Array(8).fill(null),
+    partnerRemaining: { kick: 1, snare: 1, hihat: 1, clap: 1 },
+    ...overrides,
+  }
+}
+
+describe('filterLegalActions', () => {
+  it('accepts a legal place', () => {
+    const { legal, dropped } = filterLegalActions(
+      [{ op: 'place', pieceType: 'kick', slot: 1 }],
+      ctx()
+    )
+    expect(legal).toHaveLength(1)
+    expect(dropped).toHaveLength(0)
+  })
+
+  it('drops a wrong-archetype piece', () => {
+    const actions: PartnerAction[] = [{ op: 'place', pieceType: 'bell', slot: 1 }]
+    const { legal, dropped } = filterLegalActions(actions, ctx())
+    expect(legal).toHaveLength(0)
+    expect(dropped[0].reason).toContain('not a rhythm_piece')
+  })
+
+  it('drops an out-of-range slot', () => {
+    const { legal } = filterLegalActions([{ op: 'place', pieceType: 'kick', slot: 99 }], ctx())
+    expect(legal).toHaveLength(0)
+  })
+
+  it('drops a place with no piece left', () => {
+    const c = ctx({ partnerRemaining: { kick: 0, snare: 1, hihat: 1, clap: 1 } })
+    const { legal, dropped } = filterLegalActions([{ op: 'place', pieceType: 'kick', slot: 1 }], c)
+    expect(legal).toHaveLength(0)
+    expect(dropped[0].reason).toContain('no kick left')
+  })
+
+  it('drops a remove on an empty slot', () => {
+    const { legal, dropped } = filterLegalActions(
+      [{ op: 'remove', pieceType: 'kick', slot: 3 }],
+      ctx()
+    )
+    expect(legal).toHaveLength(0)
+    expect(dropped[0].reason).toContain('nothing to remove')
+  })
+
+  it('sequentially exhausts the pool across actions', () => {
+    const c = ctx({ partnerRemaining: { kick: 1, snare: 0, hihat: 0, clap: 0 } })
+    const actions: PartnerAction[] = [
+      { op: 'place', pieceType: 'kick', slot: 1 },
+      { op: 'place', pieceType: 'kick', slot: 2 }, // no kick left after the first
+    ]
+    const { legal, dropped } = filterLegalActions(actions, c)
+    expect(legal).toHaveLength(1)
+    expect(dropped).toHaveLength(1)
+  })
+
+  it('allows a swap (remove then place) freeing the displaced count', () => {
+    const c = ctx({
+      partnerSlots: ['snare', ...new Array(7).fill(null)],
+      partnerRemaining: { kick: 1, snare: 0, hihat: 0, clap: 0 },
+    })
+    const actions: PartnerAction[] = [
+      { op: 'remove', pieceType: 'snare', slot: 1 },
+      { op: 'place', pieceType: 'kick', slot: 1 },
+    ]
+    const { legal, dropped } = filterLegalActions(actions, c)
+    expect(legal).toHaveLength(2)
+    expect(dropped).toHaveLength(0)
+  })
+
+  it('drops a forged remove whose pieceType is not the slot occupant (r14)', () => {
+    const c = ctx({
+      partnerSlots: ['kick', ...new Array(7).fill(null)],
+      partnerRemaining: { kick: 0, snare: 1, hihat: 1, clap: 1 },
+    })
+    // slot 1 holds kick, not snare — this must be rejected, not silently
+    // restoring kick's count for a later place to duplicate.
+    const { legal, dropped } = filterLegalActions(
+      [{ op: 'remove', pieceType: 'snare', slot: 1 }],
+      c
+    )
+    expect(legal).toHaveLength(0)
+    expect(dropped[0].reason).toContain('does not match kick')
+  })
+
+  it('a forged remove cannot free a count for a following place (r14)', () => {
+    const c = ctx({
+      partnerSlots: ['kick', ...new Array(7).fill(null)],
+      partnerRemaining: { kick: 0, snare: 1, hihat: 1, clap: 1 },
+    })
+    const actions: PartnerAction[] = [
+      { op: 'remove', pieceType: 'snare', slot: 1 }, // forged (slot 1 = kick)
+      { op: 'place', pieceType: 'kick', slot: 3 }, // would duplicate the single kick
+    ]
+    const { legal, dropped } = filterLegalActions(actions, c)
+    expect(legal).toHaveLength(0) // both dropped: forged remove, then no kick left
+    expect(dropped).toHaveLength(2)
+  })
+})

--- a/packages/game-sound-garden/src/partner/legality.ts
+++ b/packages/game-sound-garden/src/partner/legality.ts
@@ -1,0 +1,100 @@
+/**
+ * Partner action legality guard (L2 arch note B5, risk #1).
+ *
+ * A partner brain — scripted now, an LLM in Round B — can propose illegal or
+ * hallucinated moves: a piece on an occupied-by-itself slot, a piece it has run
+ * out of, a wrong-archetype type, an out-of-range slot, or a remove on an empty
+ * slot. This guard validates each proposed action against the live board BEFORE
+ * it reaches `performAction`, dropping the illegal ones (the caller logs them).
+ *
+ * Actions are validated SEQUENTIALLY against a working copy of the board so a
+ * place that consumes the partner's last piece correctly invalidates a later
+ * place of the same type in the same reaction.
+ */
+
+import { MELODY_TYPES, RHYTHM_TYPES } from '../game/constants'
+import type { PieceType } from '../game/constants'
+import type { Archetype, PartnerAction, Pool } from '../game/types'
+
+export interface LegalityContext {
+  partnerArchetype: Archetype
+  slots: number
+  /** Partner's current lane occupancy, 0-based by slot index (type or null). */
+  partnerSlots: (PieceType | null)[]
+  /** Partner's remaining per-type pool. */
+  partnerRemaining: Pool
+}
+
+export interface DroppedAction {
+  action: PartnerAction
+  reason: string
+}
+
+export interface GuardResult {
+  legal: PartnerAction[]
+  dropped: DroppedAction[]
+}
+
+function validTypesFor(archetype: Archetype): readonly PieceType[] {
+  return archetype === 'rhythm_piece' ? RHYTHM_TYPES : MELODY_TYPES
+}
+
+/** Validate + sequentially simulate a partner reaction's actions. */
+export function filterLegalActions(actions: PartnerAction[], ctx: LegalityContext): GuardResult {
+  const legal: PartnerAction[] = []
+  const dropped: DroppedAction[] = []
+  const valid = validTypesFor(ctx.partnerArchetype)
+  // Working copies mutated as legal actions are accepted.
+  const slots = [...ctx.partnerSlots]
+  const remaining: Pool = { ...ctx.partnerRemaining }
+
+  for (const action of actions) {
+    const idx = action.slot - 1
+    if (!valid.includes(action.pieceType)) {
+      dropped.push({ action, reason: `${action.pieceType} is not a ${ctx.partnerArchetype}` })
+      continue
+    }
+    if (action.slot < 1 || action.slot > ctx.slots) {
+      dropped.push({ action, reason: `slot ${action.slot} out of range` })
+      continue
+    }
+    if (action.op === 'remove') {
+      if (slots[idx] === null) {
+        dropped.push({ action, reason: `nothing to remove at slot ${action.slot}` })
+        continue
+      }
+      // The remove's pieceType MUST match the real occupant. A forged type
+      // would restore the wrong material count here while the store's remove
+      // no-ops a non-placed element — leaving the real piece in place and its
+      // count phantom-freed for a later place to duplicate. Reject-with-log.
+      if (slots[idx] !== action.pieceType) {
+        dropped.push({
+          action,
+          reason: `remove ${action.pieceType} does not match ${slots[idx]} at slot ${action.slot}`,
+        })
+        continue
+      }
+      remaining[action.pieceType] = (remaining[action.pieceType] ?? 0) + 1
+      slots[idx] = null
+      legal.push(action)
+      continue
+    }
+    // op === 'place'
+    if (slots[idx] === action.pieceType) {
+      dropped.push({ action, reason: `${action.pieceType} already at slot ${action.slot}` })
+      continue
+    }
+    if ((remaining[action.pieceType] ?? 0) <= 0) {
+      dropped.push({ action, reason: `no ${action.pieceType} left in pool` })
+      continue
+    }
+    // Replacement restores the displaced piece's count.
+    const displaced = slots[idx]
+    if (displaced !== null) remaining[displaced] = (remaining[displaced] ?? 0) + 1
+    remaining[action.pieceType] = (remaining[action.pieceType] ?? 0) - 1
+    slots[idx] = action.pieceType
+    legal.push(action)
+  }
+
+  return { legal, dropped }
+}

--- a/packages/game-sound-garden/src/partner/trigger-bus.test.ts
+++ b/packages/game-sound-garden/src/partner/trigger-bus.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { TriggerBus } from './trigger-bus'
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('TriggerBus', () => {
+  it('serializes overlapping triggers, including session_start (r7 fix)', async () => {
+    let active = 0
+    let maxActive = 0
+    let calls = 0
+    const runner = async () => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      calls += 1
+      await delay(20)
+      active -= 1
+    }
+    const bus = new TriggerBus(runner, { debounceMs: 0, idleMs: 1_000_000 })
+    bus.notify('session_start') // fires immediately
+    bus.notify('session_start') // arrives while busy → held pending
+    await delay(80)
+    bus.dispose()
+    expect(calls).toBe(2)
+    expect(maxActive).toBe(1) // never two partner turns at once
+  })
+
+  it('debounces a flurry of player actions into one reaction', async () => {
+    let calls = 0
+    const bus = new TriggerBus(
+      async () => {
+        calls += 1
+      },
+      { debounceMs: 20, idleMs: 1_000_000 }
+    )
+    bus.notify('player_planted')
+    bus.notify('player_planted')
+    bus.notify('player_planted')
+    await delay(60)
+    bus.dispose()
+    expect(calls).toBe(1)
+  })
+})

--- a/packages/game-sound-garden/src/partner/trigger-bus.ts
+++ b/packages/game-sound-garden/src/partner/trigger-bus.ts
@@ -1,0 +1,90 @@
+/**
+ * Partner reaction trigger bus (L2 arch note B3).
+ *
+ * Under free-flow play the partner reacts on three triggers, all funneled
+ * through one serial guard so at most one partner turn is ever in flight:
+ *   1. player action — debounced (~600ms) so a flurry of clicks yields ONE
+ *      reaction;
+ *   2. player speech utterance-end (Round B; Web Speech `onend`);
+ *   3. idle (~8s of no activity → an unprompted nudge).
+ *
+ * If a trigger arrives while a partner turn is running it is held and replayed
+ * once the turn finishes (single-flight with one pending slot), so the last
+ * player action is never dropped.
+ */
+
+import type { PartnerTrigger } from '../game/types'
+
+type Timer = ReturnType<typeof setTimeout>
+type Runner = (trigger: PartnerTrigger) => Promise<void>
+
+export interface TriggerBusConfig {
+  debounceMs?: number
+  idleMs?: number
+}
+
+export class TriggerBus {
+  private readonly runner: Runner
+  private readonly debounceMs: number
+  private readonly idleMs: number
+  private busy = false
+  private pending: PartnerTrigger | null = null
+  private debounceTimer: Timer | null = null
+  private idleTimer: Timer | null = null
+  private disposed = false
+
+  constructor(runner: Runner, config: TriggerBusConfig = {}) {
+    this.runner = runner
+    this.debounceMs = config.debounceMs ?? 600
+    this.idleMs = config.idleMs ?? 8000
+  }
+
+  /** Begin the idle countdown (call once the session board is ready). */
+  start(): void {
+    this.armIdle()
+  }
+
+  notify(trigger: PartnerTrigger): void {
+    if (this.disposed) return
+    this.armIdle()
+    if (trigger === 'session_start' || trigger === 'player_spoke') {
+      void this.fire(trigger)
+      return
+    }
+    // player_planted → debounce so rapid plants coalesce into one reaction.
+    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    this.debounceTimer = setTimeout(() => void this.fire('player_planted'), this.debounceMs)
+  }
+
+  dispose(): void {
+    this.disposed = true
+    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    if (this.idleTimer) clearTimeout(this.idleTimer)
+  }
+
+  private armIdle(): void {
+    if (this.idleTimer) clearTimeout(this.idleTimer)
+    if (this.disposed) return
+    this.idleTimer = setTimeout(() => void this.fire('idle'), this.idleMs)
+  }
+
+  private async fire(trigger: PartnerTrigger): Promise<void> {
+    if (this.disposed) return
+    if (this.busy) {
+      this.pending = trigger
+      return
+    }
+    this.busy = true
+    try {
+      await this.runner(trigger)
+    } finally {
+      this.busy = false
+      if (!this.disposed) {
+        this.armIdle()
+        const next = this.pending
+        this.pending = null
+        if (next) void this.fire(next)
+      }
+    }
+  }
+}

--- a/packages/game-sound-garden/src/styles/sound-garden.css
+++ b/packages/game-sound-garden/src/styles/sound-garden.css
@@ -1,0 +1,940 @@
+/* ============================================================
+   Sound Garden — playable probe styles.
+   Dark-only by design (no light mode). CSS-only animation (no JS
+   animation libs). Mobile-first, works at 375px; tap targets >= 44px.
+   Garden visual language lifted from the validated rough-cut.
+   ============================================================ */
+
+/* Chrome + relation semantics source from Atlas / the registered game accents in
+   tokens.css (no bespoke chrome hex here). The legacy var names are kept as thin
+   aliases so the rules below stay untouched — values now flow from platform
+   tokens (chrome) + the game's registered palette (piece / harmony hues). */
+:root {
+  --bg: var(--bg-grad-start);
+  --bg2: var(--bg-grad-mid-2);
+  --panel: var(--sg-surface);
+  --panel2: var(--sg-surface-2);
+  --line: var(--sg-line);
+  --ink: var(--sg-ink);
+  --ink-dim: var(--sg-ink-dim);
+  --melody: var(--sg-melody);
+  --melody2: var(--sg-melody-2);
+  --rhythm: var(--sg-rhythm);
+  --green: var(--sg-bloom);
+  --synergy: var(--sg-synergy);
+  --compat: var(--sg-compat);
+  --neutral: var(--sg-neutral);
+  --harsh: var(--sg-harsh);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: linear-gradient(180deg, var(--bg) 0%, var(--bg2) 100%);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+button {
+  font-family: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.sg-app {
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 14px 12px 32px;
+  position: relative;
+  min-height: 100vh;
+}
+
+/* ---------- header ---------- */
+.sg-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.sg-icon-btn {
+  flex: 0 0 auto;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  font-size: 20px;
+  line-height: 1;
+}
+.sg-icon-btn:active {
+  transform: scale(0.95);
+}
+.sg-titlewrap {
+  flex: 1 1 auto;
+  text-align: center;
+}
+.sg-title {
+  font-size: 16px;
+  font-weight: 700;
+}
+.sg-subtitle {
+  font-size: 11px;
+  color: var(--ink-dim);
+  margin-top: 2px;
+}
+
+/* ---------- garden timeline ---------- */
+.sg-gardenwrap {
+  position: relative;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 10px 8px 12px;
+  margin-bottom: 12px;
+}
+.sg-lanetags {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--ink-dim);
+  padding: 0 4px 6px;
+}
+.sg-garden {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 4px;
+  scrollbar-width: thin;
+}
+.sg-garden::-webkit-scrollbar {
+  height: 5px;
+}
+.sg-garden::-webkit-scrollbar-thumb {
+  background: var(--line);
+  border-radius: 9px;
+}
+.sg-col {
+  flex: 0 0 auto;
+  width: 58px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  border-radius: 12px;
+  padding: 4px 3px;
+  transition:
+    background 0.12s ease,
+    box-shadow 0.12s ease;
+}
+.sg-col.active {
+  background: rgba(79, 212, 144, 0.1);
+  box-shadow:
+    inset 0 0 0 1px rgba(79, 212, 144, 0.45),
+    0 0 14px rgba(79, 212, 144, 0.25);
+}
+.sg-cell {
+  height: 54px;
+  border-radius: 11px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  border: 1px solid var(--line);
+  background: transparent;
+  padding: 0;
+  width: 100%;
+  transition:
+    transform 0.12s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+.sg-cell.partner {
+  cursor: default;
+}
+.sg-cell .pemoji {
+  font-size: 20px;
+  line-height: 1;
+}
+.sg-cell .plabel {
+  font-size: 10px;
+  color: var(--ink);
+}
+.sg-cell .planticon {
+  font-size: 15px;
+  opacity: 0.35;
+}
+
+/* melody lane (flowers) */
+.sg-cell.melody.empty.owned {
+  background: repeating-linear-gradient(135deg, #13251b, #13251b 6px, #152a1e 6px, #152a1e 12px);
+}
+.sg-cell.melody.empty.owned:active {
+  transform: scale(0.95);
+}
+.sg-cell.melody.filled {
+  background: var(--panel2);
+  animation: sg-pop 0.28s ease;
+}
+/* rhythm lane (roots) */
+.sg-cell.rhythm.empty {
+  background: #0f1a14;
+  border-style: dashed;
+}
+.sg-cell.rhythm.empty.owned:active {
+  transform: scale(0.95);
+}
+.sg-cell.rhythm.filled {
+  background: linear-gradient(180deg, #241d15, #1a150f);
+  border-color: #3a2e20;
+}
+.sg-cell.rhythm.filled .plabel {
+  color: #d8c3a6;
+}
+
+/* per-pair relation glow on the whole column once both lanes fill a slot */
+.sg-col.rel-synergy .sg-cell.filled {
+  border-color: var(--synergy);
+  box-shadow: 0 0 12px rgba(255, 215, 107, 0.4);
+}
+.sg-col.rel-compatible .sg-cell.filled {
+  border-color: var(--compat);
+  box-shadow: 0 0 8px rgba(127, 224, 166, 0.25);
+}
+.sg-col.rel-neutral .sg-cell.filled {
+  border-color: #3a4d42;
+}
+.sg-col.rel-incompatible .sg-cell.filled {
+  border-color: var(--harsh);
+  box-shadow: 0 0 10px rgba(255, 106, 90, 0.4);
+  animation: sg-shake 0.3s ease;
+}
+.sg-beat {
+  text-align: center;
+  font-size: 10px;
+  color: var(--ink-dim);
+}
+
+/* placement toast */
+.sg-toast {
+  position: absolute;
+  left: 50%;
+  top: 6px;
+  transform: translate(-50%, 0);
+  padding: 6px 13px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  background: #0d1712;
+  border: 1px solid var(--line);
+  color: var(--ink);
+  white-space: nowrap;
+  z-index: 5;
+  pointer-events: none;
+  animation: sg-toast 1.5s ease forwards;
+}
+.sg-toast.tone-synergy {
+  color: #0c1310;
+  background: linear-gradient(90deg, var(--synergy), #ffb03a);
+  border-color: var(--synergy);
+}
+.sg-toast.tone-compatible {
+  color: #0c1310;
+  background: var(--compat);
+  border-color: var(--compat);
+}
+.sg-toast.tone-incompatible {
+  color: var(--ink);
+  background: var(--harsh);
+  border-color: var(--harsh);
+}
+
+/* ---------- guide + palette ---------- */
+.sg-guide {
+  font-size: 11px;
+  color: var(--ink-dim);
+  margin: 0 2px 8px;
+}
+.sg-palette {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 7px;
+  margin-bottom: 12px;
+}
+.sg-chip {
+  position: relative;
+  border-radius: 13px;
+}
+.sg-chip-main {
+  width: 100%;
+  min-height: 64px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  transition:
+    transform 0.12s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    opacity 0.2s ease;
+}
+.sg-chip-main:active {
+  transform: scale(0.95);
+}
+.sg-chip.selected .sg-chip-main {
+  border-color: var(--melody);
+  box-shadow:
+    0 0 0 1px var(--melody),
+    0 0 14px rgba(255, 207, 107, 0.35);
+  background: #25301d;
+}
+.sg-chip.depleted .sg-chip-main {
+  opacity: 0.34;
+}
+.sg-chip .cemoji {
+  font-size: 22px;
+  line-height: 1;
+}
+.sg-chip .clabel {
+  font-size: 11px;
+}
+.sg-chip .ccount {
+  font-size: 10px;
+  color: var(--green);
+}
+.sg-chip.depleted .ccount {
+  color: var(--ink-dim);
+}
+.sg-chip .clisten {
+  position: absolute;
+  bottom: 3px;
+  right: 3px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid var(--line);
+  background: #0e1712;
+  font-size: 11px;
+  line-height: 1;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ---------- transport + score ---------- */
+.sg-transport {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 10px;
+  margin-bottom: 12px;
+}
+.sg-play {
+  flex: 0 0 auto;
+  min-width: 96px;
+  height: 46px;
+  border-radius: 11px;
+  border: 1px solid var(--green);
+  background: linear-gradient(180deg, #1e3a2a, #153025);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+.sg-play:active {
+  transform: scale(0.97);
+}
+.sg-play.playing {
+  background: linear-gradient(180deg, #3a2a1e, #2a1c14);
+  border-color: var(--melody);
+}
+.sg-scorebox {
+  flex: 1 1 auto;
+}
+.sg-score {
+  font-size: 14px;
+  font-weight: 600;
+}
+.sg-score .sg-scoreval {
+  color: var(--green);
+  font-size: 18px;
+}
+.sg-meter {
+  height: 7px;
+  border-radius: 99px;
+  background: #0e1712;
+  margin-top: 6px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+}
+.sg-meter-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--green), var(--melody));
+  border-radius: 99px;
+  transition: width 0.35s ease;
+}
+
+/* ---------- bloom ---------- */
+.sg-bloombanner {
+  margin-bottom: 12px;
+  text-align: center;
+  padding: 12px;
+  background: linear-gradient(90deg, rgba(255, 207, 107, 0.14), rgba(255, 158, 196, 0.14));
+  border: 1px solid var(--melody);
+  border-radius: 12px;
+}
+.sg-bloomtitle {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.sg-bloomcta {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.sg-btn {
+  min-height: 44px;
+  padding: 0 16px;
+  border-radius: 11px;
+  border: 1px solid var(--line);
+  background: var(--panel2);
+  font-size: 14px;
+  font-weight: 600;
+}
+.sg-btn.primary {
+  background: linear-gradient(90deg, var(--melody), var(--melody2));
+  border-color: var(--melody);
+  color: #0c1310;
+}
+.sg-btn.ghost {
+  background: transparent;
+  color: var(--ink-dim);
+}
+.sg-btn:active {
+  transform: scale(0.97);
+}
+
+/* bloom petal layer (CSS-only celebration) */
+.sg-bloomlayer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+  z-index: 4;
+  border-radius: 16px;
+}
+.sg-bloomlayer.on {
+  opacity: 1;
+}
+.sg-petal {
+  position: absolute;
+  top: -24px;
+  font-size: 18px;
+  opacity: 0;
+}
+.sg-bloomlayer.on .sg-petal {
+  opacity: 1;
+  animation: sg-fall linear infinite;
+}
+
+/* ---------- partner chat ---------- */
+.sg-chat {
+  background: linear-gradient(180deg, var(--panel2), var(--panel));
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 11px 12px;
+  margin-bottom: 12px;
+}
+.sg-chat-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 7px;
+}
+.sg-chat-avatar {
+  font-size: 18px;
+}
+.sg-chat-name {
+  font-size: 13px;
+  font-weight: 700;
+}
+.sg-chat-tag {
+  margin-left: auto;
+  font-size: 9px;
+  color: var(--ink-dim);
+  border: 1px dashed var(--line);
+  border-radius: 999px;
+  padding: 2px 7px;
+}
+.sg-chat-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.sg-chat-line {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--ink);
+  background: #0e1712;
+  border-radius: 10px;
+  padding: 9px 11px;
+  border: 1px solid var(--line);
+  animation: sg-fadein 0.35s ease;
+}
+.sg-chat-line.player {
+  align-self: flex-end;
+  max-width: 85%;
+  background: #1c2b20;
+  border-color: #2f4a38;
+  color: var(--compat);
+}
+.sg-chat-who {
+  font-size: 10px;
+  color: var(--ink-dim);
+  margin-right: 6px;
+}
+
+/* ---------- voice bar (push-to-talk) ---------- */
+.sg-voicebar {
+  margin-bottom: 12px;
+}
+.sg-mic {
+  width: 100%;
+  min-height: 46px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+}
+.sg-mic:active {
+  transform: scale(0.99);
+}
+.sg-mic.listening {
+  border-color: var(--melody);
+  background: #2a2213;
+  color: var(--melody);
+  animation: sg-glowpulse 1.4s ease-in-out infinite;
+}
+
+/* ---------- audio notice ---------- */
+.sg-audionotice {
+  font-size: 12px;
+  color: #ffd9a8;
+  background: #2a2012;
+  border: 1px solid #4a3a1e;
+  border-radius: 10px;
+  padding: 8px 10px;
+}
+
+/* ---------- level select ---------- */
+.sg-select-head {
+  text-align: center;
+  margin: 8px 0 18px;
+}
+.sg-brand {
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: 0.5px;
+}
+.sg-brand-tag {
+  font-size: 10px;
+  font-weight: 600;
+  color: #0c1310;
+  background: linear-gradient(90deg, var(--melody), var(--melody2));
+  padding: 2px 7px;
+  border-radius: 999px;
+  vertical-align: middle;
+}
+.sg-brand-sub {
+  font-size: 12px;
+  color: var(--ink-dim);
+  margin: 6px 0 0;
+}
+.sg-sidepick {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 12px;
+  margin-bottom: 16px;
+  text-align: center;
+}
+.sg-sidepick-label {
+  display: block;
+  font-size: 11px;
+  color: var(--ink-dim);
+  margin-bottom: 8px;
+}
+.sg-segmented {
+  display: flex;
+  gap: 6px;
+  background: #0e1712;
+  border-radius: 12px;
+  padding: 4px;
+}
+.sg-segmented button {
+  flex: 1 1 0;
+  min-height: 44px;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  background: transparent;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink-dim);
+}
+.sg-segmented button.active {
+  background: var(--panel2);
+  border-color: var(--line);
+  color: var(--ink);
+}
+.sg-sidepick-hint {
+  display: block;
+  font-size: 11px;
+  color: var(--ink-dim);
+  margin-top: 8px;
+}
+.sg-levellist {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.sg-levelcard {
+  text-align: left;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 12px 14px;
+  width: 100%;
+}
+.sg-levelcard:active {
+  transform: scale(0.99);
+}
+.sg-levelcard-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.sg-levelnum {
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  background: var(--panel2);
+  border: 1px solid var(--line);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+}
+.sg-levelname {
+  font-size: 16px;
+  font-weight: 700;
+}
+.sg-leveltarget {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--green);
+}
+.sg-levelsub {
+  font-size: 12px;
+  color: var(--ink);
+  margin-top: 6px;
+}
+.sg-leveltension {
+  font-size: 11px;
+  color: var(--ink-dim);
+  margin-top: 3px;
+}
+.sg-select-foot {
+  text-align: center;
+  font-size: 11px;
+  color: var(--ink-dim);
+  margin-top: 18px;
+}
+
+/* ---------- keyframes ---------- */
+@keyframes sg-pop {
+  0% {
+    transform: scale(0.6);
+  }
+  60% {
+    transform: scale(1.12);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+@keyframes sg-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-3px);
+  }
+  75% {
+    transform: translateX(3px);
+  }
+}
+@keyframes sg-fadein {
+  from {
+    opacity: 0.2;
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes sg-toast {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -6px);
+  }
+  15%,
+  75% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, 0);
+  }
+}
+@keyframes sg-fall {
+  0% {
+    transform: translateY(-24px) rotate(0deg);
+  }
+  100% {
+    transform: translateY(560px) rotate(320deg);
+  }
+}
+@keyframes sg-glowpulse {
+  0%,
+  100% {
+    box-shadow: 0 0 6px rgba(255, 207, 107, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 16px rgba(255, 207, 107, 0.7);
+  }
+}
+
+/* ---------- eligibility checking ---------- */
+.sg-checking {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+}
+.sg-checking-text {
+  color: var(--ink-dim);
+  font-size: 15px;
+}
+
+/* ---------- mode② voice partner panel ---------- */
+.sg-voice {
+  margin: 14px 0 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--panel);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.sg-voice-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.sg-voice-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.sg-voice-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--ink-dim);
+}
+.sg-voice-dot[data-phase='listening'] {
+  background: var(--compat);
+}
+.sg-voice-dot[data-phase='thinking'] {
+  background: var(--synergy);
+}
+.sg-voice-dot[data-phase='speaking'] {
+  background: var(--melody);
+  animation: sg-glowpulse 1.4s ease-in-out infinite;
+}
+.sg-voice-statustext {
+  font-size: 13px;
+  color: var(--ink-dim);
+}
+.sg-voice-dots {
+  display: inline-flex;
+  gap: 3px;
+}
+.sg-voice-dots i {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--melody);
+  display: inline-block;
+  animation: sg-voicebounce 1s ease-in-out infinite;
+}
+.sg-voice-dots i:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.sg-voice-dots i:nth-child(3) {
+  animation-delay: 0.3s;
+}
+.sg-voice-you {
+  font-size: 14px;
+  color: var(--ink-dim);
+  margin: 0;
+}
+.sg-voice-reply {
+  font-size: 15px;
+  color: var(--ink);
+  min-height: 22px;
+}
+.sg-voice-reply p {
+  margin: 0;
+}
+.sg-voice-label {
+  color: var(--ink-dim);
+  margin-right: 4px;
+}
+.sg-voice-placeholder {
+  color: var(--ink-dim);
+}
+.sg-voice-error {
+  color: var(--harsh);
+  font-size: 13px;
+  margin: 0;
+}
+.sg-voice-hint {
+  color: var(--ink-dim);
+  font-size: 12px;
+  margin: 0;
+}
+.sg-voice-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+@keyframes sg-voicebounce {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.6;
+  }
+  50% {
+    transform: translateY(-3px);
+    opacity: 1;
+  }
+}
+
+/* ---------- first-bloom settlement overlay ---------- */
+.sg-results {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: var(--amio-surface-dark, rgba(0, 0, 0, 0.55));
+  z-index: 20;
+  animation: sg-fadein 0.3s ease-out;
+}
+.sg-results-card {
+  width: 100%;
+  max-width: 340px;
+  text-align: center;
+  padding: 22px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+}
+.sg-results-title {
+  margin: 0;
+  font-size: 22px;
+  color: var(--melody);
+}
+.sg-results-sub {
+  margin: 0;
+  color: var(--ink-dim);
+  font-size: 14px;
+}
+.sg-results-score {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  margin: 4px 0 10px;
+}
+.sg-results-score b {
+  font-size: 30px;
+  color: var(--green);
+}
+.sg-results-score span {
+  color: var(--ink-dim);
+  font-size: 14px;
+}
+.sg-results-cardwrap {
+  width: 100%;
+  max-width: 340px;
+  display: flex;
+}
+.sg-results-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+.sg-results-continue {
+  margin-top: 2px;
+  background: none;
+  border: none;
+  color: var(--ink-dim);
+  font-size: 13px;
+  padding: 4px;
+}
+.sg-results-continue:hover {
+  color: var(--ink);
+}
+
+@keyframes sg-fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/packages/game-sound-garden/src/styles/tokens.css
+++ b/packages/game-sound-garden/src/styles/tokens.css
@@ -1,0 +1,32 @@
+/* Sound Garden design tokens — the game's ONE registered accent layer
+   (bounded-accent rule, DesignSystem.md §Platform Grammar). Sound Garden's owned
+   hues are the melody/rhythm piece palette + the warm synergy gold, painted only
+   on garden graphics (pieces / lanes / harmony feedback) — never on platform
+   chrome. Everything else INHERITS the Atlas cosmic shell + platform semantics
+   from @amiclaw/ui (--bg-grad-*, --text-*, --border-*, --positive / --amio-*),
+   imported before this file. Dark-only; no light mode. */
+:root {
+  /* Registered game palette — the melody/rhythm piece hues (game graphics only). */
+  --sg-melody: #ffcf6b;
+  --sg-melody-2: #ff9ec4;
+  --sg-rhythm: #8a6b4f;
+  /* Warm synergy gold — the one game accent kept as a bespoke hue. */
+  --sg-synergy: #ffd76b;
+
+  /* Harmony-relation feedback reconciles with the platform semantic colors
+     (§Semantic Color Law) — never bespoke hexes. */
+  --sg-compat: var(--amio-success); /* compatible = softer success green */
+  --sg-neutral: var(--amio-fg-666); /* neutral = platform gray */
+  --sg-harsh: var(--amio-danger); /* incompatible = platform danger red */
+  --sg-bloom: var(--positive); /* bloom = platform success green */
+
+  /* Chrome inherits Atlas — aliases only, Atlas is SSOT (no bespoke chrome hex). */
+  --sg-ink: var(--text-1);
+  --sg-ink-dim: var(--text-3);
+  --sg-line: var(--border-soft);
+
+  /* Elevated green-tinted dark glass over the cosmic base (game panels only —
+     same pattern as BombSquad's blue-tinted glass / Botanical's --garden-surface). */
+  --sg-surface: rgba(14, 23, 18, 0.72);
+  --sg-surface-2: rgba(20, 34, 26, 0.66);
+}

--- a/packages/game-sound-garden/src/test-setup.ts
+++ b/packages/game-sound-garden/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/packages/game-sound-garden/src/ui/GameScreen.anon-partner.test.tsx
+++ b/packages/game-sound-garden/src/ui/GameScreen.anon-partner.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+// Anon tier: force ineligible so GameScreen mounts the scripted partner store
+// synchronously (no async eligibility fetch).
+vi.mock('../voice/sound-garden-voice-eligibility', () => ({
+  useSoundGardenVoiceEligibility: () => ({ status: 'ineligible', reason: 'unavailable' }),
+}))
+
+import { GameScreen } from './GameScreen'
+import { levelByIndex } from '../game/levels'
+
+const lv1 = levelByIndex(1)!
+
+/**
+ * A `speechSynthesis` whose `speak()` NEVER fires `onend` — faithfully models a
+ * real browser that throttles / never resolves speech with no user gesture. This
+ * is exactly the condition that deadlocked the anon partner: the session_start
+ * greeting's `voice.speak` hung, keeping the serial trigger bus `busy` forever, so
+ * every later `player_planted` was swallowed.
+ */
+class HangingUtterance {
+  lang = ''
+  onend: (() => void) | null = null
+  onerror: (() => void) | null = null
+  constructor(public text: string) {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal('speechSynthesis', { speak: vi.fn(), cancel: vi.fn() })
+  vi.stubGlobal('SpeechSynthesisUtterance', HangingUtterance)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+function filledRhythmCells(container: HTMLElement): number {
+  return container.querySelectorAll('.sg-cell.rhythm.filled').length
+}
+
+describe('GameScreen anon partner — UI → trigger-bus → brain wiring (live regression)', () => {
+  it('responds to a plant with a partner rhythm piece even when TTS never resolves', async () => {
+    const { container } = render(
+      <GameScreen
+        level={lv1}
+        side="melody"
+        hasNext={false}
+        onExit={() => undefined}
+        onReplay={() => undefined}
+        onNext={() => undefined}
+      />
+    )
+
+    // session_start applied: the greeting + the pre-seed 底鼓@1 (one filled rhythm
+    // cell). This renders BEFORE the (now non-blocking) greeting speech.
+    await screen.findByText(/一起让花园唱起来/)
+    await waitFor(() => expect(filledRhythmCells(container)).toBe(1))
+
+    // Plant a melody piece on an EMPTY beat (slot 2), where the partner has a move.
+    fireEvent.click(screen.getByLabelText(/选择铃铛/))
+    fireEvent.click(screen.getByLabelText('旋律 第2拍'))
+
+    // The partner must lay a rhythm piece within the debounce window. Before the
+    // fix the serial bus stayed `busy` on the hung greeting speech, so this never
+    // happened and the wait times out (the regression).
+    await waitFor(() => expect(filledRhythmCells(container)).toBe(2), { timeout: 2500 })
+  })
+})

--- a/packages/game-sound-garden/src/ui/GameScreen.tsx
+++ b/packages/game-sound-garden/src/ui/GameScreen.tsx
@@ -1,0 +1,280 @@
+/**
+ * The playing screen — orchestrates the GameStore, the AudioEngine, and the
+ * presentational components. Owns only transient view state (selected chip,
+ * playhead step, transport on/off); all game truth lives in the store.
+ *
+ * Two partner tiers (PR-2 §3), resolved by voice eligibility BEFORE the store is
+ * built (the partner driver is fixed at construction):
+ *   - mode② (signed-in + named companion): the platform co_build voice session
+ *     (`SoundGardenPartnerChannel`) drives the partner via `applyPartnerActions`.
+ *   - anon (everyone else, incl. the standalone dev build with no Worker): the
+ *     offline scripted partner + browser voice.
+ */
+
+import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import type { PieceType } from '../game/constants'
+import { GameStore } from '../game/store'
+import type { Archetype, LevelConfig, Side } from '../game/types'
+import { AudioEngine } from '../audio/engine'
+import { ScriptedPartnerBrain } from '../partner/brain'
+import { createVoice } from '../voice/voice-io'
+import { useSoundGardenVoiceEligibility } from '../voice/sound-garden-voice-eligibility'
+import { buildSoundGardenManualData } from '../voice/sound-garden-manual'
+import SoundGardenPartnerChannel from '../voice/SoundGardenPartnerChannel'
+import { Garden } from './Garden'
+import { Palette } from './Palette'
+import { PartnerChat } from './PartnerChat'
+import { Transport } from './Transport'
+import SoundGardenResults from './SoundGardenResults'
+
+interface GameScreenProps {
+  level: LevelConfig
+  side: Side
+  hasNext: boolean
+  onExit: () => void
+  onReplay: () => void
+  onNext: () => void
+}
+
+/** The platform voice gameId (companion partner) in production. */
+const VOICE_GAME_ID = 'sound-garden'
+
+/**
+ * Outer gate: resolve companion voice eligibility, then mount the run in the right
+ * partner tier. The standalone dev build has no platform Worker, so the eligibility
+ * fetch fails → `unavailable` → the anon scripted tier (no dev-only branch needed).
+ */
+export function GameScreen(props: GameScreenProps) {
+  const eligibility = useSoundGardenVoiceEligibility(true)
+
+  if (eligibility.status === 'checking') {
+    return (
+      <main className="sg-app sg-checking">
+        <p className="sg-checking-text" role="status">
+          正在确认你的 AI 伙伴…
+        </p>
+      </main>
+    )
+  }
+
+  const platform = eligibility.status === 'eligible'
+  return <GameScreenInner key={platform ? 'platform' : 'anon'} {...props} platform={platform} />
+}
+
+function GameScreenInner(props: GameScreenProps & { platform: boolean }) {
+  const [store] = useState(() => {
+    if (props.platform) {
+      // mode②: no internal scripted brain / bus turn; the platform session drives.
+      return new GameStore(props.level, props.side, { partnerMode: 'platform' })
+    }
+    const partnerArchetype: Archetype = props.side === 'melody' ? 'rhythm_piece' : 'melody_piece'
+    const brain = new ScriptedPartnerBrain(props.level.matrix, partnerArchetype)
+    const voice = createVoice()
+    return new GameStore(props.level, props.side, { brain, voice })
+  })
+  const [audio] = useState(() => new AudioEngine())
+  const manualData = useMemo(() => buildSoundGardenManualData(props.level), [props.level])
+
+  const state = useSyncExternalStore(store.subscribe, store.getSnapshot)
+  const [selected, setSelected] = useState<PieceType | null>(null)
+  const [activeStep, setActiveStep] = useState(-1)
+  const [playing, setPlaying] = useState(false)
+  const [audioBlocked, setAudioBlocked] = useState(false)
+  const [listening, setListening] = useState(false)
+  // Settlement overlay is dismissible: shown on the first bloom, then closed for
+  // good this run (the `settled` latch stays true, so it never auto-reopens). The
+  // dismiss state is per-run, reset by the keyed remount on replay / next level.
+  const [resultsDismissed, setResultsDismissed] = useState(false)
+
+  useEffect(() => {
+    return () => {
+      audio.dispose()
+      store.dispose()
+    }
+  }, [audio, store])
+
+  const petals = useMemo(() => buildPetals(), [])
+
+  function afterGesture() {
+    if (audio.unavailable) setAudioBlocked(true)
+  }
+
+  function handleSelect(type: PieceType) {
+    setSelected((prev) => (prev === type ? null : type))
+    audio.preview(type)
+    afterGesture()
+  }
+
+  function handlePreview(type: PieceType) {
+    audio.preview(type)
+    afterGesture()
+  }
+
+  function handleSlotTap(slot: number) {
+    const owned =
+      state.playerArchetype === 'melody_piece' ? state.melody[slot - 1] : state.rhythm[slot - 1]
+    if (selected) {
+      store.plantPlayer(selected, slot)
+      audio.preview(selected)
+      setSelected(null)
+    } else if (owned) {
+      store.removePlayer(slot)
+    }
+    afterGesture()
+  }
+
+  function handleTogglePlay() {
+    if (playing) {
+      audio.stop()
+      setPlaying(false)
+      setActiveStep(-1)
+      return
+    }
+    audio.start({
+      getStep: (step) => {
+        const s = store.getSnapshot()
+        return { rhythm: s.rhythm[step], melody: s.melody[step] }
+      },
+      onStep: (step) => setActiveStep(step),
+    })
+    setPlaying(true)
+    afterGesture()
+  }
+
+  async function handleMic() {
+    if (listening) {
+      store.stopListening()
+      return
+    }
+    setListening(true)
+    try {
+      const text = await store.captureUtterance()
+      if (text) store.submitUtterance(text)
+    } finally {
+      setListening(false)
+    }
+  }
+
+  return (
+    <main className="sg-app">
+      <header className="sg-header">
+        <button type="button" className="sg-icon-btn" aria-label="返回选关" onClick={props.onExit}>
+          ‹
+        </button>
+        <div className="sg-titlewrap">
+          <div className="sg-title">
+            第 {state.levelIndex} 关 · {state.levelName}
+          </div>
+          <div className="sg-subtitle">{state.levelSubtitle}</div>
+        </div>
+        <button
+          type="button"
+          className="sg-icon-btn"
+          aria-label="重来本关"
+          onClick={props.onReplay}
+        >
+          ↻
+        </button>
+      </header>
+
+      <div className="sg-gardenwrap">
+        <div className="sg-lanetags">
+          <span>🌼 旋律花{state.playerArchetype === 'melody_piece' ? '（你）' : '（伙伴）'}</span>
+          <span>{state.playerArchetype === 'rhythm_piece' ? '（你）' : '（伙伴）'}节奏根 🌱</span>
+        </div>
+        <Garden
+          slots={state.slots}
+          melody={state.melody}
+          rhythm={state.rhythm}
+          relations={state.relations}
+          activeStep={activeStep}
+          playerArchetype={state.playerArchetype}
+          onSlotTap={handleSlotTap}
+          onPartnerHint={() => undefined}
+        />
+        {state.toast && (
+          <div className={`sg-toast tone-${state.toast.tone}`} key={state.toast.seq}>
+            {state.toast.text}
+          </div>
+        )}
+        <div className={`sg-bloomlayer ${state.bloomed ? 'on' : ''}`} aria-hidden="true">
+          {petals.map((p, i) => (
+            <span
+              className="sg-petal"
+              key={i}
+              style={{ left: p.left, animationDuration: p.dur, animationDelay: p.delay }}
+            >
+              {p.emoji}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <p className="sg-guide">
+        点一株{state.playerArchetype === 'melody_piece' ? '旋律花' : '节奏根'}
+        选中，再点上方空土种下；点 🔊 试听
+      </p>
+      <Palette
+        palette={state.palette}
+        selected={selected}
+        onSelect={handleSelect}
+        onPreview={handlePreview}
+      />
+
+      <Transport
+        playing={playing}
+        score={state.score}
+        target={state.target}
+        bloomed={state.bloomed}
+        onTogglePlay={handleTogglePlay}
+      />
+
+      {props.platform ? (
+        <SoundGardenPartnerChannel store={store} gameId={VOICE_GAME_ID} manualData={manualData} />
+      ) : (
+        <>
+          {store.micAvailable && (
+            <div className="sg-voicebar">
+              <button
+                type="button"
+                className={`sg-mic ${listening ? 'listening' : ''}`}
+                aria-label={listening ? '停止说话' : '按住说话'}
+                onClick={handleMic}
+              >
+                {listening ? '🎙 聆听中…（点此结束）' : '🎤 对伙伴说话'}
+              </button>
+            </div>
+          )}
+          <PartnerChat chat={state.chat} offline />
+        </>
+      )}
+
+      <SoundGardenResults
+        open={state.settled && !resultsDismissed}
+        score={state.score}
+        target={state.target}
+        hasNext={props.hasNext}
+        onReplay={props.onReplay}
+        onNext={props.onNext}
+        onExit={props.onExit}
+        onDismiss={() => setResultsDismissed(true)}
+      />
+
+      {audioBlocked && (
+        <div className="sg-audionotice">
+          此环境音频被禁用——请在本机浏览器打开听声。视觉与玩法仍可正常体验。
+        </div>
+      )}
+    </main>
+  )
+}
+
+function buildPetals() {
+  const emojis = ['🌸', '🌼', '✨', '🌷', '💮']
+  return Array.from({ length: 14 }, (_, i) => ({
+    emoji: emojis[i % emojis.length],
+    left: `${Math.round(Math.random() * 92)}%`,
+    dur: `${(3 + Math.random() * 3).toFixed(2)}s`,
+    delay: `${(Math.random() * 3).toFixed(2)}s`,
+  }))
+}

--- a/packages/game-sound-garden/src/ui/Garden.tsx
+++ b/packages/game-sound-garden/src/ui/Garden.tsx
@@ -1,0 +1,76 @@
+/**
+ * The garden timeline — two lanes (melody flowers on top, rhythm roots below)
+ * across N slots, horizontally scrollable inside its own container. The
+ * player's lane is interactive; tapping the partner's lane just explains it.
+ * Per-pair relation feedback is shown via the column's relation class once both
+ * lanes fill a slot — the full matrix is never rendered (协作发现).
+ */
+
+import { PIECE_META } from '../game/constants'
+import type { MelodyType, RhythmType } from '../game/constants'
+import type { Archetype, RelationName } from '../game/types'
+
+interface GardenProps {
+  slots: number
+  melody: (MelodyType | null)[]
+  rhythm: (RhythmType | null)[]
+  relations: (RelationName | null)[]
+  activeStep: number
+  playerArchetype: Archetype
+  onSlotTap: (slot: number) => void
+  onPartnerHint: () => void
+}
+
+export function Garden(props: GardenProps) {
+  const { slots, melody, rhythm, relations, activeStep, playerArchetype } = props
+  const columns = []
+  for (let i = 0; i < slots; i++) {
+    const m = melody[i]
+    const r = rhythm[i]
+    const rel = relations[i]
+    const colClass = ['sg-col', activeStep === i ? 'active' : '', rel ? `rel-${rel}` : '']
+      .filter(Boolean)
+      .join(' ')
+
+    const melodyOwned = playerArchetype === 'melody_piece'
+    const rhythmOwned = playerArchetype === 'rhythm_piece'
+
+    columns.push(
+      <div className={colClass} key={i}>
+        <button
+          type="button"
+          className={`sg-cell melody ${m ? 'filled' : 'empty'} ${melodyOwned ? 'owned' : 'partner'}`}
+          aria-label={melodyOwned ? `旋律 第${i + 1}拍` : `伙伴旋律 第${i + 1}拍`}
+          onClick={() => (melodyOwned ? props.onSlotTap(i + 1) : props.onPartnerHint())}
+        >
+          {m ? (
+            <>
+              <span className="pemoji">{PIECE_META[m].emoji}</span>
+              <span className="plabel">{PIECE_META[m].label}</span>
+            </>
+          ) : (
+            <span className="planticon">{melodyOwned ? '🌱' : '·'}</span>
+          )}
+        </button>
+        <button
+          type="button"
+          className={`sg-cell rhythm ${r ? 'filled' : 'empty'} ${rhythmOwned ? 'owned' : 'partner'}`}
+          aria-label={rhythmOwned ? `节奏 第${i + 1}拍` : `伙伴节奏 第${i + 1}拍`}
+          onClick={() => (rhythmOwned ? props.onSlotTap(i + 1) : props.onPartnerHint())}
+        >
+          {r ? (
+            <>
+              <span className="pemoji">{PIECE_META[r].emoji}</span>
+              <span className="plabel">{PIECE_META[r].label}</span>
+            </>
+          ) : (
+            <span className="planticon">{rhythmOwned ? '🌱' : '·'}</span>
+          )}
+        </button>
+        <div className="sg-beat">{i + 1}</div>
+      </div>
+    )
+  }
+
+  return <div className="sg-garden">{columns}</div>
+}

--- a/packages/game-sound-garden/src/ui/LevelSelect.tsx
+++ b/packages/game-sound-garden/src/ui/LevelSelect.tsx
@@ -1,0 +1,70 @@
+/**
+ * Level select + the session-start side-swap toggle (L2 arch note B3). The
+ * player defaults to the melody side and may swap to rhythm before starting;
+ * the harmony matrix stays hidden from the player in both assignments.
+ */
+
+import { useState } from 'react'
+import { LEVELS } from '../game/levels'
+import type { Side } from '../game/types'
+
+interface LevelSelectProps {
+  onStart: (levelIndex: number, side: Side) => void
+}
+
+export function LevelSelect(props: LevelSelectProps) {
+  const [side, setSide] = useState<Side>('melody')
+
+  return (
+    <main className="sg-app sg-select">
+      <header className="sg-select-head">
+        <div className="sg-brand">声音花园</div>
+        <p className="sg-brand-sub">和 AI 伙伴一起，把 8 拍时间线种成一座会唱歌的花园</p>
+      </header>
+
+      <div className="sg-sidepick">
+        <span className="sg-sidepick-label">你的角色</span>
+        <div className="sg-segmented" role="group" aria-label="选择你的角色">
+          <button
+            type="button"
+            className={side === 'melody' ? 'active' : ''}
+            onClick={() => setSide('melody')}
+          >
+            🌼 旋律花
+          </button>
+          <button
+            type="button"
+            className={side === 'rhythm' ? 'active' : ''}
+            onClick={() => setSide('rhythm')}
+          >
+            🌱 节奏根
+          </button>
+        </div>
+        <span className="sg-sidepick-hint">
+          {side === 'melody' ? '你种旋律，伙伴铺节奏' : '你铺节奏，伙伴种旋律'}
+        </span>
+      </div>
+
+      <section className="sg-levellist">
+        {LEVELS.map((lv) => (
+          <button
+            type="button"
+            className="sg-levelcard"
+            key={lv.id}
+            onClick={() => props.onStart(lv.index, side)}
+          >
+            <div className="sg-levelcard-top">
+              <span className="sg-levelnum">{lv.index}</span>
+              <span className="sg-levelname">{lv.name}</span>
+              <span className="sg-leveltarget">目标 {lv.target}</span>
+            </div>
+            <div className="sg-levelsub">{lv.subtitle}</div>
+            <div className="sg-leveltension">{lv.tension}</div>
+          </button>
+        ))}
+      </section>
+
+      <p className="sg-select-foot">自由流 · 无败绽放 · 靠听觉与伙伴提示摸索和声</p>
+    </main>
+  )
+}

--- a/packages/game-sound-garden/src/ui/Palette.tsx
+++ b/packages/game-sound-garden/src/ui/Palette.tsx
@@ -1,0 +1,55 @@
+/**
+ * The player's piece palette — one chip per pool type with its remaining count.
+ * Tap a chip to select it (and preview-listen), then tap an empty slot to
+ * plant. A depleted type dims out. The 🔊 button previews without selecting.
+ */
+
+import { PIECE_META } from '../game/constants'
+import type { PieceType } from '../game/constants'
+
+interface PaletteProps {
+  palette: { type: PieceType; remaining: number }[]
+  selected: PieceType | null
+  onSelect: (type: PieceType) => void
+  onPreview: (type: PieceType) => void
+}
+
+export function Palette(props: PaletteProps) {
+  return (
+    <section className="sg-palette">
+      {props.palette.map(({ type, remaining }) => {
+        const depleted = remaining <= 0
+        const cls = [
+          'sg-chip',
+          props.selected === type ? 'selected' : '',
+          depleted ? 'depleted' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')
+        return (
+          <div className={cls} key={type}>
+            <button
+              type="button"
+              className="sg-chip-main"
+              disabled={depleted}
+              aria-label={`选择${PIECE_META[type].label}，剩余 ${remaining}`}
+              onClick={() => props.onSelect(type)}
+            >
+              <span className="cemoji">{PIECE_META[type].emoji}</span>
+              <span className="clabel">{PIECE_META[type].label}</span>
+              <span className="ccount">×{remaining}</span>
+            </button>
+            <button
+              type="button"
+              className="clisten"
+              aria-label={`试听${PIECE_META[type].label}`}
+              onClick={() => props.onPreview(type)}
+            >
+              🔊
+            </button>
+          </div>
+        )
+      })}
+    </section>
+  )
+}

--- a/packages/game-sound-garden/src/ui/PartnerChat.tsx
+++ b/packages/game-sound-garden/src/ui/PartnerChat.tsx
@@ -1,0 +1,35 @@
+/**
+ * The partner chat strip. Renders the 园丁 partner's lines plus the player's
+ * spoken utterances (push-to-talk). When `offline` the source is the scripted
+ * brain; otherwise it is the real DeepSeek partner — the component is the same
+ * either way (the store swaps the brain behind it).
+ */
+
+import type { ChatLine } from '../game/types'
+
+interface PartnerChatProps {
+  chat: ChatLine[]
+  /** True → scripted fallback (no DeepSeek key). False → real AI partner. */
+  offline: boolean
+}
+
+export function PartnerChat(props: PartnerChatProps) {
+  const recent = props.chat.slice(-3)
+  return (
+    <section className="sg-chat">
+      <div className="sg-chat-head">
+        <span className="sg-chat-avatar">🤖</span>
+        <span className="sg-chat-name">园丁伙伴</span>
+        <span className="sg-chat-tag">{props.offline ? '脚本兜底 · 未接 AI' : 'AI 伙伴'}</span>
+      </div>
+      <div className="sg-chat-lines">
+        {recent.map((line) => (
+          <div className={`sg-chat-line ${line.speaker}`} key={line.seq}>
+            {line.speaker === 'player' && <span className="sg-chat-who">你</span>}
+            {line.text}
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/packages/game-sound-garden/src/ui/SoundGardenResults.test.tsx
+++ b/packages/game-sound-garden/src/ui/SoundGardenResults.test.tsx
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useState } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import SoundGardenResults from './SoundGardenResults'
+
+afterEach(cleanup)
+
+const noop = () => undefined
+
+function overlay(props: Partial<Parameters<typeof SoundGardenResults>[0]> = {}) {
+  return (
+    <SoundGardenResults
+      open
+      score={9}
+      target={8}
+      hasNext={false}
+      onReplay={noop}
+      onNext={noop}
+      onExit={noop}
+      onDismiss={noop}
+      {...props}
+    />
+  )
+}
+
+/** Mirrors GameScreen's gating: a permanently-latched `settled` + per-run dismiss. */
+function Harness({ settled }: { settled: boolean }) {
+  const [dismissed, setDismissed] = useState(false)
+  const [plants, setPlants] = useState(0)
+  return (
+    <div>
+      {/* Garden interaction proxy — must stay usable once the overlay is gone. */}
+      <button type="button" onClick={() => setPlants((n) => n + 1)}>
+        种一株
+      </button>
+      <span data-testid="plants">{plants}</span>
+      {overlay({ open: settled && !dismissed, onDismiss: () => setDismissed(true) })}
+    </div>
+  )
+}
+
+describe('SoundGardenResults — dismissible settlement overlay (PR-2 §4)', () => {
+  it('renders nothing when closed (no scrim over the garden)', () => {
+    render(overlay({ open: false }))
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('is dismissible: 继续修剪 and a backdrop tap both fire onDismiss; a card tap does not', () => {
+    const onDismiss = vi.fn()
+    render(overlay({ onDismiss }))
+
+    // Tapping inside the card must NOT dismiss (stopPropagation).
+    fireEvent.click(screen.getByText('🌸 花园绽放了'))
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    // The 继续修剪 tertiary action dismisses.
+    fireEvent.click(screen.getByText(/继续修剪/))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+
+    // A backdrop (scrim) tap dismisses.
+    fireEvent.click(screen.getByRole('dialog'))
+    expect(onDismiss).toHaveBeenCalledTimes(2)
+  })
+
+  it('after bloom + dismiss, the garden stays interactive and the overlay does not reappear', () => {
+    render(<Harness settled />)
+    // First bloom → overlay shown.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // Dismiss (继续修剪) → overlay unmounts (no scrim blocking the garden).
+    fireEvent.click(screen.getByText(/继续修剪/))
+    expect(screen.queryByRole('dialog')).toBeNull()
+
+    // Planting still works after dismissal.
+    fireEvent.click(screen.getByText('种一株'))
+    fireEvent.click(screen.getByText('种一株'))
+    expect(screen.getByTestId('plants').textContent).toBe('2')
+
+    // `settled` stays latched, but the overlay never auto-reopens.
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})

--- a/packages/game-sound-garden/src/ui/SoundGardenResults.tsx
+++ b/packages/game-sound-garden/src/ui/SoundGardenResults.tsx
@@ -1,0 +1,75 @@
+import { Button, GlassCard } from '@amiclaw/ui'
+
+interface SoundGardenResultsProps {
+  /** Whether the overlay is shown — `settled && !dismissed`. The latch stays true
+   *  after dismissal, so the overlay never auto-reopens for the run. */
+  open: boolean
+  score: number
+  target: number
+  hasNext: boolean
+  onReplay: () => void
+  onNext: () => void
+  onExit: () => void
+  /** Dismiss and keep playing (backdrop tap or 继续修剪). Fires once; latch unaffected. */
+  onDismiss: () => void
+}
+
+/**
+ * First-bloom settlement overlay (PR-2 §4). Shows over the still-visible garden on
+ * the first bloom — bloom is the settlement event (no leaderboard, no score
+ * submission). It is DISMISSIBLE: the locked semantics are "settlement fires once,
+ * continued play allowed", so tapping the backdrop or 继续修剪 closes it and the
+ * garden is fully interactive again. The `settled` latch stays true, so the overlay
+ * never auto-reopens this run; only a remount (replay / next level) resets it.
+ */
+export default function SoundGardenResults({
+  open,
+  score,
+  target,
+  hasNext,
+  onReplay,
+  onNext,
+  onExit,
+  onDismiss,
+}: SoundGardenResultsProps) {
+  if (!open) return null
+  return (
+    <div
+      className="sg-results"
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="sg-result-title"
+      onClick={onDismiss}
+    >
+      {/* Stop taps on the card from bubbling to the dismiss-on-backdrop handler. */}
+      <div className="sg-results-cardwrap" onClick={(e) => e.stopPropagation()}>
+        <GlassCard radius="2xl" className="sg-results-card">
+          <h2 id="sg-result-title" className="sg-results-title">
+            🌸 花园绽放了
+          </h2>
+          <p className="sg-results-sub">你们一起种出了一首歌。</p>
+          <div className="sg-results-score">
+            <b>{score}</b>
+            <span>/ {target} 和声分</span>
+          </div>
+          <div className="sg-results-cta">
+            <Button variant="primary" onClick={onReplay}>
+              再玩一次
+            </Button>
+            {hasNext && (
+              <Button variant="ghost" onClick={onNext}>
+                下一关 ›
+              </Button>
+            )}
+            <Button variant="ghost" onClick={onExit}>
+              换个花园
+            </Button>
+          </div>
+          <button type="button" className="sg-results-continue" onClick={onDismiss}>
+            继续修剪这座花园 ›
+          </button>
+        </GlassCard>
+      </div>
+    </div>
+  )
+}

--- a/packages/game-sound-garden/src/ui/Transport.tsx
+++ b/packages/game-sound-garden/src/ui/Transport.tsx
@@ -1,0 +1,39 @@
+/**
+ * Transport + score. Play/stop loops the 8-step garden (~96 BPM); the harmony
+ * meter fills toward the target. Time is not a deadline — bloom is the reward,
+ * and the garden keeps playing after it (free-flow, no-fail).
+ */
+
+interface TransportProps {
+  playing: boolean
+  score: number
+  target: number
+  bloomed: boolean
+  onTogglePlay: () => void
+}
+
+export function Transport(props: TransportProps) {
+  const pct = Math.max(0, Math.min(100, (props.score / props.target) * 100))
+  return (
+    <section className="sg-transport">
+      <button
+        type="button"
+        className={`sg-play ${props.playing ? 'playing' : ''}`}
+        onClick={props.onTogglePlay}
+      >
+        {props.playing ? '⏸ 停止' : '▶ 播放'}
+      </button>
+      <div className="sg-scorebox">
+        <div className="sg-score">
+          和声 <span className="sg-scoreval">{props.score}</span> / 目标 {props.target}
+        </div>
+        <div className="sg-meter">
+          <div
+            className={`sg-meter-fill ${props.bloomed ? 'bloomed' : ''}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/packages/game-sound-garden/src/ui/ui.test.tsx
+++ b/packages/game-sound-garden/src/ui/ui.test.tsx
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { App } from '../App'
+
+describe('UI smoke', () => {
+  beforeEach(() => {
+    // Hermetic: the App probes /api/capabilities on mount. Report no keys →
+    // scripted brain + NullVoice (Round A behavior), no real network.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ deepseek: false, doubao: false })))
+    )
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('renders the level select with three levels and a side toggle', () => {
+    render(<App />)
+    expect(screen.getByText(/声音花园/)).toBeInTheDocument()
+    expect(screen.getByText('学步')).toBeInTheDocument()
+    expect(screen.getByText('取舍')).toBeInTheDocument()
+    expect(screen.getByText('荆棘')).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: '选择你的角色' })).toBeInTheDocument()
+  })
+
+  it('starts a level and shows the play screen with the partner greeting', async () => {
+    render(<App />)
+    fireEvent.click(screen.getByText('学步'))
+    // Transport renders synchronously; the greeting arrives after the async opening turn.
+    expect(await screen.findByText('▶ 播放')).toBeInTheDocument()
+    expect(screen.getByText('园丁伙伴')).toBeInTheDocument()
+    // The greeting arrives from the async opening partner turn.
+    expect(await screen.findByText(/一起让花园唱起来/)).toBeInTheDocument()
+    // The player palette shows the melody pool (default melody side).
+    expect(screen.getByLabelText(/选择铃铛/)).toBeInTheDocument()
+  })
+})

--- a/packages/game-sound-garden/src/vite-env.d.ts
+++ b/packages/game-sound-garden/src/vite-env.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="vite/client" />
+
+// Raw YAML imports (Vite `?raw` suffix) — used to load the sound-garden
+// GameType vocabulary from the creation package fixtures without a build step.
+declare module '*.yaml?raw' {
+  const content: string
+  export default content
+}

--- a/packages/game-sound-garden/src/voice/SoundGardenPartnerChannel.test.tsx
+++ b/packages/game-sound-garden/src/voice/SoundGardenPartnerChannel.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import type { CoBuildAction } from '@shared/voice/voice-session-protocol'
+
+/**
+ * Capture the options the channel passes to `useGameVoiceSession` so a test can
+ * drive the `onAction` / `getGameState` wiring without a real WebSocket session.
+ */
+const hook = vi.hoisted(() => ({
+  onAction: null as null | ((actions: CoBuildAction[]) => void),
+  getGameState: null as null | (() => unknown),
+  session: {
+    status: 'ready',
+    conversationPhase: 'listening',
+    aiText: '',
+    playerTranscript: '',
+    isAiSpeaking: false,
+    error: null as string | null,
+    openSession: vi.fn(),
+    endSession: vi.fn(),
+    requestClosing: vi.fn(() => Promise.resolve()),
+  },
+}))
+
+vi.mock('@shared/voice/use-game-voice-session', () => ({
+  useGameVoiceSession: (opts: {
+    onAction?: (actions: CoBuildAction[]) => void
+    getGameState?: () => unknown
+  }) => {
+    hook.onAction = opts.onAction ?? null
+    hook.getGameState = opts.getGameState ?? null
+    return hook.session
+  },
+}))
+
+import SoundGardenPartnerChannel from './SoundGardenPartnerChannel'
+import { GameStore } from '../game/store'
+import { ScriptedPartnerBrain } from '../partner/brain'
+import { levelByIndex } from '../game/levels'
+import { buildSoundGardenManualData } from './sound-garden-manual'
+
+const lv1 = levelByIndex(1)!
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  hook.onAction = null
+  hook.getGameState = null
+})
+
+describe('SoundGardenPartnerChannel (mode② wiring)', () => {
+  it('renders the live voice panel when the session is ready', () => {
+    const store = new GameStore(lv1, 'melody', { partnerMode: 'platform' })
+    render(
+      <SoundGardenPartnerChannel
+        store={store}
+        gameId="sound-garden"
+        manualData={buildSoundGardenManualData(lv1)}
+      />
+    )
+    expect(screen.getByLabelText('AI 伙伴语音')).toBeInTheDocument()
+    store.dispose()
+  })
+
+  it('onAction routes co_build moves through the legality guard into the engine board', () => {
+    const store = new GameStore(lv1, 'melody', { partnerMode: 'platform' })
+    store.plantPlayer('bell', 1)
+    render(
+      <SoundGardenPartnerChannel
+        store={store}
+        gameId="sound-garden"
+        manualData={buildSoundGardenManualData(lv1)}
+      />
+    )
+    expect(hook.onAction).toBeTypeOf('function')
+
+    // A legal partner move + an illegal (wrong-lane) one arrive from the server.
+    act(() => {
+      hook.onAction?.([
+        { op: 'place', pieceType: 'kick', slot: 1 },
+        { op: 'place', pieceType: 'bell', slot: 2 }, // wrong lane → dropped by the guard
+      ])
+    })
+    expect(store.getSnapshot().rhythm[0]).toBe('kick')
+    expect(store.getSnapshot().rhythm[1]).toBeNull()
+    expect(store.getSnapshot().score).toBe(3) // kick×bell synergy
+    store.dispose()
+  })
+
+  it('getGameState exposes the live board publicContext for the speech-start pull', () => {
+    const store = new GameStore(lv1, 'melody', { partnerMode: 'platform' })
+    store.plantPlayer('bell', 1)
+    render(
+      <SoundGardenPartnerChannel
+        store={store}
+        gameId="sound-garden"
+        manualData={buildSoundGardenManualData(lv1)}
+      />
+    )
+    const gs = hook.getGameState?.() as {
+      relevantSections: string[]
+      publicContext: { melody: (string | null)[]; partnerArchetype: string }
+    }
+    expect(gs.relevantSections).toEqual(['matrix', 'rules'])
+    expect(gs.publicContext.melody[0]).toBe('bell')
+    expect(gs.publicContext.partnerArchetype).toBe('rhythm_piece')
+    store.dispose()
+  })
+
+  it('fires the closing recap exactly once on the first bloom (§4 settlement)', async () => {
+    const store = new GameStore(lv1, 'melody', { partnerMode: 'platform' })
+    // The scripted brain computes the synergy rhythm for each planted melody, so
+    // the test drives a real cooperative bloom without hardcoding the matrix.
+    const brain = new ScriptedPartnerBrain(lv1.matrix, 'rhythm_piece')
+    render(
+      <SoundGardenPartnerChannel
+        store={store}
+        gameId="sound-garden"
+        manualData={buildSoundGardenManualData(lv1)}
+      />
+    )
+
+    for (const [type, slot] of [
+      ['bell', 1],
+      ['chime', 2],
+      ['flute', 3],
+      ['harp', 4],
+    ] as const) {
+      store.plantPlayer(type, slot)
+      const reaction = await brain.react(store.voiceGameState().publicContext)
+      await act(async () => {
+        hook.onAction?.(reaction.actions)
+      })
+      if (store.getSnapshot().settled) break
+    }
+
+    expect(store.getSnapshot().settled).toBe(true)
+    // Fire-and-forget recap, once per run (bloom = the `defused` win register).
+    expect(hook.session.requestClosing).toHaveBeenCalledTimes(1)
+    expect(hook.session.requestClosing).toHaveBeenCalledWith('defused')
+    store.dispose()
+  })
+})

--- a/packages/game-sound-garden/src/voice/SoundGardenPartnerChannel.tsx
+++ b/packages/game-sound-garden/src/voice/SoundGardenPartnerChannel.tsx
@@ -1,0 +1,208 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
+import {
+  useGameVoiceSession,
+  type GameVoiceGuards,
+  type GameVoiceManualData,
+} from '@shared/voice/use-game-voice-session'
+import type { CoBuildAction } from '@shared/voice/voice-session-protocol'
+import type { ConversationPhase, VoiceStatus } from '@shared/voice/voice-session-protocol'
+import type { PieceType } from '../game/constants'
+import type { GameStore } from '../game/store'
+import type { PartnerAction } from '../game/types'
+
+/**
+ * mode② partner channel — the account companion as the 园丁 co-builder, over the
+ * shared `@shared/voice/use-game-voice-session` hook (the same client BombSquad /
+ * Botanical use), same-origin to the platform Worker with `gameId:'sound-garden'`.
+ *
+ * Wiring (on top of the PR-1 protocol):
+ *  - `onAction` — the partner's co_build moves flow through the SAME client
+ *    legality guard the scripted partner uses (`store.applyPartnerActions`) into
+ *    the engine as the partner role. Barge-in / closing-turn suppression come
+ *    free from PR-1 (the hook drops a barged turn's action; the recap never moves).
+ *  - `getGameState` — the live board (`store.voiceGameState`) is pulled on each
+ *    speech-start; the memoized `gameState` also re-steers the session on every
+ *    board change (the hook diffs the signature), so the partner always reasons
+ *    against the current lanes/score.
+ *
+ * Hands-free once started; the mic opens behind the「呼叫伙伴」gesture (getUserMedia
+ * needs one). Dark-only, CSS-only animation.
+ */
+
+export const SOUND_GARDEN_VOICE_GUARDS: GameVoiceGuards = {
+  connectMs: 5_000,
+  responseMs: 15_000,
+  silenceMs: 45_000,
+  maxPlayerTurns: 24,
+  maxDurationMs: 600_000,
+}
+
+interface SoundGardenPartnerChannelProps {
+  store: GameStore
+  /** `'sound-garden'` (companion) in production. */
+  gameId: string
+  manualData: GameVoiceManualData
+}
+
+const PHASE_LABEL: Record<ConversationPhase, string> = {
+  listening: '聆听中',
+  thinking: '思考中',
+  speaking: '说话中',
+}
+
+const STATUS_LABEL: Partial<Record<VoiceStatus, string>> = {
+  idle: '准备中',
+  connecting: '连接中',
+  error: '连接出错',
+  closed: '已结束',
+}
+
+function coBuildToPartnerActions(actions: CoBuildAction[]): PartnerAction[] {
+  // The server parse-guard already validated op ∈ {place,remove} + pieceType ∈ the
+  // Sound Garden vocabulary; the store's `filterLegalActions` re-validates lane /
+  // range / material against the live board, so this cast is safe.
+  return actions.map((a) => ({ op: a.op, pieceType: a.pieceType as PieceType, slot: a.slot }))
+}
+
+function SoundGardenPartnerChannelImpl({
+  store,
+  gameId,
+  manualData,
+}: SoundGardenPartnerChannelProps) {
+  const gameStoreState = useSyncExternalStore(store.subscribe, store.getSnapshot)
+  // Board-derived voice game state: re-memoized whenever the store state changes,
+  // so the hook re-steers (update-gamestate) on every board change. `voiceGameState`
+  // reads the store's live snapshot, so `gameStoreState` is the deliberate recompute
+  // trigger even though it is not textually referenced in the memo body.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const gameState = useMemo(() => store.voiceGameState(), [store, gameStoreState])
+
+  const onAction = useCallback(
+    (actions: CoBuildAction[]) => {
+      store.applyPartnerActions(coBuildToPartnerActions(actions))
+    },
+    [store]
+  )
+  const getGameState = useCallback(() => store.voiceGameState(), [store])
+
+  const {
+    status,
+    conversationPhase,
+    aiText,
+    playerTranscript,
+    isAiSpeaking,
+    error,
+    openSession,
+    endSession,
+    requestClosing,
+  } = useGameVoiceSession({
+    manualData,
+    gameState,
+    gameId,
+    onAction,
+    getGameState,
+    guards: SOUND_GARDEN_VOICE_GUARDS,
+    sessionNamePrefix: 'sound-garden',
+    // getUserMedia needs a user gesture → connect on the「呼叫伙伴」click.
+    autoConnect: false,
+  })
+
+  // Settlement recap (§4): on the FIRST bloom, ask the platform partner for its
+  // closing line. Fire-and-forget, once per run — closing turns are action-free by
+  // PR-1 design (the partner speaks a recap, it does not move the board). Bloom is
+  // the win outcome, so it maps to the `defused` recap register; resolves
+  // immediately (a no-op) if the session is not live.
+  const closingSentRef = useRef(false)
+  useEffect(() => {
+    if (gameStoreState.settled && !closingSentRef.current && status === 'ready') {
+      closingSentRef.current = true
+      void requestClosing('defused')
+    }
+  }, [gameStoreState.settled, status, requestClosing])
+
+  const isLive = status === 'ready'
+  const notStarted = status === 'idle' || status === 'closed' || status === 'error'
+  const indicatorLabel = isLive
+    ? PHASE_LABEL[conversationPhase]
+    : (STATUS_LABEL[status] ?? '准备中')
+
+  if (notStarted) {
+    return (
+      <section className="sg-voice" aria-label="AI 伙伴语音">
+        <button type="button" className="sg-btn primary" onClick={() => openSession()}>
+          {status === 'idle' ? '呼叫伙伴' : '重新连接'}
+        </button>
+        {error && (
+          <p className="sg-voice-error" role="alert">
+            {error}
+          </p>
+        )}
+        <p className="sg-voice-hint">
+          点「呼叫伙伴」授权麦克风，伙伴会先打招呼；随后直接对它说话即可。
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="sg-voice" aria-label="AI 伙伴语音">
+      <div className="sg-voice-head">
+        <span className="sg-voice-status">
+          <span
+            className="sg-voice-dot"
+            data-status={status}
+            data-phase={isLive ? conversationPhase : undefined}
+            aria-hidden="true"
+          />
+          <span className="sg-voice-statustext" role="status">
+            {indicatorLabel}
+          </span>
+        </span>
+        {isLive && isAiSpeaking && (
+          <span className="sg-voice-speaking" role="status" aria-label="伙伴正在说话">
+            <span className="sg-voice-dots" aria-hidden="true">
+              <i />
+              <i />
+              <i />
+            </span>
+          </span>
+        )}
+      </div>
+
+      {playerTranscript && (
+        <p className="sg-voice-you" aria-label="你说的话">
+          <span className="sg-voice-label">你：</span>
+          {playerTranscript}
+        </p>
+      )}
+
+      <div className="sg-voice-reply" role="status" aria-live="polite">
+        {aiText ? (
+          <p aria-label="伙伴说的话">
+            <span className="sg-voice-label">伙伴：</span>
+            {aiText}
+          </p>
+        ) : (
+          <p className="sg-voice-placeholder">开口说话，伙伴会即时回应并在花园里搭手</p>
+        )}
+      </div>
+
+      {error && (
+        <p className="sg-voice-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="sg-voice-foot">
+        <p className="sg-voice-hint">免提对话已开启，直接对伙伴说话即可。</p>
+        <button type="button" className="sg-btn ghost" onClick={endSession}>
+          结束对话
+        </button>
+      </div>
+    </section>
+  )
+}
+
+/** Memoized so the transport/playhead re-render does not re-render the panel. */
+const SoundGardenPartnerChannel = memo(SoundGardenPartnerChannelImpl)
+export default SoundGardenPartnerChannel

--- a/packages/game-sound-garden/src/voice/sound-garden-manual.ts
+++ b/packages/game-sound-garden/src/voice/sound-garden-manual.ts
@@ -1,0 +1,29 @@
+import type { GameVoiceManualData } from '@shared/voice/use-game-voice-session'
+import { RELATION_SCORES } from '../game/constants'
+import type { LevelConfig } from '../game/types'
+
+/**
+ * The per-run manual for the mode② partner. The harmony matrix is the coop hidden
+ * info: it rides here as `sections.matrix` (client → `create`), injected
+ * server-side as the authoritative manual (never shown to the player). This keeps
+ * the probe's existing UI-only hidden-info model — matrix is client-held, not
+ * server-authoritative (⚠ the same tradeoff as BombSquad's client-side answer
+ * calc; flagged, not silently claimed as server-secret). The static `rules`
+ * section gives the partner the scoring model + this level's target.
+ */
+export function buildSoundGardenManualData(level: LevelConfig): GameVoiceManualData {
+  return {
+    version: level.id,
+    sections: {
+      matrix: level.matrix,
+      rules: {
+        target: level.target,
+        slots: level.slots,
+        relation_scores: RELATION_SCORES,
+        summary:
+          '同一拍两侧都有元素才计分：synergy 最好、compatible 次之、neutral 平淡、incompatible 会倒扣。' +
+          '用有限的材料把元素放在最能共鸣的拍上，让和声总分达到 target，花园就会绽放。',
+      },
+    },
+  }
+}

--- a/packages/game-sound-garden/src/voice/sound-garden-voice-eligibility.test.ts
+++ b/packages/game-sound-garden/src/voice/sound-garden-voice-eligibility.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import { checkSoundGardenVoiceEligibility } from './sound-garden-voice-eligibility'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/** A fetch double routing `/api/auth/session` + `/api/companion` to fixed responses. */
+function fetcher(routes: Record<string, Response>): typeof fetch {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const key = Object.keys(routes).find((r) => url.includes(r))
+    if (!key) throw new Error(`unexpected fetch ${url}`)
+    return routes[key]
+  }) as unknown as typeof fetch
+}
+
+describe('checkSoundGardenVoiceEligibility', () => {
+  it('eligible when authenticated with a named companion', async () => {
+    const result = await checkSoundGardenVoiceEligibility(
+      fetcher({
+        '/api/auth/session': jsonResponse({ authenticated: true }),
+        '/api/companion': jsonResponse({ name: '小星' }),
+      })
+    )
+    expect(result).toEqual({ status: 'eligible', companionName: '小星' })
+  })
+
+  it('anonymous when not authenticated', async () => {
+    const result = await checkSoundGardenVoiceEligibility(
+      fetcher({ '/api/auth/session': jsonResponse({ authenticated: false }) })
+    )
+    expect(result).toEqual({ status: 'ineligible', reason: 'anonymous' })
+  })
+
+  it('no-companion when the companion is missing (404) or unnamed', async () => {
+    expect(
+      await checkSoundGardenVoiceEligibility(
+        fetcher({
+          '/api/auth/session': jsonResponse({ authenticated: true }),
+          '/api/companion': new Response(null, { status: 404 }),
+        })
+      )
+    ).toEqual({ status: 'ineligible', reason: 'no-companion' })
+    expect(
+      await checkSoundGardenVoiceEligibility(
+        fetcher({
+          '/api/auth/session': jsonResponse({ authenticated: true }),
+          '/api/companion': jsonResponse({ name: '   ' }),
+        })
+      )
+    ).toEqual({ status: 'ineligible', reason: 'no-companion' })
+  })
+
+  it('unavailable when the session endpoint fails or throws (standalone dev / no Worker)', async () => {
+    expect(
+      await checkSoundGardenVoiceEligibility(
+        fetcher({ '/api/auth/session': new Response(null, { status: 500 }) })
+      )
+    ).toEqual({ status: 'ineligible', reason: 'unavailable' })
+    const throwing = vi.fn(async () => {
+      throw new Error('no worker')
+    }) as unknown as typeof fetch
+    expect(await checkSoundGardenVoiceEligibility(throwing)).toEqual({
+      status: 'ineligible',
+      reason: 'unavailable',
+    })
+  })
+})

--- a/packages/game-sound-garden/src/voice/sound-garden-voice-eligibility.ts
+++ b/packages/game-sound-garden/src/voice/sound-garden-voice-eligibility.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Companion-voice eligibility for the mode② Sound Garden partner (copied from
+ * game-botanical's `voice-eligibility.ts`). A signed-in player with a named
+ * account companion gets the platform co_build partner; everyone else (anonymous,
+ * no companion, or the standalone dev build with no Worker) falls back to the
+ * offline scripted partner (§3). A shared `@shared/voice/voice-eligibility` lift is
+ * the clean follow-up now that a third game copies this.
+ */
+export type SoundGardenVoiceEligibility =
+  | { status: 'checking' }
+  | { status: 'eligible'; companionName: string }
+  | { status: 'ineligible'; reason: 'anonymous' | 'no-companion' | 'unavailable' }
+
+interface SessionBody {
+  authenticated?: boolean
+}
+
+interface CompanionBody {
+  name?: unknown
+}
+
+export async function checkSoundGardenVoiceEligibility(
+  fetcher: typeof fetch = fetch,
+  signal?: AbortSignal
+): Promise<SoundGardenVoiceEligibility> {
+  try {
+    const sessionResponse = await fetcher('/api/auth/session', {
+      credentials: 'include',
+      signal,
+    })
+    if (!sessionResponse.ok) return { status: 'ineligible', reason: 'unavailable' }
+    const session = (await sessionResponse.json()) as SessionBody
+    if (!session.authenticated) return { status: 'ineligible', reason: 'anonymous' }
+
+    const companionResponse = await fetcher('/api/companion', {
+      credentials: 'include',
+      signal,
+    })
+    if (companionResponse.status === 404) {
+      return { status: 'ineligible', reason: 'no-companion' }
+    }
+    if (!companionResponse.ok) return { status: 'ineligible', reason: 'unavailable' }
+    const companion = (await companionResponse.json()) as CompanionBody
+    if (typeof companion.name !== 'string' || companion.name.trim().length === 0) {
+      return { status: 'ineligible', reason: 'no-companion' }
+    }
+    return { status: 'eligible', companionName: companion.name.trim() }
+  } catch {
+    return { status: 'ineligible', reason: 'unavailable' }
+  }
+}
+
+export function useSoundGardenVoiceEligibility(enabled: boolean): SoundGardenVoiceEligibility {
+  const [eligibility, setEligibility] = useState<SoundGardenVoiceEligibility>(
+    enabled ? { status: 'checking' } : { status: 'ineligible', reason: 'unavailable' }
+  )
+
+  useEffect(() => {
+    if (!enabled) return
+    const controller = new AbortController()
+    let active = true
+    void checkSoundGardenVoiceEligibility(fetch, controller.signal).then((result) => {
+      if (active) setEligibility(result)
+    })
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [enabled])
+
+  return eligibility
+}

--- a/packages/game-sound-garden/src/voice/voice-io.test.ts
+++ b/packages/game-sound-garden/src/voice/voice-io.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createVoice, NullVoice } from './voice-io'
+
+const win = window as unknown as Record<string, unknown>
+const glob = globalThis as unknown as Record<string, unknown>
+
+class FakeRecognition {
+  lang = ''
+  continuous = false
+  interimResults = false
+  onresult: (() => void) | null = null
+  onerror: (() => void) | null = null
+  onend: (() => void) | null = null
+  start(): void {}
+  stop(): void {}
+  abort(): void {}
+}
+
+class FakeUtterance {
+  lang = ''
+  onend: (() => void) | null = null
+  onerror: (() => void) | null = null
+  constructor(public text: string) {}
+}
+
+afterEach(() => {
+  delete win.webkitSpeechRecognition
+  delete win.speechSynthesis
+  delete glob.SpeechSynthesisUtterance
+  vi.unstubAllGlobals()
+})
+
+describe('createVoice (anon browser voice)', () => {
+  it('returns NullVoice with nothing available (no browser support)', () => {
+    const voice = createVoice()
+    expect(voice).toBeInstanceOf(NullVoice)
+    expect(voice.canListen).toBe(false)
+  })
+
+  it('exposes canListen when Web Speech ASR is available', () => {
+    win.webkitSpeechRecognition = FakeRecognition
+    const voice = createVoice()
+    expect(voice.canListen).toBe(true)
+  })
+
+  it('speaks via browser speechSynthesis when supported', async () => {
+    const synthSpeak = vi.fn((utterance: FakeUtterance) => utterance.onend?.())
+    win.speechSynthesis = { speak: synthSpeak, cancel: vi.fn() }
+    glob.SpeechSynthesisUtterance = FakeUtterance
+
+    const voice = createVoice()
+    await voice.speak('你好')
+
+    expect(synthSpeak).toHaveBeenCalled()
+  })
+
+  it('cancels in-flight speech on visibilitychange → hidden (background-tab catch-up guard)', () => {
+    const cancel = vi.fn()
+    win.speechSynthesis = { speak: vi.fn(), cancel }
+    glob.SpeechSynthesisUtterance = FakeUtterance
+    createVoice()
+    // Simulate backgrounding: document.hidden true + the event fires.
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true })
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(cancel).toHaveBeenCalled()
+  })
+})

--- a/packages/game-sound-garden/src/voice/voice-io.ts
+++ b/packages/game-sound-garden/src/voice/voice-io.ts
@@ -1,0 +1,239 @@
+/**
+ * Anon-tier voice I/O (PR-2). Voice is a swappable driver so the game loop never
+ * changes when voice does.
+ *
+ * This is the ANON path only. The signed-in mode② partner runs on the platform
+ * `useGameVoiceSession` (server ASR + Doubao TTS streamed) and does NOT use this
+ * module. Here:
+ *   - ASR (listen): browser Web Speech `zh-CN`, PUSH-TO-TALK (tap the mic chip to
+ *     capture one utterance). Hidden entirely when unsupported.
+ *   - TTS (speak): browser `speechSynthesis` when supported, else silent.
+ *   - Neither supported → NullVoice + the scripted brain (fully offline play).
+ *
+ * The dev proxy tier (`/api/partner`, `/api/tts` Doubao) and the capability probe
+ * that selected them were removed with the dev server — the platform session
+ * replaces them for signed-in play.
+ */
+
+// --- interface ---------------------------------------------------------------
+
+export interface VoiceIO {
+  /** True when push-to-talk ASR is available (drives the mic-chip visibility). */
+  readonly canListen: boolean
+  /** Capture one player utterance (push-to-talk). Resolves '' if none / unsupported. */
+  listen(): Promise<string>
+  /** Force-stop an in-flight capture (mic-chip second tap). */
+  stopListening(): void
+  /** Speak a partner line. Resolves when playback finishes (or is skipped). */
+  speak(text: string): Promise<void>
+  dispose(): void
+}
+
+// --- Default: no mic, no TTS -------------------------------------------------
+
+export class NullVoice implements VoiceIO {
+  readonly canListen = false
+  async listen(): Promise<string> {
+    return ''
+  }
+  stopListening(): void {
+    // nothing to stop
+  }
+  async speak(_text: string): Promise<void> {
+    // no-op — partner speech is rendered as text
+  }
+  dispose(): void {
+    // nothing to tear down
+  }
+}
+
+// --- feature detection -------------------------------------------------------
+
+interface SpeechRecognitionResultLike {
+  0: { transcript: string }
+}
+interface SpeechRecognitionEventLike {
+  results: ArrayLike<SpeechRecognitionResultLike>
+}
+interface SpeechRecognitionLike {
+  lang: string
+  continuous: boolean
+  interimResults: boolean
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null
+  onerror: (() => void) | null
+  onend: (() => void) | null
+  start(): void
+  stop(): void
+  abort(): void
+}
+type SpeechRecognitionCtor = new () => SpeechRecognitionLike
+
+function speechRecognitionCtor(): SpeechRecognitionCtor | null {
+  if (typeof window === 'undefined') return null
+  const w = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionCtor
+    webkitSpeechRecognition?: SpeechRecognitionCtor
+  }
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null
+}
+
+function speechSynthSupported(): boolean {
+  return typeof window !== 'undefined' && 'speechSynthesis' in window
+}
+
+// --- ASR: Web Speech push-to-talk -------------------------------------------
+
+class WebSpeechListener {
+  private readonly ctor: SpeechRecognitionCtor
+  private active: SpeechRecognitionLike | null = null
+
+  constructor(ctor: SpeechRecognitionCtor) {
+    this.ctor = ctor
+  }
+
+  listen(): Promise<string> {
+    if (this.active) return Promise.resolve('')
+    return new Promise<string>((resolve) => {
+      const rec = new this.ctor()
+      this.active = rec
+      rec.lang = 'zh-CN'
+      rec.continuous = false
+      rec.interimResults = false
+      let transcript = ''
+      let settled = false
+      const done = (text: string) => {
+        if (settled) return
+        settled = true
+        this.active = null
+        resolve(text)
+      }
+      rec.onresult = (event) => {
+        const parts: string[] = []
+        for (let i = 0; i < event.results.length; i++) parts.push(event.results[i][0].transcript)
+        transcript = parts.join('').trim()
+      }
+      rec.onerror = () => done('')
+      rec.onend = () => done(transcript)
+      try {
+        rec.start()
+      } catch {
+        done('')
+      }
+    })
+  }
+
+  stop(): void {
+    try {
+      this.active?.stop()
+    } catch {
+      // ignore
+    }
+  }
+
+  dispose(): void {
+    try {
+      this.active?.abort()
+    } catch {
+      // ignore
+    }
+    this.active = null
+  }
+}
+
+// --- TTS speakers ------------------------------------------------------------
+
+interface Speaker {
+  speak(text: string): Promise<void>
+  dispose(): void
+}
+
+class NullSpeaker implements Speaker {
+  async speak(_text: string): Promise<void> {}
+  dispose(): void {}
+}
+
+/**
+ * Browser `speechSynthesis` TTS (anon tier). Background-tab handling (r13
+ * followup): Chrome throttles / queues speech synthesis in a hidden tab, so a
+ * line started before backgrounding can replay or pile up on return. We cancel
+ * any in-flight utterance on `visibilitychange → hidden` and on dispose, so a
+ * backgrounded partner line is dropped rather than caught up later.
+ */
+class SpeechSynthSpeaker implements Speaker {
+  private readonly onVisibility: () => void
+
+  constructor() {
+    this.onVisibility = () => {
+      if (typeof document !== 'undefined' && document.hidden) this.cancel()
+    }
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', this.onVisibility)
+    }
+  }
+
+  private cancel(): void {
+    try {
+      window.speechSynthesis?.cancel()
+    } catch {
+      // ignore
+    }
+  }
+
+  speak(text: string): Promise<void> {
+    return new Promise<void>((resolve) => {
+      try {
+        const synth = window.speechSynthesis
+        synth.cancel()
+        const utterance = new SpeechSynthesisUtterance(text)
+        utterance.lang = 'zh-CN'
+        utterance.onend = () => resolve()
+        utterance.onerror = () => resolve()
+        synth.speak(utterance)
+      } catch {
+        resolve()
+      }
+    })
+  }
+
+  dispose(): void {
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.onVisibility)
+    }
+    this.cancel()
+  }
+}
+
+// --- composite + factory -----------------------------------------------------
+
+class BrowserVoice implements VoiceIO {
+  constructor(
+    private readonly listener: WebSpeechListener | null,
+    private readonly speaker: Speaker
+  ) {}
+
+  get canListen(): boolean {
+    return this.listener !== null
+  }
+  listen(): Promise<string> {
+    return this.listener ? this.listener.listen() : Promise.resolve('')
+  }
+  stopListening(): void {
+    this.listener?.stop()
+  }
+  speak(text: string): Promise<void> {
+    return this.speaker.speak(text)
+  }
+  dispose(): void {
+    this.listener?.dispose()
+    this.speaker.dispose()
+  }
+}
+
+/** Resolve the anon voice driver from browser support alone (no server caps). */
+export function createVoice(): VoiceIO {
+  const ctor = speechRecognitionCtor()
+  const listener = ctor ? new WebSpeechListener(ctor) : null
+  const speaker: Speaker = speechSynthSupported() ? new SpeechSynthSpeaker() : new NullSpeaker()
+  if (listener === null && speaker instanceof NullSpeaker) return new NullVoice()
+  return new BrowserVoice(listener, speaker)
+}

--- a/packages/game-sound-garden/tsconfig.json
+++ b/packages/game-sound-garden/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["../../shared/*"]
+    },
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "../../shared"]
+}

--- a/packages/game-sound-garden/vite.config.ts
+++ b/packages/game-sound-garden/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
+
+export default defineConfig({
+  // Served from /sound-garden/ on Cloudflare Pages (merged into
+  // platform/dist/sound-garden/ by scripts/assemble-pages.mjs). The base only
+  // rewrites built asset URLs; the SPA has a single screen and no router, so
+  // route matching is unaffected.
+  base: '/sound-garden/',
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+      // Game-agnostic voice-session client (mode② partner) — mirrors bombsquad /
+      // botanical so `useGameVoiceSession` resolves without a workspace dep.
+      '@shared': resolve(__dirname, '../../shared'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
+    globals: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,61 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/game-sound-garden:
+    dependencies:
+      '@amiclaw/creation':
+        specifier: workspace:*
+        version: link:../creation
+      '@amiclaw/ui':
+        specifier: workspace:*
+        version: link:../ui
+      js-yaml:
+        specifier: ^4.2.0
+        version: 4.2.0
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@amiclaw/platform-ai':
+        specifier: workspace:*
+        version: link:../platform-ai
+      '@testing-library/jest-dom':
+        specifier: ^6.4.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: ^26.0.1
+        version: 26.0.1
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/game-yijing:
     dependencies:
       '@amiclaw/arcade-profile':


### PR DESCRIPTION
## Summary

- **Sound Garden becomes a platform game package** built on the co_build protocol (#243): the mode② platform companion sees the live board and plants rhythm roots through the structured action channel (legality-guarded), while anonymous players get a scripted partner with a pre-seeded opening move — the game is fully playable in both tiers.
- **Atlas v2 skin** via local tokens aliasing platform tokens (no new design dialect); first-bloom settlement latch with a dismissible platform-style results overlay (play continues after bloom); closing recap wired for mode②.
- Probe followups closed: late-reply session guard, background-tab audio cancel, dev-tier removal; plus a live-caught anon deadlock fix (awaited hung speechSynthesis pinned the partner trigger bus — cosmetic speech is now fire-and-forget, with a failing-first jsdom wiring test).

## Review notes

- Not listed yet: the package is intentionally NOT in assemble-pages/routes — listing lands in the follow-up PR after this merges.
- Creation package gains one additive public root export used by the game.

## Test plan

- [x] game-sound-garden 60 (incl. DOM-level wiring test, settlement latch, once-only pre-seed)
- [x] platform-ai 441 / consumers unchanged (bombsquad 508, botanical 71, shadow-chase 121, platform 211)
- [x] Full typecheck, eslint, prettier
- [x] Live real-browser drive: plant→partner response→bloom→settlement (twice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Wc24r89aktaszk8JE3JC
