### PR TITLE
fix(e2e): advance Sound Garden partner clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ codebook page to hand your partner, a per-segment transcription pad, first-run
 onboarding, and a count-up stopwatch with a wrong-answer time penalty. Dark-only,
 CSS-only animation, running on the shared creation engine.
 
+### Bug Fixes
+
+- **Sound Garden browser verification** — Anonymous co-build checks now advance
+  the controlled browser clock through the scripted partner's debounce, so the
+  real seed, response, and bloom journey can guard releases without false stalls.
+
 <!-- Add every change that will land on main directly below this header. -->
 <!-- Entries below are maintained manually -->
 

--- a/e2e/regression/fix-sound-garden-partner-frozen-clock.gherkin
+++ b/e2e/regression/fix-sound-garden-partner-frozen-clock.gherkin
@@ -1,0 +1,17 @@
+# bug: GitHub Actions run 29155916878 left the anonymous scripted partner at
+# one opening rhythm root after the player planted melody. Shared navigation
+# paused Playwright's controlled clock, so the product's 600ms debounce never
+# fired and wall-time polling could not observe an answer.
+# fix: e2e/steps/sound-garden.steps.ts advances the controlled clock through the
+# real partner debounce before asserting the resulting board state.
+
+Feature: Sound Garden scripted partner survives the controlled e2e clock
+
+  @playwright
+  Scenario: A single melody plant receives a scripted rhythm answer
+    Given I open /sound-garden/
+    When I start Sound Garden level "学步"
+    Then the Sound Garden partner seeds the garden with an opening root
+
+    When I plant Sound Garden melody "风铃" on beat 2
+    Then the Sound Garden partner answers with rhythm roots

--- a/e2e/steps/sound-garden.steps.ts
+++ b/e2e/steps/sound-garden.steps.ts
@@ -6,6 +6,9 @@
 import { expect } from '@playwright/test'
 import { Then, When } from './fixtures'
 
+/** Must match the anon partner's product debounce in `TriggerBus`. */
+const PARTNER_DEBOUNCE_MS = 600
+
 When('I start Sound Garden level {string}', async ({ page }, level: string) => {
   // The default role is the melody flower side, so the player plants melody and
   // the partner plants rhythm. Clicking the level button starts that run.
@@ -32,12 +35,14 @@ When(
   }
 )
 
-Then('the Sound Garden partner answers with rhythm roots', async ({ page }) => {
+Then('the Sound Garden partner answers with rhythm roots', async ({ page, world }) => {
   // The scripted partner (debounced) lays synergizing rhythm roots under the new
-  // melody flowers, so the rhythm lane grows past the single pre-seed root.
-  await expect
-    .poll(() => page.locator('.sg-cell.rhythm.filled').count(), { timeout: 15_000 })
-    .toBeGreaterThanOrEqual(2)
+  // melody flowers, so the rhythm lane grows past the single pre-seed root. Shared
+  // navigation pauses Playwright's controlled clock at the deterministic seed;
+  // explicitly advance the product debounce instead of waiting on wall time, which
+  // cannot fire a timer on that paused clock.
+  await world.advance(PARTNER_DEBOUNCE_MS)
+  await expect.poll(() => page.locator('.sg-cell.rhythm.filled').count()).toBeGreaterThanOrEqual(2)
 })
 
 Then('the Sound Garden blooms', async ({ page }) => {

--- a/e2e/steps/sound-garden.steps.ts
+++ b/e2e/steps/sound-garden.steps.ts
@@ -37,12 +37,14 @@ When(
 
 Then('the Sound Garden partner answers with rhythm roots', async ({ page, world }) => {
   // The scripted partner (debounced) lays synergizing rhythm roots under the new
-  // melody flowers, so the rhythm lane grows past the single pre-seed root. Shared
+  // melody flowers, so the rhythm lane grows beyond its opening state. Shared
   // navigation pauses Playwright's controlled clock at the deterministic seed;
   // explicitly advance the product debounce instead of waiting on wall time, which
   // cannot fire a timer on that paused clock.
+  const filledPartnerCells = page.locator('.sg-cell.rhythm.filled')
+  const filledBeforeResponse = await filledPartnerCells.count()
   await world.advance(PARTNER_DEBOUNCE_MS)
-  await expect.poll(() => page.locator('.sg-cell.rhythm.filled').count()).toBeGreaterThanOrEqual(2)
+  await expect.poll(() => filledPartnerCells.count()).toBeGreaterThan(filledBeforeResponse)
 })
 
 Then('the Sound Garden blooms', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Advance the controlled Playwright clock through the anonymous Sound Garden partner debounce before asserting the board response.
- Add a focused frozen-clock regression while keeping production runtime and signed-in Mode② code unchanged.
- Restore deterministic coverage for the seed, response, and bloom journey that currently makes main CI red.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [x] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Test plan:

- [x] `CI=1 pnpm test:e2e` — 43/43 passed
- [x] Focused Sound Garden journey plus regression — 2/2 passed; 6/6 with `--repeat-each=3`
- [x] `pnpm --filter @amiclaw/game-sound-garden test:run` — 60/60 passed
- [x] `pnpm test:run`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test:regression`
- [x] `pnpm e2e:audit`

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

No breaking changes. Root-cause probes confirmed that production timers advance normally; the failure occurred only when shared E2E navigation paused the Playwright clock.

Claude Code attribution: none; this PR was produced and independently verified in Codex.