### PR TITLE
fix(platform-ai): make the co_build action contract mandatory

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -61,6 +61,11 @@ jobs:
           mkdir -p packages/platform/dist/radio-cipher
           cp -r packages/game-radio-cipher/dist/. packages/platform/dist/radio-cipher/
 
+      - name: Merge game-sound-garden build into platform/dist under /sound-garden/
+        run: |
+          mkdir -p packages/platform/dist/sound-garden
+          cp -r packages/game-sound-garden/dist/. packages/platform/dist/sound-garden/
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.1.0...HEAD)
 
+**Sound Garden joins AMIO Arcade** — Added. A new co-build voice game at
+`claw.amio.fans/sound-garden`. You plant melody flowers along an 8-beat timeline
+while your companion plants rhythm roots on the same beats; a root and a flower
+sharing a beat harmonize — synergy, compatible, neutral, or a harsh clash — and
+when the harmony score reaches the level's target the garden blooms. Signed-in
+players with a named companion co-build by voice: the companion speaks its
+guidance AND places its own rhythm roots on your shared board through the new
+co_build action channel — its moves pass the same client-side legality guard your
+own plants do, and it never moves during its closing recap. Everyone else —
+anonymous, no companion, or a standalone build with no platform worker — plays an
+offline scripted partner over the browser's own voice, which opens the garden with
+a seed move and answers each plant. It is a no-fail sandbox: a clashing pair only
+sounds harsh, nothing detonates, and bloom is a reward you can keep playing past.
+Ships with three levels, dark-only, CSS-only animation, running on the shared
+creation engine.
+
 **The platform companion learns to act in co-build games** — Added. The voice
 AI pipeline gains a backward-compatible action channel: in games flagged as
 co-build, the companion's reply can carry one structured board action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.1.0...HEAD)
 
+**The co-build companion now actually plants** — Fixed. In Sound Garden's
+signed-in tier the companion would narrate a move ("I placed a snare on beat
+three") without the board changing: the deployed prompt made the structured
+action block optional, so the model talked instead of acting. The action
+contract is now mandatory with a worked example, the parser accepts the
+vocabulary's Chinese display labels alongside piece ids, and every co-build
+turn leaves a bounded diagnostic breadcrumb so a silent drop can never hide
+again.
+
 **Sound Garden joins AMIO Arcade** — Added. A new co-build voice game at
 `claw.amio.fans/sound-garden`. You plant melody flowers along an 8-beat timeline
 while your companion plants rhythm roots on the same beats; a root and a flower

--- a/e2e/flow-inventory.yaml
+++ b/e2e/flow-inventory.yaml
@@ -21,9 +21,9 @@
 #
 # --- Regression size budget --------------------------------------------------
 # Per the governance model (rule 3): the e2e regression suite is capped at
-# 2 x the journey-scenario count. With 34 active flows <-> 34 journey
-# scenarios, the regression size budget is 68 (2026-07-11, after the Radio
-# Cipher listener-run flow landed as a @playwright journey).
+# 2 x the journey-scenario count. With 35 active flows <-> 35 journey
+# scenarios, the regression size budget is 70 (2026-07-11, after the Sound
+# Garden anon-run flow landed as a @playwright journey).
 # Crossing it triggers a forced prune audit. Current regression count: 2.
 #
 # --- Retired scenario --------------------------------------------------------
@@ -513,4 +513,30 @@ flows:
       shareable decoder codebook then teaches the finals-ring cipher and channel
       protocol while leaking no listener-side plaintext answer.
     steps: [radio-listener-open, onboarding-dismiss, tutorial-decrypt, run-won, codebook-partition]
+    status: active
+
+  # === Sound Garden flows =====================================================
+  # The /sound-garden/ single-screen SPA. A co-build music game: on the anon tier
+  # (no platform worker → voice eligibility fails) the offline scripted partner
+  # runs entirely client-side, seeding the garden with an opening rhythm root and
+  # answering each melody plant with a synergizing root, so a no-account visitor
+  # can co-build a garden to bloom with no live session.
+
+  - id: sound-garden-anon-run
+    name: Sound Garden anon co-build bloom
+    description: >-
+      An anonymous visitor opens Sound Garden and starts the 学步 level; the
+      offline scripted partner seeds the garden with an opening rhythm root, then
+      answers the visitor's three planted melody flowers with synergizing rhythm
+      roots until the shared harmony reaches the target and the garden blooms — a
+      no-fail co-build entirely client-side (no account, no worker, no session).
+    steps:
+      [
+        sound-garden-open,
+        sound-garden-start,
+        partner-seed,
+        plant-melody,
+        partner-rhythm,
+        garden-bloom,
+      ]
     status: active

--- a/e2e/sound-garden.gherkin
+++ b/e2e/sound-garden.gherkin
@@ -1,0 +1,24 @@
+# Sound Garden anon co-build bloom smoke. The /sound-garden/ single-screen SPA
+# plays fully client-side for a no-account visitor: with no platform worker the
+# voice eligibility probe fails and the offline scripted partner runs, seeding the
+# garden with an opening rhythm root and answering each plant with a synergizing
+# root until the shared harmony reaches the target and the garden blooms — a
+# no-fail co-build that needs neither an account nor a live session.
+
+Feature: Sound Garden anon co-build run
+  As an AMIO Arcade visitor without an account
+  I want to co-build a singing garden with the offline partner
+  So that we bloom the garden together entirely client-side
+
+  # Source: sound-garden-anon-run
+  @playwright
+  Scenario: The scripted partner seeds, answers plants, and the garden blooms
+    Given I open /sound-garden/
+    When I start Sound Garden level "学步"
+    Then the Sound Garden partner seeds the garden with an opening root
+
+    When I plant Sound Garden melody "铃铛" on beat 1
+    And I plant Sound Garden melody "风铃" on beat 2
+    And I plant Sound Garden melody "笛音" on beat 3
+    Then the Sound Garden partner answers with rhythm roots
+    And the Sound Garden blooms

--- a/e2e/steps/sound-garden.steps.ts
+++ b/e2e/steps/sound-garden.steps.ts
@@ -1,0 +1,47 @@
+/** Sound Garden anon co-build journey steps. The /sound-garden/ single-screen SPA
+ * plays fully client-side; with no platform worker the voice-eligibility probe
+ * fails and the offline scripted partner runs, so these steps drive the real
+ * engine + scripted brain through the DOM: seed → plants → synergizing rhythm
+ * roots → bloom. `Given I open /sound-garden/` is the shared navigation step. */
+import { expect } from '@playwright/test'
+import { Then, When } from './fixtures'
+
+When('I start Sound Garden level {string}', async ({ page }, level: string) => {
+  // The default role is the melody flower side, so the player plants melody and
+  // the partner plants rhythm. Clicking the level button starts that run.
+  await page.getByRole('button', { name: new RegExp(level) }).click()
+  // The anon partner tier renders once eligibility resolves (no worker → anon):
+  // the melody palette is the ready signal.
+  await expect(page.getByRole('button', { name: /选择铃铛/ })).toBeVisible()
+})
+
+Then('the Sound Garden partner seeds the garden with an opening root', async ({ page }) => {
+  // The scripted partner greets AND pre-seeds exactly one rhythm root (the PR-2
+  // anon opening move), so the garden starts with one filled rhythm cell.
+  await expect(page.getByText(/一起让花园唱起来/)).toBeVisible()
+  await expect.poll(() => page.locator('.sg-cell.rhythm.filled').count()).toBeGreaterThanOrEqual(1)
+})
+
+When(
+  'I plant Sound Garden melody {string} on beat {int}',
+  async ({ page }, piece: string, beat: number) => {
+    // Select the palette chip (剩余 count in its label), then tap the player's melody
+    // cell on that beat.
+    await page.getByRole('button', { name: new RegExp(`选择${piece}`) }).click()
+    await page.getByRole('button', { name: `旋律 第${beat}拍` }).click()
+  }
+)
+
+Then('the Sound Garden partner answers with rhythm roots', async ({ page }) => {
+  // The scripted partner (debounced) lays synergizing rhythm roots under the new
+  // melody flowers, so the rhythm lane grows past the single pre-seed root.
+  await expect
+    .poll(() => page.locator('.sg-cell.rhythm.filled').count(), { timeout: 15_000 })
+    .toBeGreaterThanOrEqual(2)
+})
+
+Then('the Sound Garden blooms', async ({ page }) => {
+  // Reaching the harmony target blooms the garden (no-fail sandbox — bloom is the
+  // settlement event).
+  await expect(page.getByText(/花园绽放了/).first()).toBeVisible({ timeout: 15_000 })
+})

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint:fix": "pnpm exec eslint . --fix && pnpm exec markdownlint-cli2 --fix \"*.md\" \".github/**/*.md\" \"docs/changelog-style-guide.md\"",
     "format": "pnpm exec prettier . --write",
     "format:check": "pnpm exec prettier --check .",
-    "build": "pnpm --filter manual build && pnpm --filter @amiclaw/platform build && pnpm --filter @amiclaw/game-bombsquad build && pnpm --filter @amiclaw/game-yijing build && pnpm --filter @amiclaw/game-shadow-chase build && pnpm --filter @amiclaw/game-botanical build && pnpm --filter @amiclaw/game-radio-cipher build && node scripts/assemble-pages.mjs",
+    "build": "pnpm --filter manual build && pnpm --filter @amiclaw/platform build && pnpm --filter @amiclaw/game-bombsquad build && pnpm --filter @amiclaw/game-yijing build && pnpm --filter @amiclaw/game-shadow-chase build && pnpm --filter @amiclaw/game-botanical build && pnpm --filter @amiclaw/game-radio-cipher build && pnpm --filter @amiclaw/game-sound-garden build && node scripts/assemble-pages.mjs",
     "gen:daily": "node scripts/generate-daily-from-practice.mjs",
     "test": "pnpm -r run test",
     "test:run": "pnpm -r run test:run",

--- a/packages/platform-ai/src/cobuild-splitter.test.ts
+++ b/packages/platform-ai/src/cobuild-splitter.test.ts
@@ -23,6 +23,13 @@ function run(deltas: string[]): { speech: string; actions: CoBuildAction[] } {
   return { speech, actions: flushed.actions }
 }
 
+/** The full flush result (incl. the observability diagnostic) for a delta run. */
+function flushOf(deltas: string[]) {
+  const splitter = new CoBuildSplitter(parseCoBuildActions)
+  for (const d of deltas) splitter.push(d)
+  return splitter.flush()
+}
+
 describe('CoBuildSplitter', () => {
   it('streams pure speech immediately and parses a trailing fenced action block', () => {
     const { speech, actions } = run([
@@ -129,8 +136,49 @@ describe('CoBuildSplitter', () => {
     const splitter = new CoBuildSplitter(parseCoBuildActions)
     // '看' streams immediately; the '<<' partial-prefix is HELD for flush.
     expect(splitter.push('看<<')).toBe('看')
-    expect(splitter.flush()).toEqual({ speech: '<<', actions: [] })
-    expect(splitter.flush()).toEqual({ speech: '', actions: [] })
+    // No fence ever came → the held carry is real speech, flushed once.
+    expect(splitter.flush()).toEqual({
+      speech: '<<',
+      actions: [],
+      diagnostic: 'no-fence',
+      bodyChars: 0,
+    })
+    expect(splitter.flush()).toEqual({ speech: '', actions: [], diagnostic: 'empty', bodyChars: 0 })
+  })
+})
+
+describe('CoBuildSplitter flush diagnostic (observability breadcrumb)', () => {
+  it('reports no-fence when the model spoke but emitted no action block', () => {
+    // The production failure: the partner narrates a move in prose, no fence.
+    const flushed = flushOf(['好，第三拍我放一个军鼓打底，你听。'])
+    expect(flushed.diagnostic).toBe('no-fence')
+    expect(flushed.actions).toEqual([])
+    expect(flushed.bodyChars).toBe(0)
+  })
+
+  it('reports emitted with the action count + body length when a valid block lands', () => {
+    const flushed = flushOf([
+      '放个底鼓。',
+      `${CO_BUILD_OPEN}[{"op":"place","piece_type":"kick","slot":1}]${CO_BUILD_CLOSE}`,
+    ])
+    expect(flushed.diagnostic).toBe('emitted')
+    expect(flushed.actions).toHaveLength(1)
+    expect(flushed.bodyChars).toBeGreaterThan(0)
+  })
+
+  it('reports parse-reject when a block is emitted but fails the strict parser', () => {
+    const flushed = flushOf([
+      `${CO_BUILD_OPEN}[{"op":"place","piece_type":"kazoo","slot":1}]${CO_BUILD_CLOSE}`,
+    ])
+    expect(flushed.diagnostic).toBe('parse-reject')
+    expect(flushed.actions).toEqual([])
+    expect(flushed.bodyChars).toBeGreaterThan(0)
+  })
+
+  it('reports discard-overflow when the action buffer exceeds ACTION_MAX_BYTES', () => {
+    const flushed = flushOf([`${CO_BUILD_OPEN}${'x'.repeat(ACTION_MAX_BYTES + 100)}`])
+    expect(flushed.diagnostic).toBe('discard-overflow')
+    expect(flushed.actions).toEqual([])
   })
 })
 
@@ -141,5 +189,20 @@ describe('buildCoBuildInstruction', () => {
     expect(instruction).toContain(CO_BUILD_CLOSE)
     expect(instruction).toContain('place')
     expect(instruction).toContain('remove')
+  })
+
+  it('is a hard contract: mandatory, one-move, with a concrete worked example', () => {
+    const instruction = buildCoBuildInstruction({ verbs: CO_BUILD_VERBS })
+    // Mandatory + violation framing (fixes the narrate-instead-of-emit failure).
+    expect(instruction).toMatch(/MUST/)
+    expect(instruction).toMatch(/CONTRACT VIOLATION/)
+    // Exactly one move per reply.
+    expect(instruction).toMatch(/EXACTLY ONE/)
+    // A concrete, parseable worked example (speech then the block).
+    expect(instruction).toContain(
+      `${CO_BUILD_OPEN}[{"op":"place","piece_type":"snare","slot":3}]${CO_BUILD_CLOSE}`
+    )
+    // Steer toward enum ids over Chinese names.
+    expect(instruction).toMatch(/NOT its Chinese name/)
   })
 })

--- a/packages/platform-ai/src/cobuild-splitter.ts
+++ b/packages/platform-ai/src/cobuild-splitter.ts
@@ -55,12 +55,29 @@ function longestOpenPrefixSuffix(s: string): number {
   return 0
 }
 
+/**
+ * Outcome of a turn's action channel — a bounded diagnostic for the production
+ * breadcrumb (turn-pipeline logs it via `traceTurn`). `no-fence` distinguishes the
+ * "model narrated a move but emitted no block" symptom from `parse-reject` (a
+ * block was emitted but failed the strict parser).
+ */
+export type CoBuildDiagnostic =
+  | 'no-fence'
+  | 'parse-reject'
+  | 'discard-overflow'
+  | 'emitted'
+  | 'empty'
+
 /** The trailing speech + parsed actions produced when the LLM stream ends. */
 export interface CoBuildFlushResult {
   /** Trailing speech to emit (the held carry in SPEECH state; '' otherwise). */
   speech: string
   /** Parsed actions, or `[]` on discard / parse-reject / no fence. */
   actions: CoBuildAction[]
+  /** Bounded outcome for the observability breadcrumb. */
+  diagnostic: CoBuildDiagnostic
+  /** Char length of the raw fence body (0 when no fence was seen). */
+  bodyChars: number
 }
 
 export class CoBuildSplitter {
@@ -116,18 +133,32 @@ export class CoBuildSplitter {
    * → `[]`). Idempotent.
    */
   flush(): CoBuildFlushResult {
-    if (this.ended) return { speech: '', actions: [] }
+    if (this.ended) return { speech: '', actions: [], diagnostic: 'empty', bodyChars: 0 }
     this.ended = true
     if (this.state === 'speech') {
       const speech = this.carry
       this.carry = ''
-      return { speech, actions: [] }
+      // No fence ever came — the model spoke (and may have NARRATED a move) but
+      // emitted no action block. This is the weak-prompt symptom the breadcrumb
+      // exists to catch.
+      return { speech, actions: [], diagnostic: 'no-fence', bodyChars: 0 }
     }
     if (this.state === 'discard') {
-      return { speech: '', actions: [] }
+      return { speech: '', actions: [], diagnostic: 'discard-overflow', bodyChars: 0 }
     }
     const body = this.actionBuf.split(CO_BUILD_CLOSE)[0]
-    return { speech: '', actions: this.parse(body) ?? [] }
+    const parsed = this.parse(body)
+    if (parsed === null) {
+      // A fence WAS emitted but failed the strict parser (bad token / shape) — the
+      // second failure mode. The body length is logged, never the body text.
+      return { speech: '', actions: [], diagnostic: 'parse-reject', bodyChars: body.length }
+    }
+    return {
+      speech: '',
+      actions: parsed,
+      diagnostic: parsed.length > 0 ? 'emitted' : 'empty',
+      bodyChars: body.length,
+    }
   }
 }
 
@@ -138,15 +169,29 @@ export class CoBuildSplitter {
  * the model and the parser can never drift.
  */
 export function buildCoBuildInstruction(coBuild: { verbs: readonly string[] }): string {
+  // Positioned LAST in the system message (see assembleSystem) for recency, framed
+  // as a hard contract because the real model (DeepSeek) otherwise NARRATES the
+  // move in prose and never emits the block — which changes nothing on the board.
   return [
-    'Co-build channel: besides speaking, you may place or remove pieces on the shared board.',
-    'To do so, append EXACTLY ONE fenced action block at the very END of your reply, after all',
-    'your spoken words. The block is a JSON array of moves. Format:',
-    `${CO_BUILD_OPEN}[{"op":"place","piece_type":"kick","slot":1}]${CO_BUILD_CLOSE}`,
-    `- "op" is one of: ${coBuild.verbs.join(', ')}.`,
-    '- "piece_type" is the piece to place or remove; "slot" is a 1-based integer.',
-    '- The fenced block is parsed as structured moves and is NEVER read aloud: keep every',
-    '  human-facing word in your speech, and put ONLY the JSON array inside the fence.',
-    '- Omit the fence entirely on a turn where you make no move. Never emit more than one fence.',
+    '━━━ ACTION-OUTPUT CONTRACT — read this last, obey it exactly ━━━',
+    'You do NOT move a piece by describing it. A move happens ONLY when you emit a',
+    'fenced action block. If your words say you placed or removed a piece but you do',
+    'NOT emit the block, the board does not change and the player sees nothing happen',
+    '— that is a CONTRACT VIOLATION, a broken promise. Therefore:',
+    'WHENEVER your reply places or removes a piece, you MUST end the reply — after all',
+    'your spoken words — with EXACTLY ONE action block, in this EXACT syntax:',
+    '',
+    `${CO_BUILD_OPEN}[{"op":"place","piece_type":"snare","slot":3}]${CO_BUILD_CLOSE}`,
+    '',
+    `- "op": exactly one of ${coBuild.verbs.join(' / ')}.`,
+    '- "piece_type": the piece\'s short id (kick / snare / hihat / clap / bell / chime /',
+    '  flute / harp), NOT its Chinese name.',
+    '- "slot": the 1-based beat number.',
+    '- Put EXACTLY ONE move in the array (one element) — never batch several.',
+    '- The block is parsed as data and is NEVER read aloud, so keep every human-facing',
+    '  word in your speech and put ONLY the JSON array inside the fence.',
+    '- Make no move this turn? Then say so in words and emit NO block. Never emit two.',
+    'Worked example (speech, then the mandatory block):',
+    `好，第三拍我给你放一个军鼓打底。${CO_BUILD_OPEN}[{"op":"place","piece_type":"snare","slot":3}]${CO_BUILD_CLOSE}`,
   ].join('\n')
 }

--- a/packages/platform-ai/src/sound-garden-action.test.ts
+++ b/packages/platform-ai/src/sound-garden-action.test.ts
@@ -95,6 +95,34 @@ describe('parseCoBuildActions', () => {
     expect(parseCoBuildActions('[{"op":"place","slot":1}]')).toBeNull()
   })
 
+  it('accepts a vocabulary display label and normalizes it to the enum id (军鼓 → snare)', () => {
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"军鼓","slot":3}]')).toEqual([
+      { op: 'place', pieceType: 'snare', slot: 3 },
+    ])
+    // Every Chinese display label maps back to its canonical id.
+    const labelToId: Array<[string, string]> = [
+      ['底鼓', 'kick'],
+      ['军鼓', 'snare'],
+      ['踩镲', 'hihat'],
+      ['拍掌', 'clap'],
+      ['铃铛', 'bell'],
+      ['风铃', 'chime'],
+      ['笛音', 'flute'],
+      ['竖琴', 'harp'],
+    ]
+    for (const [label, id] of labelToId) {
+      expect(parseCoBuildActions(`[{"op":"place","piece_type":"${label}","slot":1}]`)).toEqual([
+        { op: 'place', pieceType: id, slot: 1 },
+      ])
+    }
+  })
+
+  it('rejects a Chinese label OUTSIDE the vocabulary (labels stay vocabulary-bounded)', () => {
+    // A real-sounding but non-vocabulary label must still drop the whole set.
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"小提琴","slot":1}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"鼓","slot":1}]')).toBeNull()
+  })
+
   it('rejects a forged piece type outside the vocabulary', () => {
     expect(parseCoBuildActions('[{"op":"place","piece_type":"drum","slot":1}]')).toBeNull()
     expect(parseCoBuildActions('[{"op":"place","piece_type":"guitar","slot":1}]')).toBeNull()

--- a/packages/platform-ai/src/sound-garden-action.ts
+++ b/packages/platform-ai/src/sound-garden-action.ts
@@ -50,6 +50,37 @@ export const SOUND_GARDEN_PIECE_TYPES = [
 
 const PIECE_TYPE_SET = new Set<string>(SOUND_GARDEN_PIECE_TYPES)
 
+type SoundGardenPieceType = (typeof SOUND_GARDEN_PIECE_TYPES)[number]
+
+/**
+ * Display-label → enum-id aliases, mirroring the `display_labels` map in the
+ * game-type SSOT (`packages/creation/fixtures/sound-garden/game-type.yaml`). The
+ * real partner (DeepSeek) speaks Chinese, so it emits the piece's Chinese name
+ * (e.g. 军鼓) in the fence rather than the `snare` id; this maps those back to the
+ * canonical id. It stays VOCABULARY-BOUNDED — a token outside both the id set and
+ * this alias map still rejects, so a hallucinated element cannot slip through.
+ */
+const PIECE_ALIASES = new Map<string, SoundGardenPieceType>([
+  ['底鼓', 'kick'],
+  ['军鼓', 'snare'],
+  ['踩镲', 'hihat'],
+  ['拍掌', 'clap'],
+  ['铃铛', 'bell'],
+  ['风铃', 'chime'],
+  ['笛音', 'flute'],
+  ['竖琴', 'harp'],
+])
+
+/**
+ * Resolve a raw piece token to a canonical id, or null if outside the vocabulary.
+ * Uses a `Map` (not a plain-object lookup) so a token like `__proto__` cannot
+ * resolve to a prototype value and slip past the vocabulary guard.
+ */
+function resolvePieceType(raw: string): SoundGardenPieceType | null {
+  if (PIECE_TYPE_SET.has(raw)) return raw as SoundGardenPieceType
+  return PIECE_ALIASES.get(raw) ?? null
+}
+
 /**
  * Parse and validate the raw fence body into a list of co_build actions.
  *
@@ -81,10 +112,14 @@ export function parseCoBuildActions(raw: string): CoBuildAction[] | null {
     if (typeof entry !== 'object' || entry === null) return null
     const record = entry as Record<string, unknown>
     const op = record.op
-    const pieceType = record.piece_type ?? record.pieceType
+    const rawPiece = record.piece_type ?? record.pieceType
     const slot = record.slot
     if (typeof op !== 'string' || !VERB_SET.has(op)) return null
-    if (typeof pieceType !== 'string' || !PIECE_TYPE_SET.has(pieceType)) return null
+    if (typeof rawPiece !== 'string') return null
+    // Accept the enum id OR a vocabulary display label (军鼓 → snare); anything
+    // else is out-of-vocabulary and drops the whole set.
+    const pieceType = resolvePieceType(rawPiece)
+    if (pieceType === null) return null
     if (typeof slot !== 'number' || !Number.isInteger(slot) || slot < 1) return null
     actions.push({ op: op as 'place' | 'remove', pieceType, slot })
   }

--- a/packages/platform-ai/src/trace.ts
+++ b/packages/platform-ai/src/trace.ts
@@ -50,6 +50,10 @@ export interface TraceFields {
   sentenceCount?: number
   frameCount?: number
   ttsFrameCount?: number
+  /** Number of parsed co_build actions a turn emitted (0 on drop / no move). */
+  actionCount?: number
+  /** Char length of a co_build fence body (a count of the JSON, never its text). */
+  bodyChars?: number
 
   // --- Lengths / byte tallies (counts of content, never the content) ---
   transcriptChars?: number

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -13,6 +13,7 @@ import {
   type TurnProviders,
 } from './turn-pipeline'
 import { CO_BUILD_VERBS, parseCoBuildActions } from './sound-garden-action'
+import { CO_BUILD_CLOSE } from './cobuild-splitter'
 import { createDeepSeekLlmProvider } from './providers/deepseek'
 import type { AiResponseChunk, AudioChunk, ManualData } from './contract'
 import type {
@@ -975,5 +976,21 @@ describe('co_build turn gating', () => {
       )
     )
     expect(chunks.filter((c) => c.kind === 'action')).toHaveLength(1)
+  })
+
+  it('assembles the strengthened action contract into the system prompt, positioned LAST for recency', async () => {
+    let captured: LlmCompletionRequest | undefined
+    const llm = mockLlm(['好。'], { capture: (r) => (captured = r) })
+    await collect(runOpeningTurn({ llm, tts: mockTts([]) }, coBuildState()))
+
+    const system = captured?.messages[0]
+    expect(system?.role).toBe('system')
+    // The hard contract is present (fixes the narrate-instead-of-emit failure).
+    expect(system?.content).toContain('ACTION-OUTPUT CONTRACT')
+    expect(system?.content).toMatch(/MUST/)
+    expect(system?.content).toMatch(/CONTRACT VIOLATION/)
+    // …and it is the LAST thing in the system message (recency): the block ends on
+    // the worked example's closing fence marker.
+    expect(system?.content.trimEnd().endsWith(CO_BUILD_CLOSE)).toBe(true)
   })
 })

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -496,6 +496,17 @@ async function* streamLlmTts(
               yield { kind: 'text', text: flushed.speech, done: false }
             }
             pendingActions = flushed.actions
+            // Permanent observability breadcrumb for the co_build action channel:
+            // one `turn-trace` line per co_build turn recording the outcome —
+            // `no-fence` (model narrated but emitted no block), `parse-reject` (a
+            // block was emitted but failed the strict parser), or `emitted`. The
+            // diagnostic is a bounded enum in the stage; only counts ride the
+            // fields (never the fence text).
+            traceTurn('cobuild', flushed.diagnostic, {
+              sessionId: traceSessionId,
+              actionCount: flushed.actions.length,
+              bodyChars: flushed.bodyChars,
+            })
           }
           const { sentences, remainder } = splitSentences(pending)
           for (const sentence of sentences) queueSentence(sentence)

--- a/packages/platform/public/_routes.json
+++ b/packages/platform/public/_routes.json
@@ -8,6 +8,7 @@
     "/oracle/*",
     "/shadow-chase/*",
     "/radio-cipher/*",
+    "/sound-garden/*",
     "/favicon.ico",
     "/favicon.svg",
     "/_redirects",

--- a/packages/platform/src/components/home/UpcomingGames.module.css
+++ b/packages/platform/src/components/home/UpcomingGames.module.css
@@ -147,6 +147,19 @@
     var(--bg-grad-mid-2);
 }
 
+/* Sound Garden — a blooming garden in platform hues (bounded-accent rule: the
+   game's warm melody/rhythm palette stays inside the game). A gold bloom accent
+   (🌸) warms the upper garden over the cosmic base, garden-green growth settles
+   below, and a soft violet music haze threads between — distinct from .garden
+   (green + blue) and .radio (violet + a blue band). CSS gradients only. */
+.sound {
+  background:
+    radial-gradient(circle at 38% 38%, rgba(255, 229, 62, 0.36), transparent 52%),
+    radial-gradient(circle at 70% 70%, rgba(75, 210, 102, 0.32), transparent 55%),
+    radial-gradient(circle at 54% 56%, rgba(180, 120, 255, 0.16), transparent 60%),
+    var(--bg-grad-mid-2);
+}
+
 .artLabel {
   /* Sits above the (optional) .artShot gameplay capture. */
   position: relative;

--- a/packages/platform/src/components/home/UpcomingGames.test.tsx
+++ b/packages/platform/src/components/home/UpcomingGames.test.tsx
@@ -42,7 +42,7 @@ describe('UpcomingGames — Game Lab Discord tile', () => {
     expect(screen.getByText('Game Lab')).toBeInTheDocument()
   })
 
-  it('renders Shadow Chase, Oracle, Botanical and Radio Cipher as playable peer cards before future games', async () => {
+  it('renders Shadow Chase, Oracle, Botanical, Radio Cipher and Sound Garden as playable peer cards before future games', async () => {
     await renderWith('')
 
     const links = screen.getAllByRole('link')
@@ -50,14 +50,17 @@ describe('UpcomingGames — Game Lab Discord tile', () => {
     const oracle = screen.getByRole('link', { name: /易经签卜/ })
     const botanical = screen.getByRole('link', { name: /植物园养护/ })
     const radio = screen.getByRole('link', { name: /密码电台/ })
+    const sound = screen.getByRole('link', { name: /声音花园/ })
     expect(shadow).toHaveAttribute('href', '/shadow-chase/')
     expect(oracle).toHaveAttribute('href', '/oracle/#/home')
     expect(botanical).toHaveAttribute('href', '/botanical/')
     expect(radio).toHaveAttribute('href', '/radio-cipher/')
+    expect(sound).toHaveAttribute('href', '/sound-garden/')
     expect(links.indexOf(shadow)).toBeLessThan(links.indexOf(oracle))
     expect(links.indexOf(oracle)).toBeLessThan(links.indexOf(botanical))
     expect(links.indexOf(botanical)).toBeLessThan(links.indexOf(radio))
-    expect(screen.getAllByText('可玩')).toHaveLength(4)
+    expect(links.indexOf(radio)).toBeLessThan(links.indexOf(sound))
+    expect(screen.getAllByText('可玩')).toHaveLength(5)
 
     // Future games remain honest, non-clickable cards.
     expect(screen.getAllByText('星海回声').length).toBeGreaterThan(0)

--- a/packages/platform/src/mocks/upcoming-games.ts
+++ b/packages/platform/src/mocks/upcoming-games.ts
@@ -4,7 +4,15 @@
    components/home/UpcomingGames. */
 
 export type GameStatus = 'soon' | 'dev' | 'live'
-export type GameArtVariant = 'shadow' | 'oracle' | 'garden' | 'radio' | 'echo' | 'draw' | 'lab'
+export type GameArtVariant =
+  | 'shadow'
+  | 'oracle'
+  | 'garden'
+  | 'radio'
+  | 'sound'
+  | 'echo'
+  | 'draw'
+  | 'lab'
 
 export interface UpcomingGame {
   id: string
@@ -58,6 +66,14 @@ export const upcomingGames: UpcomingGame[] = [
     status: 'live',
     artVariant: 'radio',
     href: '/radio-cipher/',
+  },
+  {
+    id: 'sound-garden',
+    name: '声音花园',
+    blurb: '和你的 AI 伙伴，把 8 拍时间线种成一座会唱歌的花园。',
+    status: 'live',
+    artVariant: 'sound',
+    href: '/sound-garden/',
   },
   {
     id: 'echo',

--- a/packages/platform/src/pages/GamesPage.test.tsx
+++ b/packages/platform/src/pages/GamesPage.test.tsx
@@ -288,7 +288,7 @@ describe('GamesPage homepage', () => {
     // The hero's static platform stat counts playable games, not supported AI
     // tools.
     expect(
-      screen.getByText((_, el) => el?.textContent?.replace(/\s+/g, '') === '5已上线游戏')
+      screen.getByText((_, el) => el?.textContent?.replace(/\s+/g, '') === '6已上线游戏')
     ).toBeInTheDocument()
     expect(screen.getAllByRole('link', { name: /双影追逃/ })).toHaveLength(1)
     expect(screen.getByRole('link', { name: /易经签卜/ })).toHaveAttribute('href', '/oracle/#/home')

--- a/scripts/assemble-pages.mjs
+++ b/scripts/assemble-pages.mjs
@@ -8,12 +8,14 @@ const yijingDistDir = resolve('packages/game-yijing/dist')
 const shadowChaseDistDir = resolve('packages/game-shadow-chase/dist')
 const botanicalDistDir = resolve('packages/game-botanical/dist')
 const radioCipherDistDir = resolve('packages/game-radio-cipher/dist')
+const soundGardenDistDir = resolve('packages/game-sound-garden/dist')
 const manualTargetDir = resolve(platformDistDir, 'manual')
 const bombsquadTargetDir = resolve(platformDistDir, 'bombsquad')
 const yijingTargetDir = resolve(platformDistDir, 'oracle')
 const shadowChaseTargetDir = resolve(platformDistDir, 'shadow-chase')
 const botanicalTargetDir = resolve(platformDistDir, 'botanical')
 const radioCipherTargetDir = resolve(platformDistDir, 'radio-cipher')
+const soundGardenTargetDir = resolve(platformDistDir, 'sound-garden')
 
 if (!existsSync(platformDistDir)) {
   throw new Error(`Platform build output not found: ${platformDistDir}`)
@@ -43,6 +45,10 @@ if (!existsSync(radioCipherDistDir)) {
   throw new Error(`Radio Cipher build output not found: ${radioCipherDistDir}`)
 }
 
+if (!existsSync(soundGardenDistDir)) {
+  throw new Error(`Sound Garden build output not found: ${soundGardenDistDir}`)
+}
+
 rmSync(manualTargetDir, { recursive: true, force: true })
 mkdirSync(manualTargetDir, { recursive: true })
 cpSync(manualDistDir, manualTargetDir, { recursive: true })
@@ -67,9 +73,14 @@ rmSync(radioCipherTargetDir, { recursive: true, force: true })
 mkdirSync(radioCipherTargetDir, { recursive: true })
 cpSync(radioCipherDistDir, radioCipherTargetDir, { recursive: true })
 
+rmSync(soundGardenTargetDir, { recursive: true, force: true })
+mkdirSync(soundGardenTargetDir, { recursive: true })
+cpSync(soundGardenDistDir, soundGardenTargetDir, { recursive: true })
+
 console.log(`Assembled Cloudflare Pages assets in ${manualTargetDir}`)
 console.log(`Assembled Cloudflare Pages assets in ${bombsquadTargetDir}`)
 console.log(`Assembled Cloudflare Pages assets in ${yijingTargetDir}`)
 console.log(`Assembled Cloudflare Pages assets in ${shadowChaseTargetDir}`)
 console.log(`Assembled Cloudflare Pages assets in ${botanicalTargetDir}`)
 console.log(`Assembled Cloudflare Pages assets in ${radioCipherTargetDir}`)
+console.log(`Assembled Cloudflare Pages assets in ${soundGardenTargetDir}`)


### PR DESCRIPTION
## Summary

- **Fixes the signed-in Sound Garden companion narrating moves without acting.** Live production capture showed the model saying "I placed a snare on beat three" with zero `action` frames across the session — the deployed prompt literally allowed omitting the action block. The instruction is now a hard ACTION-OUTPUT CONTRACT (MUST + worked example + exactly-one-move + ids-not-labels), placed last in the system prompt for recency.
- Parser now accepts the vocabulary's Chinese display labels (军鼓→snare) as aliases — vocabulary-bounded, still rejects hallucinated types; this rewrite also fixes a prototype-pollution lookup slip in the old plain-object map.
- Permanent bounded trace breadcrumb per co_build turn (`no-fence` / `parse-reject` / `emitted` + counts only) so a silent action drop can never hide again. Server-side repair was evaluated and skipped (would buffer the full reply and kill streaming TTS).

## Test plan

- [x] platform-ai 449 (+8: alias/reject, splitter diagnostics, hard-contract, prompt recency)
- [x] Consumers untouched: game-sound-garden 60, botanical 71, bombsquad 508
- [x] Full typecheck / eslint / prettier
- [ ] Post-deploy: live production speech→action round-trip re-run (manager, immediately after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Wc24r89aktaszk8JE3JC
