### PR TITLE
feat(platform): sound garden joins the arcade as a live game

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -61,6 +61,11 @@ jobs:
           mkdir -p packages/platform/dist/radio-cipher
           cp -r packages/game-radio-cipher/dist/. packages/platform/dist/radio-cipher/
 
+      - name: Merge game-sound-garden build into platform/dist under /sound-garden/
+        run: |
+          mkdir -p packages/platform/dist/sound-garden
+          cp -r packages/game-sound-garden/dist/. packages/platform/dist/sound-garden/
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.1.0...HEAD)
 
+**Sound Garden joins AMIO Arcade** — Added. A new co-build voice game at
+`claw.amio.fans/sound-garden`. You plant melody flowers along an 8-beat timeline
+while your companion plants rhythm roots on the same beats; a root and a flower
+sharing a beat harmonize — synergy, compatible, neutral, or a harsh clash — and
+when the harmony score reaches the level's target the garden blooms. Signed-in
+players with a named companion co-build by voice: the companion speaks its
+guidance AND places its own rhythm roots on your shared board through the new
+co_build action channel — its moves pass the same client-side legality guard your
+own plants do, and it never moves during its closing recap. Everyone else —
+anonymous, no companion, or a standalone build with no platform worker — plays an
+offline scripted partner over the browser's own voice, which opens the garden with
+a seed move and answers each plant. It is a no-fail sandbox: a clashing pair only
+sounds harsh, nothing detonates, and bloom is a reward you can keep playing past.
+Ships with three levels, dark-only, CSS-only animation, running on the shared
+creation engine.
+
 **The platform companion learns to act in co-build games** — Added. The voice
 AI pipeline gains a backward-compatible action channel: in games flagged as
 co-build, the companion's reply can carry one structured board action

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -21,9 +21,9 @@
 #
 # --- Regression size budget --------------------------------------------------
 # Per the governance model (rule 3): the e2e regression suite is capped at
-# 2 x the journey-scenario count. With 34 active flows <-> 34 journey
-# scenarios, the regression size budget is 68 (2026-07-11, after the Radio
-# Cipher listener-run flow landed as a @playwright journey).
+# 2 x the journey-scenario count. With 35 active flows <-> 35 journey
+# scenarios, the regression size budget is 70 (2026-07-11, after the Sound
+# Garden anon-run flow landed as a @playwright journey).
 # Crossing it triggers a forced prune audit. Current regression count: 2.
 #
 # --- Retired scenario --------------------------------------------------------
@@ -513,4 +513,30 @@ flows:
       shareable decoder codebook then teaches the finals-ring cipher and channel
       protocol while leaking no listener-side plaintext answer.
     steps: [radio-listener-open, onboarding-dismiss, tutorial-decrypt, run-won, codebook-partition]
+    status: active
+
+  # === Sound Garden flows =====================================================
+  # The /sound-garden/ single-screen SPA. A co-build music game: on the anon tier
+  # (no platform worker → voice eligibility fails) the offline scripted partner
+  # runs entirely client-side, seeding the garden with an opening rhythm root and
+  # answering each melody plant with a synergizing root, so a no-account visitor
+  # can co-build a garden to bloom with no live session.
+
+  - id: sound-garden-anon-run
+    name: Sound Garden anon co-build bloom
+    description: >-
+      An anonymous visitor opens Sound Garden and starts the 学步 level; the
+      offline scripted partner seeds the garden with an opening rhythm root, then
+      answers the visitor's three planted melody flowers with synergizing rhythm
+      roots until the shared harmony reaches the target and the garden blooms — a
+      no-fail co-build entirely client-side (no account, no worker, no session).
+    steps:
+      [
+        sound-garden-open,
+        sound-garden-start,
+        partner-seed,
+        plant-melody,
+        partner-rhythm,
+        garden-bloom,
+      ]
     status: active

--- a/e2e/sound-garden.gherkin
+++ b/e2e/sound-garden.gherkin
@@ -1,0 +1,24 @@
+# Sound Garden anon co-build bloom smoke. The /sound-garden/ single-screen SPA
+# plays fully client-side for a no-account visitor: with no platform worker the
+# voice eligibility probe fails and the offline scripted partner runs, seeding the
+# garden with an opening rhythm root and answering each plant with a synergizing
+# root until the shared harmony reaches the target and the garden blooms — a
+# no-fail co-build that needs neither an account nor a live session.
+
+Feature: Sound Garden anon co-build run
+  As an AMIO Arcade visitor without an account
+  I want to co-build a singing garden with the offline partner
+  So that we bloom the garden together entirely client-side
+
+  # Source: sound-garden-anon-run
+  @playwright
+  Scenario: The scripted partner seeds, answers plants, and the garden blooms
+    Given I open /sound-garden/
+    When I start Sound Garden level "学步"
+    Then the Sound Garden partner seeds the garden with an opening root
+
+    When I plant Sound Garden melody "铃铛" on beat 1
+    And I plant Sound Garden melody "风铃" on beat 2
+    And I plant Sound Garden melody "笛音" on beat 3
+    Then the Sound Garden partner answers with rhythm roots
+    And the Sound Garden blooms

--- a/e2e/steps/sound-garden.steps.ts
+++ b/e2e/steps/sound-garden.steps.ts
@@ -1,0 +1,47 @@
+/** Sound Garden anon co-build journey steps. The /sound-garden/ single-screen SPA
+ * plays fully client-side; with no platform worker the voice-eligibility probe
+ * fails and the offline scripted partner runs, so these steps drive the real
+ * engine + scripted brain through the DOM: seed → plants → synergizing rhythm
+ * roots → bloom. `Given I open /sound-garden/` is the shared navigation step. */
+import { expect } from '@playwright/test'
+import { Then, When } from './fixtures'
+
+When('I start Sound Garden level {string}', async ({ page }, level: string) => {
+  // The default role is the melody flower side, so the player plants melody and
+  // the partner plants rhythm. Clicking the level button starts that run.
+  await page.getByRole('button', { name: new RegExp(level) }).click()
+  // The anon partner tier renders once eligibility resolves (no worker → anon):
+  // the melody palette is the ready signal.
+  await expect(page.getByRole('button', { name: /选择铃铛/ })).toBeVisible()
+})
+
+Then('the Sound Garden partner seeds the garden with an opening root', async ({ page }) => {
+  // The scripted partner greets AND pre-seeds exactly one rhythm root (the PR-2
+  // anon opening move), so the garden starts with one filled rhythm cell.
+  await expect(page.getByText(/一起让花园唱起来/)).toBeVisible()
+  await expect.poll(() => page.locator('.sg-cell.rhythm.filled').count()).toBeGreaterThanOrEqual(1)
+})
+
+When(
+  'I plant Sound Garden melody {string} on beat {int}',
+  async ({ page }, piece: string, beat: number) => {
+    // Select the palette chip (剩余 count in its label), then tap the player's melody
+    // cell on that beat.
+    await page.getByRole('button', { name: new RegExp(`选择${piece}`) }).click()
+    await page.getByRole('button', { name: `旋律 第${beat}拍` }).click()
+  }
+)
+
+Then('the Sound Garden partner answers with rhythm roots', async ({ page }) => {
+  // The scripted partner (debounced) lays synergizing rhythm roots under the new
+  // melody flowers, so the rhythm lane grows past the single pre-seed root.
+  await expect
+    .poll(() => page.locator('.sg-cell.rhythm.filled').count(), { timeout: 15_000 })
+    .toBeGreaterThanOrEqual(2)
+})
+
+Then('the Sound Garden blooms', async ({ page }) => {
+  // Reaching the harmony target blooms the garden (no-fail sandbox — bloom is the
+  // settlement event).
+  await expect(page.getByText(/花园绽放了/).first()).toBeVisible({ timeout: 15_000 })
+})

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint:fix": "pnpm exec eslint . --fix && pnpm exec markdownlint-cli2 --fix \"*.md\" \".github/**/*.md\" \"docs/changelog-style-guide.md\"",
     "format": "pnpm exec prettier . --write",
     "format:check": "pnpm exec prettier --check .",
-    "build": "pnpm --filter manual build && pnpm --filter @amiclaw/platform build && pnpm --filter @amiclaw/game-bombsquad build && pnpm --filter @amiclaw/game-yijing build && pnpm --filter @amiclaw/game-shadow-chase build && pnpm --filter @amiclaw/game-botanical build && pnpm --filter @amiclaw/game-radio-cipher build && node scripts/assemble-pages.mjs",
+    "build": "pnpm --filter manual build && pnpm --filter @amiclaw/platform build && pnpm --filter @amiclaw/game-bombsquad build && pnpm --filter @amiclaw/game-yijing build && pnpm --filter @amiclaw/game-shadow-chase build && pnpm --filter @amiclaw/game-botanical build && pnpm --filter @amiclaw/game-radio-cipher build && pnpm --filter @amiclaw/game-sound-garden build && node scripts/assemble-pages.mjs",
     "gen:daily": "node scripts/generate-daily-from-practice.mjs",
     "test": "pnpm -r run test",
     "test:run": "pnpm -r run test:run",

--- a/packages/platform/public/_routes.json
+++ b/packages/platform/public/_routes.json
@@ -8,6 +8,7 @@
     "/oracle/*",
     "/shadow-chase/*",
     "/radio-cipher/*",
+    "/sound-garden/*",
     "/favicon.ico",
     "/favicon.svg",
     "/_redirects",

--- a/packages/platform/src/components/home/UpcomingGames.module.css
+++ b/packages/platform/src/components/home/UpcomingGames.module.css
@@ -147,6 +147,19 @@
     var(--bg-grad-mid-2);
 }
 
+/* Sound Garden — a blooming garden in platform hues (bounded-accent rule: the
+   game's warm melody/rhythm palette stays inside the game). A gold bloom accent
+   (🌸) warms the upper garden over the cosmic base, garden-green growth settles
+   below, and a soft violet music haze threads between — distinct from .garden
+   (green + blue) and .radio (violet + a blue band). CSS gradients only. */
+.sound {
+  background:
+    radial-gradient(circle at 38% 38%, rgba(255, 229, 62, 0.36), transparent 52%),
+    radial-gradient(circle at 70% 70%, rgba(75, 210, 102, 0.32), transparent 55%),
+    radial-gradient(circle at 54% 56%, rgba(180, 120, 255, 0.16), transparent 60%),
+    var(--bg-grad-mid-2);
+}
+
 .artLabel {
   /* Sits above the (optional) .artShot gameplay capture. */
   position: relative;

--- a/packages/platform/src/components/home/UpcomingGames.test.tsx
+++ b/packages/platform/src/components/home/UpcomingGames.test.tsx
@@ -42,7 +42,7 @@ describe('UpcomingGames — Game Lab Discord tile', () => {
     expect(screen.getByText('Game Lab')).toBeInTheDocument()
   })
 
-  it('renders Shadow Chase, Oracle, Botanical and Radio Cipher as playable peer cards before future games', async () => {
+  it('renders Shadow Chase, Oracle, Botanical, Radio Cipher and Sound Garden as playable peer cards before future games', async () => {
     await renderWith('')
 
     const links = screen.getAllByRole('link')
@@ -50,14 +50,17 @@ describe('UpcomingGames — Game Lab Discord tile', () => {
     const oracle = screen.getByRole('link', { name: /易经签卜/ })
     const botanical = screen.getByRole('link', { name: /植物园养护/ })
     const radio = screen.getByRole('link', { name: /密码电台/ })
+    const sound = screen.getByRole('link', { name: /声音花园/ })
     expect(shadow).toHaveAttribute('href', '/shadow-chase/')
     expect(oracle).toHaveAttribute('href', '/oracle/#/home')
     expect(botanical).toHaveAttribute('href', '/botanical/')
     expect(radio).toHaveAttribute('href', '/radio-cipher/')
+    expect(sound).toHaveAttribute('href', '/sound-garden/')
     expect(links.indexOf(shadow)).toBeLessThan(links.indexOf(oracle))
     expect(links.indexOf(oracle)).toBeLessThan(links.indexOf(botanical))
     expect(links.indexOf(botanical)).toBeLessThan(links.indexOf(radio))
-    expect(screen.getAllByText('可玩')).toHaveLength(4)
+    expect(links.indexOf(radio)).toBeLessThan(links.indexOf(sound))
+    expect(screen.getAllByText('可玩')).toHaveLength(5)
 
     // Future games remain honest, non-clickable cards.
     expect(screen.getAllByText('星海回声').length).toBeGreaterThan(0)

--- a/packages/platform/src/mocks/upcoming-games.ts
+++ b/packages/platform/src/mocks/upcoming-games.ts
@@ -4,7 +4,15 @@
    components/home/UpcomingGames. */
 
 export type GameStatus = 'soon' | 'dev' | 'live'
-export type GameArtVariant = 'shadow' | 'oracle' | 'garden' | 'radio' | 'echo' | 'draw' | 'lab'
+export type GameArtVariant =
+  | 'shadow'
+  | 'oracle'
+  | 'garden'
+  | 'radio'
+  | 'sound'
+  | 'echo'
+  | 'draw'
+  | 'lab'
 
 export interface UpcomingGame {
   id: string
@@ -58,6 +66,14 @@ export const upcomingGames: UpcomingGame[] = [
     status: 'live',
     artVariant: 'radio',
     href: '/radio-cipher/',
+  },
+  {
+    id: 'sound-garden',
+    name: '声音花园',
+    blurb: '和你的 AI 伙伴，把 8 拍时间线种成一座会唱歌的花园。',
+    status: 'live',
+    artVariant: 'sound',
+    href: '/sound-garden/',
   },
   {
     id: 'echo',

--- a/packages/platform/src/pages/GamesPage.test.tsx
+++ b/packages/platform/src/pages/GamesPage.test.tsx
@@ -288,7 +288,7 @@ describe('GamesPage homepage', () => {
     // The hero's static platform stat counts playable games, not supported AI
     // tools.
     expect(
-      screen.getByText((_, el) => el?.textContent?.replace(/\s+/g, '') === '5已上线游戏')
+      screen.getByText((_, el) => el?.textContent?.replace(/\s+/g, '') === '6已上线游戏')
     ).toBeInTheDocument()
     expect(screen.getAllByRole('link', { name: /双影追逃/ })).toHaveLength(1)
     expect(screen.getByRole('link', { name: /易经签卜/ })).toHaveAttribute('href', '/oracle/#/home')

--- a/scripts/assemble-pages.mjs
+++ b/scripts/assemble-pages.mjs
@@ -8,12 +8,14 @@ const yijingDistDir = resolve('packages/game-yijing/dist')
 const shadowChaseDistDir = resolve('packages/game-shadow-chase/dist')
 const botanicalDistDir = resolve('packages/game-botanical/dist')
 const radioCipherDistDir = resolve('packages/game-radio-cipher/dist')
+const soundGardenDistDir = resolve('packages/game-sound-garden/dist')
 const manualTargetDir = resolve(platformDistDir, 'manual')
 const bombsquadTargetDir = resolve(platformDistDir, 'bombsquad')
 const yijingTargetDir = resolve(platformDistDir, 'oracle')
 const shadowChaseTargetDir = resolve(platformDistDir, 'shadow-chase')
 const botanicalTargetDir = resolve(platformDistDir, 'botanical')
 const radioCipherTargetDir = resolve(platformDistDir, 'radio-cipher')
+const soundGardenTargetDir = resolve(platformDistDir, 'sound-garden')
 
 if (!existsSync(platformDistDir)) {
   throw new Error(`Platform build output not found: ${platformDistDir}`)
@@ -43,6 +45,10 @@ if (!existsSync(radioCipherDistDir)) {
   throw new Error(`Radio Cipher build output not found: ${radioCipherDistDir}`)
 }
 
+if (!existsSync(soundGardenDistDir)) {
+  throw new Error(`Sound Garden build output not found: ${soundGardenDistDir}`)
+}
+
 rmSync(manualTargetDir, { recursive: true, force: true })
 mkdirSync(manualTargetDir, { recursive: true })
 cpSync(manualDistDir, manualTargetDir, { recursive: true })
@@ -67,9 +73,14 @@ rmSync(radioCipherTargetDir, { recursive: true, force: true })
 mkdirSync(radioCipherTargetDir, { recursive: true })
 cpSync(radioCipherDistDir, radioCipherTargetDir, { recursive: true })
 
+rmSync(soundGardenTargetDir, { recursive: true, force: true })
+mkdirSync(soundGardenTargetDir, { recursive: true })
+cpSync(soundGardenDistDir, soundGardenTargetDir, { recursive: true })
+
 console.log(`Assembled Cloudflare Pages assets in ${manualTargetDir}`)
 console.log(`Assembled Cloudflare Pages assets in ${bombsquadTargetDir}`)
 console.log(`Assembled Cloudflare Pages assets in ${yijingTargetDir}`)
 console.log(`Assembled Cloudflare Pages assets in ${shadowChaseTargetDir}`)
 console.log(`Assembled Cloudflare Pages assets in ${botanicalTargetDir}`)
 console.log(`Assembled Cloudflare Pages assets in ${radioCipherTargetDir}`)
+console.log(`Assembled Cloudflare Pages assets in ${soundGardenTargetDir}`)


### PR DESCRIPTION
## Summary

- **Sound Garden goes live on claw.amio.fans** at `/sound-garden/`, following the radio-cipher (#240) listing anatomy exactly: assembly, SPA route, live entry card (GATE-A-approved copy, new `sound` art variant), pages-deploy merge step, root build ordering.
- Anonymous-tier e2e journey (seed move → plant → partner responds → bloom) wired into the flow inventory (coverage audit 35/35).
- CHANGELOG launch entry — honest about the signed-in voice co-build tier vs the anonymous scripted tier.

## Test plan

- [x] Full local `pnpm build` + assemble smoke: `platform/dist/sound-garden` emitted alongside existing games
- [x] platform 211 tests; e2e typegen (bddgen) + coverage audit 35/35
- [x] typecheck / eslint / prettier clean
- [x] Conformance spot-check vs #240: file-list parity, card copy verbatim, zero disturbance to other games' cards/routes/workflow lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Wc24r89aktaszk8JE3JC
