### PR TITLE
fix(platform-ai): enforce co-build action output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Versions follow [Semantic Versioning](https://semver.org).
 
 ## [Unreleased](https://github.com/amio-love/amiclaw/compare/0.1.0...HEAD)
 
+**The co-build companion now follows through** — Fixed. In signed-in Sound
+Garden sessions, the companion could describe planting a piece without changing
+the board. Its action output is now a mandatory one-move contract with a concrete
+example, the parser accepts the garden vocabulary's Chinese display labels, and
+each co-build turn records a bounded action-channel outcome so rejected or
+missing action blocks can be diagnosed without logging their contents.
+
 **Sound Garden joins AMIO Arcade** — Added. A new co-build voice game at
 `claw.amio.fans/sound-garden`. You plant melody flowers along an 8-beat timeline
 while your companion plants rhythm roots on the same beats; a root and a flower

--- a/packages/platform-ai/src/cobuild-splitter.test.ts
+++ b/packages/platform-ai/src/cobuild-splitter.test.ts
@@ -23,6 +23,13 @@ function run(deltas: string[]): { speech: string; actions: CoBuildAction[] } {
   return { speech, actions: flushed.actions }
 }
 
+/** The full flush result (incl. the observability diagnostic) for a delta run. */
+function flushOf(deltas: string[]) {
+  const splitter = new CoBuildSplitter(parseCoBuildActions)
+  for (const d of deltas) splitter.push(d)
+  return splitter.flush()
+}
+
 describe('CoBuildSplitter', () => {
   it('streams pure speech immediately and parses a trailing fenced action block', () => {
     const { speech, actions } = run([
@@ -129,8 +136,54 @@ describe('CoBuildSplitter', () => {
     const splitter = new CoBuildSplitter(parseCoBuildActions)
     // '看' streams immediately; the '<<' partial-prefix is HELD for flush.
     expect(splitter.push('看<<')).toBe('看')
-    expect(splitter.flush()).toEqual({ speech: '<<', actions: [] })
-    expect(splitter.flush()).toEqual({ speech: '', actions: [] })
+    expect(splitter.flush()).toEqual({
+      speech: '<<',
+      actions: [],
+      diagnostic: 'no-fence',
+      bodyChars: 0,
+    })
+    expect(splitter.flush()).toEqual({ speech: '', actions: [], diagnostic: 'empty', bodyChars: 0 })
+  })
+})
+
+describe('CoBuildSplitter flush diagnostic (observability breadcrumb)', () => {
+  it('reports no-fence when the model spoke but emitted no action block', () => {
+    const flushed = flushOf(['好，第三拍我放一个军鼓打底，你听。'])
+    expect(flushed.diagnostic).toBe('no-fence')
+    expect(flushed.actions).toEqual([])
+    expect(flushed.bodyChars).toBe(0)
+  })
+
+  it('also reports no-fence for a legitimate no-move turn', () => {
+    const flushed = flushOf(['这一拍我先听听，不下子。'])
+    expect(flushed.diagnostic).toBe('no-fence')
+    expect(flushed.actions).toEqual([])
+    expect(flushed.bodyChars).toBe(0)
+  })
+
+  it('reports emitted with the action count + body length when a valid block lands', () => {
+    const flushed = flushOf([
+      '放个底鼓。',
+      `${CO_BUILD_OPEN}[{"op":"place","piece_type":"kick","slot":1}]${CO_BUILD_CLOSE}`,
+    ])
+    expect(flushed.diagnostic).toBe('emitted')
+    expect(flushed.actions).toHaveLength(1)
+    expect(flushed.bodyChars).toBeGreaterThan(0)
+  })
+
+  it('reports parse-reject when a block is emitted but fails the strict parser', () => {
+    const flushed = flushOf([
+      `${CO_BUILD_OPEN}[{"op":"place","piece_type":"kazoo","slot":1}]${CO_BUILD_CLOSE}`,
+    ])
+    expect(flushed.diagnostic).toBe('parse-reject')
+    expect(flushed.actions).toEqual([])
+    expect(flushed.bodyChars).toBeGreaterThan(0)
+  })
+
+  it('reports discard-overflow when the action buffer exceeds ACTION_MAX_BYTES', () => {
+    const flushed = flushOf([`${CO_BUILD_OPEN}${'x'.repeat(ACTION_MAX_BYTES + 100)}`])
+    expect(flushed.diagnostic).toBe('discard-overflow')
+    expect(flushed.actions).toEqual([])
   })
 })
 
@@ -141,5 +194,16 @@ describe('buildCoBuildInstruction', () => {
     expect(instruction).toContain(CO_BUILD_CLOSE)
     expect(instruction).toContain('place')
     expect(instruction).toContain('remove')
+  })
+
+  it('is a hard contract: mandatory, one-move, with a concrete worked example', () => {
+    const instruction = buildCoBuildInstruction({ verbs: CO_BUILD_VERBS })
+    expect(instruction).toMatch(/MUST/)
+    expect(instruction).toMatch(/CONTRACT VIOLATION/)
+    expect(instruction).toMatch(/EXACTLY ONE/)
+    expect(instruction).toContain(
+      `${CO_BUILD_OPEN}[{"op":"place","piece_type":"snare","slot":3}]${CO_BUILD_CLOSE}`
+    )
+    expect(instruction).toMatch(/NOT its Chinese name/)
   })
 })

--- a/packages/platform-ai/src/cobuild-splitter.ts
+++ b/packages/platform-ai/src/cobuild-splitter.ts
@@ -55,12 +55,30 @@ function longestOpenPrefixSuffix(s: string): number {
   return 0
 }
 
+/**
+ * Outcome of a turn's action channel — a bounded diagnostic for the production
+ * breadcrumb (turn-pipeline logs it via `traceTurn`). `no-fence` means no action
+ * block was emitted; it can represent either a legitimate no-move turn or the
+ * observed narrate-without-acting symptom. `parse-reject` means a block was
+ * emitted but failed the strict parser.
+ */
+export type CoBuildDiagnostic =
+  | 'no-fence'
+  | 'parse-reject'
+  | 'discard-overflow'
+  | 'emitted'
+  | 'empty'
+
 /** The trailing speech + parsed actions produced when the LLM stream ends. */
 export interface CoBuildFlushResult {
   /** Trailing speech to emit (the held carry in SPEECH state; '' otherwise). */
   speech: string
   /** Parsed actions, or `[]` on discard / parse-reject / no fence. */
   actions: CoBuildAction[]
+  /** Bounded outcome for the observability breadcrumb. */
+  diagnostic: CoBuildDiagnostic
+  /** Char length of the raw fence body (0 when no fence was seen). */
+  bodyChars: number
 }
 
 export class CoBuildSplitter {
@@ -116,18 +134,32 @@ export class CoBuildSplitter {
    * → `[]`). Idempotent.
    */
   flush(): CoBuildFlushResult {
-    if (this.ended) return { speech: '', actions: [] }
+    if (this.ended) return { speech: '', actions: [], diagnostic: 'empty', bodyChars: 0 }
     this.ended = true
     if (this.state === 'speech') {
       const speech = this.carry
       this.carry = ''
-      return { speech, actions: [] }
+      // No fence ever came. This can be an intentional no-move turn or the
+      // narrate-without-acting symptom; the breadcrumb records the observation
+      // without trying to infer intent.
+      return { speech, actions: [], diagnostic: 'no-fence', bodyChars: 0 }
     }
     if (this.state === 'discard') {
-      return { speech: '', actions: [] }
+      return { speech: '', actions: [], diagnostic: 'discard-overflow', bodyChars: 0 }
     }
     const body = this.actionBuf.split(CO_BUILD_CLOSE)[0]
-    return { speech: '', actions: this.parse(body) ?? [] }
+    const parsed = this.parse(body)
+    if (parsed === null) {
+      // A fence WAS emitted but failed the strict parser (bad token / shape) — the
+      // second failure mode. The body length is logged, never the body text.
+      return { speech: '', actions: [], diagnostic: 'parse-reject', bodyChars: body.length }
+    }
+    return {
+      speech: '',
+      actions: parsed,
+      diagnostic: parsed.length > 0 ? 'emitted' : 'empty',
+      bodyChars: body.length,
+    }
   }
 }
 
@@ -138,15 +170,29 @@ export class CoBuildSplitter {
  * the model and the parser can never drift.
  */
 export function buildCoBuildInstruction(coBuild: { verbs: readonly string[] }): string {
+  // Positioned LAST in the system message (see assembleSystem) for recency, framed
+  // as a hard contract because the real model (DeepSeek) otherwise NARRATES the
+  // move in prose and never emits the block — which changes nothing on the board.
   return [
-    'Co-build channel: besides speaking, you may place or remove pieces on the shared board.',
-    'To do so, append EXACTLY ONE fenced action block at the very END of your reply, after all',
-    'your spoken words. The block is a JSON array of moves. Format:',
-    `${CO_BUILD_OPEN}[{"op":"place","piece_type":"kick","slot":1}]${CO_BUILD_CLOSE}`,
-    `- "op" is one of: ${coBuild.verbs.join(', ')}.`,
-    '- "piece_type" is the piece to place or remove; "slot" is a 1-based integer.',
-    '- The fenced block is parsed as structured moves and is NEVER read aloud: keep every',
-    '  human-facing word in your speech, and put ONLY the JSON array inside the fence.',
-    '- Omit the fence entirely on a turn where you make no move. Never emit more than one fence.',
+    '━━━ ACTION-OUTPUT CONTRACT — read this last, obey it exactly ━━━',
+    'You do NOT move a piece by describing it. A move happens ONLY when you emit a',
+    'fenced action block. If your words say you placed or removed a piece but you do',
+    'NOT emit the block, the board does not change and the player sees nothing happen',
+    '— that is a CONTRACT VIOLATION, a broken promise. Therefore:',
+    'WHENEVER your reply places or removes a piece, you MUST end the reply — after all',
+    'your spoken words — with EXACTLY ONE action block, in this EXACT syntax:',
+    '',
+    `${CO_BUILD_OPEN}[{"op":"place","piece_type":"snare","slot":3}]${CO_BUILD_CLOSE}`,
+    '',
+    `- "op": exactly one of ${coBuild.verbs.join(' / ')}.`,
+    '- "piece_type": the piece\'s short id (kick / snare / hihat / clap / bell / chime /',
+    '  flute / harp), NOT its Chinese name.',
+    '- "slot": the 1-based beat number.',
+    '- Put EXACTLY ONE move in the array (one element) — never batch several.',
+    '- The block is parsed as data and is NEVER read aloud, so keep every human-facing',
+    '  word in your speech and put ONLY the JSON array inside the fence.',
+    '- Make no move this turn? Then say so in words and emit NO block. Never emit two.',
+    'Worked example (speech, then the mandatory block):',
+    `好，第三拍我给你放一个军鼓打底。${CO_BUILD_OPEN}[{"op":"place","piece_type":"snare","slot":3}]${CO_BUILD_CLOSE}`,
   ].join('\n')
 }

--- a/packages/platform-ai/src/sound-garden-action.test.ts
+++ b/packages/platform-ai/src/sound-garden-action.test.ts
@@ -8,8 +8,9 @@ import {
 /**
  * The strict co_build parse-guard: valid moves parse (accepting either wire
  * `piece_type` or `pieceType`), a validly-empty array yields `[]`, and ANY
- * structural violation drops the WHOLE set (`null`) — never throws. Game-specific
- * legality (lane / range / material) is NOT enforced here; only shape.
+ * structural or exactly-one-move violation drops the WHOLE set (`null`) — never
+ * throws. Game-specific legality (lane / range / material) is NOT enforced here;
+ * only shape.
  */
 describe('parseCoBuildActions', () => {
   it('exposes the aligned verb vocabulary', () => {
@@ -43,15 +44,12 @@ describe('parseCoBuildActions', () => {
     ])
   })
 
-  it('parses multiple valid actions preserving order', () => {
+  it('rejects an otherwise-valid two-action array', () => {
     expect(
       parseCoBuildActions(
         '[{"op":"place","piece_type":"kick","slot":1},{"op":"remove","piece_type":"snare","slot":3}]'
       )
-    ).toEqual([
-      { op: 'place', pieceType: 'kick', slot: 1 },
-      { op: 'remove', pieceType: 'snare', slot: 3 },
-    ])
+    ).toBeNull()
   })
 
   it('accepts camelCase pieceType as well as snake_case piece_type', () => {
@@ -95,6 +93,29 @@ describe('parseCoBuildActions', () => {
     expect(parseCoBuildActions('[{"op":"place","slot":1}]')).toBeNull()
   })
 
+  it('accepts vocabulary display labels and normalizes them to enum ids', () => {
+    const labelToId: Array<[string, string]> = [
+      ['底鼓', 'kick'],
+      ['军鼓', 'snare'],
+      ['踩镲', 'hihat'],
+      ['拍掌', 'clap'],
+      ['铃铛', 'bell'],
+      ['风铃', 'chime'],
+      ['笛音', 'flute'],
+      ['竖琴', 'harp'],
+    ]
+    for (const [label, id] of labelToId) {
+      expect(parseCoBuildActions(`[{"op":"place","piece_type":"${label}","slot":1}]`)).toEqual([
+        { op: 'place', pieceType: id, slot: 1 },
+      ])
+    }
+  })
+
+  it('rejects a Chinese label outside the vocabulary', () => {
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"小提琴","slot":1}]')).toBeNull()
+    expect(parseCoBuildActions('[{"op":"place","piece_type":"鼓","slot":1}]')).toBeNull()
+  })
+
   it('rejects a forged piece type outside the vocabulary', () => {
     expect(parseCoBuildActions('[{"op":"place","piece_type":"drum","slot":1}]')).toBeNull()
     expect(parseCoBuildActions('[{"op":"place","piece_type":"guitar","slot":1}]')).toBeNull()
@@ -109,27 +130,11 @@ describe('parseCoBuildActions', () => {
     expect(parseCoBuildActions('[{"op":"place","piece_type":" kick","slot":1}]')).toBeNull()
   })
 
-  it('drops the whole set when one action names an unknown element', () => {
-    expect(
-      parseCoBuildActions(
-        '[{"op":"place","piece_type":"kick","slot":1},{"op":"place","piece_type":"tuba","slot":2}]'
-      )
-    ).toBeNull()
-  })
-
   it('rejects a non-integer / non-positive slot (1-based)', () => {
     expect(parseCoBuildActions('[{"op":"place","piece_type":"kick","slot":1.5}]')).toBeNull()
     expect(parseCoBuildActions('[{"op":"place","piece_type":"kick","slot":0}]')).toBeNull()
     expect(parseCoBuildActions('[{"op":"place","piece_type":"kick","slot":-2}]')).toBeNull()
     expect(parseCoBuildActions('[{"op":"place","piece_type":"kick","slot":"1"}]')).toBeNull()
-  })
-
-  it('drops the WHOLE set when any one action is invalid (reject-on-invalid)', () => {
-    expect(
-      parseCoBuildActions(
-        '[{"op":"place","piece_type":"kick","slot":1},{"op":"place","piece_type":"snare","slot":0}]'
-      )
-    ).toBeNull()
   })
 
   it('rejects a non-object array element', () => {

--- a/packages/platform-ai/src/sound-garden-action.ts
+++ b/packages/platform-ai/src/sound-garden-action.ts
@@ -8,7 +8,8 @@
  * Chase's reject-on-invalid stance (`shadow-chase-intent.ts`
  * `parseShadowChaseIntentResponse`): any violation — non-array body, unknown verb,
  * a piece type outside the fixed Sound Garden vocabulary, non-integer / non-positive
- * slot — drops the WHOLE action set (the partner still speaks) and never throws.
+ * slot, or more than one move — drops the WHOLE action set (the partner still
+ * speaks) and never throws.
  *
  * Board-state legality (piece belongs to THIS partner's lane, slot in range,
  * material still available) is NOT checked here — that stays client-side in the
@@ -50,11 +51,42 @@ export const SOUND_GARDEN_PIECE_TYPES = [
 
 const PIECE_TYPE_SET = new Set<string>(SOUND_GARDEN_PIECE_TYPES)
 
+type SoundGardenPieceType = (typeof SOUND_GARDEN_PIECE_TYPES)[number]
+
+/**
+ * Display-label → enum-id aliases, mirroring the `display_labels` map in the
+ * game-type SSOT (`packages/creation/fixtures/sound-garden/game-type.yaml`). The
+ * real partner (DeepSeek) speaks Chinese, so it emits the piece's Chinese name
+ * (e.g. 军鼓) in the fence rather than the `snare` id; this maps those back to the
+ * canonical id. It stays VOCABULARY-BOUNDED — a token outside both the id set and
+ * this alias map still rejects, so a hallucinated element cannot slip through.
+ */
+const PIECE_ALIASES = new Map<string, SoundGardenPieceType>([
+  ['底鼓', 'kick'],
+  ['军鼓', 'snare'],
+  ['踩镲', 'hihat'],
+  ['拍掌', 'clap'],
+  ['铃铛', 'bell'],
+  ['风铃', 'chime'],
+  ['笛音', 'flute'],
+  ['竖琴', 'harp'],
+])
+
+/**
+ * Resolve a raw piece token to a canonical id, or null if outside the vocabulary.
+ * Uses a `Map` (not a plain-object lookup) so a token like `__proto__` cannot
+ * resolve to a prototype value and slip past the vocabulary guard.
+ */
+function resolvePieceType(raw: string): SoundGardenPieceType | null {
+  if (PIECE_TYPE_SET.has(raw)) return raw as SoundGardenPieceType
+  return PIECE_ALIASES.get(raw) ?? null
+}
+
 /**
  * Parse and validate the raw fence body into a list of co_build actions.
  *
  * Tolerates an optional ```json code fence around the array (the model
- * occasionally wraps it), then requires a JSON array whose every element is a
+ * occasionally wraps it), then requires a JSON array containing zero or one
  * well-shaped action. Returns `null` on ANY violation so the caller drops the
  * entire set; returns `[]` for a validly-empty array (no move this turn). Never
  * throws.
@@ -76,15 +108,20 @@ export function parseCoBuildActions(raw: string): CoBuildAction[] | null {
     return null
   }
   if (!Array.isArray(parsed)) return null
+  if (parsed.length > 1) return null
   const actions: CoBuildAction[] = []
   for (const entry of parsed) {
     if (typeof entry !== 'object' || entry === null) return null
     const record = entry as Record<string, unknown>
     const op = record.op
-    const pieceType = record.piece_type ?? record.pieceType
+    const rawPiece = record.piece_type ?? record.pieceType
     const slot = record.slot
     if (typeof op !== 'string' || !VERB_SET.has(op)) return null
-    if (typeof pieceType !== 'string' || !PIECE_TYPE_SET.has(pieceType)) return null
+    if (typeof rawPiece !== 'string') return null
+    // Accept the enum id OR a vocabulary display label (军鼓 → snare); anything
+    // else is out-of-vocabulary and drops the whole set.
+    const pieceType = resolvePieceType(rawPiece)
+    if (pieceType === null) return null
     if (typeof slot !== 'number' || !Number.isInteger(slot) || slot < 1) return null
     actions.push({ op: op as 'place' | 'remove', pieceType, slot })
   }

--- a/packages/platform-ai/src/trace.ts
+++ b/packages/platform-ai/src/trace.ts
@@ -50,6 +50,10 @@ export interface TraceFields {
   sentenceCount?: number
   frameCount?: number
   ttsFrameCount?: number
+  /** Number of parsed co_build actions a turn emitted (0 on drop / no move). */
+  actionCount?: number
+  /** Char length of a co_build fence body (a count of the JSON, never its text). */
+  bodyChars?: number
 
   // --- Lengths / byte tallies (counts of content, never the content) ---
   transcriptChars?: number

--- a/packages/platform-ai/src/turn-pipeline.test.ts
+++ b/packages/platform-ai/src/turn-pipeline.test.ts
@@ -13,6 +13,7 @@ import {
   type TurnProviders,
 } from './turn-pipeline'
 import { CO_BUILD_VERBS, parseCoBuildActions } from './sound-garden-action'
+import { CO_BUILD_CLOSE } from './cobuild-splitter'
 import { createDeepSeekLlmProvider } from './providers/deepseek'
 import type { AiResponseChunk, AudioChunk, ManualData } from './contract'
 import type {
@@ -975,5 +976,18 @@ describe('co_build turn gating', () => {
       )
     )
     expect(chunks.filter((c) => c.kind === 'action')).toHaveLength(1)
+  })
+
+  it('assembles the strengthened action contract into the system prompt, positioned LAST for recency', async () => {
+    let captured: LlmCompletionRequest | undefined
+    const llm = mockLlm(['好。'], { capture: (r) => (captured = r) })
+    await collect(runOpeningTurn({ llm, tts: mockTts([]) }, coBuildState()))
+
+    const system = captured?.messages[0]
+    expect(system?.role).toBe('system')
+    expect(system?.content).toContain('ACTION-OUTPUT CONTRACT')
+    expect(system?.content).toMatch(/MUST/)
+    expect(system?.content).toMatch(/CONTRACT VIOLATION/)
+    expect(system?.content.trimEnd().endsWith(CO_BUILD_CLOSE)).toBe(true)
   })
 })

--- a/packages/platform-ai/src/turn-pipeline.ts
+++ b/packages/platform-ai/src/turn-pipeline.ts
@@ -496,6 +496,17 @@ async function* streamLlmTts(
               yield { kind: 'text', text: flushed.speech, done: false }
             }
             pendingActions = flushed.actions
+            // Permanent observability breadcrumb for the co_build action channel:
+            // one `turn-trace` line per co_build turn recording the outcome —
+            // `no-fence` (including legitimate no-move turns), `parse-reject` (a
+            // block was emitted but failed the strict parser), or `emitted`.
+            // The diagnostic records the wire outcome without inferring model
+            // intent. Only bounded counts ride the fields (never the fence text).
+            traceTurn('cobuild', flushed.diagnostic, {
+              sessionId: traceSessionId,
+              actionCount: flushed.actions.length,
+              bodyChars: flushed.bodyChars,
+            })
           }
           const { sentences, remainder } = splitSentences(pending)
           for (const sentence of sentences) queueSentence(sentence)


### PR DESCRIPTION
## Summary

- Make Sound Garden's signed-in co-build action fence a mandatory, single-move contract so narrated moves produce structured board actions.
- Normalize the bounded Chinese display-label vocabulary, reject action batches, and add content-free diagnostics for missing, rejected, overflowed, or emitted action blocks.
- Carry only the action-contract repair from conflicting PR #249 onto current `main`; the duplicate Sound Garden listing commit is excluded. Supersedes #249.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] CI or configuration

## Testing

- [x] Existing tests pass
- [x] New tests added if behavior changed
- [x] Tested manually and documented below

Independent verification covered Chinese alias normalization, forged and prototype-key tokens, empty and single-action inputs, two- and 100-action rejection, no-fence no-move turns, parse rejection, overflow, prompt ordering, and non-co-build isolation.

- `pnpm --filter @amiclaw/platform-ai test:run` — 35 files, 448 tests passed
- `pnpm test:run` — full workspace passed in independent verification and the commit hook
- Workspace typecheck, ESLint, Prettier, and `git diff --check` passed

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the diff
- [x] No debug logging remains
- [x] Documentation updated if needed
- [x] Breaking changes documented if any

The action channel continues to stream speech without whole-response buffering. Diagnostics contain only bounded enums, counts, and lengths; model content is never logged.

Claude Code attribution: none; this replacement was produced and independently verified in Codex.
